### PR TITLE
04: Make balance and transaction writes concurrency-safe (v1.15.0)

### DIFF
--- a/backend/src/accounts/accounts.service.spec.ts
+++ b/backend/src/accounts/accounts.service.spec.ts
@@ -360,12 +360,25 @@ describe("AccountsService", () => {
   });
 
   describe("updateBalance", () => {
+    /**
+     * The guarded UPDATE reports whether it matched a row.
+     *
+     * `is_closed = false` is a predicate of the write, not of a read that came
+     * before it: a separate check let a mutation of an existing transaction read
+     * the account as open, wait behind `close()`, and then add its delta to a row
+     * that had since been closed at zero (audit P4-008). So the double has to
+     * answer the way the statement does -- a row, or nothing.
+     */
+    function stageBalanceUpdate(matched: boolean): void {
+      mockQueryRunner.query.mockImplementation(async (sql: string) =>
+        String(sql).includes("UPDATE accounts") && matched
+          ? [[{ id: "account-1" }], 1]
+          : [[], 0],
+      );
+    }
+
     it("adds positive amount to balance", async () => {
-      accountsRepository.findOne.mockResolvedValue({
-        ...mockAccount,
-        currentBalance: 1000,
-      });
-      accountsRepository.query.mockResolvedValue(undefined);
+      stageBalanceUpdate(true);
       accountsRepository.findOneOrFail.mockResolvedValue({
         ...mockAccount,
         currentBalance: 1500,
@@ -373,19 +386,16 @@ describe("AccountsService", () => {
 
       const result = await service.updateBalance("account-1", 500);
 
-      expect(mockQueryRunner.query).toHaveBeenCalledWith(
-        `UPDATE accounts SET current_balance = ROUND(CAST(current_balance AS numeric) + $1, 4) WHERE id = $2`,
-        [500, "account-1"],
-      );
+      const [sql, params] = mockQueryRunner.query.mock.calls[0];
+      expect(sql).toContain("current_balance AS numeric) + $1");
+      expect(sql).toContain("is_closed = false");
+      expect(sql).toContain("RETURNING");
+      expect(params).toEqual([500, "account-1"]);
       expect(result.currentBalance).toBe(1500);
     });
 
     it("subtracts negative amount from balance", async () => {
-      accountsRepository.findOne.mockResolvedValue({
-        ...mockAccount,
-        currentBalance: 1000,
-      });
-      accountsRepository.query.mockResolvedValue(undefined);
+      stageBalanceUpdate(true);
       accountsRepository.findOneOrFail.mockResolvedValue({
         ...mockAccount,
         currentBalance: 700,
@@ -393,14 +403,15 @@ describe("AccountsService", () => {
 
       const result = await service.updateBalance("account-1", -300);
 
-      expect(mockQueryRunner.query).toHaveBeenCalledWith(
-        `UPDATE accounts SET current_balance = ROUND(CAST(current_balance AS numeric) + $1, 4) WHERE id = $2`,
-        [-300, "account-1"],
-      );
+      expect(mockQueryRunner.query.mock.calls[0][1]).toEqual([
+        -300,
+        "account-1",
+      ]);
       expect(result.currentBalance).toBe(700);
     });
 
     it("throws NotFoundException when account not found", async () => {
+      stageBalanceUpdate(false);
       accountsRepository.findOne.mockResolvedValue(null);
 
       await expect(service.updateBalance("nonexistent", 100)).rejects.toThrow(
@@ -409,6 +420,9 @@ describe("AccountsService", () => {
     });
 
     it("throws BadRequestException for closed accounts", async () => {
+      // No row matched and the account exists: it is closed. Told apart so the
+      // caller gets 400 rather than one ambiguous error.
+      stageBalanceUpdate(false);
       accountsRepository.findOne.mockResolvedValue({
         ...mockAccount,
         isClosed: true,
@@ -419,12 +433,26 @@ describe("AccountsService", () => {
       );
     });
 
-    it("rounds to 4 decimal places to match DB schema precision", async () => {
+    it("refuses the delta when close() committed while the ledger write waited", async () => {
+      // The regression guard for P4-008: an unvoid read the account as open, the
+      // close committed at zero, and the delta then landed on the closed row --
+      // a closed account holding -10.00. Re-evaluating the predicate after the
+      // row lock refuses instead, and the throw rolls the ledger mutation back
+      // with it.
+      stageBalanceUpdate(false);
       accountsRepository.findOne.mockResolvedValue({
         ...mockAccount,
-        currentBalance: 10.1,
+        isClosed: true,
       });
-      accountsRepository.query.mockResolvedValue(undefined);
+
+      await expect(
+        service.updateBalance("account-1", -10),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(accountsRepository.findOneOrFail).not.toHaveBeenCalled();
+    });
+
+    it("rounds to 4 decimal places to match DB schema precision", async () => {
+      stageBalanceUpdate(true);
       accountsRepository.findOneOrFail.mockResolvedValue({
         ...mockAccount,
         currentBalance: 20.3,
@@ -432,19 +460,12 @@ describe("AccountsService", () => {
 
       const result = await service.updateBalance("account-1", 10.2);
 
-      expect(mockQueryRunner.query).toHaveBeenCalledWith(
-        `UPDATE accounts SET current_balance = ROUND(CAST(current_balance AS numeric) + $1, 4) WHERE id = $2`,
-        [10.2, "account-1"],
-      );
+      expect(mockQueryRunner.query.mock.calls[0][0]).toContain("ROUND(");
       expect(result.currentBalance).toBe(20.3);
     });
 
-    it("uses atomic SQL UPDATE to prevent race conditions", async () => {
-      accountsRepository.findOne.mockResolvedValue({
-        ...mockAccount,
-        currentBalance: 1000,
-      });
-      accountsRepository.query.mockResolvedValue(undefined);
+    it("uses atomic SQL arithmetic to prevent race conditions", async () => {
+      stageBalanceUpdate(true);
       accountsRepository.findOneOrFail.mockResolvedValue({
         ...mockAccount,
         currentBalance: 1100,
@@ -456,6 +477,25 @@ describe("AccountsService", () => {
         expect.stringContaining("UPDATE accounts"),
         [100, "account-1"],
       );
+    });
+  });
+
+  describe("touchAccount", () => {
+    it("advances updated_at with an owner-scoped UPDATE and no balance change", async () => {
+      // The crash-recovery backstop for net-worth snapshots: a snapshot-only
+      // change (a past-dated row moved to another past month) leaves
+      // current_balance untouched, so nothing would bump accounts.updated_at and
+      // sweepStaleSnapshots could never find the stale snapshot. touchAccount
+      // advances the timestamp -- owner-scoped, and it must not write the balance.
+      mockQueryRunner.query.mockResolvedValue(undefined);
+
+      await service.touchAccount("user-1", "account-1");
+
+      const [sql, params] = mockQueryRunner.query.mock.calls[0];
+      expect(sql).toContain("UPDATE accounts SET updated_at = now()");
+      expect(sql).toContain("WHERE id = $1 AND user_id = $2");
+      expect(sql).not.toContain("current_balance");
+      expect(params).toEqual(["account-1", "user-1"]);
     });
   });
 
@@ -1001,6 +1041,27 @@ describe("AccountsService", () => {
   });
 
   describe("findAll", () => {
+    it("stays strictly owner-scoped -- AI/MCP listings exclude joint accounts (N2)", async () => {
+      // The joint-account union happens only in the HTTP controller. Every
+      // other consumer of findAll -- AI tools, MCP, internal summaries --
+      // deliberately sees own accounts only (joint-accounts spec, N2 scope
+      // cut). This pins the predicate so a widened findAll fails loudly.
+      const where = jest.fn().mockReturnThis();
+      const getMany = jest.fn().mockResolvedValue([]);
+      accountsRepository.createQueryBuilder.mockReturnValue({
+        where,
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany,
+      });
+
+      await service.findAll("user-1");
+
+      expect(where).toHaveBeenCalledWith("account.userId = :userId", {
+        userId: "user-1",
+      });
+    });
+
     it("returns accounts with canDelete computed", async () => {
       const getMany = jest.fn().mockResolvedValue([mockAccount]);
       accountsRepository.createQueryBuilder.mockReturnValue({
@@ -1028,27 +1089,6 @@ describe("AccountsService", () => {
       const result = await service.findAll("user-1");
 
       expect(result).toHaveLength(0);
-    });
-
-    it("stays strictly owner-scoped -- AI/MCP listings exclude joint accounts (N2)", async () => {
-      // The joint-account union happens only in the HTTP controller. Every
-      // other consumer of findAll -- AI tools, MCP, internal summaries --
-      // deliberately sees own accounts only (joint-accounts spec, N2 scope
-      // cut). This pins the predicate so a widened findAll fails loudly.
-      const where = jest.fn().mockReturnThis();
-      const getMany = jest.fn().mockResolvedValue([]);
-      accountsRepository.createQueryBuilder.mockReturnValue({
-        where,
-        andWhere: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        getMany,
-      });
-
-      await service.findAll("user-1");
-
-      expect(where).toHaveBeenCalledWith("account.userId = :userId", {
-        userId: "user-1",
-      });
     });
   });
 
@@ -2534,7 +2574,6 @@ describe("AccountsService", () => {
   });
 
   // ─── extra branch coverage ────────────────────────────────────────────
-
   describe("update extra branches", () => {
     it("throws NotFoundException when account is not found", async () => {
       mockQueryRunner.manager.findOne.mockResolvedValue(null);
@@ -2691,17 +2730,19 @@ describe("AccountsService", () => {
 
   describe("updateBalance", () => {
     it("applies the atomic UPDATE and re-reads the balance in one scoped transaction", async () => {
-      accountsRepository.findOne.mockResolvedValue({
-        ...mockAccount,
-        currentBalance: 100,
-      });
+      // The guarded UPDATE answers as the driver does: a matched row, as a tuple.
+      mockQueryRunner.query.mockImplementation(async (sql: string) =>
+        String(sql).includes("UPDATE accounts")
+          ? [[{ id: "account-1" }], 1]
+          : [[], 0],
+      );
       accountsRepository.findOneOrFail.mockResolvedValue({
         ...mockAccount,
         currentBalance: 200,
       });
       const result = await service.updateBalance("account-1", 100);
-      expect(mockQueryRunner.manager.query).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE accounts SET current_balance"),
+      expect(mockQueryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE accounts"),
         [100, "account-1"],
       );
       expect(result.currentBalance).toBe(200);
@@ -2709,47 +2750,113 @@ describe("AccountsService", () => {
   });
 
   describe("recalculateCurrentBalance", () => {
-    it("throws NotFoundException when account not found", async () => {
-      accountsRepository.findOne.mockResolvedValue(null);
-      await expect(service.recalculateCurrentBalance("nope")).rejects.toThrow(
-        NotFoundException,
-      );
+    /**
+     * The recomputation locks the account rows and then reads the ledger.
+     *
+     * That order is the fix, not a detail: it writes an absolute balance, and
+     * under READ COMMITTED its SELECT and its UPDATE are separate statement
+     * snapshots -- so a delta committing between them used to be overwritten by a
+     * total that never saw it (audit P4-005). The double answers the lock, the
+     * sum, and the write in the order the transaction issues them.
+     */
+    function stageRecalc(balanceRows: unknown[]): jest.Mock {
+      const query = jest.fn().mockImplementation(async (sql: string) => {
+        if (String(sql).includes("FOR UPDATE")) return [{ id: "account-1" }];
+        if (String(sql).includes("COALESCE(SUM(t.amount)")) return balanceRows;
+        return [];
+      });
+      (mockQueryRunner.manager as unknown as { query: jest.Mock }).query =
+        query;
+      return query;
+    }
+
+    it("throws NotFoundException when the account is gone", async () => {
+      // The ledger sum joins from `accounts`, so no row means no account.
+      stageRecalc([]);
+      await expect(
+        service.recalculateCurrentBalance("user-1", "nope"),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it("computes the new balance from the summed transactions", async () => {
-      accountsRepository.findOne.mockResolvedValue({
-        id: "account-1",
-        openingBalance: 100,
+      stageRecalc([{ balance: "150.5" }]);
+      accountsRepository.findOneOrFail.mockResolvedValue({
+        ...mockAccount,
+        currentBalance: 150.5,
       });
-      accountsRepository.save.mockImplementation((d) => Promise.resolve(d));
-      const ds = mockQueryRunner.manager as unknown as { query: jest.Mock };
-      ds.query = jest.fn().mockResolvedValue([{ balance: "150.5" }]);
-      const result = await service.recalculateCurrentBalance("account-1");
+
+      const result = await service.recalculateCurrentBalance(
+        "user-1",
+        "account-1",
+      );
+
       expect(result.currentBalance).toBe(150.5);
     });
 
-    it("falls back to openingBalance when query returns empty", async () => {
-      accountsRepository.findOne.mockResolvedValue({
-        id: "account-1",
-        openingBalance: 100,
-        currentBalance: 50,
-      });
-      const ds = mockQueryRunner.manager as unknown as { query: jest.Mock };
-      ds.query = jest.fn().mockResolvedValue([]);
-      const r = await service.recalculateCurrentBalance("account-1");
-      expect(r.currentBalance).toBe(100);
+    it("locks the account before reading the ledger, scoped to the owner", async () => {
+      const query = stageRecalc([{ balance: "150.5" }]);
+      accountsRepository.findOneOrFail.mockResolvedValue({ ...mockAccount });
+
+      await service.recalculateCurrentBalance("user-1", "account-1");
+
+      const statements = query.mock.calls.map((c) => String(c[0]));
+      const lockAt = statements.findIndex((sql) => sql.includes("FOR UPDATE"));
+      const sumAt = statements.findIndex((sql) =>
+        sql.includes("COALESCE(SUM(t.amount)"),
+      );
+      expect(lockAt).toBeGreaterThanOrEqual(0);
+      expect(lockAt).toBeLessThan(sumAt);
+
+      // The balance-write lock is owner-scoped: an own-context recomputation
+      // must never lock an account that is not the caller's (maintainer review,
+      // PR #1095). The userId reaches lockAccountsForBalanceWrite and lands in
+      // the FOR UPDATE predicate.
+      const lockCall = query.mock.calls.find((c) =>
+        String(c[0]).includes("FOR UPDATE"),
+      );
+      expect(String(lockCall![0])).toContain("user_id = $2");
+      expect(lockCall![1]).toEqual([["account-1"], "user-1"]);
     });
 
-    it("persists the recomputed balance", async () => {
-      accountsRepository.findOne.mockResolvedValue({
-        id: "account-1",
-        openingBalance: 100,
+    it("writes only current_balance, never the whole account row", async () => {
+      // Saving the entity read before the transaction would write back every
+      // other column from that snapshot, so a concurrent rename or
+      // opening-balance edit would be reverted by a balance recalculation.
+      const query = stageRecalc([{ balance: "275.5" }]);
+      accountsRepository.findOneOrFail.mockResolvedValue({
+        ...mockAccount,
+        currentBalance: 275.5,
       });
-      accountsRepository.save.mockImplementation((d) => Promise.resolve(d));
-      const ds = mockQueryRunner.manager as unknown as { query: jest.Mock };
-      ds.query = jest.fn().mockResolvedValue([{ balance: "275.5" }]);
-      const r = await service.recalculateCurrentBalance("account-1");
-      expect(r.currentBalance).toBe(275.5);
+
+      const result = await service.recalculateCurrentBalance(
+        "user-1",
+        "account-1",
+      );
+
+      expect(result.currentBalance).toBe(275.5);
+      expect(accountsRepository.save).not.toHaveBeenCalled();
+      const write = query.mock.calls
+        .map((c) => String(c[0]))
+        .find((sql) => sql.startsWith("UPDATE accounts"));
+      expect(write).toBe(
+        "UPDATE accounts SET current_balance = $1 WHERE id = $2",
+      );
+    });
+
+    it("resolves an account with no transactions to its opening balance", async () => {
+      // The old implementation fell back to `openingBalance` in code when the
+      // sum query returned nothing; the LEFT JOIN + COALESCE now answer that
+      // case in SQL, so an empty result means only "no such account". The
+      // behaviour the fallback protected -- no ledger rows means the opening
+      // balance -- is asserted here through the query's own answer.
+      stageRecalc([{ balance: "100" }]);
+      accountsRepository.findOneOrFail.mockResolvedValue({
+        ...mockAccount,
+        openingBalance: 100,
+        currentBalance: 100,
+      });
+      const r = await service.recalculateCurrentBalance("user-1", "account-1");
+      expect(r.currentBalance).toBe(100);
     });
   });
 
@@ -3181,6 +3288,9 @@ describe("AccountsService", () => {
         .mockResolvedValueOnce([{ user_id: "u1", timezone: "America/Toronto" }])
         // accountRows
         .mockResolvedValueOnce([{ account_id: "a1" }])
+        // ...locked FOR UPDATE before the ledger is read, so the absolute write
+        // cannot overwrite a delta that commits in between (audit P4-005)
+        .mockResolvedValueOnce([{ id: "a1" }])
         // balances
         .mockResolvedValueOnce([{ account_id: "a1", balance: "150" }])
         // bulk UPDATE ... FROM (VALUES ...)
@@ -3195,6 +3305,13 @@ describe("AccountsService", () => {
       expect(bulkUpdateCall).toBeDefined();
       expect(bulkUpdateCall?.[1]).toEqual(["a1", 150]);
       expect(accountsRepository.update).not.toHaveBeenCalled();
+      // And the lock came first.
+      const statements = ds.query.mock.calls.map((c) => String(c[0]));
+      expect(
+        statements.findIndex((sql) => sql.includes("FOR UPDATE")),
+      ).toBeLessThan(
+        statements.findIndex((sql) => sql.includes("COALESCE(SUM(t.amount)")),
+      );
     });
 
     it("logs error when query throws", async () => {

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -40,6 +40,8 @@ import { didYouMean } from "../common/name-suggestions.util";
 import { ActionHistoryService } from "../action-history/action-history.service";
 import { withSystemContext } from "../common/db/with-context";
 import { withScopedDb } from "../common/db/scoped-db";
+import { lockAccountsForBalanceWrite } from "../common/db/locks";
+import { affectedRowCount } from "../common/db/query-result";
 
 @Injectable()
 export class AccountsService {
@@ -949,41 +951,52 @@ export class AccountsService {
 
   /**
    * Update account balance (called internally by transactions).
-   * Uses atomic SQL UPDATE to prevent race conditions from concurrent requests.
+   *
+   * The arithmetic is done by PostgreSQL, so two concurrent deltas compose: the
+   * `UPDATE` re-reads `current_balance` after it wins the row lock. Two things
+   * make that guarantee real rather than nominal:
+   *
+   * - `is_closed = false` is a predicate of the **write**, not of a read that
+   *   preceded it. A separate check-then-update let a mutation of an existing
+   *   transaction read the account as open, wait behind `close()`, and then add
+   *   its delta to a row that had since been closed with a zero balance -- a
+   *   closed account holding `-10.00` (audit P4-008). Re-evaluating the
+   *   predicate after the lock is what refuses instead.
+   * - the refusal has to reach the caller, which is why this returns 0 rows into
+   *   a throw rather than reporting success. The ledger mutation shares this
+   *   transaction, so the throw rolls it back too.
    */
   async updateBalance(accountId: string, amount: number): Promise<Account> {
-    const account = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(Account).findOne({
-        where: { id: accountId },
-      }),
-    );
+    // One statement: lock, re-check `is_closed`, apply the delta, report back.
+    const sql = `UPDATE accounts
+                    SET current_balance = ROUND(CAST(current_balance AS numeric) + $1, 4)
+                  WHERE id = $2 AND is_closed = false
+                  RETURNING id`;
 
-    if (!account) {
-      throw new NotFoundException(
-        tr(
-          "errors.accounts.accountWithIdNotFound",
-          `Account with ID ${accountId} not found`,
-          { id: accountId },
-        ),
-      );
-    }
-
-    if (account.isClosed) {
-      throw new BadRequestException(
-        tr(
-          "errors.accounts.modifyBalanceClosed",
-          "Cannot modify balance of a closed account",
-        ),
-      );
-    }
-
-    const sql = `UPDATE accounts SET current_balance = ROUND(CAST(current_balance AS numeric) + $1, 4) WHERE id = $2`;
-
-    // Atomic update at the database level to avoid read-modify-write race
-    // conditions. A caller already inside a scoped transaction joins it (F2
-    // re-entrancy), so the update and the re-read stay in that transaction.
     return withScopedDb(this.dataSource, async (m) => {
-      await m.query(sql, [amount, accountId]);
+      const updated: unknown = await m.query(sql, [amount, accountId]);
+      if (affectedRowCount(updated) === 0) {
+        // No row matched: either the account is gone or it is closed. Tell those
+        // apart so the caller gets 404 vs 400 rather than one ambiguous error.
+        const exists = await m.getRepository(Account).findOne({
+          where: { id: accountId },
+        });
+        if (!exists) {
+          throw new NotFoundException(
+            tr(
+              "errors.accounts.accountWithIdNotFound",
+              `Account with ID ${accountId} not found`,
+              { id: accountId },
+            ),
+          );
+        }
+        throw new BadRequestException(
+          tr(
+            "errors.accounts.modifyBalanceClosed",
+            "Cannot modify balance of a closed account",
+          ),
+        );
+      }
       return m.getRepository(Account).findOneOrFail({
         where: { id: accountId },
       });
@@ -991,49 +1004,91 @@ export class AccountsService {
   }
 
   /**
+   * Advance an account's `updated_at` without touching its balance.
+   *
+   * `NetWorthService.sweepStaleSnapshots` derives snapshot staleness from
+   * `accounts.updated_at > MAX(monthly_account_balances.updated_at)`, which only
+   * works because every write that can change a snapshot also touches the account
+   * row. One transaction edit breaks that on its own: moving a past-dated row to
+   * another past month leaves `current_balance` identical (the running total is
+   * unchanged) yet changes the intervening months' `monthly_account_balances`. No
+   * balance write runs, so nothing bumps `updated_at`, and if the in-memory
+   * debounce is lost the sweep can never find the stale snapshot (audit
+   * DR-04-03). This keeps the invariant true for that one case: a snapshot-only
+   * change still advances the account's timestamp.
+   *
+   * Owner-scoped and a no-op on a missing row -- it only advances a timestamp, so
+   * there is nothing to refuse and no balance to protect with a lock.
+   */
+  async touchAccount(userId: string, accountId: string): Promise<void> {
+    await withScopedDb(this.dataSource, (m) =>
+      m.query(
+        `UPDATE accounts SET updated_at = now() WHERE id = $1 AND user_id = $2`,
+        [accountId, userId],
+      ),
+    );
+  }
+
+  /**
    * Recalculate currentBalance from source-of-truth transactions,
    * only including transactions dated on or before today.
    * Used when future-dated transactions are created/modified/deleted
    * to ensure the balance is always correct regardless of history.
+   *
+   * This writes an **absolute** balance, which is the protocol that cannot race
+   * an atomic delta unaided: under `READ COMMITTED` the ledger `SELECT` and the
+   * account `UPDATE` are separate statement snapshots, so a delta committing
+   * between them was silently overwritten by a total that never saw it (audit
+   * P4-005). `lockAccountsForBalanceWrite` closes that window from the front --
+   * see the protocol note in `common/db/locks.ts` for why locking before the
+   * ledger read makes the two protocols compose.
+   *
+   * The write is a targeted `UPDATE` of one column. Saving the `Account` entity
+   * loaded before the transaction would also write back every other column from
+   * that snapshot, so a concurrent rename or opening-balance edit would be
+   * reverted by a balance recalculation.
    */
-  async recalculateCurrentBalance(accountId: string): Promise<Account> {
-    const account = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(Account).findOne({
-        where: { id: accountId },
-      }),
-    );
-
-    if (!account) {
-      throw new NotFoundException(
-        tr(
-          "errors.accounts.accountWithIdNotFound",
-          `Account with ID ${accountId} not found`,
-          { id: accountId },
-        ),
-      );
-    }
-
-    const balanceSql = `SELECT COALESCE($2::NUMERIC, 0) + COALESCE(SUM(t.amount), 0) as balance
-       FROM transactions t
-       WHERE t.account_id = $1
+  async recalculateCurrentBalance(
+    userId: string,
+    accountId: string,
+  ): Promise<Account> {
+    const balanceSql = `SELECT COALESCE(a.opening_balance, 0) + COALESCE(SUM(t.amount), 0) as balance
+       FROM accounts a
+       LEFT JOIN transactions t ON t.account_id = a.id
          AND (t.status IS NULL OR t.status != 'VOID')
          AND t.parent_transaction_id IS NULL
-         AND t.transaction_date <= $3`;
+         AND t.transaction_date <= $2
+      WHERE a.id = $1
+      GROUP BY a.id, a.opening_balance`;
 
     const today = todayYMD();
 
     return withScopedDb(this.dataSource, async (m) => {
+      // First statement of the transaction, before the ledger is read.
+      await lockAccountsForBalanceWrite(m, [accountId], userId);
+
       const result: { balance: string }[] = await m.query(balanceSql, [
         accountId,
-        account.openingBalance,
         today,
       ]);
-      const newBalance =
-        result.length > 0
-          ? roundMoney(Number(result[0].balance))
-          : roundMoney(Number(account.openingBalance));
-      account.currentBalance = newBalance;
-      return m.getRepository(Account).save(account);
+      if (result.length === 0) {
+        throw new NotFoundException(
+          tr(
+            "errors.accounts.accountWithIdNotFound",
+            `Account with ID ${accountId} not found`,
+            { id: accountId },
+          ),
+        );
+      }
+
+      const newBalance = roundMoney(Number(result[0].balance));
+      await m.query(`UPDATE accounts SET current_balance = $1 WHERE id = $2`, [
+        newBalance,
+        accountId,
+      ]);
+      return m.getRepository(Account).findOneOrFail({
+        where: { id: accountId },
+      });
     });
   }
 
@@ -1627,6 +1682,13 @@ export class AccountsService {
 
         // One read-modify-write block per timezone bucket: find due accounts,
         // recompute their balances, apply them in a single UPDATE.
+        //
+        // The recomputation writes absolute balances, so it must hold the
+        // account rows from before it reads the ledger -- otherwise an
+        // interactive transaction committing between the SELECT and the UPDATE
+        // is overwritten by a total that never saw it (audit P4-005). Locking
+        // in ascending id order keeps it deadlock-free against a transfer
+        // touching two of the same accounts.
         const applied = await withScopedDb(this.dataSource, async (m) => {
           const accountRows: { account_id: string }[] = await m.query(
             `SELECT DISTINCT t.account_id
@@ -1642,6 +1704,8 @@ export class AccountsService {
           if (accountRows.length === 0) return 0;
 
           const accountIds = accountRows.map((r) => r.account_id);
+          await lockAccountsForBalanceWrite(m, accountIds);
+
           const balances: { account_id: string; balance: string }[] =
             await m.query(
               `SELECT a.id as account_id,

--- a/backend/src/accounts/rls-context-smoke.spec.ts
+++ b/backend/src/accounts/rls-context-smoke.spec.ts
@@ -34,11 +34,17 @@ describe("accounts module RLS context smoke (real withScopedDb)", () => {
     const { manager, dataSource } = createScopedDbMocks([
       [Account, accountsRepo],
     ]);
-    // Timezone fan-out (its own withScopedDb) finds one UTC user...
-    // ...whose due-account scan (inside withScopedDb) returns one account to apply.
+    // The per-user body issues five queries in order: the timezone fan-out (its
+    // own withScopedDb) finds one UTC user; then, inside the system-context
+    // withScopedDb, the due-account scan, the FOR UPDATE lock
+    // (lockAccountsForBalanceWrite -- it holds the rows before the ledger read,
+    // audit P4-005), the balance recompute, and the bulk UPDATE. The lock query
+    // sits between the scan and the recompute, so the mock chain has to account
+    // for it or the recompute reads the wrong row.
     manager.query
       .mockResolvedValueOnce([{ user_id: OWNER_ID, timezone: "UTC" }])
       .mockResolvedValueOnce([{ account_id: "a1" }])
+      .mockResolvedValueOnce([{ id: "a1" }])
       .mockResolvedValueOnce([{ account_id: "a1", balance: "150" }])
       .mockResolvedValueOnce(undefined);
 

--- a/backend/src/action-history/action-history.service.spec.ts
+++ b/backend/src/action-history/action-history.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { NotFoundException, ConflictException } from "@nestjs/common";
+import { NotFoundException, ConflictException, Logger } from "@nestjs/common";
 import { DataSource } from "typeorm";
 import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
 import { ActionHistoryService } from "./action-history.service";
@@ -70,6 +70,37 @@ describe("ActionHistoryService", () => {
   });
 
   describe("record", () => {
+    it("reports a failed recording as an error naming what cannot be undone", async () => {
+      // Recording is best-effort so it cannot fail the user's operation, but the
+      // operation succeeded and its undo entry did not -- the user will look for
+      // an undo that is not there, so this is not a `warn` (DR-04-03).
+      const errorSpy = jest
+        .spyOn(Logger.prototype, "error")
+        .mockImplementation();
+      const warnSpy = jest.spyOn(Logger.prototype, "warn").mockImplementation();
+      mockRepository.delete.mockResolvedValue({ affected: 0 });
+      mockRepository.create.mockReturnValue(mockAction);
+      mockRepository.save.mockRejectedValue(new Error("DB down"));
+
+      const result = await service.record(userId, {
+        entityType: "transaction",
+        entityId: "tx-77",
+        action: "delete",
+        description: "Deleted a transaction",
+      });
+
+      expect(result).toBeNull();
+      const message = String(errorSpy.mock.calls[0][0]);
+      expect(message).toContain("delete");
+      expect(message).toContain("transaction");
+      expect(message).toContain("tx-77");
+      expect(message).toContain("DB down");
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
     it("should record an action", async () => {
       mockRepository.delete.mockResolvedValue({ affected: 0 });
       mockRepository.create.mockReturnValue(mockAction);
@@ -1448,8 +1479,11 @@ describe("ActionHistoryService", () => {
       mockQueryRunner.manager.findOne.mockResolvedValueOnce(mockInvTx);
       mockQueryRunner.manager.remove.mockResolvedValue(undefined);
       mockQueryRunner.manager.update.mockResolvedValue({ affected: 1 });
-      // rebuildHoldings: DELETE returns void, SELECT returns investment transactions
+      // rebuildHoldings takes the shared holdings lock first -- a rebuild replays
+      // investment_transactions and replaces what it derives from them, so the
+      // trade it must not lose is an insert no holdings row locks (P4-006).
       mockQueryRunner.query
+        .mockResolvedValueOnce([]) // pg_advisory_xact_lock
         .mockResolvedValueOnce(undefined) // DELETE FROM holdings
         .mockResolvedValueOnce([
           {

--- a/backend/src/action-history/action-history.service.ts
+++ b/backend/src/action-history/action-history.service.ts
@@ -21,6 +21,10 @@ import { Budget } from "../budgets/entities/budget.entity";
 import { CustomReport } from "../reports/entities/custom-report.entity";
 import { withSystemContext } from "../common/db/with-context";
 import { withScopedDb } from "../common/db/scoped-db";
+import {
+  lockAccountsForBalanceWrite,
+  lockHoldingScope,
+} from "../common/db/locks";
 
 export interface RecordActionParams {
   entityType: string;
@@ -279,9 +283,21 @@ export class ActionHistoryService {
 
       return saved;
     } catch (error) {
-      // Recording is best-effort -- never fail the original operation
-      this.logger.warn(
-        `Failed to record action history: ${error instanceof Error ? error.message : String(error)}`,
+      // Best-effort by design: recording an undo entry must never fail the
+      // operation the user actually asked for, and every caller invokes this
+      // AFTER its own transaction committed (a source-scan guard in
+      // common/db/derived-state-writers.guard.spec.ts keeps it that way -- called
+      // inside a transaction, this swallow would hide the abort and the caller's
+      // next statement would die with 25P02).
+      //
+      // But `error`, not `warn`: the operation succeeded and its undo entry did
+      // not, so the user will look for an undo that is not there. Name the entity
+      // so the gap can be tied to what happened.
+      this.logger.error(
+        `Failed to record action history for ${params.action} on ${params.entityType} ${params.entityId} (the operation itself succeeded; it cannot be undone): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        error instanceof Error ? error.stack : undefined,
       );
       return null;
     }
@@ -498,7 +514,7 @@ export class ActionHistoryService {
     await manager.remove(transaction);
 
     // Reverse balance
-    await this.recalculateBalance(accountId, manager);
+    await this.recalculateBalance(action.userId, accountId, manager);
   }
 
   private async undoTransactionUpdate(
@@ -591,7 +607,7 @@ export class ActionHistoryService {
     accountIds.add(transaction.accountId);
 
     for (const accountId of accountIds) {
-      await this.recalculateBalance(accountId, manager);
+      await this.recalculateBalance(action.userId, accountId, manager);
     }
   }
 
@@ -674,7 +690,7 @@ export class ActionHistoryService {
       }
     }
 
-    await this.recalculateBalance(before.accountId, manager);
+    await this.recalculateBalance(action.userId, before.accountId, manager);
   }
 
   // --- Transfer undo handlers ---
@@ -734,10 +750,10 @@ export class ActionHistoryService {
     }
 
     if (fromAccountId) {
-      await this.recalculateBalance(fromAccountId, manager);
+      await this.recalculateBalance(action.userId, fromAccountId, manager);
     }
     if (toAccountId) {
-      await this.recalculateBalance(toAccountId, manager);
+      await this.recalculateBalance(action.userId, toAccountId, manager);
     }
   }
 
@@ -786,8 +802,16 @@ export class ActionHistoryService {
       linkedTransactionId: fromTransaction.id,
     });
 
-    await this.recalculateBalance(fromTransaction.accountId, manager);
-    await this.recalculateBalance(toTransaction.accountId, manager);
+    await this.recalculateBalance(
+      action.userId,
+      fromTransaction.accountId,
+      manager,
+    );
+    await this.recalculateBalance(
+      action.userId,
+      toTransaction.accountId,
+      manager,
+    );
   }
 
   // --- Investment transaction undo ---
@@ -909,7 +933,11 @@ export class ActionHistoryService {
             [cashTx.id],
           );
           await manager.remove(cashTx);
-          await this.recalculateBalance(cashTx.accountId, manager);
+          await this.recalculateBalance(
+            action.userId,
+            cashTx.accountId,
+            manager,
+          );
         }
       }
     }
@@ -973,7 +1001,7 @@ export class ActionHistoryService {
           cashTx.createdAt ?? new Date(),
         ],
       );
-      await this.recalculateBalance(cashTx.accountId, manager);
+      await this.recalculateBalance(action.userId, cashTx.accountId, manager);
     }
 
     // Re-insert the investment transaction
@@ -1117,7 +1145,7 @@ export class ActionHistoryService {
     }
 
     for (const accountId of accountIds) {
-      await this.recalculateBalance(accountId, manager);
+      await this.recalculateBalance(action.userId, accountId, manager);
     }
   }
 
@@ -1170,7 +1198,7 @@ export class ActionHistoryService {
     }
 
     for (const accountId of accountIds) {
-      await this.recalculateBalance(accountId, manager);
+      await this.recalculateBalance(action.userId, accountId, manager);
     }
   }
 
@@ -1238,9 +1266,24 @@ export class ActionHistoryService {
   // --- Utility methods ---
 
   private async recalculateBalance(
+    userId: string,
     accountId: string,
     manager: EntityManager,
   ): Promise<void> {
+    // Lock the account before reading the ledger, like every other absolute
+    // balance writer.
+    //
+    // This is the same protocol boundary as AccountsService.recalculateCurrentBalance
+    // (audit P4-005): the SELECT and the UPDATE below are separate statement
+    // snapshots under READ COMMITTED, so without the lock an ordinary
+    // transaction committing between them is overwritten by a total that never
+    // saw it -- and an undo is precisely when a user is watching the balance.
+    //
+    // Owner-scoped like every own-context balance-write lock: an undo only ever
+    // touches the acting user's own accounts, so the lock must never land on a
+    // row that is not theirs (maintainer review, PR #1095).
+    await lockAccountsForBalanceWrite(manager, [accountId], userId);
+
     // Use the same recalculation logic as AccountsService
     const result = await manager.query(
       `SELECT a.opening_balance, COALESCE(SUM(t.amount), 0) as tx_sum
@@ -1273,6 +1316,12 @@ export class ActionHistoryService {
     accountId: string,
     manager: EntityManager,
   ): Promise<void> {
+    // Same lock namespace every holdings writer takes, before the ledger is
+    // read. A rebuild replays investment_transactions and replaces the holdings
+    // derived from them, so what it must not lose is a *trade* -- an insert no
+    // holdings row locks (audit P4-006).
+    await lockHoldingScope(manager, [accountId]);
+
     // Delete existing holdings for this account
     await manager.query(`DELETE FROM holdings WHERE account_id = $1`, [
       accountId,

--- a/backend/src/common/db/derived-state-writers.guard.spec.ts
+++ b/backend/src/common/db/derived-state-writers.guard.spec.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { globSync } from "glob";
+
+/**
+ * Source-scanning guards for two of the mistakes the Phase 4 concurrency audit
+ * found over and over, in different files, each time looking locally reasonable.
+ *
+ * A rule in prose gets read, agreed with, and violated anyway -- so these are
+ * tests. They scan the source rather than exercising behaviour, because both
+ * mistakes are mechanical: not "this calculation is wrong" but "this shape is the
+ * wrong shape", and the next instance will be in a file nobody thought to check.
+ *
+ * Each list below is an allowlist of *reviewed* exceptions. An entry needs a
+ * reason, and the list may only shrink.
+ */
+const SRC = join(__dirname, "..", "..");
+
+function sourceFiles(): string[] {
+  return globSync("**/*.ts", {
+    cwd: SRC,
+    absolute: true,
+    ignore: ["**/*.spec.ts", "**/*.d.ts", "**/node_modules/**"],
+  });
+}
+
+function read(file: string): string {
+  return readFileSync(file, "utf8");
+}
+
+function relative(file: string): string {
+  return file.slice(SRC.length + 1).replace(/\\/g, "/");
+}
+
+describe("derived financial state has one set of writers", () => {
+  /**
+   * A balance reversal must be gated on the row this call actually removed.
+   *
+   * `manager.remove(entity)` deletes by primary key and reports nothing, so two
+   * concurrent removals each reversed the same amount while one row went away --
+   * and it reversed whatever the *snapshot* held, and reversed it even for a VOID
+   * row that had contributed nothing. That is four separate mistakes in one
+   * four-line shape, which is why it survived three fixes and reappeared a fourth
+   * time in split removal (audit FV4-002).
+   *
+   * `removeLockedTransactionLeg` is the whole sequence in one place. This scan
+   * fails on any *new* file that reverses a balance with a bare `remove()` beside
+   * it -- the mistake is mechanical, so the guard is a scan and not a review note.
+   */
+  it("removes a ledger row conditionally wherever it reverses a balance", () => {
+    const ALLOWED = new Map([
+      [
+        "securities/investment-transactions.service.ts",
+        "reverseTransactionEffectsInTransaction reverses HOLDINGS under the " +
+          "holdings advisory lock, not accounts.current_balance from a ledger " +
+          "snapshot; its cash-leg deletions already read affectedRowCount",
+      ],
+      [
+        "import/import-post-processing.service.ts",
+        "recomputes balances absolutely under the shared account lock after an " +
+          "import; there is no per-row delta to gate",
+      ],
+    ]);
+
+    const offenders = sourceFiles()
+      .filter((file) => {
+        const source = read(file);
+        // A file that reverses a ledger row's contribution to a balance.
+        if (!/accountsService\.updateBalance\(/.test(source)) return false;
+        // ...and still deletes a transaction-shaped row by entity identity.
+        return /\b(?:m|manager|txRepo|repo)\s*\.\s*remove\s*\(\s*(?!allSplits|splits\b)\w*(?:[Tt]ransaction|[Ll]eg|[Tt]x)\w*\s*[,)]/.test(
+          source,
+        );
+      })
+      .map(relative)
+      .filter((file) => !ALLOWED.has(file));
+
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * `ActionHistoryService.record` swallows its own failures on purpose: recording
+   * an undo entry must never fail the operation the user actually asked for. That
+   * is only safe *outside* a transaction. Called inside one, a failed insert has
+   * already aborted the caller's transaction, and swallowing the error hides it
+   * until the next statement dies with `25P02 in_failed_sql_transaction` -- so
+   * the user's write fails, with a message about the audit trail.
+   *
+   * Nothing about the call site says which side of the boundary it is on, which is
+   * exactly the kind of mistake prose does not prevent. Currently zero call sites
+   * are inside a transaction; this keeps it that way.
+   */
+  it("records action history outside the caller's transaction, never inside it", () => {
+    /** The body of each `withScopedDb(...)` call in a file, by paren matching. */
+    function scopedDbCallbacks(source: string): string[] {
+      const bodies: string[] = [];
+      for (const match of source.matchAll(/withScopedDb\s*\(/g)) {
+        let depth = 0;
+        let i = match.index! + match[0].length - 1;
+        const start = i;
+        while (i < source.length) {
+          if (source[i] === "(") depth++;
+          else if (source[i] === ")" && --depth === 0) break;
+          i++;
+        }
+        bodies.push(source.slice(start, i));
+      }
+      return bodies;
+    }
+
+    const offenders = sourceFiles()
+      .filter((file) =>
+        scopedDbCallbacks(read(file)).some((body) =>
+          /\bactionHistory\w*\s*\.\s*record\s*\(/.test(body),
+        ),
+      )
+      .map(relative);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/backend/src/i18n/locales/de/errors.json
+++ b/backend/src/i18n/locales/de/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "E-Mail ist nicht konfiguriert. Notfallzugriff kann erst aktiviert werden, wenn SMTP eingerichtet ist.",
     "encryptionNotConfigured": "Verschlüsselungsschlüssel ist nicht konfiguriert. Die Freitextnachricht kann erst sicher gespeichert werden, wenn AI_ENCRYPTION_KEY gesetzt ist.",
+    "encryptionRequiredToEnable": "Die Verschlüsselung von Zugangsdaten ist nicht konfiguriert. Notfallzugriff kann erst aktiviert werden, wenn AI_ENCRYPTION_KEY gesetzt ist, denn eine Gewährung muss den Zugangslink jedes Kontakts sicher speichern.",
     "contactEmailExists": "Ein Notfallkontakt mit dieser E-Mail-Adresse existiert bereits.",
     "contactNotFound": "Kontakt nicht gefunden",
     "notConfigured": "Notfallzugriff nicht konfiguriert",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "Quell- und Zielkonto müssen verschieden sein",
     "requiresBrokerageAccount": "Terminierte Investmentbuchungen erfordern ein Maklerkonto",
     "notFound": "Terminierte Buchung mit ID {{ id }} nicht gefunden",
+    "occurrenceAlreadyPosted": "Dieser Vorgang wurde bereits gebucht.",
+    "fxPlainOnly": "Eine abweichende Währung ist nur bei einer einfachen terminierten Buchung möglich, nicht bei einer Aufteilung, Überweisung oder Investition",
+    "fxRateUnavailable": "Für {{ from }} zu {{ to }} ist am {{ date }} kein Wechselkurs verfügbar. Geben Sie den Betrag in {{ to }} ein, um ihn zu buchen.",
     "investmentActionRequired": "Investmentaktion ist für terminierte Investmentbuchungen erforderlich",
     "actionRequiresSecurity": "Aktion {{ action }} erfordert ein Wertpapier",
     "actionRequiresPositiveQuantity": "Aktion {{ action }} erfordert eine positive Menge",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "Betrag ist beim Erstellen einer Buchungsteil-Überschreibung erforderlich",
     "overrideNotFound": "Überschreibung mit ID {{ overrideId }} nicht gefunden",
     "updateSplitOverrideRequiresAmount": "Betrag ist für Buchungsteil-Überschreibung erforderlich",
-    "dateMustBeYMD": "Datum muss im Format YYYY-MM-DD sein",
-    "fxPlainOnly": "Eine abweichende Währung ist nur bei einer einfachen terminierten Buchung möglich, nicht bei einer Aufteilung, Überweisung oder Investition",
-    "fxRateUnavailable": "Für {{ from }} zu {{ to }} ist am {{ date }} kein Wechselkurs verfügbar. Geben Sie den Betrag in {{ to }} ein, um ihn zu buchen."
+    "dateMustBeYMD": "Datum muss im Format YYYY-MM-DD sein"
   },
   "securities": {
     "exchangeRateUnavailable": "Wechselkurs für {{ from }} -> {{ to }} zum Transaktionsdatum konnte nicht ermittelt werden. Geben Sie einen expliziten exchangeRate an, damit die Buchung auf dem Geldkonto korrekt ist.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId muss eine gültige UUID sein",
     "amountFromMustBeNumber": "amountFrom muss eine Zahl sein",
     "amountToMustBeNumber": "amountTo muss eine Zahl sein",
+    "tagKeyTooLong": "tagKey darf 100 Zeichen nicht überschreiten",
+    "invalidTagKeyOp": "Ungültiger tagKeyOp: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue ist für contains / notContains erforderlich",
+    "tagKeyRequired": "Ein Tag-Schlüssel (1–100 Zeichen) ist erforderlich",
     "invalidGroupBy": "groupBy muss 'category' oder 'payee' sein",
     "limitMustBePositive": "limit muss eine positive Zahl sein",
     "recurringPayeeRequired": "payeeIds ist erforderlich",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance muss eine Zahl sein",
     "categoryNotFound": "Kategorie nicht gefunden",
     "categoriesNotFound": "Kategorien nicht gefunden: {{ ids }}",
+    "crossOwnerTransferLocked": "Die Gegenseite dieser Umbuchung liegt in einem Konto, auf das Sie keinen Zugriff mehr haben. Sie können die Details dieser Transaktion bearbeiten, aber Betrag, Datum und Konten sind gesperrt.",
+    "crossOwnerAccountMoveLocked": "Diese Umbuchung betrifft das Konto eines anderen Benutzers und kann daher nicht auf andere Konten verschoben werden.",
+    "cannotEditTransfer": "Umbuchungen können hier nicht bearbeitet werden. Bearbeiten Sie die Umbuchung im Transaktionsbildschirm.",
+    "cannotEditSplit": "Aufgeteilte Transaktionen können hier nicht bearbeitet werden. Bearbeiten Sie die Aufteilung im Transaktionsbildschirm.",
+    "noUpdateFields": "Geben Sie mindestens ein zu änderndes Feld an.",
     "investmentSplitRequiresPayload": "Investmentteil erfordert eine Investment-Nutzlast",
     "investmentActionNotAllowedInSplit": "Investmentaktion {{ action }} ist innerhalb einer Buchungsteil-Buchung nicht zulässig",
     "investmentSplitCannotSetCategoryOrTransfer": "Investmentteile können nicht gleichzeitig categoryId oder transferAccountId setzen",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Einige Buchungen wurden nicht gefunden oder gehören nicht zum angegebenen Konto",
     "cannotReconcileVoidPlural": "Ungültige Buchungen können nicht abgeglichen werden",
     "transferSameAccount": "Quell- und Zielkonto müssen verschieden sein",
+    "transferChangedConcurrently": "Diese Übertragung wurde von einer anderen Anfrage geändert. Bitte neu laden und erneut versuchen.",
     "transferAmountNegative": "Überweisungsbetrag darf nicht negativ sein",
     "notATransfer": "Buchung ist keine Überweisung",
     "splitTransferLegAccountLocked": "Diese Überweisung ist Teil einer geteilten Buchung. Ändern Sie die Konten, indem Sie stattdessen den Buchungsteil in der Ursprungsbuchung bearbeiten.",
     "notFoundById": "Buchung mit ID {{ id }} nicht gefunden",
     "bulkUpdateNoFields": "Mindestens ein Aktualisierungsfeld muss angegeben werden",
     "payeeNotFound": "Zahlungsempfänger nicht gefunden",
-    "crossOwnerTransferLocked": "Die Gegenseite dieser Umbuchung liegt in einem Konto, auf das Sie keinen Zugriff mehr haben. Sie können die Details dieser Transaktion bearbeiten, aber Betrag, Datum und Konten sind gesperrt.",
-    "crossOwnerAccountMoveLocked": "Diese Umbuchung betrifft das Konto eines anderen Benutzers und kann daher nicht auf andere Konten verschoben werden.",
-    "cannotEditTransfer": "Umbuchungen können hier nicht bearbeitet werden. Bearbeiten Sie die Umbuchung im Transaktionsbildschirm.",
-    "cannotEditSplit": "Aufgeteilte Transaktionen können hier nicht bearbeitet werden. Bearbeiten Sie die Aufteilung im Transaktionsbildschirm.",
-    "noUpdateFields": "Geben Sie mindestens ein zu änderndes Feld an.",
-    "tagKeyTooLong": "tagKey darf 100 Zeichen nicht überschreiten",
-    "invalidTagKeyOp": "Ungültiger tagKeyOp: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue ist für contains / notContains erforderlich",
-    "tagKeyRequired": "Ein Tag-Schlüssel (1–100 Zeichen) ist erforderlich",
     "fxFieldsIncomplete": "originalAmount und originalCurrencyCode müssen zusammen angegeben werden",
     "fxRateRequired": "Für eine Fremdwährungstransaktion ist ein positiver Wechselkurs erforderlich",
     "fxSignMismatch": "originalAmount und amount müssen dasselbe Vorzeichen haben",
@@ -539,5 +542,8 @@
     "signalNotFound": "Strategiesignal nicht gefunden",
     "signalStrategyMismatch": "Dieses Signal gehört zu einer anderen Strategie.",
     "strategyNotFound": "Strategie nicht gefunden"
+  },
+  "maintenance": {
+    "inProgress": "Eine andere Operation ersetzt derzeit die Daten dieses Kontos. Warten Sie, bis sie abgeschlossen ist, und versuchen Sie es erneut."
   }
 }

--- a/backend/src/i18n/locales/en/errors.json
+++ b/backend/src/i18n/locales/en/errors.json
@@ -282,6 +282,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "Email is not configured. Emergency access cannot be enabled until SMTP is set up.",
     "encryptionNotConfigured": "Encryption key is not configured. The free-form message cannot be stored securely until AI_ENCRYPTION_KEY is set.",
+    "encryptionRequiredToEnable": "Credential encryption is not configured. Emergency access cannot be enabled until AI_ENCRYPTION_KEY is set, because a grant has to store each contact's access link securely.",
     "contactEmailExists": "An emergency contact with this email already exists.",
     "contactNotFound": "Contact not found",
     "notConfigured": "Emergency access not configured",
@@ -365,6 +366,7 @@
     "sameSourceAndDestination": "Source and destination accounts must be different",
     "requiresBrokerageAccount": "Scheduled investment transactions require a brokerage account",
     "notFound": "Scheduled transaction with ID {{ id }} not found",
+    "occurrenceAlreadyPosted": "This occurrence has already been posted.",
     "fxPlainOnly": "A different currency can only be used on a plain scheduled transaction, not a split, transfer or investment",
     "fxRateUnavailable": "No exchange rate is available for {{ from }} to {{ to }} on {{ date }}. Enter the amount in {{ to }} to post it.",
     "investmentActionRequired": "Investment action is required for scheduled investment transactions",
@@ -489,6 +491,7 @@
     "bulkReconcileNotFound": "Some transactions were not found or do not belong to the specified account",
     "cannotReconcileVoidPlural": "Cannot reconcile void transactions",
     "transferSameAccount": "Source and destination accounts must be different",
+    "transferChangedConcurrently": "This transfer was changed by another request. Reload it and try again.",
     "transferAmountNegative": "Transfer amount must not be negative",
     "notATransfer": "Transaction is not a transfer",
     "splitTransferLegAccountLocked": "This transfer is part of a split transaction. Change its accounts by editing the split on the source transaction instead.",
@@ -539,5 +542,8 @@
     "signalNotFound": "Strategy signal not found",
     "signalStrategyMismatch": "That signal belongs to a different strategy.",
     "strategyNotFound": "Strategy not found"
+  },
+  "maintenance": {
+    "inProgress": "Another operation is currently replacing this account's data. Wait for it to finish and try again."
   }
 }

--- a/backend/src/i18n/locales/es/errors.json
+++ b/backend/src/i18n/locales/es/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "El correo electrónico no está configurado. El acceso de emergencia no puede habilitarse hasta que se configure SMTP.",
     "encryptionNotConfigured": "La clave de cifrado no está configurada. El mensaje de texto libre no se puede almacenar de forma segura hasta que se establezca AI_ENCRYPTION_KEY.",
+    "encryptionRequiredToEnable": "El cifrado de credenciales no está configurado. El acceso de emergencia no puede habilitarse hasta que se establezca AI_ENCRYPTION_KEY, porque una concesión tiene que almacenar de forma segura el enlace de acceso de cada contacto.",
     "contactEmailExists": "Ya existe un contacto de emergencia con este correo electrónico.",
     "contactNotFound": "Contacto no encontrado",
     "notConfigured": "Acceso de emergencia no configurado",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "Las cuentas de origen y destino deben ser diferentes",
     "requiresBrokerageAccount": "Las transacciones de inversión planificadas requieren una cuenta de corretaje",
     "notFound": "Transacción planificada con ID {{ id }} no encontrada",
+    "occurrenceAlreadyPosted": "Esta ocurrencia ya se ha registrado.",
+    "fxPlainOnly": "Solo se puede usar otra moneda en una transacción planificada simple, no en un desglose, una transferencia ni una inversión",
+    "fxRateUnavailable": "No hay un tipo de cambio disponible de {{ from }} a {{ to }} el {{ date }}. Introduce el importe en {{ to }} para registrarlo.",
     "investmentActionRequired": "Se requiere acción de inversión para las transacciones de inversión planificadas",
     "actionRequiresSecurity": "La acción {{ action }} requiere un valor",
     "actionRequiresPositiveQuantity": "La acción {{ action }} requiere una cantidad positiva",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "La cantidad es obligatoria al crear una modificación de desglose",
     "overrideNotFound": "Modificación con ID {{ overrideId }} no encontrada",
     "updateSplitOverrideRequiresAmount": "La cantidad es obligatoria para la modificación de desglose",
-    "dateMustBeYMD": "la fecha debe estar en formato YYYY-MM-DD",
-    "fxPlainOnly": "Solo se puede usar otra moneda en una transacción planificada simple, no en un desglose, una transferencia ni una inversión",
-    "fxRateUnavailable": "No hay un tipo de cambio disponible de {{ from }} a {{ to }} el {{ date }}. Introduce el importe en {{ to }} para registrarlo."
+    "dateMustBeYMD": "la fecha debe estar en formato YYYY-MM-DD"
   },
   "securities": {
     "exchangeRateUnavailable": "No se pudo determinar un tipo de cambio para {{ from }} -> {{ to }} en la fecha de la transacción. Indica un exchangeRate explícito para que el asiento en la cuenta de efectivo sea correcto.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId debe ser un UUID válido",
     "amountFromMustBeNumber": "amountFrom debe ser un número",
     "amountToMustBeNumber": "amountTo debe ser un número",
+    "tagKeyTooLong": "tagKey no debe superar los 100 caracteres",
+    "invalidTagKeyOp": "tagKeyOp no válido: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue es obligatorio para contains / notContains",
+    "tagKeyRequired": "Se requiere una clave de etiqueta (1-100 caracteres)",
     "invalidGroupBy": "groupBy debe ser 'category' o 'payee'",
     "limitMustBePositive": "limit debe ser un número positivo",
     "recurringPayeeRequired": "payeeIds es obligatorio",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance debe ser un número",
     "categoryNotFound": "Categoría no encontrada",
     "categoriesNotFound": "Categorías no encontradas: {{ ids }}",
+    "crossOwnerTransferLocked": "El otro lado de esta transferencia está en una cuenta a la que ya no tienes acceso. Puedes editar los detalles de esta transacción, pero su importe, fecha y cuentas están bloqueados.",
+    "crossOwnerAccountMoveLocked": "Esta transferencia involucra la cuenta de otro usuario, por lo que no se puede mover a otras cuentas.",
+    "cannotEditTransfer": "Las transferencias no se pueden editar aquí. Edita la transferencia desde la pantalla de Transacciones.",
+    "cannotEditSplit": "Las transacciones divididas no se pueden editar aquí. Edita la división desde la pantalla de Transacciones.",
+    "noUpdateFields": "Proporciona al menos un campo para cambiar.",
     "investmentSplitRequiresPayload": "El desglose de inversión requiere un payload de inversión",
     "investmentActionNotAllowedInSplit": "La acción de inversión {{ action }} no está permitida dentro de una transacción desglosada",
     "investmentSplitCannotSetCategoryOrTransfer": "Los desgloses de inversión no pueden establecer también categoryId o transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Algunas transacciones no se encontraron o no pertenecen a la cuenta especificada",
     "cannotReconcileVoidPlural": "No se pueden conciliar transacciones anuladas",
     "transferSameAccount": "Las cuentas de origen y destino deben ser diferentes",
+    "transferChangedConcurrently": "Otra solicitud modificó esta transferencia. Vuelve a cargarla e inténtalo de nuevo.",
     "transferAmountNegative": "La cantidad de la transferencia no puede ser negativa",
     "notATransfer": "La transacción no es una transferencia",
     "splitTransferLegAccountLocked": "Esta transferencia forma parte de una transacción desglosada. Para cambiar sus cuentas, edite el desglose en la transacción de origen.",
     "notFoundById": "Transacción con ID {{ id }} no encontrada",
     "bulkUpdateNoFields": "Se debe proporcionar al menos un campo de actualización",
     "payeeNotFound": "Beneficiario no encontrado",
-    "crossOwnerTransferLocked": "El otro lado de esta transferencia está en una cuenta a la que ya no tienes acceso. Puedes editar los detalles de esta transacción, pero su importe, fecha y cuentas están bloqueados.",
-    "crossOwnerAccountMoveLocked": "Esta transferencia involucra la cuenta de otro usuario, por lo que no se puede mover a otras cuentas.",
-    "cannotEditTransfer": "Las transferencias no se pueden editar aquí. Edita la transferencia desde la pantalla de Transacciones.",
-    "cannotEditSplit": "Las transacciones divididas no se pueden editar aquí. Edita la división desde la pantalla de Transacciones.",
-    "noUpdateFields": "Proporciona al menos un campo para cambiar.",
-    "tagKeyTooLong": "tagKey no debe superar los 100 caracteres",
-    "invalidTagKeyOp": "tagKeyOp no válido: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue es obligatorio para contains / notContains",
-    "tagKeyRequired": "Se requiere una clave de etiqueta (1-100 caracteres)",
     "fxFieldsIncomplete": "originalAmount y originalCurrencyCode deben proporcionarse juntos",
     "fxRateRequired": "Se requiere un tipo de cambio positivo para una transacción en moneda extranjera",
     "fxSignMismatch": "originalAmount y amount deben tener el mismo signo",
@@ -539,5 +542,8 @@
     "signalNotFound": "Señal de estrategia no encontrada",
     "signalStrategyMismatch": "Esa señal pertenece a otra estrategia.",
     "strategyNotFound": "Estrategia no encontrada"
+  },
+  "maintenance": {
+    "inProgress": "Otra operacion esta reemplazando actualmente los datos de esta cuenta. Espera a que termine e intentalo de nuevo."
   }
 }

--- a/backend/src/i18n/locales/fr/errors.json
+++ b/backend/src/i18n/locales/fr/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "L'e-mail n'est pas configuré. L'accès d'urgence ne peut pas être activé tant que SMTP n'est pas configuré.",
     "encryptionNotConfigured": "La clé de chiffrement n'est pas configurée. Le message libre ne peut pas être stocké de manière sécurisée tant que AI_ENCRYPTION_KEY n'est pas défini.",
+    "encryptionRequiredToEnable": "Le chiffrement des identifiants n'est pas configuré. L'accès d'urgence ne peut pas être activé tant que AI_ENCRYPTION_KEY n'est pas défini, car un octroi doit stocker de manière sécurisée le lien d'accès de chaque contact.",
     "contactEmailExists": "Un contact d'urgence avec cet e-mail existe déjà.",
     "contactNotFound": "Contact introuvable",
     "notConfigured": "Accès d'urgence non configuré",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "Les comptes source et destination doivent être différents",
     "requiresBrokerageAccount": "Les transactions d'investissement récurrentes nécessitent un compte de courtage",
     "notFound": "Transaction récurrente avec l'ID {{ id }} introuvable",
+    "occurrenceAlreadyPosted": "Cette occurrence a déjà été enregistrée.",
+    "fxPlainOnly": "Une devise différente n'est possible que sur une transaction récurrente simple, pas sur une transaction fractionnée, un virement ou un investissement",
+    "fxRateUnavailable": "Aucun taux de change n'est disponible de {{ from }} vers {{ to }} le {{ date }}. Saisissez le montant en {{ to }} pour l'enregistrer.",
     "investmentActionRequired": "Une action d'investissement est requise pour les transactions d'investissement récurrentes",
     "actionRequiresSecurity": "L'action {{ action }} nécessite un titre",
     "actionRequiresPositiveQuantity": "L'action {{ action }} nécessite une quantité positive",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "Le montant est requis lors de la création d'un remplacement fractionné",
     "overrideNotFound": "Remplacement avec l'ID {{ overrideId }} introuvable",
     "updateSplitOverrideRequiresAmount": "Le montant est requis pour le remplacement fractionné",
-    "dateMustBeYMD": "La date doit être au format YYYY-MM-DD",
-    "fxPlainOnly": "Une devise différente n'est possible que sur une transaction récurrente simple, pas sur une transaction fractionnée, un virement ou un investissement",
-    "fxRateUnavailable": "Aucun taux de change n'est disponible de {{ from }} vers {{ to }} le {{ date }}. Saisissez le montant en {{ to }} pour l'enregistrer."
+    "dateMustBeYMD": "La date doit être au format YYYY-MM-DD"
   },
   "securities": {
     "exchangeRateUnavailable": "Impossible de déterminer un taux de change pour {{ from }} -> {{ to }} à la date de la transaction. Fournissez un exchangeRate explicite afin que l'écriture sur le compte d'espèces soit correcte.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId doit être un UUID valide",
     "amountFromMustBeNumber": "amountFrom doit être un nombre",
     "amountToMustBeNumber": "amountTo doit être un nombre",
+    "tagKeyTooLong": "tagKey ne doit pas dépasser 100 caractères",
+    "invalidTagKeyOp": "tagKeyOp non valide : {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue est requis pour contains / notContains",
+    "tagKeyRequired": "Une clé d'étiquette (1 à 100 caractères) est requise",
     "invalidGroupBy": "groupBy doit être 'category' ou 'payee'",
     "limitMustBePositive": "limit doit être un nombre positif",
     "recurringPayeeRequired": "payeeIds est requis",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance doit être un nombre",
     "categoryNotFound": "Catégorie introuvable",
     "categoriesNotFound": "Catégories introuvables : {{ ids }}",
+    "crossOwnerTransferLocked": "L'autre côté de ce virement se trouve dans un compte auquel vous n'avez plus accès. Vous pouvez modifier les détails de cette transaction, mais son montant, sa date et ses comptes sont verrouillés.",
+    "crossOwnerAccountMoveLocked": "Ce virement implique le compte d'un autre utilisateur et ne peut donc pas être déplacé vers d'autres comptes.",
+    "cannotEditTransfer": "Les virements ne peuvent pas être modifiés ici. Modifiez le virement depuis l'écran Transactions.",
+    "cannotEditSplit": "Les transactions ventilées ne peuvent pas être modifiées ici. Modifiez la ventilation depuis l'écran Transactions.",
+    "noUpdateFields": "Indiquez au moins un champ à modifier.",
     "investmentSplitRequiresPayload": "Une fraction d'investissement nécessite un contenu d'investissement",
     "investmentActionNotAllowedInSplit": "L'action d'investissement {{ action }} n'est pas autorisée dans une transaction fractionnée",
     "investmentSplitCannotSetCategoryOrTransfer": "Les fractions d'investissement ne peuvent pas définir categoryId ou transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Certaines transactions sont introuvables ou n'appartiennent pas au compte spécifié",
     "cannotReconcileVoidPlural": "Impossible de rapprocher des transactions annulées",
     "transferSameAccount": "Les comptes source et destination doivent être différents",
+    "transferChangedConcurrently": "Ce transfert a été modifié par une autre requête. Rechargez-le puis réessayez.",
     "transferAmountNegative": "Le montant du virement ne doit pas être négatif",
     "notATransfer": "La transaction n'est pas un virement",
     "splitTransferLegAccountLocked": "Ce virement fait partie d'une transaction fractionnée. Pour changer ses comptes, modifiez la fraction sur la transaction d'origine.",
     "notFoundById": "Transaction avec l'ID {{ id }} introuvable",
     "bulkUpdateNoFields": "Au moins un champ de mise à jour doit être fourni",
     "payeeNotFound": "Bénéficiaire introuvable",
-    "crossOwnerTransferLocked": "L'autre côté de ce virement se trouve dans un compte auquel vous n'avez plus accès. Vous pouvez modifier les détails de cette transaction, mais son montant, sa date et ses comptes sont verrouillés.",
-    "crossOwnerAccountMoveLocked": "Ce virement implique le compte d'un autre utilisateur et ne peut donc pas être déplacé vers d'autres comptes.",
-    "cannotEditTransfer": "Les virements ne peuvent pas être modifiés ici. Modifiez le virement depuis l'écran Transactions.",
-    "cannotEditSplit": "Les transactions ventilées ne peuvent pas être modifiées ici. Modifiez la ventilation depuis l'écran Transactions.",
-    "noUpdateFields": "Indiquez au moins un champ à modifier.",
-    "tagKeyTooLong": "tagKey ne doit pas dépasser 100 caractères",
-    "invalidTagKeyOp": "tagKeyOp non valide : {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue est requis pour contains / notContains",
-    "tagKeyRequired": "Une clé d'étiquette (1 à 100 caractères) est requise",
     "fxFieldsIncomplete": "originalAmount et originalCurrencyCode doivent être fournis ensemble",
     "fxRateRequired": "Un taux de change positif est requis pour une transaction en devise étrangère",
     "fxSignMismatch": "originalAmount et amount doivent avoir le même signe",
@@ -539,5 +542,8 @@
     "signalNotFound": "Signal de stratégie introuvable",
     "signalStrategyMismatch": "Ce signal appartient à une autre stratégie.",
     "strategyNotFound": "Stratégie introuvable"
+  },
+  "maintenance": {
+    "inProgress": "Une autre operation remplace actuellement les donnees de ce compte. Attendez qu'elle se termine puis reessayez."
   }
 }

--- a/backend/src/i18n/locales/hi/errors.json
+++ b/backend/src/i18n/locales/hi/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "ईमेल कॉन्फ़िगर नहीं है। SMTP सेटअप होने तक आपातकालीन एक्सेस सक्षम नहीं किया जा सकता।",
     "encryptionNotConfigured": "एन्क्रिप्शन कुंजी कॉन्फ़िगर नहीं है। AI_ENCRYPTION_KEY सेट होने तक मुक्त-रूप संदेश सुरक्षित रूप से संग्रहीत नहीं किया जा सकता।",
+    "encryptionRequiredToEnable": "क्रेडेंशियल एन्क्रिप्शन कॉन्फ़िगर नहीं है। AI_ENCRYPTION_KEY सेट होने तक आपातकालीन एक्सेस सक्षम नहीं किया जा सकता, क्योंकि अनुदान को प्रत्येक संपर्क का एक्सेस लिंक सुरक्षित रूप से संग्रहीत करना होता है।",
     "contactEmailExists": "इस ईमेल से एक आपातकालीन संपर्क पहले से मौजूद है।",
     "contactNotFound": "संपर्क नहीं मिला",
     "notConfigured": "आपातकालीन एक्सेस कॉन्फ़िगर नहीं है",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "स्रोत और गंतव्य खाते अलग होने चाहिए",
     "requiresBrokerageAccount": "अनुसूचित निवेश लेनदेन के लिए ब्रोकरेज खाता आवश्यक है",
     "notFound": "ID {{ id }} वाला अनुसूचित लेनदेन नहीं मिला",
+    "occurrenceAlreadyPosted": "यह घटना पहले ही दर्ज की जा चुकी है।",
+    "fxPlainOnly": "अलग मुद्रा केवल सामान्य अनुसूचित लेनदेन पर उपयोग की जा सकती है, विभाजन, स्थानांतरण या निवेश पर नहीं",
+    "fxRateUnavailable": "{{ date }} को {{ from }} से {{ to }} के लिए कोई विनिमय दर उपलब्ध नहीं है। इसे पोस्ट करने के लिए राशि {{ to }} में दर्ज करें।",
     "investmentActionRequired": "अनुसूचित निवेश लेनदेन के लिए निवेश क्रिया आवश्यक है",
     "actionRequiresSecurity": "क्रिया {{ action }} के लिए एक प्रतिभूति आवश्यक है",
     "actionRequiresPositiveQuantity": "क्रिया {{ action }} के लिए एक सकारात्मक मात्रा आवश्यक है",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "विभाजन ओवरराइड बनाते समय राशि आवश्यक है",
     "overrideNotFound": "ID {{ overrideId }} वाला ओवरराइड नहीं मिला",
     "updateSplitOverrideRequiresAmount": "विभाजन ओवरराइड के लिए राशि आवश्यक है",
-    "dateMustBeYMD": "तिथि YYYY-MM-DD प्रारूप में होनी चाहिए",
-    "fxPlainOnly": "अलग मुद्रा केवल सामान्य अनुसूचित लेनदेन पर उपयोग की जा सकती है, विभाजन, स्थानांतरण या निवेश पर नहीं",
-    "fxRateUnavailable": "{{ date }} को {{ from }} से {{ to }} के लिए कोई विनिमय दर उपलब्ध नहीं है। इसे पोस्ट करने के लिए राशि {{ to }} में दर्ज करें।"
+    "dateMustBeYMD": "तिथि YYYY-MM-DD प्रारूप में होनी चाहिए"
   },
   "securities": {
     "exchangeRateUnavailable": "लेन-देन की तारीख पर {{ from }} -> {{ to }} के लिए विनिमय दर निर्धारित नहीं की जा सकी। नकद खाते में सही प्रविष्टि के लिए स्पष्ट exchangeRate दें।",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId एक मान्य UUID होना चाहिए",
     "amountFromMustBeNumber": "amountFrom एक संख्या होनी चाहिए",
     "amountToMustBeNumber": "amountTo एक संख्या होनी चाहिए",
+    "tagKeyTooLong": "tagKey 100 अक्षरों से अधिक नहीं होना चाहिए",
+    "invalidTagKeyOp": "अमान्य tagKeyOp: {{ op }}",
+    "tagKeyValueRequired": "contains / notContains के लिए tagKeyValue आवश्यक है",
+    "tagKeyRequired": "एक टैग कुंजी (1-100 अक्षर) आवश्यक है",
     "invalidGroupBy": "groupBy 'category' या 'payee' होना चाहिए",
     "limitMustBePositive": "limit एक धनात्मक संख्या होनी चाहिए",
     "recurringPayeeRequired": "payeeIds आवश्यक है",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance एक संख्या होनी चाहिए",
     "categoryNotFound": "श्रेणी नहीं मिली",
     "categoriesNotFound": "श्रेणियाँ नहीं मिलीं: {{ ids }}",
+    "crossOwnerTransferLocked": "इस ट्रांसफर का दूसरा पक्ष ऐसे खाते में है जिस तक अब आपकी पहुंच नहीं है। आप इस लेन-देन के अपने विवरण संपादित कर सकते हैं, लेकिन इसकी राशि, तारीख और खाते लॉक हैं।",
+    "crossOwnerAccountMoveLocked": "इस ट्रांसफर में किसी अन्य उपयोगकर्ता का खाता शामिल है, इसलिए इसे अन्य खातों में स्थानांतरित नहीं किया जा सकता।",
+    "cannotEditTransfer": "ट्रांसफर यहां संपादित नहीं किए जा सकते। ट्रांसफर को लेन-देन स्क्रीन से संपादित करें।",
+    "cannotEditSplit": "विभाजित लेन-देन यहां संपादित नहीं किए जा सकते। विभाजन को लेन-देन स्क्रीन से संपादित करें।",
+    "noUpdateFields": "बदलने के लिए कम से कम एक फ़ील्ड प्रदान करें।",
     "investmentSplitRequiresPayload": "निवेश विभाजन के लिए एक निवेश पेलोड आवश्यक है",
     "investmentActionNotAllowedInSplit": "निवेश क्रिया {{ action }} विभाजित लेनदेन के अंदर अनुमत नहीं है",
     "investmentSplitCannotSetCategoryOrTransfer": "निवेश विभाजन categoryId या transferAccountId भी सेट नहीं कर सकते",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "कुछ लेनदेन नहीं मिले या निर्दिष्ट खाते से संबंधित नहीं हैं",
     "cannotReconcileVoidPlural": "रद्द लेनदेन का समाधान नहीं किया जा सकता",
     "transferSameAccount": "स्रोत और गंतव्य खाते अलग होने चाहिए",
+    "transferChangedConcurrently": "यह ट्रांसफ़र किसी अन्य अनुरोध द्वारा बदल दिया गया। इसे फिर से लोड करके पुनः प्रयास करें।",
     "transferAmountNegative": "स्थानांतरण राशि नकारात्मक नहीं होनी चाहिए",
     "notATransfer": "लेनदेन स्थानांतरण नहीं है",
     "splitTransferLegAccountLocked": "यह ट्रांसफ़र एक विभाजित लेनदेन का हिस्सा है। इसके खाते बदलने के लिए स्रोत लेनदेन पर विभाजन को संपादित करें।",
     "notFoundById": "ID {{ id }} वाला लेनदेन नहीं मिला",
     "bulkUpdateNoFields": "कम से कम एक अपडेट फ़ील्ड प्रदान की जानी चाहिए",
     "payeeNotFound": "भुगतानकर्ता नहीं मिला",
-    "crossOwnerTransferLocked": "इस ट्रांसफर का दूसरा पक्ष ऐसे खाते में है जिस तक अब आपकी पहुंच नहीं है। आप इस लेन-देन के अपने विवरण संपादित कर सकते हैं, लेकिन इसकी राशि, तारीख और खाते लॉक हैं।",
-    "crossOwnerAccountMoveLocked": "इस ट्रांसफर में किसी अन्य उपयोगकर्ता का खाता शामिल है, इसलिए इसे अन्य खातों में स्थानांतरित नहीं किया जा सकता।",
-    "cannotEditTransfer": "ट्रांसफर यहां संपादित नहीं किए जा सकते। ट्रांसफर को लेन-देन स्क्रीन से संपादित करें।",
-    "cannotEditSplit": "विभाजित लेन-देन यहां संपादित नहीं किए जा सकते। विभाजन को लेन-देन स्क्रीन से संपादित करें।",
-    "noUpdateFields": "बदलने के लिए कम से कम एक फ़ील्ड प्रदान करें।",
-    "tagKeyTooLong": "tagKey 100 अक्षरों से अधिक नहीं होना चाहिए",
-    "invalidTagKeyOp": "अमान्य tagKeyOp: {{ op }}",
-    "tagKeyValueRequired": "contains / notContains के लिए tagKeyValue आवश्यक है",
-    "tagKeyRequired": "एक टैग कुंजी (1-100 अक्षर) आवश्यक है",
     "fxFieldsIncomplete": "originalAmount और originalCurrencyCode एक साथ दिए जाने चाहिए",
     "fxRateRequired": "विदेशी मुद्रा लेनदेन के लिए एक धनात्मक विनिमय दर आवश्यक है",
     "fxSignMismatch": "originalAmount और amount का चिह्न समान होना चाहिए",
@@ -539,5 +542,8 @@
     "signalNotFound": "रणनीति संकेत नहीं मिला",
     "signalStrategyMismatch": "वह सिग्नल किसी दूसरी रणनीति का है।",
     "strategyNotFound": "रणनीति नहीं मिली"
+  },
+  "maintenance": {
+    "inProgress": "इस खाते का डेटा वर्तमान में किसी अन्य कार्रवाई द्वारा बदला जा रहा है। उसके पूरा होने की प्रतीक्षा करें और फिर पुनः प्रयास करें।"
   }
 }

--- a/backend/src/i18n/locales/id/errors.json
+++ b/backend/src/i18n/locales/id/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "Email belum dikonfigurasi. Akses darurat tidak dapat diaktifkan hingga SMTP dikonfigurasi.",
     "encryptionNotConfigured": "Kunci enkripsi belum dikonfigurasi. Pesan teks bebas tidak dapat disimpan dengan aman hingga AI_ENCRYPTION_KEY diatur.",
+    "encryptionRequiredToEnable": "Enkripsi kredensial belum dikonfigurasi. Akses darurat tidak dapat diaktifkan hingga AI_ENCRYPTION_KEY diatur, karena pemberian akses harus menyimpan tautan akses setiap kontak dengan aman.",
     "contactEmailExists": "Kontak darurat dengan email ini sudah ada.",
     "contactNotFound": "Kontak tidak ditemukan",
     "notConfigured": "Akses darurat belum dikonfigurasi",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "Akun sumber dan tujuan harus berbeda",
     "requiresBrokerageAccount": "Transaksi investasi terjadwal memerlukan akun pialang",
     "notFound": "Transaksi terjadwal dengan ID {{ id }} tidak ditemukan",
+    "occurrenceAlreadyPosted": "Kejadian ini sudah dicatat.",
+    "fxPlainOnly": "Mata uang lain hanya dapat dipakai pada transaksi terjadwal biasa, bukan pada transaksi terbagi, transfer, atau investasi",
+    "fxRateUnavailable": "Tidak ada nilai tukar yang tersedia untuk {{ from }} ke {{ to }} pada {{ date }}. Masukkan jumlah dalam {{ to }} untuk mempostingnya.",
     "investmentActionRequired": "Tindakan investasi diperlukan untuk transaksi investasi terjadwal",
     "actionRequiresSecurity": "Tindakan {{ action }} memerlukan sekuritas",
     "actionRequiresPositiveQuantity": "Tindakan {{ action }} memerlukan kuantitas positif",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "Jumlah diperlukan saat membuat penggantian terbagi",
     "overrideNotFound": "Penggantian dengan ID {{ overrideId }} tidak ditemukan",
     "updateSplitOverrideRequiresAmount": "Jumlah diperlukan untuk penggantian terbagi",
-    "dateMustBeYMD": "tanggal harus dalam format YYYY-MM-DD",
-    "fxPlainOnly": "Mata uang lain hanya dapat dipakai pada transaksi terjadwal biasa, bukan pada transaksi terbagi, transfer, atau investasi",
-    "fxRateUnavailable": "Tidak ada nilai tukar yang tersedia untuk {{ from }} ke {{ to }} pada {{ date }}. Masukkan jumlah dalam {{ to }} untuk mempostingnya."
+    "dateMustBeYMD": "tanggal harus dalam format YYYY-MM-DD"
   },
   "securities": {
     "exchangeRateUnavailable": "Tidak dapat menentukan nilai tukar untuk {{ from }} -> {{ to }} pada tanggal transaksi. Berikan exchangeRate eksplisit agar pencatatan ke akun kas benar.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId harus berupa UUID yang valid",
     "amountFromMustBeNumber": "amountFrom harus berupa angka",
     "amountToMustBeNumber": "amountTo harus berupa angka",
+    "tagKeyTooLong": "tagKey tidak boleh melebihi 100 karakter",
+    "invalidTagKeyOp": "tagKeyOp tidak valid: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue diperlukan untuk contains / notContains",
+    "tagKeyRequired": "Kunci tag (1-100 karakter) diperlukan",
     "invalidGroupBy": "groupBy harus 'category' atau 'payee'",
     "limitMustBePositive": "limit harus berupa angka positif",
     "recurringPayeeRequired": "payeeIds wajib diisi",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance harus berupa angka",
     "categoryNotFound": "Kategori tidak ditemukan",
     "categoriesNotFound": "Kategori tidak ditemukan: {{ ids }}",
+    "crossOwnerTransferLocked": "Sisi lain dari transfer ini berada di akun yang tidak lagi dapat Anda akses. Anda dapat mengedit detail transaksi ini, tetapi jumlah, tanggal, dan akunnya terkunci.",
+    "crossOwnerAccountMoveLocked": "Transfer ini melibatkan akun pengguna lain, sehingga tidak dapat dipindahkan ke akun lain.",
+    "cannotEditTransfer": "Transfer tidak dapat diedit di sini. Edit transfer dari layar Transaksi.",
+    "cannotEditSplit": "Transaksi terpisah tidak dapat diedit di sini. Edit pemisahan dari layar Transaksi.",
+    "noUpdateFields": "Berikan setidaknya satu kolom untuk diubah.",
     "investmentSplitRequiresPayload": "Pembagian investasi memerlukan muatan investasi",
     "investmentActionNotAllowedInSplit": "Tindakan investasi {{ action }} tidak diizinkan di dalam transaksi terbagi",
     "investmentSplitCannotSetCategoryOrTransfer": "Pembagian investasi tidak dapat sekaligus menetapkan categoryId atau transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Beberapa transaksi tidak ditemukan atau tidak termasuk dalam akun yang ditentukan",
     "cannotReconcileVoidPlural": "Tidak dapat merekonsiliasi transaksi yang dibatalkan",
     "transferSameAccount": "Akun sumber dan tujuan harus berbeda",
+    "transferChangedConcurrently": "Transfer ini diubah oleh permintaan lain. Muat ulang lalu coba lagi.",
     "transferAmountNegative": "Jumlah transfer tidak boleh negatif",
     "notATransfer": "Transaksi bukan merupakan transfer",
     "splitTransferLegAccountLocked": "Transfer ini adalah bagian dari transaksi terbagi. Ubah akunnya dengan mengedit pembagian pada transaksi sumber.",
     "notFoundById": "Transaksi dengan ID {{ id }} tidak ditemukan",
     "bulkUpdateNoFields": "Minimal satu kolom pembaruan harus diberikan",
     "payeeNotFound": "Penerima tidak ditemukan",
-    "crossOwnerTransferLocked": "Sisi lain dari transfer ini berada di akun yang tidak lagi dapat Anda akses. Anda dapat mengedit detail transaksi ini, tetapi jumlah, tanggal, dan akunnya terkunci.",
-    "crossOwnerAccountMoveLocked": "Transfer ini melibatkan akun pengguna lain, sehingga tidak dapat dipindahkan ke akun lain.",
-    "cannotEditTransfer": "Transfer tidak dapat diedit di sini. Edit transfer dari layar Transaksi.",
-    "cannotEditSplit": "Transaksi terpisah tidak dapat diedit di sini. Edit pemisahan dari layar Transaksi.",
-    "noUpdateFields": "Berikan setidaknya satu kolom untuk diubah.",
-    "tagKeyTooLong": "tagKey tidak boleh melebihi 100 karakter",
-    "invalidTagKeyOp": "tagKeyOp tidak valid: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue diperlukan untuk contains / notContains",
-    "tagKeyRequired": "Kunci tag (1-100 karakter) diperlukan",
     "fxFieldsIncomplete": "originalAmount dan originalCurrencyCode harus diberikan bersama",
     "fxRateRequired": "Nilai tukar positif diperlukan untuk transaksi mata uang asing",
     "fxSignMismatch": "originalAmount dan amount harus memiliki tanda yang sama",
@@ -539,5 +542,8 @@
     "signalNotFound": "Sinyal strategi tidak ditemukan",
     "signalStrategyMismatch": "Sinyal itu milik strategi lain.",
     "strategyNotFound": "Strategi tidak ditemukan"
+  },
+  "maintenance": {
+    "inProgress": "Operasi lain sedang menggantikan data akun ini. Tunggu hingga selesai lalu coba lagi."
   }
 }

--- a/backend/src/i18n/locales/it/errors.json
+++ b/backend/src/i18n/locales/it/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "L'email non è configurata. L'accesso di emergenza non può essere abilitato finché SMTP non è configurato.",
     "encryptionNotConfigured": "La chiave di cifratura non è configurata. Il messaggio in testo libero non può essere archiviato in modo sicuro finché AI_ENCRYPTION_KEY non è impostata.",
+    "encryptionRequiredToEnable": "La cifratura delle credenziali non è configurata. L'accesso di emergenza non può essere abilitato finché AI_ENCRYPTION_KEY non è impostata, perché una concessione deve archiviare in modo sicuro il link di accesso di ogni contatto.",
     "contactEmailExists": "Esiste già un contatto di emergenza con questo indirizzo email.",
     "contactNotFound": "Contatto non trovato",
     "notConfigured": "Accesso di emergenza non configurato",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "I conti di origine e destinazione devono essere diversi",
     "requiresBrokerageAccount": "Le transazioni di investimento pianificate richiedono un conto di intermediazione",
     "notFound": "Transazione pianificata con ID {{ id }} non trovata",
+    "occurrenceAlreadyPosted": "Questa occorrenza è già stata registrata.",
+    "fxPlainOnly": "Una valuta diversa può essere usata solo su una transazione pianificata semplice, non su una suddivisione, un trasferimento o un investimento",
+    "fxRateUnavailable": "Non è disponibile alcun tasso di cambio da {{ from }} a {{ to }} il {{ date }}. Inserisci l'importo in {{ to }} per registrarla.",
     "investmentActionRequired": "L'azione di investimento è obbligatoria per le transazioni di investimento pianificate",
     "actionRequiresSecurity": "L'azione {{ action }} richiede un titolo",
     "actionRequiresPositiveQuantity": "L'azione {{ action }} richiede una quantità positiva",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "L'importo è obbligatorio quando si crea una sostituzione suddivisa",
     "overrideNotFound": "Sostituzione con ID {{ overrideId }} non trovata",
     "updateSplitOverrideRequiresAmount": "L'importo è obbligatorio per la sostituzione suddivisa",
-    "dateMustBeYMD": "la data deve essere nel formato YYYY-MM-DD",
-    "fxPlainOnly": "Una valuta diversa può essere usata solo su una transazione pianificata semplice, non su una suddivisione, un trasferimento o un investimento",
-    "fxRateUnavailable": "Non è disponibile alcun tasso di cambio da {{ from }} a {{ to }} il {{ date }}. Inserisci l'importo in {{ to }} per registrarla."
+    "dateMustBeYMD": "la data deve essere nel formato YYYY-MM-DD"
   },
   "securities": {
     "exchangeRateUnavailable": "Impossibile determinare un tasso di cambio per {{ from }} -> {{ to }} alla data della transazione. Fornisci un exchangeRate esplicito affinché la registrazione sul conto di liquidità sia corretta.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId deve essere un UUID valido",
     "amountFromMustBeNumber": "amountFrom deve essere un numero",
     "amountToMustBeNumber": "amountTo deve essere un numero",
+    "tagKeyTooLong": "tagKey non deve superare i 100 caratteri",
+    "invalidTagKeyOp": "tagKeyOp non valido: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue è obbligatorio per contains / notContains",
+    "tagKeyRequired": "È richiesta una chiave tag (1-100 caratteri)",
     "invalidGroupBy": "groupBy deve essere 'category' o 'payee'",
     "limitMustBePositive": "limit deve essere un numero positivo",
     "recurringPayeeRequired": "payeeIds è obbligatorio",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance deve essere un numero",
     "categoryNotFound": "Categoria non trovata",
     "categoriesNotFound": "Categorie non trovate: {{ ids }}",
+    "crossOwnerTransferLocked": "L'altro lato di questo trasferimento si trova in un conto a cui non hai più accesso. Puoi modificare i dettagli di questa transazione, ma importo, data e conti sono bloccati.",
+    "crossOwnerAccountMoveLocked": "Questo trasferimento coinvolge il conto di un altro utente, quindi non può essere spostato su altri conti.",
+    "cannotEditTransfer": "I trasferimenti non possono essere modificati qui. Modifica il trasferimento dalla schermata Transazioni.",
+    "cannotEditSplit": "Le transazioni suddivise non possono essere modificate qui. Modifica la suddivisione dalla schermata Transazioni.",
+    "noUpdateFields": "Fornisci almeno un campo da modificare.",
     "investmentSplitRequiresPayload": "La suddivisione di investimento richiede un payload di investimento",
     "investmentActionNotAllowedInSplit": "L'azione di investimento {{ action }} non è consentita all'interno di una transazione suddivisa",
     "investmentSplitCannotSetCategoryOrTransfer": "Le suddivisioni di investimento non possono impostare anche categoryId o transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Alcune transazioni non sono state trovate o non appartengono al conto specificato",
     "cannotReconcileVoidPlural": "Impossibile riconciliare transazioni annullate",
     "transferSameAccount": "I conti di origine e destinazione devono essere diversi",
+    "transferChangedConcurrently": "Questo trasferimento è stato modificato da un'altra richiesta. Ricaricalo e riprova.",
     "transferAmountNegative": "L'importo del trasferimento non deve essere negativo",
     "notATransfer": "La transazione non è un trasferimento",
     "splitTransferLegAccountLocked": "Questo trasferimento fa parte di una transazione suddivisa. Per cambiarne i conti, modifica la suddivisione nella transazione di origine.",
     "notFoundById": "Transazione con ID {{ id }} non trovata",
     "bulkUpdateNoFields": "Deve essere fornito almeno un campo di aggiornamento",
     "payeeNotFound": "Beneficiario non trovato",
-    "crossOwnerTransferLocked": "L'altro lato di questo trasferimento si trova in un conto a cui non hai più accesso. Puoi modificare i dettagli di questa transazione, ma importo, data e conti sono bloccati.",
-    "crossOwnerAccountMoveLocked": "Questo trasferimento coinvolge il conto di un altro utente, quindi non può essere spostato su altri conti.",
-    "cannotEditTransfer": "I trasferimenti non possono essere modificati qui. Modifica il trasferimento dalla schermata Transazioni.",
-    "cannotEditSplit": "Le transazioni suddivise non possono essere modificate qui. Modifica la suddivisione dalla schermata Transazioni.",
-    "noUpdateFields": "Fornisci almeno un campo da modificare.",
-    "tagKeyTooLong": "tagKey non deve superare i 100 caratteri",
-    "invalidTagKeyOp": "tagKeyOp non valido: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue è obbligatorio per contains / notContains",
-    "tagKeyRequired": "È richiesta una chiave tag (1-100 caratteri)",
     "fxFieldsIncomplete": "originalAmount e originalCurrencyCode devono essere forniti insieme",
     "fxRateRequired": "È richiesto un tasso di cambio positivo per una transazione in valuta estera",
     "fxSignMismatch": "originalAmount e amount devono avere lo stesso segno",
@@ -539,5 +542,8 @@
     "signalNotFound": "Segnale della strategia non trovato",
     "signalStrategyMismatch": "Quel segnale appartiene a un'altra strategia.",
     "strategyNotFound": "Strategia non trovata"
+  },
+  "maintenance": {
+    "inProgress": "Un'altra operazione sta sostituendo i dati di questo account. Attendi che termini e riprova."
   }
 }

--- a/backend/src/i18n/locales/ja/errors.json
+++ b/backend/src/i18n/locales/ja/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "メールが設定されていません。SMTPが設定されるまで緊急アクセスは有効にできません。",
     "encryptionNotConfigured": "暗号化キーが設定されていません。AI_ENCRYPTION_KEY が設定されるまでフリーフォームメッセージを安全に保存できません。",
+    "encryptionRequiredToEnable": "資格情報の暗号化が設定されていません。付与では各連絡先のアクセスリンクを安全に保存する必要があるため、AI_ENCRYPTION_KEY が設定されるまで緊急アクセスは有効にできません。",
     "contactEmailExists": "このメールアドレスの緊急連絡先はすでに存在します。",
     "contactNotFound": "連絡先が見つかりません",
     "notConfigured": "緊急アクセスが設定されていません",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "ソース口座と振替先口座は異なる必要があります",
     "requiresBrokerageAccount": "スケジュール投資取引には証券口座が必要です",
     "notFound": "ID {{ id }} のスケジュール取引が見つかりません",
+    "occurrenceAlreadyPosted": "この回はすでに記帳されています。",
+    "fxPlainOnly": "別の通貨を使用できるのは通常のスケジュール取引のみで、分割、振替、投資では使用できません",
+    "fxRateUnavailable": "{{ date }} の {{ from }} から {{ to }} への為替レートが利用できません。投稿するには金額を {{ to }} で入力してください。",
     "investmentActionRequired": "スケジュール投資取引には投資アクションが必要です",
     "actionRequiresSecurity": "アクション {{ action }} には有価証券が必要です",
     "actionRequiresPositiveQuantity": "アクション {{ action }} には正の数量が必要です",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "分割上書きを作成するには金額が必要です",
     "overrideNotFound": "ID {{ overrideId }} の上書きが見つかりません",
     "updateSplitOverrideRequiresAmount": "分割上書きには金額が必要です",
-    "dateMustBeYMD": "date は YYYY-MM-DD 形式でなければなりません",
-    "fxPlainOnly": "別の通貨を使用できるのは通常のスケジュール取引のみで、分割、振替、投資では使用できません",
-    "fxRateUnavailable": "{{ date }} の {{ from }} から {{ to }} への為替レートが利用できません。投稿するには金額を {{ to }} で入力してください。"
+    "dateMustBeYMD": "date は YYYY-MM-DD 形式でなければなりません"
   },
   "securities": {
     "exchangeRateUnavailable": "取引日における {{ from }} -> {{ to }} の為替レートを特定できませんでした。現金口座への計上が正しくなるよう、明示的な exchangeRate を指定してください。",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId は有効なUUIDでなければなりません",
     "amountFromMustBeNumber": "amountFrom は数値でなければなりません",
     "amountToMustBeNumber": "amountTo は数値でなければなりません",
+    "tagKeyTooLong": "tagKey は100文字を超えてはいけません",
+    "invalidTagKeyOp": "無効な tagKeyOp: {{ op }}",
+    "tagKeyValueRequired": "contains / notContains には tagKeyValue が必要です",
+    "tagKeyRequired": "タグキー（1〜100文字）が必要です",
     "invalidGroupBy": "groupBy は 'category' または 'payee' でなければなりません",
     "limitMustBePositive": "limit は正の数でなければなりません",
     "recurringPayeeRequired": "payeeIds は必須です",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance は数値でなければなりません",
     "categoryNotFound": "カテゴリが見つかりません",
     "categoriesNotFound": "カテゴリが見つかりません：{{ ids }}",
+    "crossOwnerTransferLocked": "この振替の相手側は、アクセスできなくなった口座にあります。この取引自体の詳細は編集できますが、金額、日付、口座はロックされています。",
+    "crossOwnerAccountMoveLocked": "この振替には他のユーザーの口座が関係しているため、別の口座に移動できません。",
+    "cannotEditTransfer": "振替はここでは編集できません。取引画面から振替を編集してください。",
+    "cannotEditSplit": "分割取引はここでは編集できません。取引画面から分割を編集してください。",
+    "noUpdateFields": "変更するフィールドを少なくとも1つ指定してください。",
     "investmentSplitRequiresPayload": "投資分割には投資ペイロードが必要です",
     "investmentActionNotAllowedInSplit": "投資アクション {{ action }} は分割取引内では許可されていません",
     "investmentSplitCannotSetCategoryOrTransfer": "投資分割では categoryId または transferAccountId を設定できません",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "一部の取引が見つからないか、指定した口座に属していません",
     "cannotReconcileVoidPlural": "無効な取引は照合できません",
     "transferSameAccount": "ソース口座と振替先口座は異なる必要があります",
+    "transferChangedConcurrently": "この振替は別のリクエストによって変更されました。再読み込みしてやり直してください。",
     "transferAmountNegative": "振替金額はマイナスにできません",
     "notATransfer": "取引は振替ではありません",
     "splitTransferLegAccountLocked": "この振替は分割取引の一部です。口座を変更するには、元の取引の分割を編集してください。",
     "notFoundById": "ID {{ id }} の取引が見つかりません",
     "bulkUpdateNoFields": "少なくとも1つの更新フィールドが必要です",
     "payeeNotFound": "支払先が見つかりません",
-    "crossOwnerTransferLocked": "この振替の相手側は、アクセスできなくなった口座にあります。この取引自体の詳細は編集できますが、金額、日付、口座はロックされています。",
-    "crossOwnerAccountMoveLocked": "この振替には他のユーザーの口座が関係しているため、別の口座に移動できません。",
-    "cannotEditTransfer": "振替はここでは編集できません。取引画面から振替を編集してください。",
-    "cannotEditSplit": "分割取引はここでは編集できません。取引画面から分割を編集してください。",
-    "noUpdateFields": "変更するフィールドを少なくとも1つ指定してください。",
-    "tagKeyTooLong": "tagKey は100文字を超えてはいけません",
-    "invalidTagKeyOp": "無効な tagKeyOp: {{ op }}",
-    "tagKeyValueRequired": "contains / notContains には tagKeyValue が必要です",
-    "tagKeyRequired": "タグキー（1〜100文字）が必要です",
     "fxFieldsIncomplete": "originalAmount と originalCurrencyCode は一緒に指定する必要があります",
     "fxRateRequired": "外貨取引には正の為替レートが必要です",
     "fxSignMismatch": "originalAmount と amount は同じ符号である必要があります",
@@ -539,5 +542,8 @@
     "signalNotFound": "戦略シグナルが見つかりません",
     "signalStrategyMismatch": "そのシグナルは別の戦略のものです。",
     "strategyNotFound": "戦略が見つかりません"
+  },
+  "maintenance": {
+    "inProgress": "現在、別の処理がこのアカウントのデータを置き換えています。完了するまで待ってから、もう一度お試しください。"
   }
 }

--- a/backend/src/i18n/locales/ko/errors.json
+++ b/backend/src/i18n/locales/ko/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "이메일이 구성되지 않았습니다. SMTP가 설정될 때까지 긴급 접근을 활성화할 수 없습니다.",
     "encryptionNotConfigured": "암호화 키가 구성되지 않았습니다. AI_ENCRYPTION_KEY가 설정될 때까지 자유 형식 메시지를 안전하게 저장할 수 없습니다.",
+    "encryptionRequiredToEnable": "자격 증명 암호화가 구성되지 않았습니다. 부여 시 각 연락처의 접근 링크를 안전하게 저장해야 하므로, AI_ENCRYPTION_KEY가 설정될 때까지 긴급 접근을 활성화할 수 없습니다.",
     "contactEmailExists": "이 이메일을 가진 긴급 연락처가 이미 존재합니다.",
     "contactNotFound": "연락처를 찾을 수 없습니다",
     "notConfigured": "긴급 접근이 구성되지 않았습니다",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "출금 계정과 입금 계정은 서로 달라야 합니다",
     "requiresBrokerageAccount": "예약 투자 거래에는 중개 계정이 필요합니다",
     "notFound": "ID가 {{ id }}인 예약 거래를 찾을 수 없습니다",
+    "occurrenceAlreadyPosted": "이 발생 건은 이미 등록되었습니다.",
+    "fxPlainOnly": "다른 통화는 일반 예약 거래에서만 사용할 수 있으며 분할, 이체, 투자에서는 사용할 수 없습니다",
+    "fxRateUnavailable": "{{ date }}에 {{ from }}에서 {{ to }}로의 환율을 사용할 수 없습니다. 게시하려면 금액을 {{ to }}로 입력하세요.",
     "investmentActionRequired": "예약 투자 거래에는 투자 작업이 필요합니다",
     "actionRequiresSecurity": "{{ action }} 작업에는 증권이 필요합니다",
     "actionRequiresPositiveQuantity": "{{ action }} 작업에는 양수 수량이 필요합니다",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "분할 재정의를 생성할 때는 금액이 필요합니다",
     "overrideNotFound": "ID가 {{ overrideId }}인 재정의를 찾을 수 없습니다",
     "updateSplitOverrideRequiresAmount": "분할 재정의에는 금액이 필요합니다",
-    "dateMustBeYMD": "date는 YYYY-MM-DD 형식이어야 합니다",
-    "fxPlainOnly": "다른 통화는 일반 예약 거래에서만 사용할 수 있으며 분할, 이체, 투자에서는 사용할 수 없습니다",
-    "fxRateUnavailable": "{{ date }}에 {{ from }}에서 {{ to }}로의 환율을 사용할 수 없습니다. 게시하려면 금액을 {{ to }}로 입력하세요."
+    "dateMustBeYMD": "date는 YYYY-MM-DD 형식이어야 합니다"
   },
   "securities": {
     "exchangeRateUnavailable": "거래일의 {{ from }} -> {{ to }} 환율을 확인할 수 없습니다. 현금 계좌 기록이 정확하도록 명시적인 exchangeRate를 입력하세요.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId는 유효한 UUID여야 합니다",
     "amountFromMustBeNumber": "amountFrom은 숫자여야 합니다",
     "amountToMustBeNumber": "amountTo는 숫자여야 합니다",
+    "tagKeyTooLong": "tagKey는 100자를 초과할 수 없습니다",
+    "invalidTagKeyOp": "잘못된 tagKeyOp: {{ op }}",
+    "tagKeyValueRequired": "contains / notContains에는 tagKeyValue가 필요합니다",
+    "tagKeyRequired": "태그 키(1~100자)가 필요합니다",
     "invalidGroupBy": "groupBy는 'category' 또는 'payee'여야 합니다",
     "limitMustBePositive": "limit은 양수여야 합니다",
     "recurringPayeeRequired": "payeeIds는 필수입니다",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance는 숫자여야 합니다",
     "categoryNotFound": "카테고리를 찾을 수 없습니다",
     "categoriesNotFound": "카테고리를 찾을 수 없습니다: {{ ids }}",
+    "crossOwnerTransferLocked": "이 이체의 상대편이 더 이상 접근할 수 없는 계좌에 있습니다. 이 거래의 세부 정보는 편집할 수 있지만 금액, 날짜, 계좌는 잠겨 있습니다.",
+    "crossOwnerAccountMoveLocked": "이 이체에는 다른 사용자의 계좌가 포함되어 있으므로 다른 계좌로 이동할 수 없습니다.",
+    "cannotEditTransfer": "이체는 여기서 편집할 수 없습니다. 거래 화면에서 이체를 편집하세요.",
+    "cannotEditSplit": "분할 거래는 여기서 편집할 수 없습니다. 거래 화면에서 분할을 편집하세요.",
+    "noUpdateFields": "변경할 항목을 하나 이상 입력하세요.",
     "investmentSplitRequiresPayload": "투자 분할에는 투자 페이로드가 필요합니다",
     "investmentActionNotAllowedInSplit": "투자 작업 {{ action }}은(는) 분할 거래 내에서 허용되지 않습니다",
     "investmentSplitCannotSetCategoryOrTransfer": "투자 분할에는 categoryId 또는 transferAccountId를 함께 설정할 수 없습니다",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "일부 거래를 찾을 수 없거나 지정된 계정에 속하지 않습니다",
     "cannotReconcileVoidPlural": "무효 거래는 조정할 수 없습니다",
     "transferSameAccount": "출금 계정과 입금 계정은 서로 달라야 합니다",
+    "transferChangedConcurrently": "다른 요청이 이 이체를 변경했습니다. 다시 불러온 후 시도하세요.",
     "transferAmountNegative": "이체 금액은 음수일 수 없습니다",
     "notATransfer": "거래가 이체가 아닙니다",
     "splitTransferLegAccountLocked": "이 이체는 분할 거래의 일부입니다. 계좌를 변경하려면 원본 거래의 분할을 편집하세요.",
     "notFoundById": "ID가 {{ id }}인 거래를 찾을 수 없습니다",
     "bulkUpdateNoFields": "하나 이상의 업데이트 필드를 제공해야 합니다",
     "payeeNotFound": "수취인을 찾을 수 없습니다",
-    "crossOwnerTransferLocked": "이 이체의 상대편이 더 이상 접근할 수 없는 계좌에 있습니다. 이 거래의 세부 정보는 편집할 수 있지만 금액, 날짜, 계좌는 잠겨 있습니다.",
-    "crossOwnerAccountMoveLocked": "이 이체에는 다른 사용자의 계좌가 포함되어 있으므로 다른 계좌로 이동할 수 없습니다.",
-    "cannotEditTransfer": "이체는 여기서 편집할 수 없습니다. 거래 화면에서 이체를 편집하세요.",
-    "cannotEditSplit": "분할 거래는 여기서 편집할 수 없습니다. 거래 화면에서 분할을 편집하세요.",
-    "noUpdateFields": "변경할 항목을 하나 이상 입력하세요.",
-    "tagKeyTooLong": "tagKey는 100자를 초과할 수 없습니다",
-    "invalidTagKeyOp": "잘못된 tagKeyOp: {{ op }}",
-    "tagKeyValueRequired": "contains / notContains에는 tagKeyValue가 필요합니다",
-    "tagKeyRequired": "태그 키(1~100자)가 필요합니다",
     "fxFieldsIncomplete": "originalAmount와 originalCurrencyCode는 함께 제공해야 합니다",
     "fxRateRequired": "외화 거래에는 양수 환율이 필요합니다",
     "fxSignMismatch": "originalAmount와 amount의 부호가 같아야 합니다",
@@ -539,5 +542,8 @@
     "signalNotFound": "전략 신호를 찾을 수 없습니다",
     "signalStrategyMismatch": "해당 시그널은 다른 전략에 속합니다.",
     "strategyNotFound": "전략을 찾을 수 없습니다"
+  },
+  "maintenance": {
+    "inProgress": "다른 작업이 이 계정의 데이터를 교체하고 있습니다. 완료될 때까지 기다린 후 다시 시도하세요."
   }
 }

--- a/backend/src/i18n/locales/nl/errors.json
+++ b/backend/src/i18n/locales/nl/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "E-mail is niet geconfigureerd. Noodtoegang kan pas worden ingeschakeld als SMTP is ingesteld.",
     "encryptionNotConfigured": "Versleutelingssleutel is niet geconfigureerd. Het vrije bericht kan pas veilig worden opgeslagen als AI_ENCRYPTION_KEY is ingesteld.",
+    "encryptionRequiredToEnable": "Versleuteling van inloggegevens is niet geconfigureerd. Noodtoegang kan pas worden ingeschakeld als AI_ENCRYPTION_KEY is ingesteld, omdat een toekenning de toegangslink van elk contact veilig moet opslaan.",
     "contactEmailExists": "Er bestaat al een noodcontact met dit e-mailadres.",
     "contactNotFound": "Contact niet gevonden",
     "notConfigured": "Noodtoegang niet geconfigureerd",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "Bron- en doelrekeningen moeten verschillend zijn",
     "requiresBrokerageAccount": "Geplande beleggingstransacties vereisen een brokerage-rekening",
     "notFound": "Geplande transactie met ID {{ id }} niet gevonden",
+    "occurrenceAlreadyPosted": "Deze keer is al geboekt.",
+    "fxPlainOnly": "Een andere valuta kan alleen bij een gewone geplande transactie, niet bij een splitsing, overboeking of belegging",
+    "fxRateUnavailable": "Er is voor {{ date }} geen wisselkoers beschikbaar voor {{ from }} naar {{ to }}. Voer het bedrag in {{ to }} in om te boeken.",
     "investmentActionRequired": "Beleggingsactie is vereist voor geplande beleggingstransacties",
     "actionRequiresSecurity": "Actie {{ action }} vereist een waardepapier",
     "actionRequiresPositiveQuantity": "Actie {{ action }} vereist een positieve hoeveelheid",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "Bedrag is vereist bij het aanmaken van een splitsingsoverschrijving",
     "overrideNotFound": "Overschrijving met ID {{ overrideId }} niet gevonden",
     "updateSplitOverrideRequiresAmount": "Bedrag is vereist voor splitsingsoverschrijving",
-    "dateMustBeYMD": "datum moet in JJJJ-MM-DD-formaat zijn",
-    "fxPlainOnly": "Een andere valuta kan alleen bij een gewone geplande transactie, niet bij een splitsing, overboeking of belegging",
-    "fxRateUnavailable": "Er is voor {{ date }} geen wisselkoers beschikbaar voor {{ from }} naar {{ to }}. Voer het bedrag in {{ to }} in om te boeken."
+    "dateMustBeYMD": "datum moet in JJJJ-MM-DD-formaat zijn"
   },
   "securities": {
     "exchangeRateUnavailable": "Kon geen wisselkoers bepalen voor {{ from }} -> {{ to }} op de transactiedatum. Geef een expliciete exchangeRate op zodat de boeking op de geldrekening correct is.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId moet een geldige UUID zijn",
     "amountFromMustBeNumber": "amountFrom moet een getal zijn",
     "amountToMustBeNumber": "amountTo moet een getal zijn",
+    "tagKeyTooLong": "tagKey mag niet langer zijn dan 100 tekens",
+    "invalidTagKeyOp": "Ongeldige tagKeyOp: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue is vereist voor contains / notContains",
+    "tagKeyRequired": "Een tagsleutel (1-100 tekens) is vereist",
     "invalidGroupBy": "groupBy moet 'category' of 'payee' zijn",
     "limitMustBePositive": "limit moet een positief getal zijn",
     "recurringPayeeRequired": "payeeIds is verplicht",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance moet een getal zijn",
     "categoryNotFound": "Categorie niet gevonden",
     "categoriesNotFound": "Categorieën niet gevonden: {{ ids }}",
+    "crossOwnerTransferLocked": "De andere kant van deze overboeking staat op een rekening waartoe je geen toegang meer hebt. Je kunt de details van deze transactie bewerken, maar het bedrag, de datum en de rekeningen zijn vergrendeld.",
+    "crossOwnerAccountMoveLocked": "Bij deze overboeking is de rekening van een andere gebruiker betrokken, dus deze kan niet naar andere rekeningen worden verplaatst.",
+    "cannotEditTransfer": "Overboekingen kunnen hier niet worden bewerkt. Bewerk de overboeking via het scherm Transacties.",
+    "cannotEditSplit": "Gesplitste transacties kunnen hier niet worden bewerkt. Bewerk de splitsing via het scherm Transacties.",
+    "noUpdateFields": "Geef ten minste één veld op om te wijzigen.",
     "investmentSplitRequiresPayload": "Beleggingssplitsing vereist een beleggingspayload",
     "investmentActionNotAllowedInSplit": "Beleggingsactie {{ action }} is niet toegestaan in een splitsingstransactie",
     "investmentSplitCannotSetCategoryOrTransfer": "Beleggingssplitsingen kunnen niet tegelijk categoryId of transferAccountId instellen",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Sommige transacties zijn niet gevonden of behoren niet tot de opgegeven rekening",
     "cannotReconcileVoidPlural": "Kan ongeldige transacties niet afstemmen",
     "transferSameAccount": "Bron- en doelrekeningen moeten verschillend zijn",
+    "transferChangedConcurrently": "Deze overboeking is door een ander verzoek gewijzigd. Laad opnieuw en probeer het nog eens.",
     "transferAmountNegative": "Overboekingsbedrag mag niet negatief zijn",
     "notATransfer": "Transactie is geen overboeking",
     "splitTransferLegAccountLocked": "Deze overboeking maakt deel uit van een gesplitste transactie. Wijzig de rekeningen door de splitsing op de brontransactie te bewerken.",
     "notFoundById": "Transactie met ID {{ id }} niet gevonden",
     "bulkUpdateNoFields": "Er moet minimaal één bijwerkveld worden opgegeven",
     "payeeNotFound": "Begunstigde niet gevonden",
-    "crossOwnerTransferLocked": "De andere kant van deze overboeking staat op een rekening waartoe je geen toegang meer hebt. Je kunt de details van deze transactie bewerken, maar het bedrag, de datum en de rekeningen zijn vergrendeld.",
-    "crossOwnerAccountMoveLocked": "Bij deze overboeking is de rekening van een andere gebruiker betrokken, dus deze kan niet naar andere rekeningen worden verplaatst.",
-    "cannotEditTransfer": "Overboekingen kunnen hier niet worden bewerkt. Bewerk de overboeking via het scherm Transacties.",
-    "cannotEditSplit": "Gesplitste transacties kunnen hier niet worden bewerkt. Bewerk de splitsing via het scherm Transacties.",
-    "noUpdateFields": "Geef ten minste één veld op om te wijzigen.",
-    "tagKeyTooLong": "tagKey mag niet langer zijn dan 100 tekens",
-    "invalidTagKeyOp": "Ongeldige tagKeyOp: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue is vereist voor contains / notContains",
-    "tagKeyRequired": "Een tagsleutel (1-100 tekens) is vereist",
     "fxFieldsIncomplete": "originalAmount en originalCurrencyCode moeten samen worden opgegeven",
     "fxRateRequired": "Een positieve wisselkoers is vereist voor een transactie in vreemde valuta",
     "fxSignMismatch": "originalAmount en amount moeten hetzelfde teken hebben",
@@ -539,5 +542,8 @@
     "signalNotFound": "Strategiesignaal niet gevonden",
     "signalStrategyMismatch": "Dat signaal hoort bij een andere strategie.",
     "strategyNotFound": "Strategie niet gevonden"
+  },
+  "maintenance": {
+    "inProgress": "Een andere bewerking vervangt momenteel de gegevens van dit account. Wacht tot deze klaar is en probeer het opnieuw."
   }
 }

--- a/backend/src/i18n/locales/pl/errors.json
+++ b/backend/src/i18n/locales/pl/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "E-mail nie jest skonfigurowany. Dostępu awaryjnego nie można włączyć, dopóki nie skonfigurujesz SMTP.",
     "encryptionNotConfigured": "Klucz szyfrowania nie jest skonfigurowany. Dowolna wiadomość nie może być bezpiecznie przechowywana, dopóki nie ustawisz AI_ENCRYPTION_KEY.",
+    "encryptionRequiredToEnable": "Szyfrowanie poświadczeń nie jest skonfigurowane. Dostępu awaryjnego nie można włączyć, dopóki nie ustawisz AI_ENCRYPTION_KEY, ponieważ przyznanie dostępu musi bezpiecznie przechowywać link dostępowy każdego kontaktu.",
     "contactEmailExists": "Kontakt awaryjny z tym adresem e-mail już istnieje.",
     "contactNotFound": "Nie znaleziono kontaktu",
     "notConfigured": "Dostęp awaryjny nie jest skonfigurowany",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "Konto źródłowe i docelowe muszą być różne",
     "requiresBrokerageAccount": "Zaplanowane transakcje inwestycyjne wymagają konta maklerskiego",
     "notFound": "Nie znaleziono zaplanowanej transakcji o ID {{ id }}",
+    "occurrenceAlreadyPosted": "Ta rata została już zaksięgowana.",
+    "fxPlainOnly": "Innej waluty można użyć tylko w zwykłej zaplanowanej transakcji, a nie w podziale, przelewie ani inwestycji",
+    "fxRateUnavailable": "Dla {{ date }} nie ma dostępnego kursu wymiany z {{ from }} na {{ to }}. Wprowadź kwotę w {{ to }}, aby ją zaksięgować.",
     "investmentActionRequired": "Operacja inwestycyjna jest wymagana dla zaplanowanych transakcji inwestycyjnych",
     "actionRequiresSecurity": "Operacja {{ action }} wymaga papieru wartościowego",
     "actionRequiresPositiveQuantity": "Operacja {{ action }} wymaga dodatniej ilości",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "Kwota jest wymagana przy tworzeniu nadpisania podziału",
     "overrideNotFound": "Nie znaleziono nadpisania o ID {{ overrideId }}",
     "updateSplitOverrideRequiresAmount": "Kwota jest wymagana dla nadpisania podziału",
-    "dateMustBeYMD": "date musi być w formacie YYYY-MM-DD",
-    "fxPlainOnly": "Innej waluty można użyć tylko w zwykłej zaplanowanej transakcji, a nie w podziale, przelewie ani inwestycji",
-    "fxRateUnavailable": "Dla {{ date }} nie ma dostępnego kursu wymiany z {{ from }} na {{ to }}. Wprowadź kwotę w {{ to }}, aby ją zaksięgować."
+    "dateMustBeYMD": "date musi być w formacie YYYY-MM-DD"
   },
   "securities": {
     "exchangeRateUnavailable": "Nie można ustalić kursu wymiany dla {{ from }} -> {{ to }} na dzień transakcji. Podaj jawny exchangeRate, aby księgowanie na koncie gotówkowym było poprawne.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId musi być prawidłowym UUID",
     "amountFromMustBeNumber": "amountFrom musi być liczbą",
     "amountToMustBeNumber": "amountTo musi być liczbą",
+    "tagKeyTooLong": "tagKey nie może przekraczać 100 znaków",
+    "invalidTagKeyOp": "Nieprawidłowy tagKeyOp: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue jest wymagany dla contains / notContains",
+    "tagKeyRequired": "Wymagany jest klucz tagu (1–100 znaków)",
     "invalidGroupBy": "groupBy musi mieć wartość 'category' lub 'payee'",
     "limitMustBePositive": "limit musi być liczbą dodatnią",
     "recurringPayeeRequired": "payeeIds jest wymagane",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance musi być liczbą",
     "categoryNotFound": "Nie znaleziono kategorii",
     "categoriesNotFound": "Nie znaleziono kategorii: {{ ids }}",
+    "crossOwnerTransferLocked": "Druga strona tego przelewu znajduje się na koncie, do którego nie masz już dostępu. Możesz edytować szczegóły tej transakcji, ale jej kwota, data i konta są zablokowane.",
+    "crossOwnerAccountMoveLocked": "Ten przelew dotyczy konta innego użytkownika, więc nie można go przenieść na inne konta.",
+    "cannotEditTransfer": "Przelewów nie można tutaj edytować. Edytuj przelew na ekranie Transakcje.",
+    "cannotEditSplit": "Transakcji podzielonych nie można tutaj edytować. Edytuj podział na ekranie Transakcje.",
+    "noUpdateFields": "Podaj co najmniej jedno pole do zmiany.",
     "investmentSplitRequiresPayload": "Podział inwestycyjny wymaga danych inwestycji",
     "investmentActionNotAllowedInSplit": "Operacja inwestycyjna {{ action }} nie jest dozwolona wewnątrz transakcji podzielonej",
     "investmentSplitCannotSetCategoryOrTransfer": "Podziały inwestycyjne nie mogą jednocześnie ustawiać categoryId ani transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Niektórych transakcji nie znaleziono lub nie należą do wskazanego konta",
     "cannotReconcileVoidPlural": "Nie można uzgodnić anulowanych transakcji",
     "transferSameAccount": "Konto źródłowe i docelowe muszą być różne",
+    "transferChangedConcurrently": "Ten przelew został zmieniony przez inne żądanie. Odśwież i spróbuj ponownie.",
     "transferAmountNegative": "Kwota przelewu nie może być ujemna",
     "notATransfer": "Transakcja nie jest przelewem",
     "splitTransferLegAccountLocked": "Ten przelew jest częścią transakcji podzielonej. Aby zmienić jego konta, edytuj podział w transakcji źródłowej.",
     "notFoundById": "Nie znaleziono transakcji o ID {{ id }}",
     "bulkUpdateNoFields": "Należy podać co najmniej jedno pole do aktualizacji",
     "payeeNotFound": "Nie znaleziono odbiorcy",
-    "crossOwnerTransferLocked": "Druga strona tego przelewu znajduje się na koncie, do którego nie masz już dostępu. Możesz edytować szczegóły tej transakcji, ale jej kwota, data i konta są zablokowane.",
-    "crossOwnerAccountMoveLocked": "Ten przelew dotyczy konta innego użytkownika, więc nie można go przenieść na inne konta.",
-    "cannotEditTransfer": "Przelewów nie można tutaj edytować. Edytuj przelew na ekranie Transakcje.",
-    "cannotEditSplit": "Transakcji podzielonych nie można tutaj edytować. Edytuj podział na ekranie Transakcje.",
-    "noUpdateFields": "Podaj co najmniej jedno pole do zmiany.",
-    "tagKeyTooLong": "tagKey nie może przekraczać 100 znaków",
-    "invalidTagKeyOp": "Nieprawidłowy tagKeyOp: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue jest wymagany dla contains / notContains",
-    "tagKeyRequired": "Wymagany jest klucz tagu (1–100 znaków)",
     "fxFieldsIncomplete": "originalAmount i originalCurrencyCode muszą być podane razem",
     "fxRateRequired": "Do transakcji w obcej walucie wymagany jest dodatni kurs wymiany",
     "fxSignMismatch": "originalAmount i amount muszą mieć ten sam znak",
@@ -539,5 +542,8 @@
     "signalNotFound": "Nie znaleziono sygnału strategii",
     "signalStrategyMismatch": "Ten sygnał należy do innej strategii.",
     "strategyNotFound": "Nie znaleziono strategii"
+  },
+  "maintenance": {
+    "inProgress": "Inna operacja wlasnie zamienia dane tego konta. Poczekaj na jej zakonczenie i sprobuj ponownie."
   }
 }

--- a/backend/src/i18n/locales/pt-BR/errors.json
+++ b/backend/src/i18n/locales/pt-BR/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "O e-mail não está configurado. O acesso de emergência não pode ser ativado até que o SMTP seja configurado.",
     "encryptionNotConfigured": "A chave de criptografia não está configurada. A mensagem de texto livre não pode ser armazenada de forma segura até que AI_ENCRYPTION_KEY seja definida.",
+    "encryptionRequiredToEnable": "A criptografia de credenciais não está configurada. O acesso de emergência não pode ser ativado até que AI_ENCRYPTION_KEY seja definida, porque uma concessão precisa armazenar com segurança o link de acesso de cada contato.",
     "contactEmailExists": "Já existe um contato de emergência com este e-mail.",
     "contactNotFound": "Contato não encontrado",
     "notConfigured": "Acesso de emergência não configurado",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "As contas de origem e destino devem ser diferentes",
     "requiresBrokerageAccount": "As transações de investimento agendadas requerem uma conta de corretagem",
     "notFound": "Transação agendada com ID {{ id }} não encontrada",
+    "occurrenceAlreadyPosted": "Esta ocorrência já foi lançada.",
+    "fxPlainOnly": "Só é possível usar outra moeda em uma transação agendada simples, não em uma divisão, transferência ou investimento",
+    "fxRateUnavailable": "Não há uma taxa de câmbio disponível de {{ from }} para {{ to }} em {{ date }}. Insira o valor em {{ to }} para lançá-la.",
     "investmentActionRequired": "A ação de investimento é obrigatória para transações de investimento agendadas",
     "actionRequiresSecurity": "A ação {{ action }} requer um título",
     "actionRequiresPositiveQuantity": "A ação {{ action }} requer uma quantidade positiva",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "O valor é obrigatório ao criar uma substituição de divisão",
     "overrideNotFound": "Substituição com ID {{ overrideId }} não encontrada",
     "updateSplitOverrideRequiresAmount": "O valor é obrigatório para substituição de divisão",
-    "dateMustBeYMD": "date deve estar no formato YYYY-MM-DD",
-    "fxPlainOnly": "Só é possível usar outra moeda em uma transação agendada simples, não em uma divisão, transferência ou investimento",
-    "fxRateUnavailable": "Não há uma taxa de câmbio disponível de {{ from }} para {{ to }} em {{ date }}. Insira o valor em {{ to }} para lançá-la."
+    "dateMustBeYMD": "date deve estar no formato YYYY-MM-DD"
   },
   "securities": {
     "exchangeRateUnavailable": "Não foi possível determinar uma taxa de câmbio para {{ from }} -> {{ to }} na data da transação. Informe um exchangeRate explícito para que o lançamento na conta de caixa fique correto.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId deve ser um UUID válido",
     "amountFromMustBeNumber": "amountFrom deve ser um número",
     "amountToMustBeNumber": "amountTo deve ser um número",
+    "tagKeyTooLong": "tagKey não deve exceder 100 caracteres",
+    "invalidTagKeyOp": "tagKeyOp inválido: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue é obrigatório para contains / notContains",
+    "tagKeyRequired": "É necessária uma chave de tag (1-100 caracteres)",
     "invalidGroupBy": "groupBy deve ser 'category' ou 'payee'",
     "limitMustBePositive": "limit deve ser um número positivo",
     "recurringPayeeRequired": "payeeIds é obrigatório",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance deve ser um número",
     "categoryNotFound": "Categoria não encontrada",
     "categoriesNotFound": "Categorias não encontradas: {{ ids }}",
+    "crossOwnerTransferLocked": "O outro lado desta transferência está em uma conta à qual você não tem mais acesso. Você pode editar os detalhes desta transação, mas o valor, a data e as contas estão bloqueados.",
+    "crossOwnerAccountMoveLocked": "Esta transferência envolve a conta de outro usuário, portanto não pode ser movida para outras contas.",
+    "cannotEditTransfer": "As transferências não podem ser editadas aqui. Edite a transferência na tela Transações.",
+    "cannotEditSplit": "As transações divididas não podem ser editadas aqui. Edite a divisão na tela Transações.",
+    "noUpdateFields": "Informe pelo menos um campo para alterar.",
     "investmentSplitRequiresPayload": "A divisão de investimento requer um payload de investimento",
     "investmentActionNotAllowedInSplit": "A ação de investimento {{ action }} não é permitida dentro de uma transação dividida",
     "investmentSplitCannotSetCategoryOrTransfer": "As divisões de investimento não podem também definir categoryId ou transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Algumas transações não foram encontradas ou não pertencem à conta especificada",
     "cannotReconcileVoidPlural": "Não é possível reconciliar transações anuladas",
     "transferSameAccount": "As contas de origem e destino devem ser diferentes",
+    "transferChangedConcurrently": "Esta transferência foi alterada por outra solicitação. Recarregue e tente novamente.",
     "transferAmountNegative": "O valor da transferência não deve ser negativo",
     "notATransfer": "A transação não é uma transferência",
     "splitTransferLegAccountLocked": "Esta transferência faz parte de uma transação dividida. Para alterar as contas, edite a divisão na transação de origem.",
     "notFoundById": "Transação com ID {{ id }} não encontrada",
     "bulkUpdateNoFields": "Deve ser fornecido pelo menos um campo de atualização",
     "payeeNotFound": "Beneficiário não encontrado",
-    "crossOwnerTransferLocked": "O outro lado desta transferência está em uma conta à qual você não tem mais acesso. Você pode editar os detalhes desta transação, mas o valor, a data e as contas estão bloqueados.",
-    "crossOwnerAccountMoveLocked": "Esta transferência envolve a conta de outro usuário, portanto não pode ser movida para outras contas.",
-    "cannotEditTransfer": "As transferências não podem ser editadas aqui. Edite a transferência na tela Transações.",
-    "cannotEditSplit": "As transações divididas não podem ser editadas aqui. Edite a divisão na tela Transações.",
-    "noUpdateFields": "Informe pelo menos um campo para alterar.",
-    "tagKeyTooLong": "tagKey não deve exceder 100 caracteres",
-    "invalidTagKeyOp": "tagKeyOp inválido: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue é obrigatório para contains / notContains",
-    "tagKeyRequired": "É necessária uma chave de tag (1-100 caracteres)",
     "fxFieldsIncomplete": "originalAmount e originalCurrencyCode devem ser fornecidos juntos",
     "fxRateRequired": "É necessária uma taxa de câmbio positiva para uma transação em moeda estrangeira",
     "fxSignMismatch": "originalAmount e amount devem ter o mesmo sinal",
@@ -539,5 +542,8 @@
     "signalNotFound": "Sinal da estratégia não encontrado",
     "signalStrategyMismatch": "Esse sinal pertence a outra estratégia.",
     "strategyNotFound": "Estratégia não encontrada"
+  },
+  "maintenance": {
+    "inProgress": "Outra operacao esta substituindo os dados desta conta. Aguarde a conclusao e tente novamente."
   }
 }

--- a/backend/src/i18n/locales/pt/errors.json
+++ b/backend/src/i18n/locales/pt/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "O e-mail não está configurado. O acesso de emergência não pode ser ativado até que o SMTP seja configurado.",
     "encryptionNotConfigured": "A chave de encriptação não está configurada. A mensagem de texto livre não pode ser armazenada de forma segura até que AI_ENCRYPTION_KEY seja definida.",
+    "encryptionRequiredToEnable": "A encriptação de credenciais não está configurada. O acesso de emergência não pode ser ativado até que AI_ENCRYPTION_KEY seja definida, porque uma concessão tem de armazenar de forma segura a ligação de acesso de cada contacto.",
     "contactEmailExists": "Já existe um contacto de emergência com este e-mail.",
     "contactNotFound": "Contacto não encontrado",
     "notConfigured": "Acesso de emergência não configurado",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "As contas de origem e destino devem ser diferentes",
     "requiresBrokerageAccount": "As transações de investimento agendadas requerem uma conta de corretagem",
     "notFound": "Transação agendada com ID {{ id }} não encontrada",
+    "occurrenceAlreadyPosted": "Esta ocorrência já foi lançada.",
+    "fxPlainOnly": "Só é possível usar outra moeda numa transação agendada simples, não numa divisão, transferência ou investimento",
+    "fxRateUnavailable": "Não há uma taxa de câmbio disponível de {{ from }} para {{ to }} em {{ date }}. Introduza o montante em {{ to }} para a lançar.",
     "investmentActionRequired": "A ação de investimento é obrigatória para transações de investimento agendadas",
     "actionRequiresSecurity": "A ação {{ action }} requer um título",
     "actionRequiresPositiveQuantity": "A ação {{ action }} requer uma quantidade positiva",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "O montante é obrigatório ao criar uma substituição de parcela",
     "overrideNotFound": "Substituição com ID {{ overrideId }} não encontrada",
     "updateSplitOverrideRequiresAmount": "O montante é obrigatório para substituição de parcela",
-    "dateMustBeYMD": "date deve estar no formato YYYY-MM-DD",
-    "fxPlainOnly": "Só é possível usar outra moeda numa transação agendada simples, não numa divisão, transferência ou investimento",
-    "fxRateUnavailable": "Não há uma taxa de câmbio disponível de {{ from }} para {{ to }} em {{ date }}. Introduza o montante em {{ to }} para a lançar."
+    "dateMustBeYMD": "date deve estar no formato YYYY-MM-DD"
   },
   "securities": {
     "exchangeRateUnavailable": "Não foi possível determinar uma taxa de câmbio para {{ from }} -> {{ to }} na data da transação. Forneça um exchangeRate explícito para que o lançamento na conta de caixa fique correto.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId deve ser um UUID válido",
     "amountFromMustBeNumber": "amountFrom deve ser um número",
     "amountToMustBeNumber": "amountTo deve ser um número",
+    "tagKeyTooLong": "tagKey não deve exceder 100 caracteres",
+    "invalidTagKeyOp": "tagKeyOp inválido: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue é obrigatório para contains / notContains",
+    "tagKeyRequired": "É necessária uma chave de etiqueta (1-100 caracteres)",
     "invalidGroupBy": "groupBy deve ser 'category' ou 'payee'",
     "limitMustBePositive": "limit deve ser um número positivo",
     "recurringPayeeRequired": "payeeIds é obrigatório",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance deve ser um número",
     "categoryNotFound": "Categoria não encontrada",
     "categoriesNotFound": "Categorias não encontradas: {{ ids }}",
+    "crossOwnerTransferLocked": "O outro lado desta transferência está numa conta à qual já não tem acesso. Pode editar os detalhes desta transação, mas o montante, a data e as contas estão bloqueados.",
+    "crossOwnerAccountMoveLocked": "Esta transferência envolve a conta de outro utilizador, pelo que não pode ser movida para outras contas.",
+    "cannotEditTransfer": "As transferências não podem ser editadas aqui. Edite a transferência no ecrã Transações.",
+    "cannotEditSplit": "As transações divididas não podem ser editadas aqui. Edite a divisão no ecrã Transações.",
+    "noUpdateFields": "Indique pelo menos um campo para alterar.",
     "investmentSplitRequiresPayload": "A parcela de investimento requer um payload de investimento",
     "investmentActionNotAllowedInSplit": "A ação de investimento {{ action }} não é permitida dentro de uma transação dividida",
     "investmentSplitCannotSetCategoryOrTransfer": "As parcelas de investimento não podem também definir categoryId ou transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Algumas transações não foram encontradas ou não pertencem à conta especificada",
     "cannotReconcileVoidPlural": "Não é possível reconciliar transações anuladas",
     "transferSameAccount": "As contas de origem e destino devem ser diferentes",
+    "transferChangedConcurrently": "Esta transferência foi alterada por outro pedido. Recarregue e tente novamente.",
     "transferAmountNegative": "O montante da transferência não deve ser negativo",
     "notATransfer": "A transação não é uma transferência",
     "splitTransferLegAccountLocked": "Esta transferência faz parte de uma transação dividida. Para alterar as contas, edite a parcela na transação de origem.",
     "notFoundById": "Transação com ID {{ id }} não encontrada",
     "bulkUpdateNoFields": "Deve ser fornecido pelo menos um campo de atualização",
     "payeeNotFound": "Beneficiário não encontrado",
-    "crossOwnerTransferLocked": "O outro lado desta transferência está numa conta à qual já não tem acesso. Pode editar os detalhes desta transação, mas o montante, a data e as contas estão bloqueados.",
-    "crossOwnerAccountMoveLocked": "Esta transferência envolve a conta de outro utilizador, pelo que não pode ser movida para outras contas.",
-    "cannotEditTransfer": "As transferências não podem ser editadas aqui. Edite a transferência no ecrã Transações.",
-    "cannotEditSplit": "As transações divididas não podem ser editadas aqui. Edite a divisão no ecrã Transações.",
-    "noUpdateFields": "Indique pelo menos um campo para alterar.",
-    "tagKeyTooLong": "tagKey não deve exceder 100 caracteres",
-    "invalidTagKeyOp": "tagKeyOp inválido: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue é obrigatório para contains / notContains",
-    "tagKeyRequired": "É necessária uma chave de etiqueta (1-100 caracteres)",
     "fxFieldsIncomplete": "originalAmount e originalCurrencyCode devem ser fornecidos em conjunto",
     "fxRateRequired": "É necessária uma taxa de câmbio positiva para uma transação em moeda estrangeira",
     "fxSignMismatch": "originalAmount e amount devem ter o mesmo sinal",
@@ -539,5 +542,8 @@
     "signalNotFound": "Sinal da estratégia não encontrado",
     "signalStrategyMismatch": "Esse sinal pertence a outra estratégia.",
     "strategyNotFound": "Estratégia não encontrada"
+  },
+  "maintenance": {
+    "inProgress": "Outra operacao esta a substituir os dados desta conta. Aguarde que termine e tente novamente."
   }
 }

--- a/backend/src/i18n/locales/ru/errors.json
+++ b/backend/src/i18n/locales/ru/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "Электронная почта не настроена. Экстренный доступ нельзя включить, пока не настроен SMTP.",
     "encryptionNotConfigured": "Ключ шифрования не настроен. Свободное сообщение не может быть безопасно сохранено, пока не задан AI_ENCRYPTION_KEY.",
+    "encryptionRequiredToEnable": "Шифрование учётных данных не настроено. Экстренный доступ нельзя включить, пока не задан AI_ENCRYPTION_KEY, потому что при предоставлении доступа ссылка доступа каждого контакта должна храниться в защищённом виде.",
     "contactEmailExists": "Контакт для экстренного доступа с таким email уже существует.",
     "contactNotFound": "Контакт не найден",
     "notConfigured": "Экстренный доступ не настроен",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "Исходный и целевой счета должны быть разными",
     "requiresBrokerageAccount": "Плановые инвестиционные проводки требуют брокерский счёт",
     "notFound": "Плановая проводка с ID {{ id }} не найдена",
+    "occurrenceAlreadyPosted": "Это событие уже проведено.",
+    "fxPlainOnly": "Другую валюту можно использовать только в обычной плановой проводке, но не в разделении, переводе или инвестиционной",
+    "fxRateUnavailable": "На {{ date }} курс обмена {{ from }} в {{ to }} недоступен. Введите сумму в {{ to }}, чтобы провести её.",
     "investmentActionRequired": "Для плановых инвестиционных проводок необходимо инвестиционное действие",
     "actionRequiresSecurity": "Действие {{ action }} требует ценную бумагу",
     "actionRequiresPositiveQuantity": "Действие {{ action }} требует положительное количество",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "При создании переопределения разделения необходима сумма",
     "overrideNotFound": "Переопределение с ID {{ overrideId }} не найдено",
     "updateSplitOverrideRequiresAmount": "Для переопределения разделения необходима сумма",
-    "dateMustBeYMD": "дата должна быть в формате ГГГГ-ММ-ДД",
-    "fxPlainOnly": "Другую валюту можно использовать только в обычной плановой проводке, но не в разделении, переводе или инвестиционной",
-    "fxRateUnavailable": "На {{ date }} курс обмена {{ from }} в {{ to }} недоступен. Введите сумму в {{ to }}, чтобы провести её."
+    "dateMustBeYMD": "дата должна быть в формате ГГГГ-ММ-ДД"
   },
   "securities": {
     "exchangeRateUnavailable": "Не удалось определить обменный курс для {{ from }} -> {{ to }} на дату транзакции. Укажите явный exchangeRate, чтобы проводка по денежному счёту была корректной.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId должен быть действительным UUID",
     "amountFromMustBeNumber": "amountFrom должен быть числом",
     "amountToMustBeNumber": "amountTo должен быть числом",
+    "tagKeyTooLong": "tagKey не должен превышать 100 символов",
+    "invalidTagKeyOp": "Недопустимый tagKeyOp: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue обязателен для contains / notContains",
+    "tagKeyRequired": "Требуется ключ тега (1–100 символов)",
     "invalidGroupBy": "groupBy должен быть 'category' или 'payee'",
     "limitMustBePositive": "limit должен быть положительным числом",
     "recurringPayeeRequired": "payeeIds обязателен",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance должен быть числом",
     "categoryNotFound": "Категория не найдена",
     "categoriesNotFound": "Категории не найдены: {{ ids }}",
+    "crossOwnerTransferLocked": "Вторая сторона этого перевода находится на счёте, к которому у вас больше нет доступа. Вы можете редактировать детали этой транзакции, но её сумма, дата и счета заблокированы.",
+    "crossOwnerAccountMoveLocked": "Этот перевод затрагивает счёт другого пользователя, поэтому его нельзя перенести на другие счета.",
+    "cannotEditTransfer": "Переводы нельзя редактировать здесь. Измените перевод на экране «Транзакции».",
+    "cannotEditSplit": "Разделённые транзакции нельзя редактировать здесь. Измените разделение на экране «Транзакции».",
+    "noUpdateFields": "Укажите хотя бы одно поле для изменения.",
     "investmentSplitRequiresPayload": "Инвестиционное разделение требует инвестиционные данные",
     "investmentActionNotAllowedInSplit": "Инвестиционное действие {{ action }} не разрешено внутри разделённой проводки",
     "investmentSplitCannotSetCategoryOrTransfer": "Инвестиционные разделения не могут также устанавливать categoryId или transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Некоторые проводки не найдены или не принадлежат указанному счёту",
     "cannotReconcileVoidPlural": "Невозможно согласовать аннулированные проводки",
     "transferSameAccount": "Исходный и целевой счета должны быть разными",
+    "transferChangedConcurrently": "Этот перевод изменён другим запросом. Обновите его и попробуйте снова.",
     "transferAmountNegative": "Сумма перевода не должна быть отрицательной",
     "notATransfer": "Проводка не является переводом",
     "splitTransferLegAccountLocked": "Этот перевод является частью разделённой проводки. Чтобы изменить его счета, отредактируйте часть в исходной проводке.",
     "notFoundById": "Проводка с ID {{ id }} не найдена",
     "bulkUpdateNoFields": "Должно быть указано хотя бы одно поле для обновления",
     "payeeNotFound": "Получатель не найден",
-    "crossOwnerTransferLocked": "Вторая сторона этого перевода находится на счёте, к которому у вас больше нет доступа. Вы можете редактировать детали этой транзакции, но её сумма, дата и счета заблокированы.",
-    "crossOwnerAccountMoveLocked": "Этот перевод затрагивает счёт другого пользователя, поэтому его нельзя перенести на другие счета.",
-    "cannotEditTransfer": "Переводы нельзя редактировать здесь. Измените перевод на экране «Транзакции».",
-    "cannotEditSplit": "Разделённые транзакции нельзя редактировать здесь. Измените разделение на экране «Транзакции».",
-    "noUpdateFields": "Укажите хотя бы одно поле для изменения.",
-    "tagKeyTooLong": "tagKey не должен превышать 100 символов",
-    "invalidTagKeyOp": "Недопустимый tagKeyOp: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue обязателен для contains / notContains",
-    "tagKeyRequired": "Требуется ключ тега (1–100 символов)",
     "fxFieldsIncomplete": "originalAmount и originalCurrencyCode должны указываться вместе",
     "fxRateRequired": "Для операции в иностранной валюте требуется положительный курс обмена",
     "fxSignMismatch": "originalAmount и amount должны иметь одинаковый знак",
@@ -539,5 +542,8 @@
     "signalNotFound": "Сигнал стратегии не найден",
     "signalStrategyMismatch": "Этот сигнал относится к другой стратегии.",
     "strategyNotFound": "Стратегия не найдена"
+  },
+  "maintenance": {
+    "inProgress": "Другая операция сейчас заменяет данные этой учётной записи. Дождитесь её завершения и попробуйте снова."
   }
 }

--- a/backend/src/i18n/locales/tr/errors.json
+++ b/backend/src/i18n/locales/tr/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "E-posta yapılandırılmamış. SMTP kurulana kadar acil erişim etkinleştirilemiyor.",
     "encryptionNotConfigured": "Şifreleme anahtarı yapılandırılmamış. AI_ENCRYPTION_KEY ayarlanana kadar serbest biçimli mesaj güvenli şekilde saklanamıyor.",
+    "encryptionRequiredToEnable": "Kimlik bilgisi şifrelemesi yapılandırılmamış. Bir erişim verme işlemi her kişinin erişim bağlantısını güvenli şekilde saklamak zorunda olduğundan, AI_ENCRYPTION_KEY ayarlanana kadar acil erişim etkinleştirilemiyor.",
     "contactEmailExists": "Bu e-postaya sahip acil durum kişisi zaten mevcut.",
     "contactNotFound": "Kişi bulunamadı",
     "notConfigured": "Acil erişim yapılandırılmamış",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "Kaynak ve hedef hesaplar farklı olmalıdır",
     "requiresBrokerageAccount": "Zamanlanmış yatırım işlemleri için aracı kurum hesabı gereklidir",
     "notFound": "{{ id }} kimliğine sahip zamanlanmış işlem bulunamadı",
+    "occurrenceAlreadyPosted": "Bu tekrar zaten kaydedildi.",
+    "fxPlainOnly": "Farklı bir para birimi yalnızca sade bir zamanlanmış işlemde kullanılabilir; bölünmüş işlem, transfer veya yatırımda kullanılamaz",
+    "fxRateUnavailable": "{{ date }} tarihinde {{ from }} biriminden {{ to }} birimine döviz kuru yok. Kaydetmek için tutarı {{ to }} cinsinden girin.",
     "investmentActionRequired": "Zamanlanmış yatırım işlemleri için yatırım eylemi gereklidir",
     "actionRequiresSecurity": "{{ action }} eylemi için menkul kıymet gereklidir",
     "actionRequiresPositiveQuantity": "{{ action }} eylemi için pozitif miktar gereklidir",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "Bölünmüş geçersiz kılma oluştururken tutar gereklidir",
     "overrideNotFound": "{{ overrideId }} kimliğine sahip geçersiz kılma bulunamadı",
     "updateSplitOverrideRequiresAmount": "Bölünmüş geçersiz kılma için tutar gereklidir",
-    "dateMustBeYMD": "tarih YYYY-AA-GG biçiminde olmalıdır",
-    "fxPlainOnly": "Farklı bir para birimi yalnızca sade bir zamanlanmış işlemde kullanılabilir; bölünmüş işlem, transfer veya yatırımda kullanılamaz",
-    "fxRateUnavailable": "{{ date }} tarihinde {{ from }} biriminden {{ to }} birimine döviz kuru yok. Kaydetmek için tutarı {{ to }} cinsinden girin."
+    "dateMustBeYMD": "tarih YYYY-AA-GG biçiminde olmalıdır"
   },
   "securities": {
     "exchangeRateUnavailable": "İşlem tarihinde {{ from }} -> {{ to }} için bir döviz kuru belirlenemedi. Nakit hesabına kaydın doğru olması için açık bir exchangeRate girin.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId geçerli bir UUID olmalıdır",
     "amountFromMustBeNumber": "amountFrom bir sayı olmalıdır",
     "amountToMustBeNumber": "amountTo bir sayı olmalıdır",
+    "tagKeyTooLong": "tagKey 100 karakteri aşmamalıdır",
+    "invalidTagKeyOp": "Geçersiz tagKeyOp: {{ op }}",
+    "tagKeyValueRequired": "contains / notContains için tagKeyValue gereklidir",
+    "tagKeyRequired": "Bir etiket anahtarı (1-100 karakter) gereklidir",
     "invalidGroupBy": "groupBy 'category' veya 'payee' olmalıdır",
     "limitMustBePositive": "limit pozitif bir sayı olmalıdır",
     "recurringPayeeRequired": "payeeIds zorunludur",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance bir sayı olmalıdır",
     "categoryNotFound": "Kategori bulunamadı",
     "categoriesNotFound": "Kategoriler bulunamadı: {{ ids }}",
+    "crossOwnerTransferLocked": "Bu transferin diğer tarafı artık erişiminiz olmayan bir hesapta. Bu işlemin kendi ayrıntılarını düzenleyebilirsiniz, ancak tutarı, tarihi ve hesapları kilitlidir.",
+    "crossOwnerAccountMoveLocked": "Bu transfer başka bir kullanıcının hesabını içerdiğinden farklı hesaplara taşınamaz.",
+    "cannotEditTransfer": "Transferler burada düzenlenemez. Transferi İşlemler ekranından düzenleyin.",
+    "cannotEditSplit": "Bölünmüş işlemler burada düzenlenemez. Bölmeyi İşlemler ekranından düzenleyin.",
+    "noUpdateFields": "Değiştirmek için en az bir alan girin.",
     "investmentSplitRequiresPayload": "Yatırım bölümü için yatırım yükü gereklidir",
     "investmentActionNotAllowedInSplit": "{{ action }} yatırım eylemi bölünmüş işlem içinde kullanılamaz",
     "investmentSplitCannotSetCategoryOrTransfer": "Yatırım bölümleri aynı zamanda categoryId veya transferAccountId ayarlayamaz",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Bazı işlemler bulunamadı veya belirtilen hesaba ait değil",
     "cannotReconcileVoidPlural": "Geçersiz işlemler için mutabakat sağlanamaz",
     "transferSameAccount": "Kaynak ve hedef hesaplar farklı olmalıdır",
+    "transferChangedConcurrently": "Bu transfer başka bir istek tarafından değiştirildi. Yeniden yükleyip tekrar deneyin.",
     "transferAmountNegative": "Transfer tutarı negatif olmamalıdır",
     "notATransfer": "İşlem bir transfer değil",
     "splitTransferLegAccountLocked": "Bu transfer, bölünmüş bir işlemin parçasıdır. Hesaplarını değiştirmek için kaynak işlemdeki bölümü düzenleyin.",
     "notFoundById": "{{ id }} kimliğine sahip işlem bulunamadı",
     "bulkUpdateNoFields": "En az bir güncelleme alanı sağlanmalıdır",
     "payeeNotFound": "Alacaklı bulunamadı",
-    "crossOwnerTransferLocked": "Bu transferin diğer tarafı artık erişiminiz olmayan bir hesapta. Bu işlemin kendi ayrıntılarını düzenleyebilirsiniz, ancak tutarı, tarihi ve hesapları kilitlidir.",
-    "crossOwnerAccountMoveLocked": "Bu transfer başka bir kullanıcının hesabını içerdiğinden farklı hesaplara taşınamaz.",
-    "cannotEditTransfer": "Transferler burada düzenlenemez. Transferi İşlemler ekranından düzenleyin.",
-    "cannotEditSplit": "Bölünmüş işlemler burada düzenlenemez. Bölmeyi İşlemler ekranından düzenleyin.",
-    "noUpdateFields": "Değiştirmek için en az bir alan girin.",
-    "tagKeyTooLong": "tagKey 100 karakteri aşmamalıdır",
-    "invalidTagKeyOp": "Geçersiz tagKeyOp: {{ op }}",
-    "tagKeyValueRequired": "contains / notContains için tagKeyValue gereklidir",
-    "tagKeyRequired": "Bir etiket anahtarı (1-100 karakter) gereklidir",
     "fxFieldsIncomplete": "originalAmount ve originalCurrencyCode birlikte sağlanmalıdır",
     "fxRateRequired": "Yabancı para birimi işlemi için pozitif bir döviz kuru gereklidir",
     "fxSignMismatch": "originalAmount ve amount aynı işarete sahip olmalıdır",
@@ -539,5 +542,8 @@
     "signalNotFound": "Strateji sinyali bulunamadı",
     "signalStrategyMismatch": "Bu sinyal başka bir stratejiye ait.",
     "strategyNotFound": "Strateji bulunamadı"
+  },
+  "maintenance": {
+    "inProgress": "Baska bir islem su anda bu hesabin verilerini degistiriyor. Tamamlanmasini bekleyip yeniden deneyin."
   }
 }

--- a/backend/src/i18n/locales/uk/errors.json
+++ b/backend/src/i18n/locales/uk/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "Електронну пошту не налаштовано. Екстрений доступ не можна увімкнути до налаштування SMTP.",
     "encryptionNotConfigured": "Ключ шифрування не налаштовано. Вільний текстовий повідомлення не можна безпечно зберегти до встановлення AI_ENCRYPTION_KEY.",
+    "encryptionRequiredToEnable": "Шифрування облікових даних не налаштовано. Екстрений доступ не можна увімкнути, доки не встановлено AI_ENCRYPTION_KEY, адже під час надання доступу посилання доступу кожного контакту має зберігатися захищено.",
     "contactEmailExists": "Екстрений контакт із цією електронною адресою вже існує.",
     "contactNotFound": "Контакт не знайдено",
     "notConfigured": "Екстрений доступ не налаштовано",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "Рахунки-джерело та призначення мають бути різними",
     "requiresBrokerageAccount": "Заплановані інвестиційні операції вимагають брокерського рахунку",
     "notFound": "Заплановану операцію з ідентифікатором {{ id }} не знайдено",
+    "occurrenceAlreadyPosted": "Цю подію вже проведено.",
+    "fxPlainOnly": "Іншу валюту можна використати лише у звичайній запланованій операції, але не в розбитті, переказі чи інвестиції",
+    "fxRateUnavailable": "На {{ date }} курс обміну {{ from }} на {{ to }} недоступний. Введіть суму в {{ to }}, щоб провести її.",
     "investmentActionRequired": "Для запланованих інвестиційних операцій необхідна інвестиційна дія",
     "actionRequiresSecurity": "Дія {{ action }} вимагає цінного паперу",
     "actionRequiresPositiveQuantity": "Дія {{ action }} вимагає позитивної кількості",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "Для створення заміни розбиття необхідна сума",
     "overrideNotFound": "Заміну з ідентифікатором {{ overrideId }} не знайдено",
     "updateSplitOverrideRequiresAmount": "Для заміни розбиття необхідна сума",
-    "dateMustBeYMD": "Дата має бути у форматі YYYY-MM-DD",
-    "fxPlainOnly": "Іншу валюту можна використати лише у звичайній запланованій операції, але не в розбитті, переказі чи інвестиції",
-    "fxRateUnavailable": "На {{ date }} курс обміну {{ from }} на {{ to }} недоступний. Введіть суму в {{ to }}, щоб провести її."
+    "dateMustBeYMD": "Дата має бути у форматі YYYY-MM-DD"
   },
   "securities": {
     "exchangeRateUnavailable": "Не вдалося визначити обмінний курс для {{ from }} -> {{ to }} на дату транзакції. Вкажіть явний exchangeRate, щоб проведення за грошовим рахунком було коректним.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId має бути дійсним UUID",
     "amountFromMustBeNumber": "amountFrom має бути числом",
     "amountToMustBeNumber": "amountTo має бути числом",
+    "tagKeyTooLong": "tagKey не має перевищувати 100 символів",
+    "invalidTagKeyOp": "Недійсний tagKeyOp: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue обов'язковий для contains / notContains",
+    "tagKeyRequired": "Потрібен ключ тегу (1–100 символів)",
     "invalidGroupBy": "groupBy має бути 'category' або 'payee'",
     "limitMustBePositive": "limit має бути додатним числом",
     "recurringPayeeRequired": "payeeIds є обов'язковим",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance має бути числом",
     "categoryNotFound": "Категорію не знайдено",
     "categoriesNotFound": "Категорії не знайдено: {{ ids }}",
+    "crossOwnerTransferLocked": "Інша сторона цього переказу знаходиться на рахунку, до якого ви більше не маєте доступу. Ви можете редагувати деталі цієї транзакції, але її сума, дата та рахунки заблоковані.",
+    "crossOwnerAccountMoveLocked": "Цей переказ стосується рахунку іншого користувача, тому його не можна перенести на інші рахунки.",
+    "cannotEditTransfer": "Перекази не можна редагувати тут. Відредагуйте переказ на екрані «Транзакції».",
+    "cannotEditSplit": "Розділені транзакції не можна редагувати тут. Відредагуйте розділення на екрані «Транзакції».",
+    "noUpdateFields": "Укажіть принаймні одне поле для зміни.",
     "investmentSplitRequiresPayload": "Інвестиційне розбиття вимагає інвестиційного навантаження",
     "investmentActionNotAllowedInSplit": "Інвестиційна дія {{ action }} не дозволена всередині розбитої операції",
     "investmentSplitCannotSetCategoryOrTransfer": "Інвестиційні розбиття не можуть також встановлювати categoryId або transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Деякі операції не знайдено або вони не належать до зазначеного рахунку",
     "cannotReconcileVoidPlural": "Неможливо узгодити анульовані операції",
     "transferSameAccount": "Рахунки-джерело та призначення мають бути різними",
+    "transferChangedConcurrently": "Цей переказ змінено іншим запитом. Оновіть його та спробуйте ще раз.",
     "transferAmountNegative": "Сума переказу не повинна бути від'ємною",
     "notATransfer": "Операція не є переказом",
     "splitTransferLegAccountLocked": "Цей переказ є частиною розбитої операції. Щоб змінити його рахунки, відредагуйте частину у вихідній операції.",
     "notFoundById": "Операцію з ідентифікатором {{ id }} не знайдено",
     "bulkUpdateNoFields": "Необхідно вказати щонайменше одне поле для оновлення",
     "payeeNotFound": "Одержувача не знайдено",
-    "crossOwnerTransferLocked": "Інша сторона цього переказу знаходиться на рахунку, до якого ви більше не маєте доступу. Ви можете редагувати деталі цієї транзакції, але її сума, дата та рахунки заблоковані.",
-    "crossOwnerAccountMoveLocked": "Цей переказ стосується рахунку іншого користувача, тому його не можна перенести на інші рахунки.",
-    "cannotEditTransfer": "Перекази не можна редагувати тут. Відредагуйте переказ на екрані «Транзакції».",
-    "cannotEditSplit": "Розділені транзакції не можна редагувати тут. Відредагуйте розділення на екрані «Транзакції».",
-    "noUpdateFields": "Укажіть принаймні одне поле для зміни.",
-    "tagKeyTooLong": "tagKey не має перевищувати 100 символів",
-    "invalidTagKeyOp": "Недійсний tagKeyOp: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue обов'язковий для contains / notContains",
-    "tagKeyRequired": "Потрібен ключ тегу (1–100 символів)",
     "fxFieldsIncomplete": "originalAmount і originalCurrencyCode потрібно вказувати разом",
     "fxRateRequired": "Для операції в іноземній валюті потрібен додатний курс обміну",
     "fxSignMismatch": "originalAmount і amount повинні мати однаковий знак",
@@ -539,5 +542,8 @@
     "signalNotFound": "Сигнал стратегії не знайдено",
     "signalStrategyMismatch": "Цей сигнал належить до іншої стратегії.",
     "strategyNotFound": "Стратегію не знайдено"
+  },
+  "maintenance": {
+    "inProgress": "Інша операція зараз замінює дані цього облікового запису. Дочекайтеся її завершення та спробуйте ще раз."
   }
 }

--- a/backend/src/i18n/locales/vi/errors.json
+++ b/backend/src/i18n/locales/vi/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "Email chưa được cấu hình. Không thể bật truy cập khẩn cấp cho đến khi SMTP được thiết lập.",
     "encryptionNotConfigured": "Khóa mã hóa chưa được cấu hình. Tin nhắn văn bản tự do không thể được lưu trữ an toàn cho đến khi AI_ENCRYPTION_KEY được thiết lập.",
+    "encryptionRequiredToEnable": "Mã hóa thông tin xác thực chưa được cấu hình. Không thể bật truy cập khẩn cấp cho đến khi AI_ENCRYPTION_KEY được thiết lập, vì việc cấp quyền phải lưu trữ an toàn liên kết truy cập của từng liên hệ.",
     "contactEmailExists": "Đã có liên hệ khẩn cấp với email này.",
     "contactNotFound": "Không tìm thấy liên hệ",
     "notConfigured": "Quyền truy cập khẩn cấp chưa được cấu hình",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "Tài khoản nguồn và đích phải khác nhau",
     "requiresBrokerageAccount": "Giao tác đầu tư theo lịch yêu cầu tài khoản môi giới",
     "notFound": "Không tìm thấy giao tác theo lịch với ID {{ id }}",
+    "occurrenceAlreadyPosted": "Lần này đã được ghi nhận.",
+    "fxPlainOnly": "Chỉ có thể dùng đơn vị tiền tệ khác trên giao tác theo lịch thông thường, không dùng được cho giao tác chia nhỏ, chuyển tiền hoặc đầu tư",
+    "fxRateUnavailable": "Không có tỷ giá từ {{ from }} sang {{ to }} vào {{ date }}. Hãy nhập số tiền bằng {{ to }} để đăng.",
     "investmentActionRequired": "Hành động đầu tư là bắt buộc cho giao tác đầu tư theo lịch",
     "actionRequiresSecurity": "Hành động {{ action }} yêu cầu chứng khoán",
     "actionRequiresPositiveQuantity": "Hành động {{ action }} yêu cầu số lượng dương",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "Số tiền là bắt buộc khi tạo ghi đè chia nhỏ",
     "overrideNotFound": "Không tìm thấy ghi đè với ID {{ overrideId }}",
     "updateSplitOverrideRequiresAmount": "Số tiền là bắt buộc cho ghi đè chia nhỏ",
-    "dateMustBeYMD": "date phải có định dạng YYYY-MM-DD",
-    "fxPlainOnly": "Chỉ có thể dùng đơn vị tiền tệ khác trên giao tác theo lịch thông thường, không dùng được cho giao tác chia nhỏ, chuyển tiền hoặc đầu tư",
-    "fxRateUnavailable": "Không có tỷ giá từ {{ from }} sang {{ to }} vào {{ date }}. Hãy nhập số tiền bằng {{ to }} để đăng."
+    "dateMustBeYMD": "date phải có định dạng YYYY-MM-DD"
   },
   "securities": {
     "exchangeRateUnavailable": "Không thể xác định tỷ giá hối đoái cho {{ from }} -> {{ to }} vào ngày giao dịch. Hãy cung cấp exchangeRate rõ ràng để bút toán vào tài khoản tiền mặt được chính xác.",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId phải là UUID hợp lệ",
     "amountFromMustBeNumber": "amountFrom phải là số",
     "amountToMustBeNumber": "amountTo phải là số",
+    "tagKeyTooLong": "tagKey không được vượt quá 100 ký tự",
+    "invalidTagKeyOp": "tagKeyOp không hợp lệ: {{ op }}",
+    "tagKeyValueRequired": "tagKeyValue là bắt buộc cho contains / notContains",
+    "tagKeyRequired": "Cần có khóa thẻ (1-100 ký tự)",
     "invalidGroupBy": "groupBy phải là 'category' hoặc 'payee'",
     "limitMustBePositive": "limit phải là số dương",
     "recurringPayeeRequired": "payeeIds là bắt buộc",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance phải là số",
     "categoryNotFound": "Không tìm thấy danh mục",
     "categoriesNotFound": "Không tìm thấy danh mục: {{ ids }}",
+    "crossOwnerTransferLocked": "Phía bên kia của khoản chuyển khoản này nằm trong tài khoản mà bạn không còn quyền truy cập. Bạn có thể chỉnh sửa chi tiết của giao dịch này, nhưng số tiền, ngày và tài khoản đã bị khóa.",
+    "crossOwnerAccountMoveLocked": "Khoản chuyển khoản này liên quan đến tài khoản của người dùng khác nên không thể chuyển sang tài khoản khác.",
+    "cannotEditTransfer": "Không thể chỉnh sửa khoản chuyển khoản tại đây. Hãy chỉnh sửa khoản chuyển khoản từ màn hình Giao dịch.",
+    "cannotEditSplit": "Không thể chỉnh sửa giao dịch chia nhỏ tại đây. Hãy chỉnh sửa phần chia nhỏ từ màn hình Giao dịch.",
+    "noUpdateFields": "Hãy cung cấp ít nhất một trường để thay đổi.",
     "investmentSplitRequiresPayload": "Phần chia đầu tư yêu cầu dữ liệu đầu tư",
     "investmentActionNotAllowedInSplit": "Hành động đầu tư {{ action }} không được phép trong giao tác chia nhỏ",
     "investmentSplitCannotSetCategoryOrTransfer": "Các phần chia đầu tư không thể đồng thời thiết lập categoryId hoặc transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "Một số giao tác không được tìm thấy hoặc không thuộc tài khoản đã chỉ định",
     "cannotReconcileVoidPlural": "Không thể điều hoà các giao tác bị hủy",
     "transferSameAccount": "Tài khoản nguồn và đích phải khác nhau",
+    "transferChangedConcurrently": "Giao dịch chuyển tiền này đã bị một yêu cầu khác thay đổi. Hãy tải lại rồi thử lại.",
     "transferAmountNegative": "Số tiền chuyển không được âm",
     "notATransfer": "Giao tác không phải là chuyển tiền",
     "splitTransferLegAccountLocked": "Chuyển khoản này là một phần của giao tác chia nhỏ. Hãy thay đổi tài khoản bằng cách chỉnh sửa phần chia trên giao tác nguồn.",
     "notFoundById": "Không tìm thấy giao tác với ID {{ id }}",
     "bulkUpdateNoFields": "Phải cung cấp ít nhất một trường cập nhật",
     "payeeNotFound": "Không tìm thấy người nhận",
-    "crossOwnerTransferLocked": "Phía bên kia của khoản chuyển khoản này nằm trong tài khoản mà bạn không còn quyền truy cập. Bạn có thể chỉnh sửa chi tiết của giao dịch này, nhưng số tiền, ngày và tài khoản đã bị khóa.",
-    "crossOwnerAccountMoveLocked": "Khoản chuyển khoản này liên quan đến tài khoản của người dùng khác nên không thể chuyển sang tài khoản khác.",
-    "cannotEditTransfer": "Không thể chỉnh sửa khoản chuyển khoản tại đây. Hãy chỉnh sửa khoản chuyển khoản từ màn hình Giao dịch.",
-    "cannotEditSplit": "Không thể chỉnh sửa giao dịch chia nhỏ tại đây. Hãy chỉnh sửa phần chia nhỏ từ màn hình Giao dịch.",
-    "noUpdateFields": "Hãy cung cấp ít nhất một trường để thay đổi.",
-    "tagKeyTooLong": "tagKey không được vượt quá 100 ký tự",
-    "invalidTagKeyOp": "tagKeyOp không hợp lệ: {{ op }}",
-    "tagKeyValueRequired": "tagKeyValue là bắt buộc cho contains / notContains",
-    "tagKeyRequired": "Cần có khóa thẻ (1-100 ký tự)",
     "fxFieldsIncomplete": "originalAmount và originalCurrencyCode phải được cung cấp cùng nhau",
     "fxRateRequired": "Cần một tỷ giá hối đoái dương cho giao dịch bằng ngoại tệ",
     "fxSignMismatch": "originalAmount và amount phải cùng dấu",
@@ -539,5 +542,8 @@
     "signalNotFound": "Không tìm thấy tín hiệu chiến lược",
     "signalStrategyMismatch": "Tín hiệu đó thuộc về một chiến lược khác.",
     "strategyNotFound": "Không tìm thấy chiến lược"
+  },
+  "maintenance": {
+    "inProgress": "Mot tac vu khac dang thay the du lieu cua tai khoan nay. Hay doi hoan tat roi thu lai."
   }
 }

--- a/backend/src/i18n/locales/xx/errors.json
+++ b/backend/src/i18n/locales/xx/errors.json
@@ -282,6 +282,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "[XX-Email is not configured. Emergency access cannot be enabled until SMTP is set up.-XX]",
     "encryptionNotConfigured": "[XX-Encryption key is not configured. The free-form message cannot be stored securely until AI_ENCRYPTION_KEY is set.-XX]",
+    "encryptionRequiredToEnable": "[XX-Credential encryption is not configured. Emergency access cannot be enabled until AI_ENCRYPTION_KEY is set, because a grant has to store each contact's access link securely.-XX]",
     "contactEmailExists": "[XX-An emergency contact with this email already exists.-XX]",
     "contactNotFound": "[XX-Contact not found-XX]",
     "notConfigured": "[XX-Emergency access not configured-XX]",
@@ -365,6 +366,7 @@
     "sameSourceAndDestination": "[XX-Source and destination accounts must be different-XX]",
     "requiresBrokerageAccount": "[XX-Scheduled investment transactions require a brokerage account-XX]",
     "notFound": "[XX-Scheduled transaction with ID {{ id }} not found-XX]",
+    "occurrenceAlreadyPosted": "[XX-This occurrence has already been posted.-XX]",
     "fxPlainOnly": "[XX-A different currency can only be used on a plain scheduled transaction, not a split, transfer or investment-XX]",
     "fxRateUnavailable": "[XX-No exchange rate is available for {{ from }} to {{ to }} on {{ date }}. Enter the amount in {{ to }} to post it.-XX]",
     "investmentActionRequired": "[XX-Investment action is required for scheduled investment transactions-XX]",
@@ -489,6 +491,7 @@
     "bulkReconcileNotFound": "[XX-Some transactions were not found or do not belong to the specified account-XX]",
     "cannotReconcileVoidPlural": "[XX-Cannot reconcile void transactions-XX]",
     "transferSameAccount": "[XX-Source and destination accounts must be different-XX]",
+    "transferChangedConcurrently": "[XX-This transfer was changed by another request. Reload it and try again.-XX]",
     "transferAmountNegative": "[XX-Transfer amount must not be negative-XX]",
     "notATransfer": "[XX-Transaction is not a transfer-XX]",
     "splitTransferLegAccountLocked": "[XX-This transfer is part of a split transaction. Change its accounts by editing the split on the source transaction instead.-XX]",
@@ -539,5 +542,8 @@
     "signalNotFound": "[XX-Strategy signal not found-XX]",
     "signalStrategyMismatch": "[XX-That signal belongs to a different strategy.-XX]",
     "strategyNotFound": "[XX-Strategy not found-XX]"
+  },
+  "maintenance": {
+    "inProgress": "[XX-Another operation is currently replacing this account's data. Wait for it to finish and try again.-XX]"
   }
 }

--- a/backend/src/i18n/locales/zh-CN/errors.json
+++ b/backend/src/i18n/locales/zh-CN/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "邮件未配置。在设置 SMTP 之前，无法启用紧急访问。",
     "encryptionNotConfigured": "加密密钥未配置。在设置 AI_ENCRYPTION_KEY 之前，无法安全存储自由格式留言。",
+    "encryptionRequiredToEnable": "凭据加密未配置。在设置 AI_ENCRYPTION_KEY 之前，无法启用紧急访问，因为授予访问权限时必须安全地存储每位联系人的访问链接。",
     "contactEmailExists": "此邮箱已存在紧急联系人。",
     "contactNotFound": "未找到联系人",
     "notConfigured": "紧急访问未配置",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "来源账户和目标账户必须不同",
     "requiresBrokerageAccount": "计划投资交易需要经纪账户",
     "notFound": "未找到 ID 为 {{ id }} 的计划交易",
+    "occurrenceAlreadyPosted": "该次记账已完成。",
+    "fxPlainOnly": "只有普通计划交易才能使用其他货币，拆分、转账和投资均不支持",
+    "fxRateUnavailable": "{{ date }} 没有从 {{ from }} 到 {{ to }} 的可用汇率。请以 {{ to }} 输入金额后再过账。",
     "investmentActionRequired": "计划投资交易需要投资操作",
     "actionRequiresSecurity": "操作 {{ action }} 需要证券",
     "actionRequiresPositiveQuantity": "操作 {{ action }} 需要正数量",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "创建拆分覆盖时需要金额",
     "overrideNotFound": "未找到 ID 为 {{ overrideId }} 的覆盖",
     "updateSplitOverrideRequiresAmount": "拆分覆盖需要金额",
-    "dateMustBeYMD": "date 必须为 YYYY-MM-DD 格式",
-    "fxPlainOnly": "只有普通计划交易才能使用其他货币，拆分、转账和投资均不支持",
-    "fxRateUnavailable": "{{ date }} 没有从 {{ from }} 到 {{ to }} 的可用汇率。请以 {{ to }} 输入金额后再过账。"
+    "dateMustBeYMD": "date 必须为 YYYY-MM-DD 格式"
   },
   "securities": {
     "exchangeRateUnavailable": "无法确定交易日 {{ from }} -> {{ to }} 的汇率。请提供明确的 exchangeRate，以便现金账户的记账正确。",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId 必须是有效的 UUID",
     "amountFromMustBeNumber": "amountFrom 必须是数字",
     "amountToMustBeNumber": "amountTo 必须是数字",
+    "tagKeyTooLong": "tagKey 不得超过 100 个字符",
+    "invalidTagKeyOp": "无效的 tagKeyOp：{{ op }}",
+    "tagKeyValueRequired": "contains / notContains 需要 tagKeyValue",
+    "tagKeyRequired": "需要标签键（1-100 个字符）",
     "invalidGroupBy": "groupBy 必须为 'category' 或 'payee'",
     "limitMustBePositive": "limit 必须为正数",
     "recurringPayeeRequired": "payeeIds 为必填项",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance 必须是数字",
     "categoryNotFound": "未找到分类",
     "categoriesNotFound": "未找到分类：{{ ids }}",
+    "crossOwnerTransferLocked": "此转账的另一方位于您已无法访问的账户中。您可以编辑此交易自身的详细信息，但其金额、日期和账户已锁定。",
+    "crossOwnerAccountMoveLocked": "此转账涉及其他用户的账户，因此无法移动到其他账户。",
+    "cannotEditTransfer": "无法在此处编辑转账。请在交易页面中编辑该转账。",
+    "cannotEditSplit": "无法在此处编辑拆分交易。请在交易页面中编辑该拆分。",
+    "noUpdateFields": "请至少提供一个要更改的字段。",
     "investmentSplitRequiresPayload": "投资拆分项需要投资载荷",
     "investmentActionNotAllowedInSplit": "投资操作 {{ action }} 不允许在拆分交易中使用",
     "investmentSplitCannotSetCategoryOrTransfer": "投资拆分项不能同时设置 categoryId 或 transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "部分交易未找到或不属于指定账户",
     "cannotReconcileVoidPlural": "无法对账作废交易",
     "transferSameAccount": "来源账户和目标账户必须不同",
+    "transferChangedConcurrently": "该笔转账已被其他请求修改，请重新加载后再试。",
     "transferAmountNegative": "转账金额不能为负数",
     "notATransfer": "交易不是转账",
     "splitTransferLegAccountLocked": "此转账属于拆分交易的一部分。请改为在源交易中编辑拆分项以更改其账户。",
     "notFoundById": "未找到 ID 为 {{ id }} 的交易",
     "bulkUpdateNoFields": "至少需要提供一个更新字段",
     "payeeNotFound": "未找到收款人",
-    "crossOwnerTransferLocked": "此转账的另一方位于您已无法访问的账户中。您可以编辑此交易自身的详细信息，但其金额、日期和账户已锁定。",
-    "crossOwnerAccountMoveLocked": "此转账涉及其他用户的账户，因此无法移动到其他账户。",
-    "cannotEditTransfer": "无法在此处编辑转账。请在交易页面中编辑该转账。",
-    "cannotEditSplit": "无法在此处编辑拆分交易。请在交易页面中编辑该拆分。",
-    "noUpdateFields": "请至少提供一个要更改的字段。",
-    "tagKeyTooLong": "tagKey 不得超过 100 个字符",
-    "invalidTagKeyOp": "无效的 tagKeyOp：{{ op }}",
-    "tagKeyValueRequired": "contains / notContains 需要 tagKeyValue",
-    "tagKeyRequired": "需要标签键（1-100 个字符）",
     "fxFieldsIncomplete": "originalAmount 和 originalCurrencyCode 必须同时提供",
     "fxRateRequired": "外币交易需要一个正的汇率",
     "fxSignMismatch": "originalAmount 和 amount 的符号必须相同",
@@ -539,5 +542,8 @@
     "signalNotFound": "未找到策略信号",
     "signalStrategyMismatch": "该信号属于另一个策略。",
     "strategyNotFound": "未找到策略"
+  },
+  "maintenance": {
+    "inProgress": "另一项操作正在替换此账户的数据。请等待其完成后重试。"
   }
 }

--- a/backend/src/i18n/locales/zh-TW/errors.json
+++ b/backend/src/i18n/locales/zh-TW/errors.json
@@ -274,6 +274,7 @@
   "emergencyAccess": {
     "smtpNotConfigured": "未設定電子郵件。在設定 SMTP 之前，無法啟用緊急存取。",
     "encryptionNotConfigured": "未設定加密金鑰。在設定 AI_ENCRYPTION_KEY 之前，無法安全儲存自由格式訊息。",
+    "encryptionRequiredToEnable": "未設定憑證加密。在設定 AI_ENCRYPTION_KEY 之前，無法啟用緊急存取，因為授予存取權時必須安全地儲存每位聯絡人的存取連結。",
     "contactEmailExists": "已有使用此電子郵件的緊急聯絡人。",
     "contactNotFound": "找不到聯絡人",
     "notConfigured": "未設定緊急存取",
@@ -357,6 +358,9 @@
     "sameSourceAndDestination": "來源和目的科目必須不同",
     "requiresBrokerageAccount": "定期投資交易需要經紀科目",
     "notFound": "找不到 ID 為 {{ id }} 的定期交易",
+    "occurrenceAlreadyPosted": "此次記帳已完成。",
+    "fxPlainOnly": "只有一般定期交易才能使用其他貨幣，分割、轉帳和投資均不支援",
+    "fxRateUnavailable": "{{ date }} 沒有從 {{ from }} 到 {{ to }} 的可用匯率。請以 {{ to }} 輸入金額後再過帳。",
     "investmentActionRequired": "定期投資交易需要投資操作",
     "actionRequiresSecurity": "操作 {{ action }} 需要證券",
     "actionRequiresPositiveQuantity": "操作 {{ action }} 需要正數數量",
@@ -367,9 +371,7 @@
     "splitOverrideRequiresAmount": "建立分割覆蓋時需要金額",
     "overrideNotFound": "找不到 ID 為 {{ overrideId }} 的覆蓋設定",
     "updateSplitOverrideRequiresAmount": "分割覆蓋需要金額",
-    "dateMustBeYMD": "date 必須為 YYYY-MM-DD 格式",
-    "fxPlainOnly": "只有一般定期交易才能使用其他貨幣，分割、轉帳和投資均不支援",
-    "fxRateUnavailable": "{{ date }} 沒有從 {{ from }} 到 {{ to }} 的可用匯率。請以 {{ to }} 輸入金額後再過帳。"
+    "dateMustBeYMD": "date 必須為 YYYY-MM-DD 格式"
   },
   "securities": {
     "exchangeRateUnavailable": "無法確定交易日 {{ from }} -> {{ to }} 的匯率。請提供明確的 exchangeRate，以便現金帳戶的記帳正確。",
@@ -447,6 +449,10 @@
     "targetTransactionIdInvalidUuid": "targetTransactionId 必須是有效的 UUID",
     "amountFromMustBeNumber": "amountFrom 必須是數字",
     "amountToMustBeNumber": "amountTo 必須是數字",
+    "tagKeyTooLong": "tagKey 不得超過 100 個字元",
+    "invalidTagKeyOp": "無效的 tagKeyOp：{{ op }}",
+    "tagKeyValueRequired": "contains / notContains 需要 tagKeyValue",
+    "tagKeyRequired": "需要標籤鍵（1-100 個字元）",
     "invalidGroupBy": "groupBy 必須為 'category' 或 'payee'",
     "limitMustBePositive": "limit 必須為正數",
     "recurringPayeeRequired": "payeeIds 為必填",
@@ -455,6 +461,11 @@
     "statementBalanceMustBeNumber": "statementBalance 必須是數字",
     "categoryNotFound": "找不到類別",
     "categoriesNotFound": "找不到類別：{{ ids }}",
+    "crossOwnerTransferLocked": "此轉帳的另一方位於您已無法存取的科目中。您可以編輯此交易本身的詳細資訊，但其金額、日期和科目已鎖定。",
+    "crossOwnerAccountMoveLocked": "此轉帳涉及其他使用者的科目，因此無法移至其他科目。",
+    "cannotEditTransfer": "無法在此處編輯轉帳。請在交易頁面中編輯該轉帳。",
+    "cannotEditSplit": "無法在此處編輯拆分交易。請在交易頁面中編輯該拆分。",
+    "noUpdateFields": "請至少提供一個要變更的欄位。",
     "investmentSplitRequiresPayload": "投資分割需要投資載荷",
     "investmentActionNotAllowedInSplit": "分割交易中不允許投資操作 {{ action }}",
     "investmentSplitCannotSetCategoryOrTransfer": "投資分割不能同時設定 categoryId 或 transferAccountId",
@@ -472,21 +483,13 @@
     "bulkReconcileNotFound": "部分交易未找到或不屬於指定科目",
     "cannotReconcileVoidPlural": "無法對帳作廢的交易",
     "transferSameAccount": "來源和目的科目必須不同",
+    "transferChangedConcurrently": "這筆轉帳已被其他請求修改，請重新載入後再試。",
     "transferAmountNegative": "轉帳金額不得為負數",
     "notATransfer": "交易不是轉帳",
     "splitTransferLegAccountLocked": "此轉帳屬於分割交易的一部分。請改為在來源交易中編輯分割以變更其帳戶。",
     "notFoundById": "找不到 ID 為 {{ id }} 的交易",
     "bulkUpdateNoFields": "至少需要提供一個更新欄位",
     "payeeNotFound": "找不到收款人",
-    "crossOwnerTransferLocked": "此轉帳的另一方位於您已無法存取的科目中。您可以編輯此交易本身的詳細資訊，但其金額、日期和科目已鎖定。",
-    "crossOwnerAccountMoveLocked": "此轉帳涉及其他使用者的科目，因此無法移至其他科目。",
-    "cannotEditTransfer": "無法在此處編輯轉帳。請在交易頁面中編輯該轉帳。",
-    "cannotEditSplit": "無法在此處編輯拆分交易。請在交易頁面中編輯該拆分。",
-    "noUpdateFields": "請至少提供一個要變更的欄位。",
-    "tagKeyTooLong": "tagKey 不得超過 100 個字元",
-    "invalidTagKeyOp": "無效的 tagKeyOp：{{ op }}",
-    "tagKeyValueRequired": "contains / notContains 需要 tagKeyValue",
-    "tagKeyRequired": "需要標籤鍵（1-100 個字元）",
     "fxFieldsIncomplete": "originalAmount 和 originalCurrencyCode 必須同時提供",
     "fxRateRequired": "外幣交易需要一個正的匯率",
     "fxSignMismatch": "originalAmount 和 amount 的符號必須相同",
@@ -539,5 +542,8 @@
     "signalNotFound": "找不到策略訊號",
     "signalStrategyMismatch": "該訊號屬於另一個策略。",
     "strategyNotFound": "找不到策略"
+  },
+  "maintenance": {
+    "inProgress": "另一項作業正在取代此帳戶的資料。請等待完成後再試一次。"
   }
 }

--- a/backend/src/net-worth/net-worth.service.spec.ts
+++ b/backend/src/net-worth/net-worth.service.spec.ts
@@ -19,6 +19,7 @@ import {
   createScopedDbMocks,
   DataSourceMock,
 } from "../test-helpers/scoped-db-testing";
+import { lockAccountsForBalanceWrite } from "../common/db/locks";
 
 jest.mock("../common/db/scoped-db", () => {
   const helpers = jest.requireActual("../test-helpers/scoped-db-testing");
@@ -29,6 +30,17 @@ jest.mock("../common/db/scoped-db", () => {
     runOutsideActiveScopedManager: (fn: () => unknown) => fn(),
   };
 });
+
+// The real lock issues a `SELECT ... FOR UPDATE` through the manager, which the
+// query router below would route to `reportQuery` and shift every assertion.
+// See test-helpers/locks-testing.
+jest.mock("../common/db/locks", () =>
+  jest.requireActual("../test-helpers/locks-testing").locksMockModule(),
+);
+
+const lockAccounts = lockAccountsForBalanceWrite as jest.MockedFunction<
+  typeof lockAccountsForBalanceWrite
+>;
 
 describe("NetWorthService", () => {
   let service: NetWorthService;
@@ -143,6 +155,10 @@ describe("NetWorthService", () => {
   };
 
   beforeEach(async () => {
+    // Module-level mock, so it survives between tests unless reset.
+    lockAccounts.mockReset();
+    lockAccounts.mockResolvedValue(undefined);
+
     mabRepository = {
       count: jest.fn().mockResolvedValue(0),
       find: jest.fn().mockResolvedValue([]),
@@ -190,6 +206,136 @@ describe("NetWorthService", () => {
     );
 
     service = new NetWorthService(dataSource as never);
+  });
+
+  describe("recalculateAccount -- serialization", () => {
+    it("locks the account before reading anything the snapshots derive from", async () => {
+      // The regression: the monthly sums were read in one autocommit
+      // transaction and written in another. Under READ COMMITTED those are two
+      // statement snapshots, so a transaction committing between them produced
+      // snapshots that did not include it -- permanently, until something else
+      // triggered a recalc.
+      const order: string[] = [];
+      lockAccounts.mockImplementation(async () => {
+        order.push("lock");
+      });
+      accountRepository.findOne.mockImplementation(async () => {
+        order.push("read-account");
+        return { ...mockRegularAccount };
+      });
+      reportQuery.mockImplementation(async () => {
+        order.push("read-ledger");
+        return [{ earliest: "2024-01-01" }];
+      });
+      snapshotQuery.mockImplementation(async () => {
+        order.push("write");
+      });
+
+      await service.recalculateAccount("user-1", "acc-1");
+
+      expect(order[0]).toBe("lock");
+      expect(order.indexOf("read-ledger")).toBeGreaterThan(0);
+      expect(order.indexOf("write")).toBeGreaterThan(
+        order.indexOf("read-ledger"),
+      );
+      // Owner-scoped: the balance-write lock carries the caller's userId so it
+      // can never land on an account that is not theirs (maintainer review,
+      // PR #1095).
+      expect(lockAccounts).toHaveBeenCalledWith(
+        expect.anything(),
+        ["acc-1"],
+        "user-1",
+      );
+    });
+  });
+
+  describe("sweepStaleSnapshots", () => {
+    // withUserContext validates the id, so the sweep's rows carry real UUIDs --
+    // a garbage owner id would raise 22P02 on every policied statement under
+    // enforcement, which is why it is checked at the wrap site.
+    const ownerA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const ownerB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+    /** The sweep's discovery query, distinguished from the recalc's own reads. */
+    function serveStale(rows: Array<{ user_id: string; account_id: string }>) {
+      reportQuery.mockImplementation(async (sql: string) => {
+        if (sql.includes("JOIN (")) return rows;
+        if (sql.includes("MIN(transaction_date)")) {
+          return [{ earliest: "2024-01-01" }];
+        }
+        return [{ month: "2024-01-01", balance: 1000 }];
+      });
+    }
+
+    it("finds accounts whose snapshots fell behind their own row", async () => {
+      // The durability answer for a debounce timer that lives in process memory:
+      // derive the staleness from the data, because the crash that loses the
+      // timer would lose a queue entry just as easily (DR-04-03).
+      serveStale([]);
+
+      await service.sweepStaleSnapshots();
+
+      const [sql, params] = reportQuery.mock.calls[0];
+      expect(sql).toContain("FROM accounts");
+      expect(sql).toContain("MAX(updated_at)");
+      expect(sql).toContain("a.updated_at >");
+      // Bounded, so a broken deployment cannot exhaust the pool in one pass.
+      expect(sql).toContain("LIMIT $2");
+      expect(params[1]).toBeGreaterThan(0);
+    });
+
+    it("recomputes each stale account as its owner", async () => {
+      serveStale([
+        { user_id: ownerA, account_id: "acc-1" },
+        { user_id: ownerB, account_id: "acc-2" },
+      ]);
+      accountRepository.findOne.mockImplementation(
+        async ({ where }: { where: { id: string } }) => ({
+          ...mockRegularAccount,
+          id: where.id,
+        }),
+      );
+
+      await service.sweepStaleSnapshots();
+
+      expect(lockAccounts.mock.calls.map((call) => call[1])).toEqual([
+        ["acc-1"],
+        ["acc-2"],
+      ]);
+    });
+
+    it("keeps going when one account's recompute fails", async () => {
+      serveStale([
+        { user_id: ownerA, account_id: "acc-1" },
+        { user_id: ownerA, account_id: "acc-2" },
+      ]);
+      accountRepository.findOne.mockImplementation(
+        async ({ where }: { where: { id: string } }) => {
+          if (where.id === "acc-1") throw new Error("DB down");
+          return { ...mockRegularAccount, id: where.id };
+        },
+      );
+
+      await expect(service.sweepStaleSnapshots()).resolves.toBeUndefined();
+      expect(snapshotWriteBlocks()).toBe(1);
+    });
+
+    it("does nothing when every snapshot is current", async () => {
+      serveStale([]);
+
+      await service.sweepStaleSnapshots();
+
+      expect(lockAccounts).not.toHaveBeenCalled();
+      expect(snapshotWriteBlocks()).toBe(0);
+    });
+
+    it("does not throw when its own discovery query fails", async () => {
+      // A cron handler that rejects takes the process down with an unhandled
+      // rejection.
+      reportQuery.mockRejectedValue(new Error("DB down"));
+
+      await expect(service.sweepStaleSnapshots()).resolves.toBeUndefined();
+    });
   });
 
   describe("recalculateAccount", () => {
@@ -719,7 +865,23 @@ describe("NetWorthService", () => {
   });
 
   describe("recalculateAllAccounts", () => {
+    /**
+     * The per-account path re-reads the account inside its own locked
+     * transaction, so `find` (the fan-out list) and `findOne` (the locked
+     * re-read) both have to answer. Routing the second from the first keeps the
+     * two consistent without each test restating the list.
+     */
+    function serveLockedReads(): void {
+      accountRepository.findOne.mockImplementation(
+        async ({ where }: { where: { id: string } }) =>
+          (await accountRepository.find()).find(
+            (a: Account) => a.id === where.id,
+          ) ?? null,
+      );
+    }
+
     it("recalculates all accounts for a user", async () => {
+      serveLockedReads();
       accountRepository.find.mockResolvedValue([
         { ...mockRegularAccount },
         { ...mockCreditCardAccount },
@@ -744,6 +906,7 @@ describe("NetWorthService", () => {
     });
 
     it("continues processing when one account fails", async () => {
+      serveLockedReads();
       accountRepository.find.mockResolvedValue([
         { ...mockRegularAccount, id: "acc-1" },
         { ...mockRegularAccount, id: "acc-2" },
@@ -773,6 +936,7 @@ describe("NetWorthService", () => {
     });
 
     it("processes brokerage accounts differently from regular accounts", async () => {
+      serveLockedReads();
       accountRepository.find.mockResolvedValue([
         { ...mockRegularAccount },
         { ...mockBrokerageAccount },

--- a/backend/src/net-worth/net-worth.service.ts
+++ b/backend/src/net-worth/net-worth.service.ts
@@ -1,10 +1,12 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
 import { DataSource, In, LessThanOrEqual } from "typeorm";
 import {
   runOutsideActiveScopedManager,
   withScopedDb,
 } from "../common/db/scoped-db";
-import { withUserContext } from "../common/db/with-context";
+import { lockAccountsForBalanceWrite } from "../common/db/locks";
+import { withSystemContext, withUserContext } from "../common/db/with-context";
 import { MonthlyAccountBalance } from "./entities/monthly-account-balance.entity";
 import {
   Account,
@@ -85,6 +87,18 @@ export class NetWorthService {
   >();
   private static readonly RECALC_DEBOUNCE_MS = 2000;
 
+  /**
+   * How stale a snapshot may be, relative to its account's last change, before
+   * the sweep recomputes it.
+   *
+   * Comfortably longer than the debounce plus a slow recalc, so the sweep does
+   * not race the timer that is about to do the same work.
+   */
+  private static readonly STALE_SNAPSHOT_GRACE_MS = 10 * 60 * 1000;
+
+  /** Accounts recomputed per sweep, so a broken deployment cannot melt the pool. */
+  private static readonly STALE_SWEEP_BATCH = 200;
+
   constructor(private dataSource: DataSource) {}
 
   /**
@@ -97,7 +111,17 @@ export class NetWorthService {
     return withScopedDb(this.dataSource, (m) => m.query(sql, params));
   }
 
-  /** Debounced trigger for recalculating a single account's net worth snapshots. */
+  /**
+   * Debounced trigger for recalculating a single account's net worth snapshots.
+   *
+   * The timer lives in this process's memory, so it is a latency optimization and
+   * nothing more: a pod killed in the two seconds before it fires, or a recalc
+   * that throws, loses the work with only a `warn` to show for it, and the
+   * snapshots then disagree with the ledger until something else happens to
+   * touch the account (audit DR-04-03). `sweepStaleSnapshots` is what makes that
+   * recoverable -- it finds the disagreement in the data rather than needing a
+   * queue entry that the same crash would have lost.
+   */
   triggerDebouncedRecalc(accountId: string, userId: string): void {
     const key = `${userId}:${accountId}`;
     const existing = this.recalcTimers.get(key);
@@ -128,13 +152,124 @@ export class NetWorthService {
   }
 
   async recalculateAccount(userId: string, accountId: string): Promise<void> {
-    const account = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(Account).findOne({
-        where: { id: accountId, userId },
-      }),
-    );
-    if (!account) return;
+    await withScopedDb(this.dataSource, async (m) => {
+      // The lock first, then every read the snapshots are derived from, then the
+      // delete-and-reinsert -- all in this transaction.
+      //
+      // Previously the monthly sums were read in one autocommit transaction and
+      // written in another. Under READ COMMITTED that is two statement snapshots:
+      // a transaction committing between them produced snapshots that did not
+      // include it, permanently, until something else triggered a recalc. Two
+      // concurrent recalcs of the same account were worse -- whichever wrote
+      // second won, and it might be the one that read first, so the newer data
+      // lost. Same protocol as every other absolute recomputation here: advisory
+      // and row locks before the read they protect (see common/db/locks.ts).
+      await lockAccountsForBalanceWrite(m, [accountId], userId);
 
+      const account = await m.getRepository(Account).findOne({
+        where: { id: accountId, userId },
+      });
+      if (!account) return;
+
+      await this.recalculateLockedAccount(userId, account);
+    });
+  }
+
+  /**
+   * Recompute snapshots that no longer agree with their account.
+   *
+   * The debounce timer is process memory, so every way it can be lost -- a pod
+   * killed inside the two-second window, a recalc that throws, a rolling deploy
+   * -- leaves snapshots that disagree with the ledger and nothing that will ever
+   * notice. A durable work queue would not help: the crash that loses the timer
+   * loses the enqueue too, unless the enqueue joins the caller's transaction, and
+   * then every write path has to know about net worth.
+   *
+   * So the staleness is *derived* rather than recorded. Every write that can
+   * change a snapshot also touches the account row in the same transaction --
+   * usually a `current_balance` delta, and for the one snapshot-only change that
+   * moves no balance (a past-dated row shifted to another past month, so the
+   * running total is unchanged) an explicit `AccountsService.touchAccount`.
+   * Either way `accounts.updated_at` advances, so it is a timestamp the account
+   * itself keeps -- and the snapshots are a delete-and-reinsert, so their
+   * `updated_at` is when they were last computed. An account whose row is newer
+   * than its own snapshots by more than the grace period was missed.
+   *
+   * This is the idempotent-predicate mechanism from `docs/cron-jobs.md`: two
+   * replicas racing the sweep recompute the same accounts from scratch, under the
+   * per-account lock, and the loser's work is simply redundant. Accounts with no
+   * snapshots at all are deliberately not swept -- there is nothing to compare
+   * against, and including them would recompute every empty account forever.
+   */
+  @Cron(CronExpression.EVERY_30_MINUTES)
+  async sweepStaleSnapshots(): Promise<void> {
+    try {
+      const stale = await withSystemContext(() =>
+        withScopedDb(this.dataSource, (m) =>
+          m.query(
+            `SELECT a.user_id, a.id AS account_id
+               FROM accounts a
+               JOIN (
+                 SELECT account_id, MAX(updated_at) AS computed_at
+                   FROM monthly_account_balances
+                  GROUP BY account_id
+               ) s ON s.account_id = a.id
+              WHERE a.updated_at > s.computed_at + ($1::text || ' milliseconds')::interval
+              ORDER BY a.updated_at
+              LIMIT $2`,
+            [
+              String(NetWorthService.STALE_SNAPSHOT_GRACE_MS),
+              NetWorthService.STALE_SWEEP_BATCH,
+            ],
+          ),
+        ),
+      );
+
+      if (stale.length === 0) return;
+
+      this.logger.log(
+        `Recomputing ${stale.length} account(s) whose net-worth snapshots fell behind`,
+      );
+      if (stale.length === NetWorthService.STALE_SWEEP_BATCH) {
+        // Say so rather than letting a truncated pass read as "all caught up".
+        this.logger.warn(
+          `Stale snapshot sweep hit its batch limit of ${NetWorthService.STALE_SWEEP_BATCH}; more remain for the next pass`,
+        );
+      }
+
+      for (const row of stale as Array<{
+        user_id: string;
+        account_id: string;
+      }>) {
+        try {
+          await withUserContext(row.user_id, () =>
+            this.recalculateAccount(row.user_id, row.account_id),
+          );
+        } catch (err) {
+          this.logger.warn(
+            `Stale snapshot recompute failed for account ${row.account_id}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
+    } catch (err) {
+      this.logger.warn(
+        `Stale snapshot sweep failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Dispatch for an account whose row is already locked inside the ambient
+   * transaction. The two branches' own `withScopedDb`/`scopedQuery` calls join it.
+   */
+  private async recalculateLockedAccount(
+    userId: string,
+    account: Account,
+  ): Promise<void> {
     if (this.isBrokerageOrStandaloneInvestment(account)) {
       await this.recalculateBrokerageAccount(userId, account);
     } else {
@@ -152,11 +287,10 @@ export class NetWorthService {
     await Promise.all(
       accounts.map(async (account) => {
         try {
-          if (this.isBrokerageOrStandaloneInvestment(account)) {
-            await this.recalculateBrokerageAccount(userId, account);
-          } else {
-            await this.recalculateRegularAccount(userId, account);
-          }
+          // One locked transaction per account, exactly as the single-account
+          // path: a full-user rebuild racing an ordinary edit must not write a
+          // snapshot derived from rows that changed while it was reading.
+          await this.recalculateAccount(userId, account.id);
         } catch (err) {
           this.logger.warn(
             `Failed to recalculate account ${account.id}: ${err.message}`,

--- a/backend/src/securities/holdings.service.spec.ts
+++ b/backend/src/securities/holdings.service.spec.ts
@@ -1097,10 +1097,21 @@ describe("HoldingsService", () => {
   });
 
   describe("remove", () => {
+    /**
+     * `remove` re-reads the holding inside its transaction, under the lock every
+     * holdings writer takes, and checks the zero-quantity rule against *that*
+     * row. Checked outside, a buy committing in between would have its shares
+     * deleted by a request that had seen zero (P4-006).
+     */
+    function stageHolding(holding: unknown): void {
+      const qb = createMockQueryBuilder(holding);
+      holdingsRepository.createQueryBuilder.mockReturnValue(qb);
+      holdingsRepository.findOne.mockResolvedValue(holding);
+    }
+
     it("removes holding with zero quantity", async () => {
       const zeroHolding = { ...mockHolding, quantity: 0 };
-      const qb = createMockQueryBuilder(zeroHolding);
-      holdingsRepository.createQueryBuilder.mockReturnValue(qb);
+      stageHolding(zeroHolding);
 
       await service.remove("11111111-1111-1111-1111-111111111111", "hold-1");
 
@@ -1108,9 +1119,7 @@ describe("HoldingsService", () => {
     });
 
     it("throws ForbiddenException when holding has non-zero quantity", async () => {
-      const nonZeroHolding = { ...mockHolding, quantity: 50 };
-      const qb = createMockQueryBuilder(nonZeroHolding);
-      holdingsRepository.createQueryBuilder.mockReturnValue(qb);
+      stageHolding({ ...mockHolding, quantity: 50 });
 
       await expect(
         service.remove("11111111-1111-1111-1111-111111111111", "hold-1"),
@@ -1118,9 +1127,7 @@ describe("HoldingsService", () => {
     });
 
     it("throws ForbiddenException with descriptive message for non-zero quantity", async () => {
-      const nonZeroHolding = { ...mockHolding, quantity: 10 };
-      const qb = createMockQueryBuilder(nonZeroHolding);
-      holdingsRepository.createQueryBuilder.mockReturnValue(qb);
+      stageHolding({ ...mockHolding, quantity: 10 });
 
       await expect(
         service.remove("11111111-1111-1111-1111-111111111111", "hold-1"),
@@ -1128,23 +1135,53 @@ describe("HoldingsService", () => {
     });
 
     it("throws NotFoundException when holding does not exist", async () => {
-      const qb = createMockQueryBuilder(null);
-      holdingsRepository.createQueryBuilder.mockReturnValue(qb);
+      stageHolding(null);
 
       await expect(
         service.remove("11111111-1111-1111-1111-111111111111", "nonexistent"),
       ).rejects.toThrow(NotFoundException);
     });
 
+    it("refuses when the committed row gained shares after the outer read", async () => {
+      // The regression guard: the outer read says zero, the locked re-read says
+      // 50. Before the re-read existed, the outer snapshot won and the shares
+      // were deleted.
+      const qb = createMockQueryBuilder({ ...mockHolding, quantity: 0 });
+      holdingsRepository.createQueryBuilder.mockReturnValue(qb);
+      holdingsRepository.findOne.mockResolvedValue({
+        ...mockHolding,
+        quantity: 50,
+      });
+
+      await expect(
+        service.remove("11111111-1111-1111-1111-111111111111", "hold-1"),
+      ).rejects.toThrow(ForbiddenException);
+      expect(holdingsRepository.remove).not.toHaveBeenCalled();
+    });
+
     it("handles string quantity '0' correctly (decimal from DB)", async () => {
       // Decimals from the database often come as strings
       const zeroHolding = { ...mockHolding, quantity: "0.00000000" };
-      const qb = createMockQueryBuilder(zeroHolding);
-      holdingsRepository.createQueryBuilder.mockReturnValue(qb);
+      stageHolding(zeroHolding);
 
       await service.remove("11111111-1111-1111-1111-111111111111", "hold-1");
 
       expect(holdingsRepository.remove).toHaveBeenCalledWith(zeroHolding);
+    });
+
+    it("re-reads the holding scoped to the owner-verified account, not a bare id", async () => {
+      // Holdings carry no user_id column; ownership is the account's. The outer
+      // findOne(userId, id) established the owner via the account join, so the
+      // locked re-read has to stay inside that account scope. A bare
+      // `where: { id }` dropped the owner scope even though the lock is on the
+      // same account -- this asserts the scope is carried through.
+      stageHolding({ ...mockHolding, accountId: "acc-1", quantity: 0 });
+
+      await service.remove("11111111-1111-1111-1111-111111111111", "hold-1");
+
+      expect(holdingsRepository.findOne).toHaveBeenCalledWith({
+        where: { id: "hold-1", accountId: "acc-1" },
+      });
     });
   });
 

--- a/backend/src/securities/holdings.service.ts
+++ b/backend/src/securities/holdings.service.ts
@@ -15,6 +15,7 @@ import { getUsersByEffectiveTimezone } from "../common/users-by-timezone.util";
 import { withSystemContext, withUserContext } from "../common/db/with-context";
 import { EntityManager, In, LessThanOrEqual, DataSource } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
+import { lockHoldingScope } from "../common/db/locks";
 import { Holding } from "./entities/holding.entity";
 import {
   InvestmentTransaction,
@@ -213,6 +214,18 @@ export class HoldingsService {
     return this.inScope(manager, async (m) => {
       const repo = m.getRepository(Holding);
 
+      // Serialize against every other holdings writer for this account before
+      // reading the quantity this update is derived from.
+      //
+      // `new = old + delta` computed in application code is a read-modify-write.
+      // The unique key on (account_id, security_id) stops two *inserts*, and the
+      // row lock PostgreSQL takes during an UPDATE serializes the physical
+      // writes -- but the second request still wrote the quantity it had
+      // calculated from the value it read before waiting. 10 shares, concurrent
+      // buys of 1 and 2, and the holding ends at 12 instead of 13: one purchase
+      // and $100 of cost basis gone, with both trades committed (audit P4-006).
+      await lockHoldingScope(m, [accountId]);
+
       // Find existing holding
       let holding = await this.findByAccountAndSecurity(
         accountId,
@@ -320,6 +333,10 @@ export class HoldingsService {
     }
 
     return this.inScope(manager, async (m) => {
+      // Same lock namespace as createOrUpdate: a split multiplies the quantity
+      // it read, so a buy committing in between would be multiplied away.
+      await lockHoldingScope(m, [accountId]);
+
       const holding = await this.findByAccountAndSecurity(
         accountId,
         securityId,
@@ -375,6 +392,9 @@ export class HoldingsService {
     return this.inScope(manager, async (m) => {
       const repo = m.getRepository(Holding);
 
+      // Same lock namespace as createOrUpdate.
+      await lockHoldingScope(m, [accountId]);
+
       let holding = await this.findByAccountAndSecurity(
         accountId,
         securityId,
@@ -427,21 +447,44 @@ export class HoldingsService {
   }
 
   async remove(userId: string, id: string): Promise<void> {
-    const holding = await this.findOne(userId, id);
+    const outer = await this.findOne(userId, id);
 
-    // Only allow deletion if quantity is zero
-    if (Math.abs(Number(holding.quantity)) >= 0.0001) {
-      throw new ForbiddenException(
-        tr(
-          "errors.securities.cannotDeleteNonZeroHolding",
-          "Cannot delete holding with non-zero quantity",
-        ),
-      );
-    }
+    await withScopedDb(this.dataSource, async (m) => {
+      // "Quantity is zero" is a refusal, so it is checked against the row this
+      // statement is about to delete, under the lock every holdings writer
+      // takes. Checked outside, a buy committing in between would have its
+      // shares deleted by a request that had seen zero.
+      await lockHoldingScope(m, [outer.accountId]);
 
-    await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(Holding).remove(holding),
-    );
+      // Scoped to the owner-verified account, not a bare `id`. Holdings carry no
+      // user_id column (ownership is the account's), so the outer
+      // findOne(userId, id) established the owner and this re-read stays inside
+      // that scope -- the unscoped `where: { id }` was an owner-scope drop even
+      // though the lock is on the same account.
+      const holding = await m.getRepository(Holding).findOne({
+        where: { id, accountId: outer.accountId },
+      });
+      if (!holding) {
+        throw new NotFoundException(
+          tr(
+            "errors.securities.holdingNotFound",
+            `Holding with ID ${id} not found`,
+            { id },
+          ),
+        );
+      }
+
+      if (Math.abs(Number(holding.quantity)) >= 0.0001) {
+        throw new ForbiddenException(
+          tr(
+            "errors.securities.cannotDeleteNonZeroHolding",
+            "Cannot delete holding with non-zero quantity",
+          ),
+        );
+      }
+
+      await m.getRepository(Holding).remove(holding);
+    });
   }
 
   /**
@@ -686,6 +729,14 @@ export class HoldingsService {
   ): Promise<void> {
     if (accountIds.length === 0) return;
 
+    // Same lock namespace as the incremental mutators, taken before the ledger
+    // is read. A rebuild replays investment_transactions and replaces the
+    // holdings derived from them, so the thing it must not lose is a *trade* --
+    // an insert into investment_transactions, which no holdings row locks. Only
+    // an account-level lock shared with the trade path serializes the two
+    // (audit P4-006).
+    await lockHoldingScope(manager, accountIds);
+
     // Only brokerage / standalone investment accounts track holdings; the cash
     // sleeve of an investment account is excluded everywhere else, so it must be
     // excluded here too or its rows would be deleted but never rebuilt.
@@ -765,37 +816,48 @@ export class HoldingsService {
     holdingsUpdated: number;
     holdingsDeleted: number;
   }> {
-    // M14: Get all investment accounts (brokerage + standalone) for the user
-    const investmentAccounts = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(Account).find({
+    const cutoff = asOfDate ?? this.serverToday();
+
+    // Account discovery, the ledger read, the delete and the recreate all in ONE
+    // transaction, with the account lock taken first.
+    //
+    // Reading the accounts and the ledger in separate transactions and writing
+    // in a third made this idempotent only against an unchanged ledger: a trade
+    // committing after the ledger read was replaced by a snapshot that never saw
+    // it, so the rebuild *deleted* a holding the trade had just updated (audit
+    // P4-006). The lock is the same one createOrUpdate takes, which is what
+    // makes the two protocols exclusive rather than merely both careful.
+    let holdingsDeleted = 0;
+    let holdingsCreated = 0;
+
+    await withScopedDb(this.dataSource, async (m) => {
+      // M14: Get all investment accounts (brokerage + standalone) for the user
+      const investmentAccounts = await m.getRepository(Account).find({
         where: {
           userId,
           accountType: AccountType.INVESTMENT,
         },
-      }),
-    );
+      });
 
-    // Include brokerage accounts and standalone investment accounts (null subType)
-    const eligibleAccounts = investmentAccounts.filter(
-      (a) =>
-        a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
-        !a.accountSubType,
-    );
+      // Include brokerage accounts and standalone investment accounts (null subType)
+      const eligibleAccounts = investmentAccounts.filter(
+        (a) =>
+          a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
+          !a.accountSubType,
+      );
 
-    if (eligibleAccounts.length === 0) {
-      return { holdingsCreated: 0, holdingsUpdated: 0, holdingsDeleted: 0 };
-    }
+      if (eligibleAccounts.length === 0) return;
 
-    const brokerageAccountIds = eligibleAccounts.map((a) => a.id);
+      const brokerageAccountIds = eligibleAccounts.map((a) => a.id);
+      await lockHoldingScope(m, brokerageAccountIds);
 
-    // Get all investment transactions for these accounts up to the cutoff date,
-    // ordered by date. Future-dated transactions are excluded so they don't
-    // affect current holdings. Callers materializing matured transactions (the
-    // hourly cron) pass the user's timezone-correct "today" so a transfer dated
-    // today in a timezone ahead of the server isn't wrongly treated as future.
-    const cutoff = asOfDate ?? this.serverToday();
-    const transactions = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(InvestmentTransaction).find({
+      // Get all investment transactions for these accounts up to the cutoff
+      // date, ordered by date. Future-dated transactions are excluded so they
+      // don't affect current holdings. Callers materializing matured
+      // transactions (the hourly cron) pass the user's timezone-correct "today"
+      // so a transfer dated today in a timezone ahead of the server isn't
+      // wrongly treated as future.
+      const transactions = await m.getRepository(InvestmentTransaction).find({
         where: {
           userId,
           accountId: In(brokerageAccountIds),
@@ -805,18 +867,11 @@ export class HoldingsService {
           transactionDate: "ASC",
           createdAt: "ASC",
         },
-      }),
-    );
+      });
 
-    // Rebuild holdings from transactions
-    // Map: accountId -> securityId -> { quantity, totalCost }
-    const holdingsMap = this.computeHoldingsMap(transactions);
+      // Map: accountId -> securityId -> { quantity, totalCost }
+      const holdingsMap = this.computeHoldingsMap(transactions);
 
-    // Wrap delete-all + rebuild in a transaction for atomicity
-    let holdingsDeleted = 0;
-    let holdingsCreated = 0;
-
-    await withScopedDb(this.dataSource, async (m) => {
       // Delete all existing holdings for these accounts
       const existingHoldings = await m.find(Holding, {
         where: { accountId: In(brokerageAccountIds) },
@@ -945,6 +1000,10 @@ export class HoldingsService {
       }
 
       const brokerageAccountIds = brokerageAccounts.map((a) => a.id);
+      // Same lock namespace: a wipe racing a trade would otherwise delete a
+      // holding the trade just wrote, leaving the ledger and the holdings
+      // disagreeing with no rebuild scheduled.
+      await lockHoldingScope(m, brokerageAccountIds);
 
       // Delete all holdings for these accounts
       const holdingsRepo = m.getRepository(Holding);

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -346,7 +346,40 @@ describe("InvestmentTransactionsService", () => {
     for (const [name, impl] of Object.entries(mockQueryRunner.manager)) {
       mocks.manager[name] = impl as jest.Mock;
     }
-    mocks.manager.query = jest.fn().mockResolvedValue([]);
+    /**
+     * The cash-leg reads that feed a balance reversal are locked ones now, so
+     * they arrive through `manager.query` rather than `findOne` -- the amount a
+     * delta reverses has to be the version the delete removes (audit P4-003).
+     *
+     * Answered from whatever `transactionRepository.findOne` is returning, so a
+     * spec states the row once. Column names are the raw SQL ones.
+     */
+    // Deletes are conditional and each reversal is gated on what the database
+    // actually removed, so the double reports a count.
+    mocks.manager.delete = jest.fn().mockResolvedValue({ affected: 1 });
+    mocks.manager.query = jest.fn().mockImplementation(async (sql: string) => {
+      if (!String(sql).includes("FOR UPDATE")) return [];
+      const row = (await transactionRepository.findOne({})) as {
+        id?: string;
+        accountId?: string;
+        amount?: number;
+        transactionDate?: string;
+        status?: string | null;
+      } | null;
+      if (!row?.id) return [];
+      return [
+        {
+          id: row.id,
+          account_id: row.accountId,
+          amount: String(row.amount ?? 0),
+          transaction_date: row.transactionDate ?? null,
+          status: row.status ?? null,
+          is_split: false,
+          linked_transaction_id: null,
+          parent_transaction_id: null,
+        },
+      ];
+    });
     mockQueryRunner = { manager: mocks.manager };
 
     service = new InvestmentTransactionsService(
@@ -2077,8 +2110,12 @@ describe("InvestmentTransactionsService", () => {
         1509.99, // Reverse of -1509.99
       );
 
-      // Should remove the cash transaction
-      expect(transactionRepository.remove).toHaveBeenCalled();
+      // Should remove the cash transaction -- conditionally, with the reversal
+      // gated on the row the database actually removed.
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: cashTransactionId,
+        userId,
+      });
     });
 
     it("triggers net worth recalculation for brokerage and cash accounts after update", async () => {
@@ -2369,7 +2406,10 @@ describe("InvestmentTransactionsService", () => {
         cashAccountId,
         1509.99,
       );
-      expect(transactionRepository.remove).toHaveBeenCalled();
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: cashTransactionId,
+        userId,
+      });
 
       // Should delete the investment transaction
       expect(investmentTransactionsRepository.remove).toHaveBeenCalledWith(tx);
@@ -3283,6 +3323,21 @@ describe("InvestmentTransactionsService", () => {
           return Promise.resolve([]);
         },
       );
+      // The cash legs are locked in ascending id order before their amounts
+      // become reversals (audit P4-003), so they arrive through the locked read.
+      mockQueryRunner.manager.query.mockImplementation(async (sql: string) => {
+        if (!String(sql).includes("FOR UPDATE")) return [];
+        return [cashTx1, cashTx2].map((tx) => ({
+          id: tx.id,
+          account_id: tx.accountId,
+          amount: String(tx.amount),
+          transaction_date: null,
+          status: tx.status,
+          is_split: false,
+          linked_transaction_id: null,
+          parent_transaction_id: null,
+        }));
+      });
 
       const result = await service.removeAll(userId);
 
@@ -3300,10 +3355,16 @@ describe("InvestmentTransactionsService", () => {
         -790.01,
       );
       // Should remove cash transactions
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith([
-        cashTx1,
-        cashTx2,
-      ]);
+      // Conditional DELETEs, one per locked leg, each reversal gated on the row
+      // the database actually removed.
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: cashTx1.id,
+        userId,
+      });
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: cashTx2.id,
+        userId,
+      });
       // Should remove investment transactions
       expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(transactions);
       expect(holdingsService.removeAllForUser).toHaveBeenCalledWith(userId);
@@ -4827,6 +4888,27 @@ describe("InvestmentTransactionsService", () => {
             return Promise.resolve([split, incomeSplit]);
           return Promise.resolve([]);
         });
+      // The parent amount a delta is derived from is read under a row lock: two
+      // concurrent edits to the same parent's splits would otherwise each apply a
+      // delta from the same stale amount (audit P4-003).
+      mockQueryRunner.manager.query = jest
+        .fn()
+        .mockImplementation(async (sql: string) =>
+          String(sql).includes("FOR UPDATE")
+            ? [
+                {
+                  id: parentTx.id,
+                  account_id: parentTx.accountId,
+                  amount: String(parentTx.amount),
+                  transaction_date: parentTx.transactionDate,
+                  status: null,
+                  is_split: true,
+                  linked_transaction_id: null,
+                  parent_transaction_id: null,
+                },
+              ]
+            : [],
+        );
 
       return { split, incomeSplit, parentTx };
     };

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -8,8 +8,9 @@ import {
   forwardRef,
 } from "@nestjs/common";
 import { tr } from "../i18n/translate";
-import { DataSource, EntityManager, In } from "typeorm";
+import { DataSource, EntityManager } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
+import { lockTransactionRow, lockTransactionRows } from "../common/db/locks";
 import {
   InvestmentTransaction,
   InvestmentAction,
@@ -600,21 +601,33 @@ export class InvestmentTransactionsService {
   ): Promise<void> {
     if (!transactionId) return;
 
-    const cashTransaction = await manager.findOne(Transaction, {
-      where: { id: transactionId, userId },
-    });
+    // Locked, and the reversal gated on the row the database actually removed:
+    // reversing an amount whose row is already gone is the double-delete
+    // corruption in P4-003.
+    const cashTransaction = await lockTransactionRow(
+      manager,
+      transactionId,
+      userId,
+    );
 
     if (cashTransaction) {
+      const removed = await manager.delete(Transaction, {
+        id: transactionId,
+        userId,
+      });
+      if ((removed.affected ?? 0) === 0) return;
       // Only un-apply the balance if the cash transaction had been live --
       // a future-dated cash entry was never folded into currentBalance, so
-      // there's nothing to reverse.
-      if (!isTransactionInFuture(cashTransaction.transactionDate)) {
+      // there's nothing to reverse. Nor was a VOID one.
+      if (
+        !isTransactionInFuture(cashTransaction.transactionDate) &&
+        cashTransaction.status !== TransactionStatus.VOID
+      ) {
         await this.accountsService.updateBalance(
           cashTransaction.accountId,
-          -Number(cashTransaction.amount),
+          -cashTransaction.amount,
         );
       }
-      await manager.remove(cashTransaction);
     }
   }
 
@@ -2048,9 +2061,15 @@ export class InvestmentTransactionsService {
       amount: newSplitAmount,
     });
 
-    const parentTransaction = await manager.findOne(Transaction, {
-      where: { id: split.transactionId, userId },
-    });
+    // Locked: the delta below reverses `oldParentAmount`, so it has to be the
+    // version this write replaces. Two concurrent edits to the same parent's
+    // splits would otherwise each apply a delta derived from the same stale
+    // amount (audit P4-003).
+    const parentTransaction = await lockTransactionRow(
+      manager,
+      split.transactionId,
+      userId,
+    );
     if (!parentTransaction) {
       throw new NotFoundException(
         tr(
@@ -2069,7 +2088,7 @@ export class InvestmentTransactionsService {
         s.id === splitId ? newSplitAmount : Number(s.amount),
       ),
     );
-    const oldParentAmount = Number(parentTransaction.amount);
+    const oldParentAmount = parentTransaction.amount;
     const delta = roundMoney(newParentAmount - oldParentAmount);
 
     await manager.update(Transaction, parentTransaction.id, {
@@ -2079,6 +2098,7 @@ export class InvestmentTransactionsService {
     if (delta !== 0) {
       if (isTransactionInFuture(parentTransaction.transactionDate)) {
         await this.accountsService.recalculateCurrentBalance(
+          userId,
           parentTransaction.accountId,
         );
       } else {
@@ -3687,21 +3707,25 @@ export class InvestmentTransactionsService {
         .filter((id): id is string => !!id);
 
       if (linkedCashTxIds.length > 0) {
-        const cashTransactions = await manager.find(Transaction, {
-          where: { id: In(linkedCashTxIds) },
-        });
+        // Locked in ascending id order before their amounts become reversals.
+        const cashTransactions = await lockTransactionRows(
+          manager,
+          linkedCashTxIds,
+          userId,
+        );
 
-        for (const cashTx of cashTransactions) {
+        for (const cashTx of cashTransactions.values()) {
+          const removed = await manager.delete(Transaction, {
+            id: cashTx.id,
+            userId,
+          });
+          if ((removed.affected ?? 0) === 0) continue;
           if (cashTx.status !== TransactionStatus.VOID) {
             await this.accountsService.updateBalance(
               cashTx.accountId,
-              -Number(cashTx.amount),
+              -cashTx.amount,
             );
           }
-        }
-
-        if (cashTransactions.length > 0) {
-          await manager.remove(cashTransactions);
         }
       }
 

--- a/backend/src/transactions/remove-transaction-leg.ts
+++ b/backend/src/transactions/remove-transaction-leg.ts
@@ -1,0 +1,63 @@
+import { EntityManager } from "typeorm";
+import { Transaction, TransactionStatus } from "./entities/transaction.entity";
+import { LockedTransactionRow } from "../common/db/locks";
+import { isTransactionInFuture } from "../common/date-utils";
+
+/**
+ * Removing a ledger row and reversing what it contributed to a balance, in one
+ * place.
+ *
+ * The sequence is not obvious and every part of it is load-bearing:
+ *
+ * 1. **Delete conditionally, and read the result.** `manager.remove(entity)`
+ *    deletes by primary key and reports nothing, so two concurrent removals each
+ *    reversed the same amount while only one row went away. The reversal has to
+ *    be gated on this request being the one that removed the row.
+ * 2. **Derive the amount from the locked row, not from a snapshot.** The caller's
+ *    copy may predate another writer's edit; reversing a stale amount leaves the
+ *    ledger and `current_balance` permanently apart.
+ * 3. **A VOID row contributed nothing, so there is nothing to reverse.**
+ *    Subtracting its amount is a straight corruption of the balance.
+ * 4. **A future-dated row is not in `current_balance` at all**, so it gets a
+ *    recomputation rather than a delta.
+ *
+ * That sequence existed in three services and needed a fourth copy for split
+ * removal, which is how the audit's FV4-002 double-reversal survived the pass
+ * that fixed the other three. `derived-state-writers.guard.spec.ts` fails on a
+ * balance reversal beside an unconditional `remove()`.
+ */
+
+/** The two balance operations a leg removal needs. */
+export interface LegBalanceWriter {
+  updateBalance(accountId: string, amount: number): Promise<unknown>;
+  recalculateCurrentBalance(
+    userId: string,
+    accountId: string,
+  ): Promise<unknown>;
+}
+
+/**
+ * Delete one locked ledger row and reverse its balance contribution.
+ *
+ * Returns true when this call removed the row. False means somebody else already
+ * did, and **nothing was reversed** -- the caller must not treat it as an error,
+ * but must not double up on any other side effect it was about to perform either.
+ */
+export async function removeLockedTransactionLeg(
+  m: EntityManager,
+  leg: LockedTransactionRow,
+  userId: string,
+  balances: LegBalanceWriter,
+): Promise<boolean> {
+  const removed = await m.delete(Transaction, { id: leg.id, userId });
+  if ((removed.affected ?? 0) === 0) {
+    return false;
+  }
+
+  if (isTransactionInFuture(leg.transactionDate)) {
+    await balances.recalculateCurrentBalance(userId, leg.accountId);
+  } else if (leg.status !== TransactionStatus.VOID) {
+    await balances.updateBalance(leg.accountId, -leg.amount);
+  }
+  return true;
+}

--- a/backend/src/transactions/transaction-bulk-update.service.spec.ts
+++ b/backend/src/transactions/transaction-bulk-update.service.spec.ts
@@ -11,6 +11,11 @@ import { NetWorthService } from "../net-worth/net-worth.service";
 import { TagsService } from "../tags/tags.service";
 import { BulkUpdateDto, BulkDeleteDto } from "./dto/bulk-update.dto";
 import { Brackets, DataSource } from "typeorm";
+import { lockTransactionRows } from "../common/db/locks";
+import {
+  lockedTransactionRow,
+  stubLockedTransactions,
+} from "../test-helpers/locks-testing";
 import {
   createScopedDbMocks,
   DataSourceMock,
@@ -18,6 +23,14 @@ import {
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
+);
+
+// Balance deltas are derived from rows locked inside the write transaction, not
+// from the pre-read: a row a concurrent request already deleted must not get a
+// reversal (audit P4-003). The double below feeds those readers from the same
+// fixtures the pre-read returns.
+jest.mock("../common/db/locks", () =>
+  jest.requireActual("../test-helpers/locks-testing").locksMockModule(),
 );
 
 jest.mock("../common/date-utils", () => ({
@@ -41,10 +54,20 @@ describe("TransactionBulkUpdateService", () => {
 
   const userId = "user-1";
 
+  /**
+   * Every transaction a test builds, by id.
+   *
+   * The locked readers are served from this, so a test that builds its fixtures
+   * with `makeTransaction` automatically has them as the *committed* rows the
+   * write transaction locks -- which is what the pre-transaction read used to be
+   * trusted for. A test that wants the rows to disagree calls `stageLocked`.
+   */
+  let builtTransactions: Map<string, Transaction>;
+
   const makeTransaction = (
     overrides: Partial<Transaction> = {},
   ): Transaction => {
-    return {
+    const built = {
       id: "tx-1",
       userId,
       accountId: "account-1",
@@ -71,6 +94,36 @@ describe("TransactionBulkUpdateService", () => {
       updatedAt: new Date("2026-01-15"),
       ...overrides,
     } as Transaction;
+    builtTransactions.set(built.id, built);
+    stageLocked([...builtTransactions.values()]);
+    return built;
+  };
+
+  /**
+   * Stage `transactions` as the rows the write transaction locks.
+   *
+   * Both bulk paths derive their balance deltas from these, not from the read
+   * that happened before the transaction opened -- a row another request deleted
+   * in the meantime is simply absent and gets no reversal.
+   */
+  const stageLocked = (transactions: Transaction[]): void => {
+    stubLockedTransactions(
+      {
+        lockTransactionRow: jest.fn(),
+        lockTransactionRows: lockTransactionRows as jest.Mock,
+      },
+      transactions.map((t) =>
+        lockedTransactionRow({
+          id: t.id,
+          accountId: t.accountId,
+          amount: Number(t.amount),
+          transactionDate: String(t.transactionDate),
+          status: t.status,
+          isSplit: t.isSplit,
+          linkedTransactionId: t.linkedTransactionId ?? null,
+        }),
+      ),
+    );
   };
 
   const createMockQueryBuilder = (
@@ -92,6 +145,7 @@ describe("TransactionBulkUpdateService", () => {
   });
 
   beforeEach(async () => {
+    builtTransactions = new Map();
     transactionsRepository = {
       createQueryBuilder: jest.fn().mockImplementation(() =>
         createMockQueryBuilder({
@@ -1297,6 +1351,50 @@ describe("TransactionBulkUpdateService", () => {
       await service.bulkDelete(userId, dto);
 
       expect(accountsService.updateBalance).toHaveBeenCalledWith("acc-1", -100);
+    });
+
+    it("does not reverse a row a concurrent request already deleted", async () => {
+      // The regression guard for P4-003's double-delete: opening 100.00 and one
+      // -10.00 row removed twice left the stored balance 10.00 above the ledger,
+      // because both requests reversed an amount only one of them removed. The
+      // reversal now comes from the locked row set, so a row that is gone by
+      // then contributes nothing.
+      const tx1 = makeTransaction({
+        id: "tx-1",
+        accountId: "acc-1",
+        amount: 100,
+      });
+
+      const resolveQb = createMockQueryBuilder({
+        getMany: jest.fn().mockResolvedValue([{ id: "tx-1" }]),
+      });
+      const detailsQb = createMockQueryBuilder({
+        getMany: jest.fn().mockResolvedValue([tx1]),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+      });
+      transactionsRepository.createQueryBuilder
+        .mockReturnValueOnce(resolveQb)
+        .mockReturnValueOnce(detailsQb);
+
+      const deleteQb = createMockQueryBuilder({
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 0 }),
+      });
+      mockManagerCreateQueryBuilder.mockReturnValueOnce(deleteQb);
+
+      // The pre-read found it; the lock did not.
+      stageLocked([]);
+
+      const result = await service.bulkDelete(userId, {
+        mode: "ids",
+        transactionIds: ["tx-1"],
+      });
+
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      // And the count reports what the database removed, not what the pre-read
+      // hoped to remove.
+      expect(result.deleted).toBe(0);
     });
 
     it("does not adjust balance for VOID transactions", async () => {

--- a/backend/src/transactions/transaction-bulk-update.service.ts
+++ b/backend/src/transactions/transaction-bulk-update.service.ts
@@ -41,6 +41,7 @@ import {
 } from "./transaction-search-parse.util";
 import { tr } from "../i18n/translate";
 import { withScopedDb } from "../common/db/scoped-db";
+import { lockTransactionRows } from "../common/db/locks";
 
 export interface BulkDeleteResult {
   deleted: number;
@@ -152,6 +153,16 @@ export class TransactionBulkUpdateService {
 
     // Balance changes and the batch update commit in a single transaction.
     await withScopedDb(this.dataSource, async (m) => {
+      // Lock every row this batch will write, ascending by id, before anything
+      // reads the statuses the VOID adjustment is derived from. One transaction
+      // was not enough: handleStatusBalanceChanges aggregates the *current*
+      // statuses and the UPDATE that changes them runs afterwards, so without
+      // the lock a concurrent single-transaction edit lands in between and the
+      // batch applies a delta for a transition that no longer happened.
+      if (isUpdatingStatus) {
+        await lockTransactionRows(m, eligibleIds, userId);
+      }
+
       // Step 3: Handle balance adjustments for VOID status changes
       if (isUpdatingStatus) {
         await this.handleStatusBalanceChanges(
@@ -240,6 +251,7 @@ export class TransactionBulkUpdateService {
     }
 
     // Balance adjustments and both delete passes commit atomically.
+    let deleted = 0;
     await withScopedDb(this.dataSource, async (m) => {
       // Collect linked transaction IDs from transfers and split transfers
       const linkedIdsToDelete = new Set<string>();
@@ -264,40 +276,33 @@ export class TransactionBulkUpdateService {
         }
       }
 
-      // Load linked transactions for balance adjustments
-      let linkedTransactions: Transaction[] = [];
-      if (linkedIdsToDelete.size > 0) {
-        linkedTransactions = await m
-          .createQueryBuilder(Transaction, "transaction")
-          .select([
-            "transaction.id",
-            "transaction.accountId",
-            "transaction.amount",
-            "transaction.status",
-            "transaction.transactionDate",
-          ])
-          .where("transaction.id IN (:...ids)", {
-            ids: [...linkedIdsToDelete],
-          })
-          .andWhere("transaction.userId = :userId", { userId })
-          .getMany();
-      }
+      // Lock every row about to be deleted -- primary and linked alike --
+      // ascending by id, and derive the reversals from the locked values.
+      //
+      // The `transactions` read above happened before this transaction opened,
+      // so its amounts and statuses are a claim about the past. A row another
+      // request deleted in the meantime is simply absent from `locked`, and gets
+      // no reversal: reversing an amount whose row is already gone is how a
+      // double delete leaves the balance 10.00 above the ledger (P4-003).
+      const locked = await lockTransactionRows(
+        m,
+        [...allIds, ...linkedIdsToDelete],
+        userId,
+      );
 
-      // Adjust balances for all transactions being deleted (primary + linked)
-      const allTransactionsToDelete = [...transactions, ...linkedTransactions];
       const balanceAdjustments = new Map<string, number>();
-
-      for (const tx of allTransactionsToDelete) {
+      for (const tx of locked.values()) {
         if (
           tx.status !== TransactionStatus.VOID &&
           !isTransactionInFuture(tx.transactionDate)
         ) {
           const current = balanceAdjustments.get(tx.accountId) || 0;
-          balanceAdjustments.set(tx.accountId, current - Number(tx.amount));
+          balanceAdjustments.set(tx.accountId, current - tx.amount);
         }
       }
 
-      for (const [accountId, adjustment] of balanceAdjustments) {
+      for (const accountId of [...balanceAdjustments.keys()].sort()) {
+        const adjustment = balanceAdjustments.get(accountId)!;
         if (adjustment !== 0) {
           await this.accountsService.updateBalance(accountId, adjustment);
         }
@@ -315,13 +320,16 @@ export class TransactionBulkUpdateService {
       }
 
       // Delete the primary transactions
-      await m
+      const primaryDeleted = await m
         .createQueryBuilder()
         .delete()
         .from(Transaction)
         .where("id IN (:...ids)", { ids: allIds })
         .andWhere("userId = :userId", { userId })
         .execute();
+      // What the database removed, not what the pre-read hoped to remove: a row
+      // a concurrent request already deleted must not be counted twice.
+      deleted = primaryDeleted.affected ?? 0;
     });
 
     // Trigger net worth recalc for all affected accounts
@@ -330,7 +338,7 @@ export class TransactionBulkUpdateService {
       this.netWorthService.triggerDebouncedRecalc(accountId, userId);
     }
 
-    return { deleted: transactions.length };
+    return { deleted };
   }
 
   private extractUpdateFields(dto: BulkUpdateDto): Partial<Transaction> {

--- a/backend/src/transactions/transaction-reconciliation.service.spec.ts
+++ b/backend/src/transactions/transaction-reconciliation.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { DataSource } from "typeorm";
-import { BadRequestException } from "@nestjs/common";
+import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { TransactionReconciliationService } from "./transaction-reconciliation.service";
 import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { AccountsService } from "../accounts/accounts.service";
@@ -9,9 +9,21 @@ import {
   createScopedDbMocks,
   DataSourceMock,
 } from "../test-helpers/scoped-db-testing";
+import { lockTransactionRow } from "../common/db/locks";
+import {
+  lockedTransactionRow,
+  stubLockedTransactions,
+} from "../test-helpers/locks-testing";
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
+);
+
+// The status a guard refuses on and the status a balance delta is derived from
+// are the same value, read under the write's own lock. A spec says what the
+// committed row holds; see test-helpers/locks-testing.
+jest.mock("../common/db/locks", () =>
+  jest.requireActual("../test-helpers/locks-testing").locksMockModule(),
 );
 
 jest.mock("../common/date-utils", () => ({
@@ -66,6 +78,37 @@ describe("TransactionReconciliationService", () => {
     } as Transaction;
   };
 
+  /**
+   * Build a transaction AND stage it as the row the service locks.
+   *
+   * The service takes an id and re-reads the row inside its own transaction, so
+   * a spec has to say what the committed row holds. Doing it here rather than at
+   * each call site keeps every existing scenario describing the same thing: the
+   * committed row is the one the test built.
+   */
+  const stageTransaction = (
+    overrides: Partial<Transaction> = {},
+  ): Transaction => {
+    const transaction = makeTransaction(overrides);
+    stubLockedTransactions(
+      {
+        lockTransactionRow: lockTransactionRow as jest.Mock,
+        lockTransactionRows: jest.fn(),
+      },
+      [
+        lockedTransactionRow({
+          id: transaction.id,
+          accountId: transaction.accountId,
+          amount: Number(transaction.amount),
+          transactionDate: String(transaction.transactionDate),
+          status: transaction.status,
+          isSplit: transaction.isSplit,
+        }),
+      ],
+    );
+    return transaction;
+  };
+
   beforeEach(async () => {
     mockedIsTransactionInFuture.mockReturnValue(false);
 
@@ -114,7 +157,7 @@ describe("TransactionReconciliationService", () => {
 
   describe("updateStatus", () => {
     it("updates status from UNRECONCILED to CLEARED without balance change", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.UNRECONCILED,
       });
       const updatedTx = makeTransaction({
@@ -123,9 +166,9 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       const result = await service.updateStatus(
-        transaction,
-        TransactionStatus.CLEARED,
         userId,
+        transaction.id,
+        TransactionStatus.CLEARED,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -140,7 +183,7 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("adds balance back when transitioning from VOID to non-VOID", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.VOID,
         amount: 250,
       });
@@ -151,9 +194,9 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.CLEARED,
         userId,
+        transaction.id,
+        TransactionStatus.CLEARED,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -166,7 +209,7 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("subtracts balance when transitioning from non-VOID to VOID", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.CLEARED,
         amount: 300,
       });
@@ -177,9 +220,9 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.VOID,
         userId,
+        transaction.id,
+        TransactionStatus.VOID,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -192,7 +235,7 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("does not change balance when staying VOID", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.VOID,
       });
       mockFindOne.mockResolvedValue(
@@ -200,9 +243,9 @@ describe("TransactionReconciliationService", () => {
       );
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.VOID,
         userId,
+        transaction.id,
+        TransactionStatus.VOID,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -212,7 +255,7 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("does not trigger net worth recalc when VOID status does not change", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.UNRECONCILED,
       });
       mockFindOne.mockResolvedValue(
@@ -220,9 +263,9 @@ describe("TransactionReconciliationService", () => {
       );
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.CLEARED,
         userId,
+        transaction.id,
+        TransactionStatus.CLEARED,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -234,7 +277,7 @@ describe("TransactionReconciliationService", () => {
       const now = new Date(2026, 1, 10);
       jest.useFakeTimers({ now });
 
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.CLEARED,
       });
       mockFindOne.mockResolvedValue(
@@ -242,17 +285,17 @@ describe("TransactionReconciliationService", () => {
       );
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.RECONCILED,
         userId,
+        transaction.id,
+        TransactionStatus.RECONCILED,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
 
+      // One UPDATE, not two: the status and the reconciled date are the same
+      // transition, applied together under the row lock.
       expect(transactionsRepository.update).toHaveBeenCalledWith("tx-1", {
         status: TransactionStatus.RECONCILED,
-      });
-      expect(transactionsRepository.update).toHaveBeenCalledWith("tx-1", {
         reconciledDate: "2026-02-10",
       });
 
@@ -260,16 +303,16 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("does not set reconciledDate when already RECONCILED", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.RECONCILED,
         reconciledDate: "2026-01-01",
       });
       mockFindOne.mockResolvedValue(transaction);
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.RECONCILED,
         userId,
+        transaction.id,
+        TransactionStatus.RECONCILED,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -282,7 +325,7 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("does not set reconciledDate when transitioning to a non-RECONCILED status", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.UNRECONCILED,
       });
       mockFindOne.mockResolvedValue(
@@ -290,9 +333,9 @@ describe("TransactionReconciliationService", () => {
       );
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.VOID,
         userId,
+        transaction.id,
+        TransactionStatus.VOID,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -305,7 +348,7 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("handles negative transaction amounts correctly for VOID transitions", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.UNRECONCILED,
         amount: -75.5,
       });
@@ -314,9 +357,9 @@ describe("TransactionReconciliationService", () => {
       );
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.VOID,
         userId,
+        transaction.id,
+        TransactionStatus.VOID,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -334,10 +377,11 @@ describe("TransactionReconciliationService", () => {
       });
       mockFindOne.mockResolvedValue(updatedTx);
 
+      const transaction = stageTransaction();
       const result = await service.updateStatus(
-        makeTransaction(),
-        TransactionStatus.CLEARED,
         userId,
+        transaction.id,
+        TransactionStatus.CLEARED,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -346,7 +390,7 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("commits the status change and balance update in a single transaction", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.VOID,
         amount: 250,
       });
@@ -355,9 +399,9 @@ describe("TransactionReconciliationService", () => {
       );
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.CLEARED,
         userId,
+        transaction.id,
+        TransactionStatus.CLEARED,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -367,7 +411,7 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("rolls back and does not commit when the balance update fails", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.VOID,
         amount: 250,
       });
@@ -377,9 +421,9 @@ describe("TransactionReconciliationService", () => {
 
       await expect(
         service.updateStatus(
-          transaction,
-          TransactionStatus.CLEARED,
           userId,
+          transaction.id,
+          TransactionStatus.CLEARED,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
@@ -393,7 +437,7 @@ describe("TransactionReconciliationService", () => {
 
   describe("markCleared", () => {
     it("marks an UNRECONCILED transaction as CLEARED", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.UNRECONCILED,
       });
       const updatedTx = makeTransaction({
@@ -402,9 +446,9 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       const result = await service.markCleared(
-        transaction,
-        true,
         userId,
+        transaction.id,
+        true,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -416,7 +460,7 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("marks a CLEARED transaction as UNRECONCILED when isCleared is false", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.CLEARED,
       });
       const updatedTx = makeTransaction({
@@ -425,9 +469,9 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       const result = await service.markCleared(
-        transaction,
-        false,
         userId,
+        transaction.id,
+        false,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -439,24 +483,24 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("throws when transaction is RECONCILED", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.RECONCILED,
       });
 
       await expect(
         service.markCleared(
-          transaction,
-          true,
           userId,
+          transaction.id,
+          true,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
       ).rejects.toThrow(BadRequestException);
       await expect(
         service.markCleared(
-          transaction,
-          true,
           userId,
+          transaction.id,
+          true,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
@@ -466,24 +510,24 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("throws when transaction is VOID", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.VOID,
       });
 
       await expect(
         service.markCleared(
-          transaction,
-          false,
           userId,
+          transaction.id,
+          false,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
       ).rejects.toThrow(BadRequestException);
       await expect(
         service.markCleared(
-          transaction,
-          false,
           userId,
+          transaction.id,
+          false,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
@@ -493,15 +537,15 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("does not call updateStatus when validation fails", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.RECONCILED,
       });
 
       await expect(
         service.markCleared(
-          transaction,
-          true,
           userId,
+          transaction.id,
+          true,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
@@ -516,7 +560,7 @@ describe("TransactionReconciliationService", () => {
     it("reconciles an UNRECONCILED transaction", async () => {
       jest.useFakeTimers({ now: new Date(2026, 0, 20) });
 
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.UNRECONCILED,
       });
       const updatedTx = makeTransaction({
@@ -526,14 +570,17 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       const result = await service.reconcile(
-        transaction,
         userId,
+        transaction.id,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
 
+      // One UPDATE, not two: the status and the reconciled date are the same
+      // transition, applied together under the row lock.
       expect(transactionsRepository.update).toHaveBeenCalledWith("tx-1", {
         status: TransactionStatus.RECONCILED,
+        reconciledDate: "2026-01-20",
       });
       expect(result).toEqual(updatedTx);
 
@@ -543,7 +590,7 @@ describe("TransactionReconciliationService", () => {
     it("reconciles a CLEARED transaction", async () => {
       jest.useFakeTimers({ now: new Date(2026, 0, 20) });
 
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.CLEARED,
       });
       const updatedTx = makeTransaction({
@@ -552,14 +599,17 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       const result = await service.reconcile(
-        transaction,
         userId,
+        transaction.id,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
 
+      // One UPDATE, not two: the status and the reconciled date are the same
+      // transition, applied together under the row lock.
       expect(transactionsRepository.update).toHaveBeenCalledWith("tx-1", {
         status: TransactionStatus.RECONCILED,
+        reconciledDate: "2026-01-20",
       });
       expect(result).toEqual(updatedTx);
 
@@ -567,22 +617,22 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("throws when transaction is already RECONCILED", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.RECONCILED,
       });
 
       await expect(
         service.reconcile(
-          transaction,
           userId,
+          transaction.id,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
       ).rejects.toThrow(BadRequestException);
       await expect(
         service.reconcile(
-          transaction,
           userId,
+          transaction.id,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
@@ -590,22 +640,22 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("throws when transaction is VOID", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.VOID,
       });
 
       await expect(
         service.reconcile(
-          transaction,
           userId,
+          transaction.id,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
       ).rejects.toThrow(BadRequestException);
       await expect(
         service.reconcile(
-          transaction,
           userId,
+          transaction.id,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
@@ -613,14 +663,14 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("does not call repository when validation fails", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.RECONCILED,
       });
 
       await expect(
         service.reconcile(
-          transaction,
           userId,
+          transaction.id,
           mockTriggerNetWorthRecalc,
           mockFindOne,
         ),
@@ -632,7 +682,7 @@ describe("TransactionReconciliationService", () => {
 
   describe("unreconcile", () => {
     it("sets status to CLEARED and clears reconciledDate", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.RECONCILED,
         reconciledDate: "2026-01-15",
       });
@@ -643,8 +693,8 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       const result = await service.unreconcile(
-        transaction,
         userId,
+        transaction.id,
         mockFindOne,
       );
 
@@ -657,51 +707,51 @@ describe("TransactionReconciliationService", () => {
     });
 
     it("throws when transaction is not RECONCILED (UNRECONCILED)", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.UNRECONCILED,
       });
 
       await expect(
-        service.unreconcile(transaction, userId, mockFindOne),
+        service.unreconcile(userId, transaction.id, mockFindOne),
       ).rejects.toThrow(BadRequestException);
       await expect(
-        service.unreconcile(transaction, userId, mockFindOne),
+        service.unreconcile(userId, transaction.id, mockFindOne),
       ).rejects.toThrow("Transaction is not reconciled");
     });
 
     it("throws when transaction is not RECONCILED (CLEARED)", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.CLEARED,
       });
 
       await expect(
-        service.unreconcile(transaction, userId, mockFindOne),
+        service.unreconcile(userId, transaction.id, mockFindOne),
       ).rejects.toThrow(BadRequestException);
       await expect(
-        service.unreconcile(transaction, userId, mockFindOne),
+        service.unreconcile(userId, transaction.id, mockFindOne),
       ).rejects.toThrow("Transaction is not reconciled");
     });
 
     it("throws when transaction is not RECONCILED (VOID)", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.VOID,
       });
 
       await expect(
-        service.unreconcile(transaction, userId, mockFindOne),
+        service.unreconcile(userId, transaction.id, mockFindOne),
       ).rejects.toThrow(BadRequestException);
       await expect(
-        service.unreconcile(transaction, userId, mockFindOne),
+        service.unreconcile(userId, transaction.id, mockFindOne),
       ).rejects.toThrow("Transaction is not reconciled");
     });
 
     it("does not call repository when validation fails", async () => {
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.CLEARED,
       });
 
       await expect(
-        service.unreconcile(transaction, userId, mockFindOne),
+        service.unreconcile(userId, transaction.id, mockFindOne),
       ).rejects.toThrow(BadRequestException);
 
       expect(transactionsRepository.update).not.toHaveBeenCalled();
@@ -852,6 +902,85 @@ describe("TransactionReconciliationService", () => {
     });
   });
 
+  describe("compare-and-set against the committed status", () => {
+    /**
+     * The regression guard for the class of bug the id-taking signature exists to
+     * prevent. Each of these hands the service a scenario where the caller's view
+     * of the status is stale, and asserts the *committed* status decides.
+     */
+    it("refuses to unreconcile a row another request has voided", async () => {
+      // Caller believed RECONCILED; the committed row is VOID. Before the locked
+      // re-read, `wasVoid` came from the snapshot and said false, so no balance
+      // adjustment ran -- while the status went VOID -> CLEARED, putting the
+      // amount back in the ledger with nothing putting it back in the balance.
+      stageTransaction({ status: TransactionStatus.VOID, amount: 250 });
+
+      await expect(
+        service.unreconcile(userId, "tx-1", mockFindOne),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(transactionsRepository.update).not.toHaveBeenCalled();
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
+
+    it("refuses to change cleared status on a row another request has voided", async () => {
+      stageTransaction({ status: TransactionStatus.VOID, amount: 250 });
+
+      await expect(
+        service.markCleared(
+          userId,
+          "tx-1",
+          true,
+          mockTriggerNetWorthRecalc,
+          mockFindOne,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(transactionsRepository.update).not.toHaveBeenCalled();
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
+
+    it("derives the un-void balance delta from the locked row's amount", async () => {
+      // The amount that goes back into the balance is the committed one, not one
+      // the caller read before another request edited it.
+      stageTransaction({ status: TransactionStatus.VOID, amount: 250 });
+      mockFindOne.mockResolvedValue(makeTransaction());
+
+      await service.updateStatus(
+        userId,
+        "tx-1",
+        TransactionStatus.CLEARED,
+        mockTriggerNetWorthRecalc,
+        mockFindOne,
+      );
+
+      expect(accountsService.updateBalance).toHaveBeenCalledWith(
+        accountId,
+        250,
+      );
+    });
+
+    it("throws NotFound when the row is gone by the time it is locked", async () => {
+      stubLockedTransactions(
+        {
+          lockTransactionRow: lockTransactionRow as jest.Mock,
+          lockTransactionRows: jest.fn(),
+        },
+        [],
+      );
+
+      await expect(
+        service.updateStatus(
+          userId,
+          "tx-1",
+          TransactionStatus.CLEARED,
+          mockTriggerNetWorthRecalc,
+          mockFindOne,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
   describe("bulkReconcile", () => {
     let mockQueryBuilder: Record<string, jest.Mock>;
 
@@ -861,6 +990,11 @@ describe("TransactionReconciliationService", () => {
         andWhere: jest.fn().mockReturnThis(),
         update: jest.fn().mockReturnThis(),
         set: jest.fn().mockReturnThis(),
+        // The VOID exclusion is a refusal, so the rows are locked in ascending
+        // id order and re-checked against the status this statement is about to
+        // overwrite.
+        orderBy: jest.fn().mockReturnThis(),
+        setLock: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([]),
         execute: jest.fn().mockResolvedValue({ affected: 0 }),
       };
@@ -993,7 +1127,7 @@ describe("TransactionReconciliationService", () => {
     it("does NOT call updateBalance when voiding a future-dated transaction", async () => {
       mockedIsTransactionInFuture.mockReturnValue(true);
 
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.CLEARED,
         amount: 300,
         transactionDate: "2027-06-15",
@@ -1006,9 +1140,9 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.VOID,
         userId,
+        transaction.id,
+        TransactionStatus.VOID,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -1024,7 +1158,7 @@ describe("TransactionReconciliationService", () => {
     it("does NOT call updateBalance when unvoiding a future-dated transaction", async () => {
       mockedIsTransactionInFuture.mockReturnValue(true);
 
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.VOID,
         amount: 250,
         transactionDate: "2027-06-15",
@@ -1037,9 +1171,9 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       await service.updateStatus(
-        transaction,
-        TransactionStatus.CLEARED,
         userId,
+        transaction.id,
+        TransactionStatus.CLEARED,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );
@@ -1055,7 +1189,7 @@ describe("TransactionReconciliationService", () => {
     it("still updates the status even for future-dated transactions", async () => {
       mockedIsTransactionInFuture.mockReturnValue(true);
 
-      const transaction = makeTransaction({
+      const transaction = stageTransaction({
         status: TransactionStatus.UNRECONCILED,
         amount: -75.5,
         transactionDate: "2027-06-15",
@@ -1068,9 +1202,9 @@ describe("TransactionReconciliationService", () => {
       mockFindOne.mockResolvedValue(updatedTx);
 
       const result = await service.updateStatus(
-        transaction,
-        TransactionStatus.VOID,
         userId,
+        transaction.id,
+        TransactionStatus.VOID,
         mockTriggerNetWorthRecalc,
         mockFindOne,
       );

--- a/backend/src/transactions/transaction-reconciliation.service.ts
+++ b/backend/src/transactions/transaction-reconciliation.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   BadRequestException,
   Inject,
+  NotFoundException,
   forwardRef,
 } from "@nestjs/common";
 import { DataSource } from "typeorm";
@@ -13,6 +14,14 @@ import {
 } from "../common/date-utils";
 import { tr } from "../i18n/translate";
 import { withScopedDb } from "../common/db/scoped-db";
+import { lockTransactionRow } from "../common/db/locks";
+
+/** What a transition resolver returns, or it throws to refuse the transition. */
+interface ResolvedTransition {
+  readonly status: TransactionStatus;
+  /** Wipe `reconciled_date`, for the transition that undoes a reconciliation. */
+  readonly clearReconciledDate?: boolean;
+}
 
 @Injectable()
 export class TransactionReconciliationService {
@@ -22,151 +31,198 @@ export class TransactionReconciliationService {
     private dataSource: DataSource,
   ) {}
 
-  async updateStatus(
-    transaction: Transaction,
-    status: TransactionStatus,
+  /**
+   * Apply one status transition as a compare-and-set against the row's own
+   * committed status.
+   *
+   * Every guard these entry points apply -- "not already reconciled", "not
+   * void", "must currently be reconciled" -- is a decision about the *current*
+   * status, and so is the balance adjustment: crossing into or out of `VOID` is
+   * the only transition that moves money. Reading that status from a snapshot
+   * loaded before the transaction made both wrong at once. A request holding a
+   * `RECONCILED` snapshot could unreconcile a row another request had since
+   * voided: `wasVoid` computed from the snapshot said false, `isVoid` said
+   * false, so no balance adjustment ran -- while the row went from VOID back to
+   * CLEARED, putting its amount back in the ledger with nothing putting it back
+   * in the balance.
+   *
+   * So the resolver runs here, inside the transaction, against the locked row.
+   * `oldStatus` is the version this write actually replaces, and a guard that
+   * refuses does so before anything is written.
+   */
+  private async applyStatusTransition(
     userId: string,
-    triggerNetWorthRecalc: (accountId: string, userId: string) => void,
-    findOne: (userId: string, id: string) => Promise<Transaction>,
-  ): Promise<Transaction> {
-    const oldStatus = transaction.status;
-    const wasVoid = oldStatus === TransactionStatus.VOID;
-    const isVoid = status === TransactionStatus.VOID;
+    transactionId: string,
+    resolve: (current: TransactionStatus) => ResolvedTransition,
+  ): Promise<{ accountId: string; balanceMoved: boolean }> {
+    return withScopedDb(this.dataSource, async (m) => {
+      const locked = await lockTransactionRow(m, transactionId, userId);
+      if (!locked) {
+        throw new NotFoundException(
+          tr(
+            "errors.transactions.notFoundById",
+            `Transaction with ID ${transactionId} not found`,
+            { id: transactionId },
+          ),
+        );
+      }
 
-    // The status change and the matching balance adjustment touch two tables
-    // (transactions + accounts) and must commit atomically, otherwise a failure
-    // between the two leaves the account balance out of sync with the status.
-    await withScopedDb(this.dataSource, async (m) => {
-      if (isTransactionInFuture(transaction.transactionDate)) {
-        await m.update(Transaction, transaction.id, {
-          status,
-        });
-        if (wasVoid !== isVoid) {
+      const oldStatus = locked.status as TransactionStatus;
+      const { status, clearReconciledDate } = resolve(oldStatus);
+
+      const wasVoid = oldStatus === TransactionStatus.VOID;
+      const isVoid = status === TransactionStatus.VOID;
+      const balanceMoved = wasVoid !== isVoid;
+
+      const fields: Partial<Transaction> = { status };
+      if (
+        status === TransactionStatus.RECONCILED &&
+        oldStatus !== TransactionStatus.RECONCILED
+      ) {
+        fields.reconciledDate = formatDateYMDLocal(new Date());
+      } else if (clearReconciledDate) {
+        fields.reconciledDate = null;
+      }
+
+      if (isTransactionInFuture(locked.transactionDate)) {
+        await m.update(Transaction, transactionId, fields);
+        if (balanceMoved) {
           await this.accountsService.recalculateCurrentBalance(
-            transaction.accountId,
+            userId,
+            locked.accountId,
           );
         }
       } else {
         if (wasVoid && !isVoid) {
           await this.accountsService.updateBalance(
-            transaction.accountId,
-            Number(transaction.amount),
+            locked.accountId,
+            locked.amount,
           );
         } else if (!wasVoid && isVoid) {
           await this.accountsService.updateBalance(
-            transaction.accountId,
-            -Number(transaction.amount),
+            locked.accountId,
+            -locked.amount,
           );
         }
-        await m.update(Transaction, transaction.id, {
-          status,
-        });
+        await m.update(Transaction, transactionId, fields);
       }
 
-      if (
-        status === TransactionStatus.RECONCILED &&
-        oldStatus !== TransactionStatus.RECONCILED
-      ) {
-        const reconciledDate = formatDateYMDLocal(new Date());
-        await m.update(Transaction, transaction.id, {
-          reconciledDate,
-        });
-      }
+      return { accountId: locked.accountId, balanceMoved };
     });
+  }
 
-    if (wasVoid !== isVoid) {
-      triggerNetWorthRecalc(transaction.accountId, userId);
+  async updateStatus(
+    userId: string,
+    transactionId: string,
+    status: TransactionStatus,
+    triggerNetWorthRecalc: (accountId: string, userId: string) => void,
+    findOne: (userId: string, id: string) => Promise<Transaction>,
+  ): Promise<Transaction> {
+    const { accountId, balanceMoved } = await this.applyStatusTransition(
+      userId,
+      transactionId,
+      () => ({ status }),
+    );
+
+    if (balanceMoved) {
+      triggerNetWorthRecalc(accountId, userId);
     }
 
-    return findOne(userId, transaction.id);
+    return findOne(userId, transactionId);
   }
 
   async markCleared(
-    transaction: Transaction,
-    isCleared: boolean,
     userId: string,
+    transactionId: string,
+    isCleared: boolean,
     triggerNetWorthRecalc: (accountId: string, userId: string) => void,
     findOne: (userId: string, id: string) => Promise<Transaction>,
   ): Promise<Transaction> {
-    if (
-      transaction.status === TransactionStatus.RECONCILED ||
-      transaction.status === TransactionStatus.VOID
-    ) {
-      throw new BadRequestException(
-        tr(
-          "errors.transactions.cannotChangeClearedStatusOfReconciledOrVoid",
-          "Cannot change cleared status of reconciled or void transactions",
-        ),
-      );
+    const { accountId, balanceMoved } = await this.applyStatusTransition(
+      userId,
+      transactionId,
+      (current) => {
+        if (
+          current === TransactionStatus.RECONCILED ||
+          current === TransactionStatus.VOID
+        ) {
+          throw new BadRequestException(
+            tr(
+              "errors.transactions.cannotChangeClearedStatusOfReconciledOrVoid",
+              "Cannot change cleared status of reconciled or void transactions",
+            ),
+          );
+        }
+        return {
+          status: isCleared
+            ? TransactionStatus.CLEARED
+            : TransactionStatus.UNRECONCILED,
+        };
+      },
+    );
+
+    if (balanceMoved) {
+      triggerNetWorthRecalc(accountId, userId);
     }
 
-    const newStatus = isCleared
-      ? TransactionStatus.CLEARED
-      : TransactionStatus.UNRECONCILED;
-    return this.updateStatus(
-      transaction,
-      newStatus,
-      userId,
-      triggerNetWorthRecalc,
-      findOne,
-    );
+    return findOne(userId, transactionId);
   }
 
   async reconcile(
-    transaction: Transaction,
     userId: string,
+    transactionId: string,
     triggerNetWorthRecalc: (accountId: string, userId: string) => void,
     findOne: (userId: string, id: string) => Promise<Transaction>,
   ): Promise<Transaction> {
-    if (transaction.status === TransactionStatus.RECONCILED) {
-      throw new BadRequestException(
-        tr(
-          "errors.transactions.alreadyReconciled",
-          "Transaction is already reconciled",
-        ),
-      );
-    }
-
-    if (transaction.status === TransactionStatus.VOID) {
-      throw new BadRequestException(
-        tr(
-          "errors.transactions.cannotReconcileVoid",
-          "Cannot reconcile a void transaction",
-        ),
-      );
-    }
-
-    return this.updateStatus(
-      transaction,
-      TransactionStatus.RECONCILED,
+    const { accountId, balanceMoved } = await this.applyStatusTransition(
       userId,
-      triggerNetWorthRecalc,
-      findOne,
+      transactionId,
+      (current) => {
+        if (current === TransactionStatus.RECONCILED) {
+          throw new BadRequestException(
+            tr(
+              "errors.transactions.alreadyReconciled",
+              "Transaction is already reconciled",
+            ),
+          );
+        }
+        if (current === TransactionStatus.VOID) {
+          throw new BadRequestException(
+            tr(
+              "errors.transactions.cannotReconcileVoid",
+              "Cannot reconcile a void transaction",
+            ),
+          );
+        }
+        return { status: TransactionStatus.RECONCILED };
+      },
     );
+
+    if (balanceMoved) {
+      triggerNetWorthRecalc(accountId, userId);
+    }
+
+    return findOne(userId, transactionId);
   }
 
   async unreconcile(
-    transaction: Transaction,
     userId: string,
+    transactionId: string,
     findOne: (userId: string, id: string) => Promise<Transaction>,
   ): Promise<Transaction> {
-    if (transaction.status !== TransactionStatus.RECONCILED) {
-      throw new BadRequestException(
-        tr(
-          "errors.transactions.notReconciled",
-          "Transaction is not reconciled",
-        ),
-      );
-    }
+    await this.applyStatusTransition(userId, transactionId, (current) => {
+      if (current !== TransactionStatus.RECONCILED) {
+        throw new BadRequestException(
+          tr(
+            "errors.transactions.notReconciled",
+            "Transaction is not reconciled",
+          ),
+        );
+      }
+      return { status: TransactionStatus.CLEARED, clearReconciledDate: true };
+    });
 
-    await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(Transaction).update(transaction.id, {
-        status: TransactionStatus.CLEARED,
-        reconciledDate: null,
-      }),
-    );
-
-    return findOne(userId, transaction.id);
+    return findOne(userId, transactionId);
   }
 
   async getReconciliationData(
@@ -261,12 +317,17 @@ export class TransactionReconciliationService {
     }
 
     return withScopedDb(this.dataSource, async (m) => {
+      // Locked in ascending id order and re-checked here: the VOID exclusion
+      // below is a refusal, so it has to be evaluated against the status this
+      // statement is about to overwrite, not against one read a moment earlier.
       const transactions = await m
         .getRepository(Transaction)
         .createQueryBuilder("transaction")
         .where("transaction.id IN (:...ids)", { ids: transactionIds })
         .andWhere("transaction.userId = :userId", { userId })
         .andWhere("transaction.accountId = :accountId", { accountId })
+        .orderBy("transaction.id", "ASC")
+        .setLock("pessimistic_write")
         .getMany();
 
       if (transactions.length !== transactionIds.length) {

--- a/backend/src/transactions/transaction-split.service.spec.ts
+++ b/backend/src/transactions/transaction-split.service.spec.ts
@@ -11,9 +11,21 @@ import {
   createScopedDbMocks,
   DataSourceMock,
 } from "../test-helpers/scoped-db-testing";
+import { lockTransactionRow, lockTransactionRows } from "../common/db/locks";
+import type { LockedTransactionRow } from "../common/db/locks";
+import {
+  lockedTransactionRow,
+  stubLockedTransactions,
+} from "../test-helpers/locks-testing";
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
+);
+
+// `addSplit` and `updateSplits` now validate against the parent row they lock,
+// not against the entity the caller passed. See test-helpers/locks-testing.
+jest.mock("../common/db/locks", () =>
+  jest.requireActual("../test-helpers/locks-testing").locksMockModule(),
 );
 
 jest.mock("../common/date-utils", () => ({
@@ -45,6 +57,51 @@ describe("TransactionSplitService", () => {
     categoryId: null,
   };
 
+  /**
+   * Make the locked parent row the service reads inside its transaction agree
+   * with the entity this test hands in.
+   *
+   * The service deliberately no longer trusts the caller's copy -- the split-sum
+   * validation has to run against the parent amount the write is serialized
+   * against (P4-009) -- so a spec has to say what the committed row holds.
+   */
+  function lockParent(
+    transaction: Partial<Transaction>,
+    ...alsoLocked: LockedTransactionRow[]
+  ): void {
+    stubLocks([
+      lockedTransactionRow({
+        id: transaction.id ?? "tx-1",
+        accountId: transaction.accountId ?? "account-1",
+        amount: Number(transaction.amount ?? 0),
+        transactionDate: String(transaction.transactionDate ?? "2026-01-15"),
+        isSplit: transaction.isSplit ?? false,
+        // The counterpart rows are built from the locked parent's payee too
+        // (FV4-002), so the committed row has to carry it.
+        payeeId: transaction.payeeId ?? null,
+        payeeName: transaction.payeeName ?? null,
+      }),
+      ...alsoLocked,
+    ]);
+  }
+
+  /**
+   * Say what the committed rows are for both locked readers.
+   *
+   * The counterpart-removal paths lock and re-read the legs they delete rather
+   * than reading them through the repository first, so a spec describes them
+   * here instead of through `transactionsRepository.find`.
+   */
+  function stubLocks(rows: LockedTransactionRow[]): void {
+    stubLockedTransactions(
+      {
+        lockTransactionRow: lockTransactionRow as jest.Mock,
+        lockTransactionRows: lockTransactionRows as jest.Mock,
+      },
+      rows,
+    );
+  }
+
   const mockSplit: Partial<TransactionSplit> = {
     id: "split-1",
     transactionId: "tx-1",
@@ -69,6 +126,10 @@ describe("TransactionSplitService", () => {
 
   beforeEach(async () => {
     mockedIsTransactionInFuture.mockReturnValue(false);
+    // Module-level mocks outlive the testing module, so a spec asserting that a
+    // reader was NOT consulted would otherwise see the previous test's calls.
+    (lockTransactionRow as jest.Mock).mockClear();
+    (lockTransactionRows as jest.Mock).mockClear();
 
     transactionsRepository = {
       create: jest
@@ -142,7 +203,9 @@ describe("TransactionSplitService", () => {
         return transactionsRepository.update(id, data);
       return Promise.resolve(undefined);
     });
-    manager.delete.mockResolvedValue(undefined);
+    // The real driver reports how many rows a conditional delete removed, and
+    // the leg-removal protocol reverses a balance only when that count is 1.
+    manager.delete.mockResolvedValue({ affected: 1, raw: [] });
     manager.findOne.mockResolvedValue(null);
     manager.find.mockImplementation((_Entity: any) => {
       if (_Entity === Category) {
@@ -459,8 +522,12 @@ describe("TransactionSplitService", () => {
       };
 
       splitsRepository.find.mockResolvedValue([transferSplit]);
-      transactionsRepository.find.mockResolvedValue([
-        { id: "linked-tx-1", accountId: "account-2", amount: 50 },
+      stubLocks([
+        lockedTransactionRow({
+          id: "linked-tx-1",
+          accountId: "account-2",
+          amount: 50,
+        }),
       ]);
 
       await service.deleteSplitSideEffects("tx-1", "user-1");
@@ -469,16 +536,22 @@ describe("TransactionSplitService", () => {
         where: { transactionId: "tx-1" },
         relations: ["linkedTransaction", "investmentTransaction"],
       });
-      expect(transactionsRepository.find).toHaveBeenCalledWith({
-        where: { id: expect.anything() },
-      });
+      // The legs are locked and re-read, not read through the repository: the
+      // amount reversed has to be the one the delete removes (FV4-002).
+      expect(lockTransactionRows).toHaveBeenCalledWith(
+        expect.anything(),
+        ["linked-tx-1"],
+        "user-1",
+      );
       expect(accountsService.updateBalance).toHaveBeenCalledWith(
         "account-2",
         -50,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(
-        expect.objectContaining({ id: "linked-tx-1" }),
-      );
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "linked-tx-1",
+        userId: "user-1",
+      });
+      expect(transactionsRepository.remove).not.toHaveBeenCalled();
     });
 
     it("skips splits without linkedTransactionId or transferAccountId", async () => {
@@ -493,9 +566,12 @@ describe("TransactionSplitService", () => {
 
       await service.deleteSplitSideEffects("tx-1", "user-1");
 
-      expect(transactionsRepository.find).not.toHaveBeenCalled();
+      expect(lockTransactionRows).not.toHaveBeenCalled();
       expect(accountsService.updateBalance).not.toHaveBeenCalled();
-      expect(transactionsRepository.remove).not.toHaveBeenCalled();
+      expect(mockQueryRunner.manager.delete).not.toHaveBeenCalledWith(
+        Transaction,
+        expect.anything(),
+      );
     });
 
     it("handles case where linked transaction not found in DB", async () => {
@@ -507,12 +583,16 @@ describe("TransactionSplitService", () => {
       };
 
       splitsRepository.find.mockResolvedValue([transferSplit]);
-      transactionsRepository.find.mockResolvedValue([]);
+      // Nothing locked: another request already removed the leg.
+      stubLocks([]);
 
       await service.deleteSplitSideEffects("tx-1", "user-1");
 
       expect(accountsService.updateBalance).not.toHaveBeenCalled();
-      expect(transactionsRepository.remove).not.toHaveBeenCalled();
+      expect(mockQueryRunner.manager.delete).not.toHaveBeenCalledWith(
+        Transaction,
+        expect.anything(),
+      );
     });
 
     it("does nothing when no splits exist", async () => {
@@ -520,7 +600,7 @@ describe("TransactionSplitService", () => {
 
       await service.deleteSplitSideEffects("tx-1", "user-1");
 
-      expect(transactionsRepository.find).not.toHaveBeenCalled();
+      expect(lockTransactionRows).not.toHaveBeenCalled();
     });
 
     it("handles multiple transfer splits", async () => {
@@ -540,15 +620,30 @@ describe("TransactionSplitService", () => {
       ];
 
       splitsRepository.find.mockResolvedValue(splits);
-      transactionsRepository.find.mockResolvedValue([
-        { id: "linked-tx-1", accountId: "account-2", amount: 30 },
-        { id: "linked-tx-2", accountId: "account-3", amount: 70 },
+      stubLocks([
+        lockedTransactionRow({
+          id: "linked-tx-1",
+          accountId: "account-2",
+          amount: 30,
+        }),
+        lockedTransactionRow({
+          id: "linked-tx-2",
+          accountId: "account-3",
+          amount: 70,
+        }),
       ]);
 
       await service.deleteSplitSideEffects("tx-1", "user-1");
 
       expect(accountsService.updateBalance).toHaveBeenCalledTimes(2);
-      expect(transactionsRepository.remove).toHaveBeenCalledTimes(2);
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "linked-tx-1",
+        userId: "user-1",
+      });
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "linked-tx-2",
+        userId: "user-1",
+      });
     });
   });
 
@@ -578,6 +673,7 @@ describe("TransactionSplitService", () => {
   describe("updateSplits", () => {
     it("validates, deletes old splits, creates new splits, and marks transaction as split", async () => {
       const transaction = { ...mockTransaction } as Transaction;
+      lockParent(transaction);
       const newSplits = [
         { amount: -70, categoryId: "cat-1" },
         { amount: -30, categoryId: "cat-2" },
@@ -608,6 +704,7 @@ describe("TransactionSplitService", () => {
 
     it("throws when splits fail validation", async () => {
       const transaction = { ...mockTransaction } as Transaction;
+      lockParent(transaction);
       const invalidSplits = [
         { amount: -50, categoryId: "cat-1" },
         { amount: -30, categoryId: "cat-2" },
@@ -626,11 +723,16 @@ describe("TransactionSplitService", () => {
         linkedTransactionId: "old-linked-tx",
         transferAccountId: "account-2",
       };
+      lockParent(
+        transaction,
+        lockedTransactionRow({
+          id: "old-linked-tx",
+          accountId: "account-2",
+          amount: 100,
+        }),
+      );
 
       splitsRepository.find.mockResolvedValue([oldTransferSplit]);
-      transactionsRepository.find.mockResolvedValue([
-        { id: "old-linked-tx", accountId: "account-2", amount: 100 },
-      ]);
 
       const newSplits = [
         { amount: -60, categoryId: "cat-1" },
@@ -648,15 +750,17 @@ describe("TransactionSplitService", () => {
         "account-2",
         -100,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(
-        expect.objectContaining({ id: "old-linked-tx" }),
-      );
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "old-linked-tx",
+        userId: "user-1",
+      });
     });
   });
 
   describe("addSplit", () => {
     it("adds a category split to an existing split transaction", async () => {
       const transaction = { ...mockTransaction, isSplit: true } as Transaction;
+      lockParent(transaction);
       const existingSplits = [
         { ...mockSplit, amount: -60 },
         { ...mockSplit2, amount: -30 },
@@ -698,6 +802,7 @@ describe("TransactionSplitService", () => {
 
     it("throws when adding split would exceed transaction amount", async () => {
       const transaction = { ...mockTransaction, amount: -100 } as Transaction;
+      lockParent(transaction);
       const existingSplits = [{ ...mockSplit, amount: -90 }];
 
       splitsRepository.find.mockResolvedValue(existingSplits);
@@ -717,6 +822,7 @@ describe("TransactionSplitService", () => {
         isSplit: false,
         amount: -100,
       } as Transaction;
+      lockParent(transaction);
       const existingSplits = [{ ...mockSplit, amount: -60 }];
 
       splitsRepository.find.mockResolvedValue(existingSplits);
@@ -751,6 +857,7 @@ describe("TransactionSplitService", () => {
         isSplit: true,
         amount: -100,
       } as Transaction;
+      lockParent(transaction);
       const existingSplits = [
         { ...mockSplit, amount: -40 },
         { ...mockSplit2, amount: -30 },
@@ -786,6 +893,7 @@ describe("TransactionSplitService", () => {
         amount: -100,
         payeeName: "My Transfer",
       } as Transaction;
+      lockParent(transaction);
       const existingSplits = [{ ...mockSplit, amount: -60 }];
 
       splitsRepository.find.mockResolvedValue(existingSplits);
@@ -851,6 +959,7 @@ describe("TransactionSplitService", () => {
         isSplit: true,
         amount: -100,
       } as Transaction;
+      lockParent(transaction);
 
       splitsRepository.find.mockResolvedValue([{ ...mockSplit, amount: -60 }]);
       splitsRepository.save.mockResolvedValue({
@@ -873,6 +982,7 @@ describe("TransactionSplitService", () => {
   describe("removeSplit", () => {
     it("removes a category split from a transaction with more than 2 splits", async () => {
       const transaction = { ...mockTransaction } as Transaction;
+      lockParent(transaction);
       const splitToRemove = {
         ...mockSplit,
         linkedTransactionId: null,
@@ -904,6 +1014,7 @@ describe("TransactionSplitService", () => {
 
     it("throws NotFoundException when split not found", async () => {
       const transaction = { ...mockTransaction } as Transaction;
+      lockParent(transaction);
       splitsRepository.findOne.mockResolvedValue(null);
 
       await expect(
@@ -920,13 +1031,16 @@ describe("TransactionSplitService", () => {
         transferAccountId: "account-2",
         amount: -50,
       };
+      lockParent(
+        transaction,
+        lockedTransactionRow({
+          id: "linked-tx-1",
+          accountId: "account-2",
+          amount: 50,
+        }),
+      );
 
       splitsRepository.findOne.mockResolvedValue(transferSplit);
-      mockQueryRunner.manager.findOne.mockResolvedValue({
-        id: "linked-tx-1",
-        accountId: "account-2",
-        amount: 50,
-      });
       // remaining splits after removal -- still 2+
       mockQueryRunner.manager.find.mockResolvedValue([
         {
@@ -949,13 +1063,19 @@ describe("TransactionSplitService", () => {
         "account-2",
         -50,
       );
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(
+      // Deleted conditionally, so a second caller reverses nothing (FV4-002).
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "linked-tx-1",
+        userId: "user-1",
+      });
+      expect(mockQueryRunner.manager.remove).not.toHaveBeenCalledWith(
         expect.objectContaining({ id: "linked-tx-1" }),
       );
     });
 
     it("collapses to non-split when only 1 split remains (category)", async () => {
       const transaction = { ...mockTransaction } as Transaction;
+      lockParent(transaction);
       const splitToRemove = {
         ...mockSplit,
         linkedTransactionId: null,
@@ -986,6 +1106,14 @@ describe("TransactionSplitService", () => {
 
     it("collapses to non-split and removes linked transaction when last split is a transfer", async () => {
       const transaction = { ...mockTransaction } as Transaction;
+      lockParent(
+        transaction,
+        lockedTransactionRow({
+          id: "linked-tx-2",
+          accountId: "account-3",
+          amount: 40,
+        }),
+      );
       const splitToRemove = {
         ...mockSplit,
         linkedTransactionId: null,
@@ -1003,11 +1131,6 @@ describe("TransactionSplitService", () => {
         amount: -40,
       };
       mockQueryRunner.manager.find.mockResolvedValue([lastSplit]);
-      mockQueryRunner.manager.findOne.mockResolvedValue({
-        id: "linked-tx-2",
-        accountId: "account-3",
-        amount: 40,
-      });
 
       await service.removeSplit(transaction, "split-1", "user-1");
 
@@ -1015,9 +1138,10 @@ describe("TransactionSplitService", () => {
         "account-3",
         -40,
       );
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(
-        expect.objectContaining({ id: "linked-tx-2" }),
-      );
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "linked-tx-2",
+        userId: "user-1",
+      });
       expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
         Transaction,
         "tx-1",
@@ -1028,6 +1152,7 @@ describe("TransactionSplitService", () => {
 
     it("sets isSplit false when no splits remain", async () => {
       const transaction = { ...mockTransaction } as Transaction;
+      lockParent(transaction);
       const splitToRemove = {
         ...mockSplit,
         linkedTransactionId: null,
@@ -1046,6 +1171,7 @@ describe("TransactionSplitService", () => {
 
     it("handles linked transaction not found gracefully for transfer split removal", async () => {
       const transaction = { ...mockTransaction } as Transaction;
+      lockParent(transaction);
       const transferSplit = {
         id: "split-1",
         transactionId: "tx-1",
@@ -1076,6 +1202,252 @@ describe("TransactionSplitService", () => {
       expect(accountsService.updateBalance).not.toHaveBeenCalled();
       expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(
         transferSplit,
+      );
+    });
+
+    /**
+     * The FV4-002 double reversal, from the losing side.
+     *
+     * Two `removeSplit` calls for the same transfer split: both lock the leg and
+     * read the same amount, one `DELETE` removes the row and the other removes
+     * nothing. Before the fix each reversed the amount, so one deleted
+     * counterpart moved the target account's balance twice and the ledger and
+     * `current_balance` were permanently apart.
+     */
+    it("reverses nothing when another request already removed the leg", async () => {
+      const transaction = { ...mockTransaction } as Transaction;
+      const transferSplit = {
+        id: "split-1",
+        transactionId: "tx-1",
+        linkedTransactionId: "linked-tx-1",
+        transferAccountId: "account-2",
+        amount: -50,
+      };
+      lockParent(
+        transaction,
+        lockedTransactionRow({
+          id: "linked-tx-1",
+          accountId: "account-2",
+          amount: 50,
+        }),
+      );
+      splitsRepository.findOne.mockResolvedValue(transferSplit);
+      mockQueryRunner.manager.find.mockResolvedValue([
+        { id: "split-2", transactionId: "tx-1", amount: -30 },
+        { id: "split-3", transactionId: "tx-1", amount: -20 },
+      ]);
+      // The row was already gone when this call's DELETE landed.
+      mockQueryRunner.manager.delete.mockImplementation(
+        (Entity: any, criteria: any) => {
+          if (Entity === Transaction && criteria?.id === "linked-tx-1") {
+            return Promise.resolve({ affected: 0, raw: [] });
+          }
+          return Promise.resolve({ affected: 1, raw: [] });
+        },
+      );
+
+      await service.removeSplit(transaction, "split-1", "user-1");
+
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "linked-tx-1",
+        userId: "user-1",
+      });
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      expect(accountsService.recalculateCurrentBalance).not.toHaveBeenCalled();
+    });
+
+    it("reverses a future-dated leg by recomputation, not by a delta", async () => {
+      mockedIsTransactionInFuture.mockReturnValue(true);
+      const transaction = { ...mockTransaction } as Transaction;
+      const transferSplit = {
+        id: "split-1",
+        transactionId: "tx-1",
+        linkedTransactionId: "linked-tx-1",
+        transferAccountId: "account-2",
+        amount: -50,
+      };
+      lockParent(
+        transaction,
+        lockedTransactionRow({
+          id: "linked-tx-1",
+          accountId: "account-2",
+          amount: 50,
+          transactionDate: "2027-06-15",
+        }),
+      );
+      splitsRepository.findOne.mockResolvedValue(transferSplit);
+      mockQueryRunner.manager.find.mockResolvedValue([
+        { id: "split-2", transactionId: "tx-1", amount: -30 },
+        { id: "split-3", transactionId: "tx-1", amount: -20 },
+      ]);
+
+      await service.removeSplit(transaction, "split-1", "user-1");
+
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+        "user-1",
+        "account-2",
+      );
+    });
+
+    it("reverses nothing for a VOID leg, which contributed nothing", async () => {
+      const transaction = { ...mockTransaction } as Transaction;
+      const transferSplit = {
+        id: "split-1",
+        transactionId: "tx-1",
+        linkedTransactionId: "linked-tx-1",
+        transferAccountId: "account-2",
+        amount: -50,
+      };
+      lockParent(
+        transaction,
+        lockedTransactionRow({
+          id: "linked-tx-1",
+          accountId: "account-2",
+          amount: 50,
+          status: "VOID",
+        }),
+      );
+      splitsRepository.findOne.mockResolvedValue(transferSplit);
+      mockQueryRunner.manager.find.mockResolvedValue([
+        { id: "split-2", transactionId: "tx-1", amount: -30 },
+        { id: "split-3", transactionId: "tx-1", amount: -20 },
+      ]);
+
+      await service.removeSplit(transaction, "split-1", "user-1");
+
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "linked-tx-1",
+        userId: "user-1",
+      });
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The split is re-read inside the write transaction, not taken from a read
+     * the caller did earlier: a `removeSplit` that arrives after a full
+     * replacement has committed must not delete a split id that no longer
+     * exists, nor reverse a counterpart the replacement already reversed.
+     */
+    it("re-reads the split inside the transaction, after the parent lock", async () => {
+      const transaction = { ...mockTransaction } as Transaction;
+      lockParent(transaction);
+      splitsRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.removeSplit(transaction, "split-1", "user-1"),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(
+        (lockTransactionRow as jest.Mock).mock.invocationCallOrder[0],
+      ).toBeLessThan(splitsRepository.findOne.mock.invocationCallOrder[0]);
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
+
+    it("refuses when the parent is gone, before touching any split", async () => {
+      const transaction = { ...mockTransaction } as Transaction;
+      stubLocks([]);
+
+      await expect(
+        service.removeSplit(transaction, "split-1", "user-1"),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(splitsRepository.findOne).not.toHaveBeenCalled();
+      expect(mockQueryRunner.manager.remove).not.toHaveBeenCalled();
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * A split's transfer counterpart and its embedded investment rows *describe*
+   * the parent -- its account, its date, its payee. Building them from the
+   * caller's pre-lock snapshot writes rows describing a parent that has since
+   * moved, silently: no error, and nothing to reconcile against (FV4-002).
+   */
+  describe("counterpart rows are built from the locked parent", () => {
+    it("addSplit uses the committed account, date and payee, not the caller's", async () => {
+      const stale = {
+        ...mockTransaction,
+        accountId: "account-stale",
+        transactionDate: "2026-01-15",
+        payeeName: "Stale Payee",
+        payeeId: "payee-stale",
+        isSplit: true,
+      } as Transaction;
+      // What another request committed while this one waited for the row lock.
+      stubLocks([
+        lockedTransactionRow({
+          id: "tx-1",
+          accountId: "account-committed",
+          amount: -100,
+          transactionDate: "2026-03-20",
+          isSplit: true,
+          payeeId: "payee-committed",
+          payeeName: "Committed Payee",
+        }),
+      ]);
+      mockQueryRunner.manager.find.mockResolvedValue([]);
+      splitsRepository.find.mockResolvedValue([]);
+      splitsRepository.findOne.mockResolvedValue({ id: "new-split" });
+
+      await service.addSplit(
+        stale,
+        { amount: -40, transferAccountId: "account-2" },
+        "user-1",
+      );
+
+      expect(accountsService.findOne).toHaveBeenCalledWith(
+        "user-1",
+        "account-committed",
+      );
+      expect(transactionsRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transactionDate: "2026-03-20",
+          payeeId: "payee-committed",
+          payeeName: "Committed Payee",
+        }),
+      );
+    });
+
+    it("updateSplits builds the replacement from the committed parent", async () => {
+      const stale = {
+        ...mockTransaction,
+        accountId: "account-stale",
+        transactionDate: "2026-01-15",
+        payeeName: "Stale Payee",
+        payeeId: "payee-stale",
+      } as Transaction;
+      stubLocks([
+        lockedTransactionRow({
+          id: "tx-1",
+          accountId: "account-committed",
+          amount: -100,
+          transactionDate: "2026-03-20",
+          isSplit: true,
+          payeeId: "payee-committed",
+          payeeName: "Committed Payee",
+        }),
+      ]);
+      splitsRepository.find.mockResolvedValue([]);
+      const createSplits = jest.spyOn(service, "createSplits");
+
+      await service.updateSplits(
+        stale,
+        [
+          { amount: -60, transferAccountId: "account-2" },
+          { amount: -40, categoryId: "cat-1" },
+        ],
+        "user-1",
+      );
+
+      expect(createSplits).toHaveBeenCalledWith(
+        "tx-1",
+        expect.anything(),
+        "user-1",
+        "account-committed",
+        new Date("2026-03-20"),
+        "Committed Payee",
+        "payee-committed",
       );
     });
   });
@@ -1145,21 +1517,26 @@ describe("TransactionSplitService", () => {
         };
 
         splitsRepository.find.mockResolvedValue([transferSplit]);
-        transactionsRepository.find.mockResolvedValue([
-          {
+        stubLocks([
+          lockedTransactionRow({
             id: "linked-tx-1",
             accountId: "account-2",
             amount: 50,
             transactionDate: "2027-06-15",
-          },
+          }),
         ]);
 
         await service.deleteSplitSideEffects("tx-1", "user-1");
 
-        expect(transactionsRepository.find).toHaveBeenCalled();
+        expect(lockTransactionRows).toHaveBeenCalled();
         expect(accountsService.updateBalance).not.toHaveBeenCalled();
-        expect(transactionsRepository.remove).toHaveBeenCalledWith(
-          expect.objectContaining({ id: "linked-tx-1" }),
+        expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+          "user-1",
+          "account-2",
+        );
+        expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(
+          Transaction,
+          { id: "linked-tx-1", userId: "user-1" },
         );
       });
 
@@ -1184,19 +1561,19 @@ describe("TransactionSplitService", () => {
         ];
 
         splitsRepository.find.mockResolvedValue(splits);
-        transactionsRepository.find.mockResolvedValue([
-          {
+        stubLocks([
+          lockedTransactionRow({
             id: "linked-tx-1",
             accountId: "account-2",
             amount: 30,
             transactionDate: "2026-01-15",
-          },
-          {
+          }),
+          lockedTransactionRow({
             id: "linked-tx-2",
             accountId: "account-3",
             amount: 70,
             transactionDate: "2027-06-15",
-          },
+          }),
         ]);
 
         await service.deleteSplitSideEffects("tx-1", "user-1");
@@ -1206,7 +1583,11 @@ describe("TransactionSplitService", () => {
           "account-2",
           -30,
         );
-        expect(transactionsRepository.remove).toHaveBeenCalledTimes(2);
+        expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+          "user-1",
+          "account-3",
+        );
+        expect(mockQueryRunner.manager.delete).toHaveBeenCalledTimes(2);
       });
     });
   });
@@ -1523,6 +1904,7 @@ describe("TransactionSplitService", () => {
 
     it("rejects adding an investment split via addSplit", async () => {
       const transaction = { ...mockTransaction, isSplit: true } as Transaction;
+      lockParent(transaction);
       await expect(
         service.addSplit(
           transaction,

--- a/backend/src/transactions/transaction-split.service.ts
+++ b/backend/src/transactions/transaction-split.service.ts
@@ -24,6 +24,8 @@ import { roundMoney, sumMoney } from "../common/round.util";
 import { validateSplitAmountSum } from "../common/split-amount.util";
 import { tr } from "../i18n/translate";
 import { withScopedDb } from "../common/db/scoped-db";
+import { lockTransactionRow, lockTransactionRows } from "../common/db/locks";
+import { removeLockedTransactionLeg } from "./remove-transaction-leg";
 
 function inferSplitKind(split: CreateTransactionSplitDto): SplitKind {
   if (split.splitKind) return split.splitKind;
@@ -353,7 +355,10 @@ export class TransactionSplitService {
       });
 
       if (dateStr && isTransactionInFuture(dateStr)) {
+        // The transfer counterpart is created under `userId` above, so its
+        // account is the caller's -- scope the balance-write lock to that owner.
         await this.accountsService.recalculateCurrentBalance(
+          userId!,
           split.transferAccountId!,
         );
       } else {
@@ -432,24 +437,15 @@ export class TransactionSplitService {
 
       if (linkedTxIds.length === 0) return;
 
-      const txRepo = m.getRepository(Transaction);
-      const linkedTransactions = await txRepo.find({
-        where: { id: In(linkedTxIds) },
-      });
-
-      for (const linkedTx of linkedTransactions) {
-        const linkedIsFuture = isTransactionInFuture(linkedTx.transactionDate);
-        const linkedAccId = linkedTx.accountId;
-        if (!linkedIsFuture) {
-          await this.accountsService.updateBalance(
-            linkedAccId,
-            -Number(linkedTx.amount),
-          );
-        }
-        await txRepo.remove(linkedTx);
-        if (linkedIsFuture) {
-          await this.accountsService.recalculateCurrentBalance(linkedAccId);
-        }
+      // Locked, re-read and conditionally deleted, exactly like the single-leg
+      // path. An unlocked `find` followed by `remove(entity)` reversed whatever
+      // amount the snapshot happened to hold and reversed it whether or not this
+      // call was the one that removed the row -- a split replacement racing a
+      // counterpart edit, or racing another replacement, each moved the target
+      // account's balance once for one deleted row (audit FV4-002).
+      const linked = await lockTransactionRows(m, linkedTxIds, userId);
+      for (const leg of linked.values()) {
+        await removeLockedTransactionLeg(m, leg, userId, this.accountsService);
       }
     });
   }
@@ -484,23 +480,42 @@ export class TransactionSplitService {
     splits: CreateTransactionSplitDto[],
     userId: string,
   ): Promise<TransactionSplit[]> {
-    this.validateSplits(splits, transaction.amount);
-
     return withScopedDb(this.dataSource, async (m) => {
+      // Same parent lock as addSplit, so full replacement and incremental
+      // addition serialize against each other, and validated against the
+      // parent's committed amount rather than the caller's snapshot of it.
+      const parent = await lockTransactionRow(m, transaction.id, userId);
+      if (!parent) {
+        throw new NotFoundException(
+          tr(
+            "errors.transactions.notFoundById",
+            `Transaction with ID ${transaction.id} not found`,
+            { id: transaction.id },
+          ),
+        );
+      }
+      this.validateSplits(splits, parent.amount);
+
       await this.deleteSplitSideEffects(transaction.id, userId);
 
       await m.delete(TransactionSplit, {
         transactionId: transaction.id,
       });
 
+      // Every field the new splits are built from comes off the locked parent,
+      // not off the caller's copy of it. The counterpart rows and embedded
+      // investment rows *describe* the parent -- its account, its date, its payee
+      // -- so a concurrent parent edit that committed after the caller read it
+      // would otherwise be written into rows claiming the old values, with no
+      // error and nothing to reconcile against (audit FV4-002).
       const newSplits = await this.createSplits(
-        transaction.id,
+        parent.id,
         splits,
         userId,
-        transaction.accountId,
-        new Date(transaction.transactionDate),
-        transaction.payeeName,
-        transaction.payeeId,
+        parent.accountId,
+        new Date(parent.transactionDate),
+        parent.payeeName,
+        parent.payeeId,
       );
 
       await m.update(Transaction, transaction.id, {
@@ -529,28 +544,55 @@ export class TransactionSplitService {
       await this.validateCategoryOwnership(userId, splitDto.categoryId);
     }
 
-    const existingSplits = await this.getSplits(transaction.id);
-    const existingTotal = sumMoney(existingSplits.map((s) => Number(s.amount)));
-    const newTotal = sumMoney([existingTotal, Number(splitDto.amount)]);
-    const transactionAmount = roundMoney(Number(transaction.amount));
-
-    if (Math.abs(newTotal) > Math.abs(transactionAmount)) {
-      throw new BadRequestException(
-        tr(
-          "errors.transactions.splitExceedsTransactionAmount",
-          `Adding this split would exceed the transaction amount. ` +
-            `Current total: ${existingTotal}, New split: ${splitDto.amount}, ` +
-            `Transaction amount: ${transaction.amount}`,
-          {
-            existingTotal,
-            newSplit: splitDto.amount,
-            transactionAmount: transaction.amount,
-          },
-        ),
-      );
-    }
-
     const savedSplitId = await withScopedDb(this.dataSource, async (m) => {
+      // The aggregate check and the insert are one serialized unit.
+      //
+      // Reading the split set, validating in application code, and inserting in
+      // a later transaction is a check-then-act with nothing under it: the schema
+      // has no aggregate constraint, and two inserts against the same parent hold
+      // compatible foreign-key key-share locks, so both commit. Parent -100.00
+      // with -60.00 already split, two concurrent -30.00 additions each
+      // validating -90.00, and the splits total -120.00 (audit P4-009).
+      //
+      // The parent row lock is what serializes them. Every other writer of this
+      // split set -- full replacement included -- takes the same lock, so the
+      // second request re-reads the set the first one committed and refuses.
+      const parent = await lockTransactionRow(m, transaction.id, userId);
+      if (!parent) {
+        throw new NotFoundException(
+          tr(
+            "errors.transactions.notFoundById",
+            `Transaction with ID ${transaction.id} not found`,
+            { id: transaction.id },
+          ),
+        );
+      }
+
+      const existingSplits = await m.getRepository(TransactionSplit).find({
+        where: { transactionId: transaction.id },
+      });
+      const existingTotal = sumMoney(
+        existingSplits.map((s) => Number(s.amount)),
+      );
+      const newTotal = sumMoney([existingTotal, Number(splitDto.amount)]);
+      const transactionAmount = roundMoney(parent.amount);
+
+      if (Math.abs(newTotal) > Math.abs(transactionAmount)) {
+        throw new BadRequestException(
+          tr(
+            "errors.transactions.splitExceedsTransactionAmount",
+            `Adding this split would exceed the transaction amount. ` +
+              `Current total: ${existingTotal}, New split: ${splitDto.amount}, ` +
+              `Transaction amount: ${transactionAmount}`,
+            {
+              existingTotal,
+              newSplit: splitDto.amount,
+              transactionAmount,
+            },
+          ),
+        );
+      }
+
       const splitKind = splitDto.transferAccountId
         ? SplitKind.TRANSFER
         : SplitKind.CATEGORY;
@@ -570,23 +612,24 @@ export class TransactionSplitService {
           userId,
           splitDto.transferAccountId,
         );
+        // Built from the locked parent, not the caller's snapshot: see the note
+        // in `updateSplits` (audit FV4-002).
         const sourceAccount = await this.accountsService.findOne(
           userId,
-          transaction.accountId,
+          parent.accountId,
         );
 
         const linkedTransaction = m.create(Transaction, {
           userId,
           accountId: splitDto.transferAccountId,
-          transactionDate: transaction.transactionDate,
+          transactionDate: parent.transactionDate,
           amount: -splitDto.amount,
           currencyCode: targetAccount.currencyCode,
           exchangeRate: 1,
           description: splitDto.memo || null,
           isTransfer: true,
-          payeeId: transaction.payeeId || null,
-          payeeName:
-            transaction.payeeName || `Transfer from ${sourceAccount.name}`,
+          payeeId: parent.payeeId || null,
+          payeeName: parent.payeeName || `Transfer from ${sourceAccount.name}`,
         });
 
         const savedLinkedTransaction = await m.save(linkedTransaction);
@@ -595,8 +638,9 @@ export class TransactionSplitService {
           linkedTransactionId: savedLinkedTransaction.id,
         });
 
-        if (isTransactionInFuture(transaction.transactionDate)) {
+        if (isTransactionInFuture(parent.transactionDate)) {
           await this.accountsService.recalculateCurrentBalance(
+            userId,
             splitDto.transferAccountId,
           );
         } else {
@@ -608,7 +652,7 @@ export class TransactionSplitService {
       }
 
       const totalSplits = existingSplits.length + 1;
-      if (totalSplits >= 2 && !transaction.isSplit) {
+      if (totalSplits >= 2 && !parent.isSplit) {
         await m.update(Transaction, transaction.id, {
           isSplit: true,
           categoryId: null,
@@ -638,29 +682,66 @@ export class TransactionSplitService {
     return splitWithRelations;
   }
 
+  /**
+   * Delete a split's transfer counterpart and reverse its balance, once.
+   *
+   * The leg is locked and re-read here rather than taken from the split's
+   * snapshot: the amount reversed has to be the amount the delete removes, and
+   * the reversal only happens when this call is the one that removed the row.
+   * Both split-removal paths below go through this, so the collapse case cannot
+   * drift from the ordinary one.
+   */
+  private async removeLinkedLeg(
+    m: EntityManager,
+    linkedTransactionId: string,
+    userId: string,
+  ): Promise<void> {
+    const linked = await lockTransactionRow(m, linkedTransactionId, userId);
+    if (!linked) return;
+    await removeLockedTransactionLeg(m, linked, userId, this.accountsService);
+  }
+
   async removeSplit(
     transaction: Transaction,
     splitId: string,
     userId: string,
   ): Promise<void> {
-    const split = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(TransactionSplit).findOne({
+    return withScopedDb(this.dataSource, async (m) => {
+      // The parent first, so a concurrent split mutation on the same parent
+      // serializes behind this one, and so the split below is read from a state
+      // that cannot change under us. The old code read the split in its own
+      // autocommit transaction before opening this one, then reversed a balance
+      // from that snapshot -- two concurrent removals of the same transfer split
+      // each applied the reversal while only one row went away (audit FV4-002).
+      const lockedParent = await lockTransactionRow(m, transaction.id, userId);
+      if (!lockedParent) {
+        throw new NotFoundException(
+          tr(
+            "errors.transactions.notFoundById",
+            `Transaction with ID ${transaction.id} not found`,
+            { id: transaction.id },
+          ),
+        );
+      }
+
+      const split = await m.getRepository(TransactionSplit).findOne({
         where: { id: splitId, transactionId: transaction.id },
         relations: ["investmentTransaction"],
-      }),
-    );
+      });
 
-    if (!split) {
-      throw new NotFoundException(
-        tr(
-          "errors.transactions.splitNotFoundById",
-          `Split with ID ${splitId} not found`,
-          { id: splitId },
-        ),
-      );
-    }
+      if (!split) {
+        // Either it never existed or another request removed it while this one
+        // waited for the parent lock. Both are "not found", and neither has left
+        // a balance for this call to reverse.
+        throw new NotFoundException(
+          tr(
+            "errors.transactions.splitNotFoundById",
+            `Split with ID ${splitId} not found`,
+            { id: splitId },
+          ),
+        );
+      }
 
-    return withScopedDb(this.dataSource, async (m) => {
       if (split.kind === SplitKind.INVESTMENT && split.investmentTransaction) {
         await this.investmentTransactionsService.reverseAndRemoveEmbedded(
           m,
@@ -668,26 +749,7 @@ export class TransactionSplitService {
           split.investmentTransaction,
         );
       } else if (split.linkedTransactionId && split.transferAccountId) {
-        const linkedTx = await m.findOne(Transaction, {
-          where: { id: split.linkedTransactionId },
-        });
-
-        if (linkedTx) {
-          const linkedIsFuture = isTransactionInFuture(
-            linkedTx.transactionDate,
-          );
-          const linkedAccId = linkedTx.accountId;
-          if (!linkedIsFuture) {
-            await this.accountsService.updateBalance(
-              linkedAccId,
-              -Number(linkedTx.amount),
-            );
-          }
-          await m.remove(linkedTx);
-          if (linkedIsFuture) {
-            await this.accountsService.recalculateCurrentBalance(linkedAccId);
-          }
-        }
+        await this.removeLinkedLeg(m, split.linkedTransactionId, userId);
       }
 
       await m.remove(split);
@@ -709,28 +771,11 @@ export class TransactionSplitService {
           }
 
           if (lastSplit.linkedTransactionId && lastSplit.transferAccountId) {
-            const linkedTx = await m.findOne(Transaction, {
-              where: { id: lastSplit.linkedTransactionId },
-            });
-
-            if (linkedTx) {
-              const lastLinkedIsFuture = isTransactionInFuture(
-                linkedTx.transactionDate,
-              );
-              const lastLinkedAccId = linkedTx.accountId;
-              if (!lastLinkedIsFuture) {
-                await this.accountsService.updateBalance(
-                  lastLinkedAccId,
-                  -Number(linkedTx.amount),
-                );
-              }
-              await m.remove(linkedTx);
-              if (lastLinkedIsFuture) {
-                await this.accountsService.recalculateCurrentBalance(
-                  lastLinkedAccId,
-                );
-              }
-            }
+            await this.removeLinkedLeg(
+              m,
+              lastSplit.linkedTransactionId,
+              userId,
+            );
           }
 
           await m.update(Transaction, transaction.id, {

--- a/backend/src/transactions/transaction-transfer.service.spec.ts
+++ b/backend/src/transactions/transaction-transfer.service.spec.ts
@@ -20,6 +20,10 @@ import {
   createScopedDbMocks,
   DataSourceMock,
 } from "../test-helpers/scoped-db-testing";
+import { ConflictException } from "@nestjs/common";
+import { lockTransactionRow, lockTransactionRows } from "../common/db/locks";
+import type { LockedTransactionRow } from "../common/db/locks";
+import { lockedTransactionRow } from "../test-helpers/locks-testing";
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
@@ -35,6 +39,14 @@ jest.mock("../common/db/with-context", () => {
 const mockedWithSystemContext = withSystemContext as jest.MockedFunction<
   typeof withSystemContext
 >;
+
+// Both legs are locked inside the write transaction and the update refuses if
+// either changed under it (audit P4-003). The double below derives the locked
+// legs from the rows this spec's `findOne` callback has returned, so a spec only
+// states the committed rows when it means them to differ.
+jest.mock("../common/db/locks", () =>
+  jest.requireActual("../test-helpers/locks-testing").locksMockModule(),
+);
 
 jest.mock("../common/date-utils", () => ({
   isTransactionInFuture: jest.fn().mockReturnValue(false),
@@ -177,6 +189,76 @@ describe("TransactionTransferService", () => {
     mockedWithSystemContext.mockClear();
     mockFindOne.mockReset();
 
+    /**
+     * Serve the locked leg readers from whatever this spec's `findOne` callback
+     * has returned.
+     *
+     * Reading the mock's recorded results consumes nothing, unlike calling it
+     * again and eating a queued `mockResolvedValueOnce`. A spec that wants the
+     * committed legs to differ from the caller's view -- the concurrency case
+     * `updateTransfer` now refuses -- overrides `lockTransactionRows` itself.
+     */
+    const resolveLocked = async (
+      ids: readonly string[],
+    ): Promise<Map<string, LockedTransactionRow>> => {
+      const byId = new Map<string, Record<string, unknown>>();
+      // The own leg comes back through the caller's `findOne`; the counterpart
+      // through the repository. Both are rows this spec described.
+      for (const mock of [
+        mockFindOne.mock,
+        transactionsRepository.findOne.mock,
+      ]) {
+        for (const result of mock.results) {
+          if (result.type !== "return") continue;
+          try {
+            const row = (await result.value) as Record<string, unknown> | null;
+            if (row?.id) byId.set(String(row.id), row);
+          } catch {
+            continue;
+          }
+        }
+      }
+      // The lock replaced the counterpart read, so on some paths nothing has
+      // been read yet. Consulting the repository mock now is exactly right:
+      // whatever the spec set up IS the committed counterpart.
+      for (const id of ids) {
+        if (byId.has(id)) continue;
+        const row = (await transactionsRepository.findOne({
+          where: { id },
+        })) as Record<string, unknown> | null;
+        if (row?.id) byId.set(String(row.id), row);
+      }
+      const found = new Map<string, LockedTransactionRow>();
+      for (const id of ids) {
+        const row = byId.get(id);
+        if (!row) continue;
+        found.set(
+          id,
+          lockedTransactionRow({
+            id: String(row.id),
+            accountId: String(row.accountId ?? ""),
+            amount: Number(row.amount ?? 0),
+            transactionDate: row.transactionDate as string,
+            status: (row.status as string | null) ?? null,
+            isSplit: Boolean(row.isSplit),
+            linkedTransactionId:
+              (row.linkedTransactionId as string | null) ?? null,
+          }),
+        );
+      }
+      return found;
+    };
+
+    (lockTransactionRows as jest.Mock).mockImplementation(
+      async (_m: unknown, ids: readonly string[]) => resolveLocked(ids),
+    );
+    // The cross-owner removal locks each leg on its own, because the two legs
+    // have different owners and the ownership predicate differs per row.
+    (lockTransactionRow as jest.Mock).mockImplementation(
+      async (_m: unknown, id: string) =>
+        (await resolveLocked([id])).get(id) ?? null,
+    );
+
     const tenantMocks = createScopedDbMocks([
       [Transaction, transactionsRepository],
       [TransactionSplit, splitsRepository],
@@ -194,6 +276,9 @@ describe("TransactionTransferService", () => {
     manager.update.mockImplementation((_Entity: any, id: any, data: any) =>
       transactionsRepository.update(id, data),
     );
+    // Both legs are deleted conditionally and each reversal is gated on what the
+    // database actually removed (audit P4-003), so the double reports a count.
+    manager.delete.mockResolvedValue({ affected: 1 });
     manager.findOne.mockImplementation((_Entity: any, opts: any) =>
       transactionsRepository.findOne(opts),
     );
@@ -809,6 +894,75 @@ describe("TransactionTransferService", () => {
     });
   });
 
+  describe("stale-snapshot refusal", () => {
+    it("returns 409 when a leg changed between the read and the write", async () => {
+      // The regression guard for P4-003 on transfers. The four balance
+      // adjustments reverse the OLD leg amounts and re-apply the new ones, so a
+      // concurrent edit makes those old values describe a version this write is
+      // not replacing -- two updates each reversing the same pair corrupt both
+      // accounts. A 409 the client can retry is the honest answer.
+      const fromTx = {
+        id: "from-tx",
+        userId: "user-1",
+        accountId: "from-account",
+        amount: -200,
+        isTransfer: true,
+        linkedTransactionId: "to-tx",
+        exchangeRate: 1,
+        transactionDate: "2026-01-15",
+      };
+      const toTx = {
+        id: "to-tx",
+        userId: "user-1",
+        accountId: "to-account",
+        amount: 200,
+        isTransfer: true,
+        linkedTransactionId: "from-tx",
+        exchangeRate: 1,
+        transactionDate: "2026-01-15",
+      };
+      mockFindOne.mockImplementation(async (_u: string, id: string) =>
+        id === "from-tx" ? fromTx : toTx,
+      );
+      splitsRepository.findOne.mockResolvedValue(null);
+
+      // The committed from-leg is already -300: another request got there first.
+      (lockTransactionRows as jest.Mock).mockResolvedValue(
+        new Map([
+          [
+            "from-tx",
+            lockedTransactionRow({
+              id: "from-tx",
+              accountId: "from-account",
+              amount: -300,
+              transactionDate: "2026-01-15",
+            }),
+          ],
+          [
+            "to-tx",
+            lockedTransactionRow({
+              id: "to-tx",
+              accountId: "to-account",
+              amount: 300,
+              transactionDate: "2026-01-15",
+            }),
+          ],
+        ]),
+      );
+
+      await expect(
+        service.updateTransfer(
+          "user-1",
+          "from-tx",
+          { amount: 250 },
+          mockFindOne,
+        ),
+      ).rejects.toBeInstanceOf(ConflictException);
+
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
+  });
+
   describe("removeTransfer", () => {
     it("removes both from and to transactions for standalone transfer", async () => {
       const fromTx = {
@@ -841,8 +995,16 @@ describe("TransactionTransferService", () => {
         -500,
       );
       // Both transactions removed
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(toTx);
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(fromTx);
+      // Conditional DELETEs, with each reversal gated on the row the database
+      // actually removed (audit P4-003).
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "to-tx",
+        userId: "user-1",
+      });
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "from-tx",
+        userId: "user-1",
+      });
     });
 
     it("throws when transaction is not a transfer", async () => {
@@ -877,13 +1039,18 @@ describe("TransactionTransferService", () => {
         "from-account",
         500,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledTimes(1);
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(tx);
+      // One conditional DELETE, for the own leg only.
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledTimes(1);
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "tx-1",
+        userId: "user-1",
+      });
     });
 
     it("delegates to removeTransferFromSplit when transaction is part of a split", async () => {
       const tx = {
         id: "linked-from-split",
+        userId: "user-1",
         isTransfer: true,
         linkedTransactionId: "parent-tx",
         accountId: "account-2",
@@ -909,9 +1076,19 @@ describe("TransactionTransferService", () => {
 
       await service.removeTransfer("user-1", "linked-from-split", mockFindOne);
 
-      // Should remove the parent transaction and all related splits
+      // Should remove the parent transaction and all related splits. Both ledger
+      // rows go through the conditional delete (audit FV4-002); only the split
+      // rows, which carry no balance, still use `remove`.
       expect(splitsRepository.remove).toHaveBeenCalled();
-      expect(transactionsRepository.remove).toHaveBeenCalled();
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "parent-tx",
+        userId: "user-1",
+      });
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "linked-from-split",
+        userId: "user-1",
+      });
+      expect(transactionsRepository.remove).not.toHaveBeenCalled();
     });
 
     it("triggers net worth recalc for affected accounts", async () => {
@@ -949,6 +1126,7 @@ describe("TransactionTransferService", () => {
 
       const tx = {
         id: "linked-from-split",
+        userId: "user-1",
         isTransfer: true,
         linkedTransactionId: "parent-tx",
         accountId: "account-2",
@@ -996,12 +1174,15 @@ describe("TransactionTransferService", () => {
       // Future-dated: balances are recalculated, never adjusted.
       expect(accountsService.updateBalance).not.toHaveBeenCalled();
       expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+        "user-1",
         "account-3",
       );
       expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+        "user-1",
         "account-1",
       );
       expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+        "user-1",
         "account-2",
       );
     });
@@ -1804,8 +1985,14 @@ describe("TransactionTransferService", () => {
         await service.removeTransfer("user-1", "from-tx", mockFindOne);
 
         expect(accountsService.updateBalance).not.toHaveBeenCalled();
-        expect(transactionsRepository.remove).toHaveBeenCalledWith(toTx);
-        expect(transactionsRepository.remove).toHaveBeenCalledWith(fromTx);
+        expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(
+          Transaction,
+          { id: "to-tx", userId: "user-1" },
+        );
+        expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(
+          Transaction,
+          { id: "from-tx", userId: "user-1" },
+        );
       });
     });
 
@@ -1863,9 +2050,11 @@ describe("TransactionTransferService", () => {
 
         // When any future date is involved, recalculate from scratch
         expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+          "user-1",
           "from-account",
         );
         expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+          "user-1",
           "to-account",
         );
         expect(accountsService.updateBalance).not.toHaveBeenCalled();
@@ -1892,9 +2081,11 @@ describe("TransactionTransferService", () => {
 
         // When any future date is involved, recalculate from scratch
         expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+          "user-1",
           "from-account",
         );
         expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+          "user-1",
           "to-account",
         );
         expect(accountsService.updateBalance).not.toHaveBeenCalled();
@@ -2749,7 +2940,17 @@ describe("TransactionTransferService", () => {
           "to-account",
           "delete",
         );
-        expect(transactionsRepository.remove).toHaveBeenCalledTimes(2);
+        // Each leg is deleted conditionally, keyed on its own owner, and only the
+        // winner of that delete reverses a balance (audit FV4-002).
+        expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(
+          Transaction,
+          { id: "foreign-leg", userId: "owner-2" },
+        );
+        expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(
+          Transaction,
+          { id: "own-leg", userId: "user-1" },
+        );
+        expect(transactionsRepository.remove).not.toHaveBeenCalled();
         expect(accountsService.updateBalance).toHaveBeenCalledWith(
           "to-account",
           -500,
@@ -2769,8 +2970,12 @@ describe("TransactionTransferService", () => {
 
         await service.removeTransfer("user-1", "own-leg", mockFindOne, actor);
 
-        expect(transactionsRepository.remove).toHaveBeenCalledTimes(1);
-        expect(transactionsRepository.remove).toHaveBeenCalledWith(ownLeg);
+        expect(mockQueryRunner.manager.delete).toHaveBeenCalledTimes(1);
+        expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(
+          Transaction,
+          { id: "own-leg", userId: "user-1" },
+        );
+        expect(transactionsRepository.remove).not.toHaveBeenCalled();
         expect(accountsService.updateBalance).toHaveBeenCalledTimes(1);
         expect(accountsService.updateBalance).toHaveBeenCalledWith(
           "from-account",

--- a/backend/src/transactions/transaction-transfer.service.ts
+++ b/backend/src/transactions/transaction-transfer.service.ts
@@ -1,6 +1,7 @@
 import {
   Injectable,
   BadRequestException,
+  ConflictException,
   Inject,
   NotFoundException,
   forwardRef,
@@ -24,6 +25,8 @@ import { roundMoney } from "../common/round.util";
 import { stripHtml } from "../common/sanitization.util";
 import { tr } from "../i18n/translate";
 import { withScopedDb } from "../common/db/scoped-db";
+import { lockTransactionRow, lockTransactionRows } from "../common/db/locks";
+import { removeLockedTransactionLeg } from "./remove-transaction-leg";
 import { withSystemContext } from "../common/db/with-context";
 
 export interface TransferResult {
@@ -263,8 +266,17 @@ export class TransactionTransferService {
       });
 
       if (isTransactionInFuture(transactionDate)) {
-        await this.accountsService.recalculateCurrentBalance(fromAccountId);
-        await this.accountsService.recalculateCurrentBalance(toAccountId);
+        // Each leg's account is owned by ITS account's owner, which for a
+        // cross-owner transfer differs from the acting user -- scope each lock
+        // to that owner, never to the caller (maintainer review, PR #1095).
+        await this.accountsService.recalculateCurrentBalance(
+          fromOwnerId,
+          fromAccountId,
+        );
+        await this.accountsService.recalculateCurrentBalance(
+          toOwnerId,
+          toAccountId,
+        );
       } else {
         await this.accountsService.updateBalance(fromAccountId, -amount);
         await this.accountsService.updateBalance(toAccountId, toAmount);
@@ -787,47 +799,44 @@ export class TransactionTransferService {
           affectedAccountIds,
         );
       } else {
-        const linkedTransaction = transaction.linkedTransactionId
-          ? await m.findOne(Transaction, {
-              where: { id: transaction.linkedTransactionId },
-            })
-          : null;
+        // Both legs are locked here, in ascending id order, and their amounts
+        // re-read: the delta each leg reverses must be the version the delete
+        // actually removes, and a fixed lock order is what keeps two concurrent
+        // transfer deletions from holding one another's second leg. A snapshot
+        // taken before the transaction let two deletions each reverse the same
+        // pair of amounts while only one pair of rows went away (P4-003).
+        const legIds = [transactionId];
+        if (transaction.linkedTransactionId) {
+          legIds.push(transaction.linkedTransactionId);
+        }
+        const locked = await lockTransactionRows(m, legIds, userId);
 
-        const txIsFuture = isTransactionInFuture(transaction.transactionDate);
-        const txAccountId = transaction.accountId;
-        affectedAccountIds.add(txAccountId);
-
-        if (!txIsFuture) {
-          await this.accountsService.updateBalance(
-            txAccountId,
-            -Number(transaction.amount),
+        const ownLeg = locked.get(transactionId);
+        if (!ownLeg) {
+          throw new NotFoundException(
+            tr(
+              "errors.transactions.notFoundById",
+              `Transaction with ID ${transactionId} not found`,
+              { id: transactionId },
+            ),
           );
         }
+        const linkedLeg = transaction.linkedTransactionId
+          ? locked.get(transaction.linkedTransactionId)
+          : undefined;
 
-        if (linkedTransaction) {
-          const linkedIsFuture = isTransactionInFuture(
-            linkedTransaction.transactionDate,
+        for (const leg of [linkedLeg, ownLeg]) {
+          if (!leg) continue;
+          affectedAccountIds.add(leg.accountId);
+          // Conditional delete, reverse only what this call removed, VOID rows
+          // reverse nothing, future-dated rows recompute. Shared with split
+          // removal so the sequence exists once (see remove-transaction-leg.ts).
+          await removeLockedTransactionLeg(
+            m,
+            leg,
+            userId,
+            this.accountsService,
           );
-          const linkedAccountId = linkedTransaction.accountId;
-          affectedAccountIds.add(linkedAccountId);
-
-          if (!linkedIsFuture) {
-            await this.accountsService.updateBalance(
-              linkedAccountId,
-              -Number(linkedTransaction.amount),
-            );
-          }
-          await m.remove(linkedTransaction);
-          if (linkedIsFuture) {
-            await this.accountsService.recalculateCurrentBalance(
-              linkedAccountId,
-            );
-          }
-        }
-
-        await m.remove(transaction);
-        if (txIsFuture) {
-          await this.accountsService.recalculateCurrentBalance(txAccountId);
         }
       }
     });
@@ -857,25 +866,35 @@ export class TransactionTransferService {
       ? await this.resolveCounterpartAccess(realUserId, counterpart, "delete")
       : "frozen";
 
+    // Both legs were loaded before this transaction opened, so the amount each
+    // reversal subtracts is re-read under the row's own lock and the reversal is
+    // gated on this call being the one that removed the row (audit FV4-002).
     const removeLeg = async (m: EntityManager, leg: Transaction) => {
-      const isFuture = isTransactionInFuture(leg.transactionDate);
-      if (!isFuture) {
-        await this.accountsService.updateBalance(
-          leg.accountId,
-          -Number(leg.amount),
-        );
-      }
-      await m.remove(leg);
-      if (isFuture) {
-        await this.accountsService.recalculateCurrentBalance(leg.accountId);
-      }
+      const locked = await lockTransactionRow(m, leg.id, leg.userId);
+      if (!locked) return;
+      await removeLockedTransactionLeg(
+        m,
+        locked,
+        leg.userId,
+        this.accountsService,
+      );
     };
 
     if (access === "connected" && counterpart) {
+      // Ascending id order, not "counterpart then mine".
+      //
+      // Either owner can start this, and each request names its *own* leg -- so
+      // taking the counterpart first meant the two sides locked the same pair in
+      // opposite orders, which is a PostgreSQL 40P01 for both (audit RV4-005).
+      // Sorting by id is what makes the order the same whoever asks.
+      const ordered = [counterpart, ownLeg].sort((a, b) =>
+        a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+      );
       await withSystemContext(() =>
         withScopedDb(this.dataSource, async (m) => {
-          await removeLeg(m, counterpart);
-          await removeLeg(m, ownLeg);
+          for (const leg of ordered) {
+            await removeLeg(m, leg);
+          }
         }),
       );
       this.triggerNetWorthRecalc(counterpart.accountId, counterpart.userId);
@@ -892,78 +911,59 @@ export class TransactionTransferService {
     transactionId: string,
     affectedAccountIds: Set<string>,
   ): Promise<void> {
+    const userId = transaction.userId;
     const parentTransactionId = parentSplit.transactionId;
-    const parentTransaction = await m.findOne(Transaction, {
-      where: { id: parentTransactionId },
+
+    // The split parent first, on its own, and only then its legs.
+    //
+    // A single sorted batch over parent-plus-legs looks tidier and deadlocks:
+    // `TransactionSplitService.removeSplit` cannot know a leg id before it has
+    // read the split, so it necessarily locks the parent and *then* the leg. A
+    // batch that sorts the two together takes them in id order instead, which is
+    // the opposite order whenever the leg's UUID sorts first -- and two requests
+    // in opposite orders is a PostgreSQL 40P01 for both (audit RV4-005).
+    //
+    // So the ordering rule is by *role*, not by id: parent before legs, legs
+    // among themselves ascending. The parent lock is then the serialization
+    // point -- any two paths touching the same parent's legs have already
+    // queued behind it, so their leg order cannot matter. See common/db/locks.ts.
+    const parent = await lockTransactionRow(m, parentTransactionId, userId);
+
+    const allSplits = await m.find(TransactionSplit, {
+      where: { transactionId: parentTransactionId },
     });
+    const siblingLegIds = allSplits
+      .map((split) => split.linkedTransactionId)
+      .filter((id): id is string => Boolean(id) && id !== transactionId);
 
-    if (parentTransaction) {
-      const allSplits = await m.find(TransactionSplit, {
-        where: { transactionId: parentTransactionId },
-      });
+    // Now the legs, in one ascending batch. Locking each as it is reached is what
+    // let two removals interleave and each reverse the same amount; every reversal
+    // below derives its amount from the locked row and only fires when this call
+    // is the one that removed it (audit FV4-002).
+    const locked = await lockTransactionRows(
+      m,
+      [...siblingLegIds, transaction.id],
+      userId,
+    );
 
-      for (const split of allSplits) {
-        if (
-          split.linkedTransactionId &&
-          split.linkedTransactionId !== transactionId
-        ) {
-          const linkedTx = await m.findOne(Transaction, {
-            where: { id: split.linkedTransactionId },
-          });
-
-          if (linkedTx) {
-            const linkedIsFuture = isTransactionInFuture(
-              linkedTx.transactionDate,
-            );
-            const linkedAccId = linkedTx.accountId;
-            affectedAccountIds.add(linkedAccId);
-            if (!linkedIsFuture) {
-              await this.accountsService.updateBalance(
-                linkedAccId,
-                -Number(linkedTx.amount),
-              );
-            }
-            await m.remove(linkedTx);
-            if (linkedIsFuture) {
-              await this.accountsService.recalculateCurrentBalance(linkedAccId);
-            }
-          }
-        }
+    if (parent) {
+      for (const legId of siblingLegIds) {
+        const leg = locked.get(legId);
+        if (!leg) continue;
+        affectedAccountIds.add(leg.accountId);
+        await removeLockedTransactionLeg(m, leg, userId, this.accountsService);
       }
 
       await m.remove(allSplits);
 
-      const parentIsFuture = isTransactionInFuture(
-        parentTransaction.transactionDate,
-      );
-      affectedAccountIds.add(parentTransaction.accountId);
-      if (!parentIsFuture) {
-        await this.accountsService.updateBalance(
-          parentTransaction.accountId,
-          -Number(parentTransaction.amount),
-        );
-      }
-      await m.remove(parentTransaction);
-      if (parentIsFuture) {
-        await this.accountsService.recalculateCurrentBalance(
-          parentTransaction.accountId,
-        );
-      }
+      affectedAccountIds.add(parent.accountId);
+      await removeLockedTransactionLeg(m, parent, userId, this.accountsService);
     }
 
-    const txIsFuture = isTransactionInFuture(transaction.transactionDate);
     affectedAccountIds.add(transaction.accountId);
-    if (!txIsFuture) {
-      await this.accountsService.updateBalance(
-        transaction.accountId,
-        -Number(transaction.amount),
-      );
-    }
-    await m.remove(transaction);
-    if (txIsFuture) {
-      await this.accountsService.recalculateCurrentBalance(
-        transaction.accountId,
-      );
+    const ownLeg = locked.get(transaction.id);
+    if (ownLeg) {
+      await removeLockedTransactionLeg(m, ownLeg, userId, this.accountsService);
     }
   }
 
@@ -1111,6 +1111,48 @@ export class TransactionTransferService {
     // Both legs' field updates and the four possible balance adjustments
     // commit atomically.
     await withScopedDb(this.dataSource, async (m) => {
+      // The four balance adjustments below reverse `oldFromAmount` /
+      // `oldToAmount` and re-apply the new ones. Those old values were read
+      // before this transaction opened, so a concurrent edit of either leg
+      // would make them describe a version this write is not replacing -- two
+      // updates each reversing the same pair and corrupting both accounts
+      // (audit P4-003).
+      //
+      // Lock both legs in ascending id order and refuse if the committed row no
+      // longer matches what was read. A 409 the client can retry is the honest
+      // answer; silently applying a delta derived from a superseded snapshot is
+      // not.
+      const locked = await lockTransactionRows(
+        m,
+        [fromTransaction.id, toTransaction.id],
+        userId,
+      );
+      const lockedFrom = locked.get(fromTransaction.id);
+      const lockedTo = locked.get(toTransaction.id);
+      if (!lockedFrom || !lockedTo) {
+        throw new NotFoundException(
+          tr(
+            "errors.transactions.notFoundById",
+            `Transaction with ID ${transactionId} not found`,
+            { id: transactionId },
+          ),
+        );
+      }
+      const unchanged =
+        Math.abs(lockedFrom.amount) === oldFromAmount &&
+        lockedTo.amount === oldToAmount &&
+        lockedFrom.accountId === oldFromAccountId &&
+        lockedTo.accountId === oldToAccountId &&
+        lockedFrom.transactionDate === oldDate;
+      if (!unchanged) {
+        throw new ConflictException(
+          tr(
+            "errors.transactions.transferChangedConcurrently",
+            "This transfer was changed by another request. Reload it and try again.",
+          ),
+        );
+      }
+
       if ((accountsOrAmountsChanged || dateChanged) && !anyFuture) {
         await this.accountsService.updateBalance(
           oldFromAccountId,
@@ -1144,14 +1186,19 @@ export class TransactionTransferService {
 
       if (accountsOrAmountsChanged || dateChanged) {
         if (anyFuture) {
-          const allAccounts = new Set([
-            oldFromAccountId,
-            oldToAccountId,
-            newFromAccountId,
-            newToAccountId,
-          ]);
+          // Sorted: the same fixed lock order every other account-balance
+          // writer uses, so two transfers touching the same pair cannot
+          // deadlock on each other's second account.
+          const allAccounts = [
+            ...new Set([
+              oldFromAccountId,
+              oldToAccountId,
+              newFromAccountId,
+              newToAccountId,
+            ]),
+          ].sort();
           for (const accId of allAccounts) {
-            await this.accountsService.recalculateCurrentBalance(accId);
+            await this.accountsService.recalculateCurrentBalance(userId, accId);
           }
         } else {
           await this.accountsService.updateBalance(
@@ -1408,11 +1455,20 @@ export class TransactionTransferService {
 
         if (amountsChanged || dateChanged) {
           if (anyFuture) {
-            for (const accId of new Set([
-              fromTransaction.accountId,
-              toTransaction.accountId,
-            ])) {
-              await this.accountsService.recalculateCurrentBalance(accId);
+            // Cross-owner transfer: the two legs belong to different owners, so
+            // each account's balance-write lock is scoped to ITS own leg's
+            // owner, never to the acting user (maintainer review, PR #1095).
+            // Keyed by account id so a degenerate same-account pair still folds
+            // to one recalculation, as the previous Set did.
+            const legsByAccount = new Map<string, string>([
+              [fromTransaction.accountId, fromTransaction.userId],
+              [toTransaction.accountId, toTransaction.userId],
+            ]);
+            for (const [accId, ownerId] of legsByAccount) {
+              await this.accountsService.recalculateCurrentBalance(
+                ownerId,
+                accId,
+              );
             }
           } else {
             await this.accountsService.updateBalance(
@@ -1536,6 +1592,7 @@ export class TransactionTransferService {
       if (amountChanged || dateChanged) {
         if (isTransactionInFuture(oldDate) || isTransactionInFuture(newDate)) {
           await this.accountsService.recalculateCurrentBalance(
+            userId,
             counterpart.accountId,
           );
         } else {
@@ -1570,6 +1627,7 @@ export class TransactionTransferService {
 
         if (isTransactionInFuture(parentTransaction.transactionDate)) {
           await this.accountsService.recalculateCurrentBalance(
+            userId,
             parentTransaction.accountId,
           );
         } else {

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -21,6 +21,8 @@ import { ActionHistoryService } from "../action-history/action-history.service";
 import { isTransactionInFuture } from "../common/date-utils";
 import { buildTransactionSearchClause } from "./transaction-search.util";
 import { TransactionAttachment } from "../attachments/entities/transaction-attachment.entity";
+import { lockTransactionRow, lockTransactionRows } from "../common/db/locks";
+import { lockedTransactionRow } from "../test-helpers/locks-testing";
 import {
   createScopedDbMocks,
   DataSourceMock,
@@ -28,6 +30,15 @@ import {
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
+);
+
+// `update` and `remove` read the values a balance delta reverses under a row
+// lock inside the write transaction, not from the snapshot `findOne` returned
+// (audit P4-003). The double below derives the locked row from whatever the
+// transactions repository is currently returning, so every existing scenario
+// keeps describing the same committed state.
+jest.mock("../common/db/locks", () =>
+  jest.requireActual("../test-helpers/locks-testing").locksMockModule(),
 );
 
 jest.mock("../common/date-utils", () => ({
@@ -56,6 +67,11 @@ describe("TransactionsService", () => {
   // shape so the pre-RLS manager assertions still read naturally.
   let mockQueryRunner: Record<string, any>;
   let mockDataSource: DataSourceMock;
+  /**
+   * Override for the committed row the write transaction locks. `undefined` means
+   * "whatever the repository mock has returned"; see beforeEach.
+   */
+  let lockedRow: Record<string, unknown> | null | undefined;
 
   const mockAccount = {
     id: "account-1",
@@ -128,6 +144,7 @@ describe("TransactionsService", () => {
       findOne: jest.fn().mockResolvedValue(mockAccount),
       updateBalance: jest.fn().mockResolvedValue(mockAccount),
       recalculateCurrentBalance: jest.fn().mockResolvedValue(mockAccount),
+      touchAccount: jest.fn().mockResolvedValue(undefined),
       getProjectedBalance: jest.fn().mockResolvedValue(0),
     };
 
@@ -153,6 +170,116 @@ describe("TransactionsService", () => {
       [TransactionAttachment, attachmentsRepository],
     ]);
     mockDataSource = tenantMocks.dataSource;
+
+    /**
+     * Serve the locked readers from the rows this spec has already made
+     * `transactionsRepository.findOne` return.
+     *
+     * `update` and `remove` read the values a balance delta reverses under a row
+     * lock inside the write transaction rather than from the snapshot `findOne`
+     * returned: two concurrent updates each held that snapshot, and the second
+     * reversed an amount the first had already replaced (audit P4-003).
+     *
+     * A spec should not have to state the same committed row twice, so this reads
+     * the mock's recorded *results* -- which consumes nothing, unlike calling
+     * `findOne` again and eating a queued `mockResolvedValueOnce`. The
+     * interesting concurrency cases, where the caller's view and the committed
+     * row disagree, override `lockedRow` instead.
+     */
+    lockedRow = undefined;
+    const toLocked = (row: Record<string, unknown>) =>
+      lockedTransactionRow({
+        id: String(row.id ?? "tx-1"),
+        accountId: String(row.accountId ?? "account-1"),
+        amount: Number(row.amount ?? 0),
+        // Passed through, not defaulted: a fixture without a date must produce a
+        // locked row without one, or the transfer CAS would see a difference the
+        // test never described.
+        transactionDate: row.transactionDate as string,
+        status: (row.status as string | null) ?? null,
+        isSplit: Boolean(row.isSplit),
+        linkedTransactionId: (row.linkedTransactionId as string | null) ?? null,
+        parentTransactionId: (row.parentTransactionId as string | null) ?? null,
+        // A split's counterpart and embedded investment rows are built from the
+        // parent's payee too, so the committed row has to carry it (FV4-002).
+        payeeId: (row.payeeId as string | null) ?? null,
+        payeeName: (row.payeeName as string | null) ?? null,
+      });
+
+    /**
+     * Every transaction-shaped row the repository has returned so far, by id --
+     * from `findOne` and from `find`, because a batch of transfer legs arrives
+     * through the latter.
+     */
+    const resolvedRows = async (): Promise<
+      Map<string, Record<string, unknown>>
+    > => {
+      const byId = new Map<string, Record<string, unknown>>();
+      const record = (row: unknown) => {
+        const candidate = row as Record<string, unknown> | null;
+        if (candidate?.id) byId.set(String(candidate.id), candidate);
+      };
+      for (const mock of [
+        transactionsRepository.findOne.mock,
+        transactionsRepository.find.mock,
+      ]) {
+        for (const result of mock.results) {
+          if (result.type !== "return") continue;
+          try {
+            const value = await result.value;
+            if (Array.isArray(value)) value.forEach(record);
+            else record(value);
+          } catch {
+            continue;
+          }
+        }
+      }
+      return byId;
+    };
+
+    (lockTransactionRow as jest.Mock).mockImplementation(
+      async (_m: unknown, id: string) => {
+        if (lockedRow !== undefined) {
+          return lockedRow ? toLocked(lockedRow) : null;
+        }
+        const rows = await resolvedRows();
+        if (!rows.has(id)) {
+          // This row has not been read yet -- a path that locks before it reads
+          // anything (a status transition), or one where the lock replaced the
+          // read entirely (the split parent). Consulting the mock now is exactly
+          // right: whatever the spec queued next IS what the committed row is.
+          const row = (await transactionsRepository.findOne({
+            where: { id },
+          })) as Record<string, unknown> | null;
+          return row ? toLocked(row) : null;
+        }
+        const row = rows.get(id);
+        return row ? toLocked(row) : null;
+      },
+    );
+    (lockTransactionRows as jest.Mock).mockImplementation(
+      async (_m: unknown, ids: readonly string[]) => {
+        const rows = await resolvedRows();
+        // The lock replaced a batch `find`, so on paths that used to read the
+        // legs first there is nothing recorded yet. Consult the mock directly for
+        // the ids still missing -- safe for a `mockResolvedValue`, and a queued
+        // chain would already have been drawn from by an earlier read.
+        if (ids.some((id) => !rows.has(id))) {
+          const batch = await transactionsRepository.find({});
+          if (Array.isArray(batch)) {
+            for (const row of batch as Record<string, unknown>[]) {
+              if (row?.id) rows.set(String(row.id), row);
+            }
+          }
+        }
+        const found = new Map();
+        for (const id of ids) {
+          const row = rows.get(id);
+          if (row) found.set(id, toLocked(row));
+        }
+        return found;
+      },
+    );
 
     const manager = tenantMocks.manager;
     // Entities without a dedicated mock fall back to the transactions repo,
@@ -180,6 +307,12 @@ describe("TransactionsService", () => {
       return transactionsRepository.update(id, data);
     });
     manager.delete.mockImplementation((_Entity: any, criteria: any) => {
+      // Deletes are conditional now and the reversal is gated on what the
+      // database actually removed, so the double has to report an affected count
+      // (audit P4-003: two deletes each reversing one row's amount).
+      if (_Entity === Transaction) {
+        return Promise.resolve({ affected: 1 });
+      }
       if (_Entity === TransactionSplit)
         return splitsRepository.delete(criteria);
       return Promise.resolve(undefined);
@@ -984,6 +1117,116 @@ describe("TransactionsService", () => {
       splits: [],
     };
 
+    it("derives the balance delta from the locked row, not the caller's snapshot", async () => {
+      // The regression guard for P4-003. Opening balance 100.00 and one -10.00
+      // row: request A changes it to -20.00 and commits (delta -10.00), then
+      // request B -- holding the pre-A snapshot of -10.00 -- changes it to
+      // -30.00. Computing B's delta from that snapshot gives -20.00 and leaves
+      // the stored balance at 60.00 against an authoritative 70.00.
+      //
+      // The locked row says -20.00, so the delta is -10.00 and the balance lands
+      // on 70.00.
+      transactionsRepository.findOne.mockResolvedValue({
+        ...mockTx,
+        amount: -10,
+      });
+      lockedRow = { ...mockTx, amount: -20 };
+      mockQueryRunner.manager.findOne.mockResolvedValueOnce({
+        ...mockTx,
+        amount: -30,
+      });
+
+      await service.update("user-1", "tx-1", { amount: -30 } as any);
+
+      expect(accountsService.updateBalance).toHaveBeenCalledWith(
+        "account-1",
+        -10,
+      );
+    });
+
+    it("touches the account (no balance write) when only a past-dated transaction's date moves", async () => {
+      // A past->past date change with unchanged amount and account leaves
+      // current_balance identical, so no balance write runs -- but moving the row
+      // between months changes monthly_account_balances. touchAccount bumps
+      // accounts.updated_at so NetWorthService.sweepStaleSnapshots can still
+      // recover the stale snapshot if the debounce is lost (audit DR-04-03).
+      // Before the fix this branch wrote nothing and the account never showed as
+      // stale.
+      const oldDate = "2026-05-15";
+      const newDate = "2026-06-20";
+      transactionsRepository.findOne.mockResolvedValue({
+        ...mockTx,
+        amount: -50,
+        accountId: "account-1",
+        transactionDate: oldDate,
+      });
+      lockedRow = {
+        ...mockTx,
+        amount: -50,
+        accountId: "account-1",
+        transactionDate: oldDate,
+      };
+      mockQueryRunner.manager.findOne.mockResolvedValueOnce({
+        ...mockTx,
+        amount: -50,
+        accountId: "account-1",
+        transactionDate: newDate,
+      });
+
+      await service.update("user-1", "tx-1", {
+        transactionDate: newDate,
+      } as any);
+
+      expect(accountsService.touchAccount).toHaveBeenCalledWith(
+        "user-1",
+        "account-1",
+      );
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      expect(accountsService.recalculateCurrentBalance).not.toHaveBeenCalled();
+    });
+
+    it("does not touch the account when nothing that moves a snapshot changed", async () => {
+      // Same account, same amount, same date: no balance write and no snapshot
+      // change, so touchAccount must not fire either -- otherwise every no-op
+      // edit would mark the account stale and the sweep would churn.
+      const sameDate = "2026-05-15";
+      transactionsRepository.findOne.mockResolvedValue({
+        ...mockTx,
+        amount: -50,
+        accountId: "account-1",
+        transactionDate: sameDate,
+      });
+      lockedRow = {
+        ...mockTx,
+        amount: -50,
+        accountId: "account-1",
+        transactionDate: sameDate,
+      };
+      mockQueryRunner.manager.findOne.mockResolvedValueOnce({
+        ...mockTx,
+        amount: -50,
+        accountId: "account-1",
+        transactionDate: sameDate,
+      });
+
+      await service.update("user-1", "tx-1", {
+        description: "note only",
+      } as any);
+
+      expect(accountsService.touchAccount).not.toHaveBeenCalled();
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
+
+    it("throws NotFound when the row is gone by the time it is locked", async () => {
+      transactionsRepository.findOne.mockResolvedValue({ ...mockTx });
+      lockedRow = null;
+
+      await expect(
+        service.update("user-1", "tx-1", { amount: -80 } as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
+
     it("updates transaction amount and adjusts balance", async () => {
       transactionsRepository.findOne.mockResolvedValue({ ...mockTx });
       mockQueryRunner.manager.findOne.mockResolvedValueOnce({
@@ -1249,7 +1492,12 @@ describe("TransactionsService", () => {
         "account-1",
         50,
       );
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalled();
+      // A conditional DELETE, not `remove(entity)`: the reversal only runs when
+      // the database actually removed the row (audit P4-003).
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "tx-1",
+        userId: "user-1",
+      });
     });
 
     it("does not revert balance for VOID transactions", async () => {
@@ -1268,6 +1516,107 @@ describe("TransactionsService", () => {
       await service.remove("user-1", "tx-1");
 
       expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
+
+    it("locks the split parent before the leg when removing a split leg (parent-before-leg, audit RV4-005)", async () => {
+      // Removing a transfer leg that belongs to a split parent must take the
+      // two rows in the same order removeSplit does -- parent first, then leg.
+      // The earlier code locked the named leg first and only reached the parent
+      // inside removeParentTransaction, so remove() and removeSplit() took the
+      // same two rows in opposite orders: a reachable deadlock whenever both ran
+      // at once. This asserts the ordering, not just that both rows are locked,
+      // so a return to leg-then-parent fails here.
+      const legTx = {
+        id: "leg-tx",
+        userId: "user-1",
+        accountId: "account-2",
+        amount: 40,
+        status: TransactionStatus.UNRECONCILED,
+        isSplit: false,
+        linkedTransactionId: "parent-tx",
+        splits: [],
+      };
+      const parentSplit = {
+        id: "parent-split-1",
+        transactionId: "parent-tx",
+        linkedTransactionId: "leg-tx",
+      };
+      const parentTx = {
+        id: "parent-tx",
+        userId: "user-1",
+        accountId: "account-1",
+        amount: -100,
+        status: TransactionStatus.UNRECONCILED,
+      };
+
+      // The access check reads the leg; the parent is read the first time the
+      // lock helper needs it (its row was never loaded up front).
+      transactionsRepository.findOne
+        .mockResolvedValueOnce(legTx)
+        .mockResolvedValueOnce(parentTx);
+      transactionsRepository.find.mockResolvedValue([]);
+      splitsRepository.findOne.mockResolvedValue(parentSplit);
+      // removeParentTransaction reads the parent's splits; only the leg itself
+      // is linked, so no sibling legs go through the batch lock.
+      mockQueryRunner.manager.find.mockResolvedValueOnce([parentSplit]);
+
+      await service.remove("user-1", "leg-tx");
+
+      const lockedIds = (lockTransactionRow as jest.Mock).mock.calls.map(
+        (c) => c[1] as string,
+      );
+      const firstParent = lockedIds.indexOf("parent-tx");
+      const firstLeg = lockedIds.indexOf("leg-tx");
+      expect(firstParent).toBeGreaterThanOrEqual(0);
+      expect(firstLeg).toBeGreaterThanOrEqual(0);
+      // Parent locked strictly before the leg.
+      expect(firstParent).toBeLessThan(firstLeg);
+    });
+
+    it("debounces the net-worth recalc on the locked account, not the pre-lock snapshot", async () => {
+      // A concurrent edit moved the row to a different account between the
+      // pre-lock read and the lock. The balance reversal correctly uses
+      // locked.accountId, so the debounce must too -- otherwise the account whose
+      // balance actually changed never gets its snapshots recomputed. Before the
+      // fix the debounce fired on the stale snapshot's account.
+      transactionsRepository.findOne.mockResolvedValue({
+        id: "tx-1",
+        userId: "user-1",
+        accountId: "account-stale",
+        amount: -50,
+        status: TransactionStatus.UNRECONCILED,
+        isSplit: false,
+        transactionDate: "2026-05-15",
+        splits: [],
+      });
+      lockedRow = {
+        id: "tx-1",
+        userId: "user-1",
+        accountId: "account-locked",
+        amount: -50,
+        status: TransactionStatus.UNRECONCILED,
+        isSplit: false,
+        transactionDate: "2026-05-15",
+      };
+      // parentSplit lookup -> none.
+      mockQueryRunner.manager.findOne.mockResolvedValueOnce(null);
+
+      await service.remove("user-1", "tx-1");
+
+      // Balance reversed on the locked account...
+      expect(accountsService.updateBalance).toHaveBeenCalledWith(
+        "account-locked",
+        50,
+      );
+      // ...and the debounce fires on the same locked account, never the stale one.
+      expect(netWorthService.triggerDebouncedRecalc).toHaveBeenCalledWith(
+        "account-locked",
+        "user-1",
+      );
+      expect(netWorthService.triggerDebouncedRecalc).not.toHaveBeenCalledWith(
+        "account-stale",
+        "user-1",
+      );
     });
   });
 
@@ -3708,6 +4057,7 @@ describe("TransactionsService", () => {
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
+        setLock: jest.fn().mockReturnThis(),
         addOrderBy: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
@@ -3868,6 +4218,7 @@ describe("TransactionsService", () => {
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
+        setLock: jest.fn().mockReturnThis(),
         addOrderBy: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
@@ -4338,7 +4689,14 @@ describe("TransactionsService", () => {
         "account-2",
         -60,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(oldLinkedTx);
+      // Conditional delete keyed on id + owner (FV4-002).
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: oldLinkedTx.id,
+        userId: "user-1",
+      });
+      expect(transactionsRepository.remove).not.toHaveBeenCalledWith(
+        oldLinkedTx,
+      );
     });
   });
 
@@ -4643,7 +5001,14 @@ describe("TransactionsService", () => {
         "account-2",
         -40,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(linkedTx);
+      // Conditional delete keyed on id + owner, not `remove(entity)`: the
+      // reversal above is gated on this call being the one that removed the row
+      // (audit FV4-002).
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: linkedTx.id,
+        userId: "user-1",
+      });
+      expect(transactionsRepository.remove).not.toHaveBeenCalledWith(linkedTx);
     });
 
     it("converts to simple transaction when fewer than 2 splits remain (1 left)", async () => {
@@ -4760,7 +5125,11 @@ describe("TransactionsService", () => {
         "account-2",
         -50,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: lastSplitLinkedTx.id,
+        userId: "user-1",
+      });
+      expect(transactionsRepository.remove).not.toHaveBeenCalledWith(
         lastSplitLinkedTx,
       );
       expect(transactionsRepository.update).toHaveBeenCalledWith("tx-1", {
@@ -4824,6 +5193,68 @@ describe("TransactionsService", () => {
       expect(transactionsRepository.update).toHaveBeenCalledWith(
         "tx-1",
         expect.objectContaining({ isSplit: false }),
+      );
+    });
+
+    /**
+     * A split replacement that names no new amount takes the parent amount from
+     * the pre-transaction snapshot. Another request can change that amount while
+     * this one waits for the parent row lock, and before the fix the replacement
+     * was validated against the stale figure -- so a split set that does not sum
+     * to its parent was accepted (audit FV4-002).
+     */
+    it("validates the replacement against the committed amount, not the caller's", async () => {
+      transactionsRepository.findOne.mockResolvedValue({ ...mockTx });
+      // Committed while this request waited: the parent is now -50.
+      lockedRow = { ...mockTx, amount: -50 };
+      splitsRepository.find.mockResolvedValue([]);
+
+      await expect(
+        service.update("user-1", "tx-1", {
+          splits: [
+            { amount: -60, categoryId: "cat-1" },
+            { amount: -40, categoryId: "cat-2" },
+          ],
+        } as any),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(splitsRepository.create).not.toHaveBeenCalled();
+      expect(transactionsRepository.update).not.toHaveBeenCalled();
+    });
+
+    it("builds the replacement's counterparts from the committed parent fields", async () => {
+      transactionsRepository.findOne.mockResolvedValue({
+        ...mockTx,
+        accountId: "account-stale",
+        transactionDate: "2026-01-15",
+        payeeName: "Stale Payee",
+        payeeId: "payee-stale",
+      });
+      lockedRow = {
+        ...mockTx,
+        accountId: "account-committed",
+        transactionDate: "2026-03-20",
+        payeeName: "Committed Payee",
+        payeeId: "payee-committed",
+      };
+      splitsRepository.find.mockResolvedValue([]);
+      const createSplits = jest.spyOn(splitService, "createSplits");
+
+      await service.update("user-1", "tx-1", {
+        splits: [
+          { amount: -60, categoryId: "cat-1" },
+          { amount: -40, categoryId: "cat-2" },
+        ],
+      } as any);
+
+      expect(createSplits).toHaveBeenCalledWith(
+        "tx-1",
+        expect.anything(),
+        "user-1",
+        "account-committed",
+        new Date("2026-03-20"),
+        "Committed Payee",
+        "payee-committed",
       );
     });
   });
@@ -5312,14 +5743,18 @@ describe("TransactionsService", () => {
         amount: 60,
       };
 
-      // findOne call sequence:
-      // 1. transactionsRepository.findOne(userId, transactionId) -> linkedTx
-      // 2. queryRunner.manager.findOne(Transaction, { where: { id: parentTransactionId } }) -> parentTx
-      // 3. queryRunner.manager.findOne(Transaction, { where: { id: split.linkedTransactionId } }) -> anotherLinkedTx
-      transactionsRepository.findOne.mockResolvedValueOnce(linkedTx);
-      mockQueryRunner.manager.findOne
-        .mockResolvedValueOnce(parentTx)
-        .mockResolvedValueOnce(anotherLinkedTx);
+      // The access check reads the named leg; the split parent is then locked on
+      // its own, *before* its legs, because a batch sorting parent and legs
+      // together would take them in the opposite order from `removeSplit`
+      // whenever a leg's UUID sorts first (audit RV4-005). The sibling legs come
+      // through the batch reader.
+      transactionsRepository.findOne
+        .mockResolvedValueOnce(linkedTx)
+        .mockResolvedValueOnce(parentTx);
+      transactionsRepository.find.mockResolvedValue([
+        parentTx,
+        anotherLinkedTx,
+      ]);
 
       const allSplits = [
         {
@@ -5344,11 +5779,12 @@ describe("TransactionsService", () => {
         "account-3",
         -60,
       );
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(
-        anotherLinkedTx,
-      );
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "another-linked-tx",
+        userId: "user-1",
+      });
 
-      // Should remove all splits
+      // Should remove all splits -- they carry no balance, so `remove` is fine
       expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(allSplits);
 
       // Should revert parent transaction balance and remove
@@ -5356,14 +5792,21 @@ describe("TransactionsService", () => {
         "account-1",
         100,
       );
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(parentTx);
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "tx-parent",
+        userId: "user-1",
+      });
 
       // Should revert the linked transaction's own balance and remove it
       expect(accountsService.updateBalance).toHaveBeenCalledWith(
         "account-2",
         -40,
       );
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(linkedTx);
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "linked-tx-1",
+        userId: "user-1",
+      });
+      expect(transactionsRepository.remove).not.toHaveBeenCalledWith(linkedTx);
     });
   });
 
@@ -5414,7 +5857,10 @@ describe("TransactionsService", () => {
         "account-2",
         -40,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(linkedTx);
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: linkedTx.id,
+        userId: "user-1",
+      });
 
       // Should revert parent balance
       expect(accountsService.updateBalance).toHaveBeenCalledWith(
@@ -5487,9 +5933,10 @@ describe("TransactionsService", () => {
         "account-3",
         -60,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(
-        anotherChildTx,
-      );
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "another-child-tx",
+        userId: "user-1",
+      });
 
       // Should remove all splits
       expect(splitsRepository.remove).toHaveBeenCalledWith(allSplits);
@@ -5499,14 +5946,20 @@ describe("TransactionsService", () => {
         "account-1",
         100,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(parentTx);
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "tx-parent",
+        userId: "user-1",
+      });
 
       // Should also revert the child tx balance and remove it
       expect(accountsService.updateBalance).toHaveBeenCalledWith(
         "account-2",
         -40,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(childTx);
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "child-tx",
+        userId: "user-1",
+      });
     });
 
     it("does not revert parent balance if parent is VOID", async () => {
@@ -5701,8 +6154,15 @@ describe("TransactionsService", () => {
         "account-3",
         -40,
       );
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(linkedTx1);
-      expect(transactionsRepository.remove).toHaveBeenCalledWith(linkedTx2);
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: linkedTx1.id,
+        userId: "user-1",
+      });
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: linkedTx2.id,
+        userId: "user-1",
+      });
+      expect(transactionsRepository.remove).not.toHaveBeenCalled();
     });
 
     it("skips splits without linked transactions", async () => {
@@ -5853,8 +6313,16 @@ describe("TransactionsService", () => {
         "account-2",
         -200,
       );
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(toTx);
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(fromTx);
+      // Conditional DELETEs, in ascending leg-id order, with each reversal gated
+      // on the row the database actually removed (audit P4-003).
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "tx-to",
+        userId: "user-1",
+      });
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "tx-from",
+        userId: "user-1",
+      });
     });
 
     it("handles removing transfer when linked transaction is missing", async () => {
@@ -5880,7 +6348,14 @@ describe("TransactionsService", () => {
         "account-1",
         200,
       );
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(fromTx);
+      // A counterpart the caller cannot read routes through the cross-owner
+      // removal, which also deletes conditionally and reverses only what it
+      // removed (audit FV4-002).
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "tx-from",
+        userId: "user-1",
+      });
+      expect(mockQueryRunner.manager.remove).not.toHaveBeenCalledWith(fromTx);
     });
 
     it("handles removing transfer without linkedTransactionId", async () => {
@@ -5903,7 +6378,10 @@ describe("TransactionsService", () => {
         "account-1",
         200,
       );
-      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(tx);
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "tx-1",
+        userId: "user-1",
+      });
     });
   });
 
@@ -5955,7 +6433,10 @@ describe("TransactionsService", () => {
       await service.remove("user-1", "tx-1");
 
       expect(accountsService.updateBalance).not.toHaveBeenCalled();
-      expect(transactionsRepository.remove).toHaveBeenCalled();
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(Transaction, {
+        id: "tx-1",
+        userId: "user-1",
+      });
     });
 
     it("recalculates balance when updating a transaction from future to current date", async () => {
@@ -5994,6 +6475,7 @@ describe("TransactionsService", () => {
 
       // When any future date is involved, recalculate from scratch
       expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+        "user-1",
         "account-1",
       );
       expect(accountsService.updateBalance).not.toHaveBeenCalled();
@@ -6035,6 +6517,7 @@ describe("TransactionsService", () => {
 
       // When any future date is involved, recalculate from scratch
       expect(accountsService.recalculateCurrentBalance).toHaveBeenCalledWith(
+        "user-1",
         "account-1",
       );
       expect(accountsService.updateBalance).not.toHaveBeenCalled();

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -68,6 +68,7 @@ import {
   bulkSkipReason,
 } from "../common/bulk-create.types";
 import { withScopedDb } from "../common/db/scoped-db";
+import { lockTransactionRow, lockTransactionRows } from "../common/db/locks";
 import {
   normalizeFxEntry,
   type FxEntry,
@@ -376,6 +377,7 @@ export class TransactionsService {
         if (savedTransaction.status !== TransactionStatus.VOID) {
           if (isTransactionInFuture(createTransactionDto.transactionDate)) {
             await this.accountsService.recalculateCurrentBalance(
+              userId,
               createTransactionDto.accountId,
             );
           } else {
@@ -1965,11 +1967,7 @@ export class TransactionsService {
   ): Promise<Transaction> {
     const transaction = await this.findOne(userId, id);
     const beforeSnapshot = this.snapshotTransaction(transaction);
-    const oldAmount = Number(transaction.amount);
     const oldAccountId = transaction.accountId;
-    const oldTransactionDate = transaction.transactionDate;
-    const oldStatus = transaction.status;
-    const wasVoid = oldStatus === TransactionStatus.VOID;
 
     const { splits, tagIds, createdAt, ...updateData } = updateTransactionDto;
 
@@ -2017,24 +2015,64 @@ export class TransactionsService {
     // One transaction: split rebuild, field update, tags, and balance
     // adjustments commit or roll back together. Nested service calls join it.
     await withScopedDb(this.dataSource, async (m) => {
+      // The values a balance delta reverses are read HERE, under a row lock,
+      // not from the snapshot `findOne` above returned.
+      //
+      // That snapshot is a claim that nothing changed in between, and two
+      // concurrent updates each held it: PostgreSQL serialized the row writes,
+      // but the second request never refreshed its "old amount" after waiting,
+      // so it reversed an amount the first had already replaced. Opening
+      // balance 100.00, one -10.00 row, A updates it to -20.00 and B to -30.00:
+      // the ledger ends at -30.00 while the stored balance says 60.00 instead
+      // of 70.00 (audit P4-003).
+      const locked = await lockTransactionRow(m, id, userId);
+      if (!locked) {
+        throw new NotFoundException(
+          tr(
+            "errors.transactions.notFoundById",
+            `Transaction with ID ${id} not found`,
+            { id },
+          ),
+        );
+      }
+      const oldAmount = locked.amount;
+      const oldLockedAccountId = locked.accountId;
+      const oldTransactionDate = locked.transactionDate;
+      const wasVoid = locked.status === TransactionStatus.VOID;
+
       if (splits !== undefined) {
         if (Array.isArray(splits) && splits.length > 0) {
+          // Re-validate against the amount the locked row holds. The check above
+          // ran on the pre-transaction snapshot, which is an early rejection and
+          // not an authoritative one: a request that only replaces the splits
+          // takes its parent amount from that snapshot, so a concurrent amount
+          // edit that committed while this one waited for the row lock would let
+          // a split set through that does not sum to the parent it is attached
+          // to (audit FV4-002).
+          this.splitService.validateSplits(
+            splits,
+            updateData.amount ?? locked.amount,
+          );
+
           await this.splitService.deleteSplitSideEffects(id, userId);
           await m.delete(TransactionSplit, {
             transactionId: id,
           });
 
-          const accountId = updateData.accountId ?? transaction.accountId;
-          const txDate =
-            updateData.transactionDate ?? transaction.transactionDate;
+          // Fallbacks come off the locked row, never the caller's snapshot: the
+          // counterpart and embedded investment rows describe the parent's
+          // account, date and payee, so a stale fallback writes rows describing a
+          // parent that has already moved.
+          const accountId = updateData.accountId ?? locked.accountId;
+          const txDate = updateData.transactionDate ?? locked.transactionDate;
           const savedSplits = await this.splitService.createSplits(
             id,
             splits,
             userId,
             accountId,
             new Date(txDate),
-            updateData.payeeName ?? transaction.payeeName,
-            updateData.payeeId ?? transaction.payeeId,
+            updateData.payeeName ?? locked.payeeName,
+            updateData.payeeId ?? locked.payeeId,
           );
 
           // Set split-level tags (and mirror them onto any transfer counterpart)
@@ -2161,21 +2199,41 @@ export class TransactionsService {
       const anyFuture = oldIsFuture || newIsFuture;
 
       if (anyFuture) {
-        const affectedAccounts = new Set([oldAccountId, newAccountId]);
+        // Deterministic order so two accounts locked by both this path and a
+        // transfer cannot be taken in opposite orders.
+        const affectedAccounts = [
+          ...new Set([oldLockedAccountId, newAccountId]),
+        ].sort();
         for (const accId of affectedAccounts) {
-          await this.accountsService.recalculateCurrentBalance(accId);
+          await this.accountsService.recalculateCurrentBalance(userId, accId);
         }
       } else if (wasVoid && !isVoid) {
         await this.accountsService.updateBalance(newAccountId, newAmount);
       } else if (!wasVoid && isVoid) {
-        await this.accountsService.updateBalance(oldAccountId, -oldAmount);
+        await this.accountsService.updateBalance(
+          oldLockedAccountId,
+          -oldAmount,
+        );
       } else if (!wasVoid && !isVoid) {
-        if (newAccountId !== oldAccountId) {
-          await this.accountsService.updateBalance(oldAccountId, -oldAmount);
+        if (newAccountId !== oldLockedAccountId) {
+          await this.accountsService.updateBalance(
+            oldLockedAccountId,
+            -oldAmount,
+          );
           await this.accountsService.updateBalance(newAccountId, newAmount);
         } else if (newAmount !== oldAmount) {
           const balanceChange = newAmount - oldAmount;
           await this.accountsService.updateBalance(newAccountId, balanceChange);
+        } else if (oldTransactionDate !== savedTransaction.transactionDate) {
+          // Same account, same amount, both dates in the past (anyFuture is
+          // handled above): current_balance is unchanged, so no balance write
+          // runs and nothing bumps accounts.updated_at. But moving the row
+          // between past months changes monthly_account_balances, and
+          // NetWorthService.sweepStaleSnapshots finds a stale snapshot only by
+          // accounts.updated_at outrunning its computed_at. Touch the account so
+          // that crash-recovery backstop still fires if the in-memory debounce
+          // is lost (audit DR-04-03).
+          await this.accountsService.touchAccount(userId, newAccountId);
         }
       }
     });
@@ -2212,39 +2270,80 @@ export class TransactionsService {
   async remove(userId: string, id: string): Promise<void> {
     const transaction = await this.findOne(userId, id);
     const beforeSnapshot = this.snapshotTransaction(transaction);
-    const accountId = transaction.accountId;
+    // The account the debounced net-worth recalc must fire on. Seeded from the
+    // pre-lock snapshot, then replaced by the locked row's account below: a
+    // concurrent edit could have moved the row, and the balance reversal already
+    // uses locked.accountId, so the debounce has to as well or it recomputes the
+    // wrong account's snapshots (or none).
+    let affectedAccountId = transaction.accountId;
 
     // One transaction: split side effects, linked/parent cleanup, the delete
     // itself, and the balance adjustment commit or roll back together.
     await withScopedDb(this.dataSource, async (m) => {
-      if (transaction.isSplit) {
-        await this.splitService.deleteSplitSideEffects(id, userId);
-      }
-
+      // Parent-before-leg (audit RV4-005). If this row is a leg of a split
+      // parent, lock the parent *before* the leg -- the same order
+      // TransactionSplitService.removeSplit takes, which cannot know a leg id
+      // before reading the split and so necessarily locks parent then leg. Two
+      // delete paths taking the same rows in opposite orders is a reachable
+      // deadlock; ordering by role (parent first) removes it. The lookup is an
+      // unlocked read, and lockTransactionRow is re-entrant within the
+      // transaction, so removeParentTransaction re-locking the parent below is a
+      // no-op that inherits this order.
       const parentSplit = await m.findOne(TransactionSplit, {
         where: { linkedTransactionId: id },
       });
+      if (parentSplit) {
+        await lockTransactionRow(m, parentSplit.transactionId, userId);
+      }
+
+      // Lock the row and re-read the amount to reverse. `m.remove(entity)`
+      // deletes by primary key and reports nothing when it hits no row, so two
+      // concurrent deletes each reversed the same amount and only one row went
+      // away: opening 100.00, one -10.00 row removed twice, stored balance
+      // 110.00 against an authoritative 100.00 (audit P4-003).
+      const locked = await lockTransactionRow(m, id, userId);
+      if (!locked) {
+        throw new NotFoundException(
+          tr(
+            "errors.transactions.notFoundById",
+            `Transaction with ID ${id} not found`,
+            { id },
+          ),
+        );
+      }
+      affectedAccountId = locked.accountId;
+
+      if (locked.isSplit) {
+        await this.splitService.deleteSplitSideEffects(id, userId);
+      }
 
       if (parentSplit) {
         await this.removeParentTransaction(m, parentSplit, id, userId);
       }
 
-      if (transaction.status !== TransactionStatus.VOID) {
-        if (isTransactionInFuture(transaction.transactionDate)) {
-          await m.remove(transaction);
-          await this.accountsService.recalculateCurrentBalance(accountId);
+      const deleted = await m.delete(Transaction, { id, userId });
+      if ((deleted.affected ?? 0) === 0) {
+        // The row was removed by the parent cleanup above (a split counterpart
+        // cascade). Reversing its amount again would double-count.
+        return;
+      }
+
+      if (locked.status !== TransactionStatus.VOID) {
+        if (isTransactionInFuture(locked.transactionDate)) {
+          await this.accountsService.recalculateCurrentBalance(
+            userId,
+            locked.accountId,
+          );
           return;
         }
         await this.accountsService.updateBalance(
-          accountId,
-          -Number(transaction.amount),
+          locked.accountId,
+          -locked.amount,
         );
       }
-
-      await m.remove(transaction);
     });
 
-    this.netWorthService.triggerDebouncedRecalc(accountId, userId);
+    this.netWorthService.triggerDebouncedRecalc(affectedAccountId, userId);
     this.recordTransactionAction(
       userId,
       { ...transaction, ...beforeSnapshot } as Transaction,
@@ -2260,9 +2359,12 @@ export class TransactionsService {
     userId: string,
   ): Promise<void> {
     const parentTransactionId = parentSplit.transactionId;
-    const parentTransaction = await m.findOne(Transaction, {
-      where: { id: parentTransactionId, userId },
-    });
+    // Locked, like every other read whose amount becomes a balance delta.
+    const parentTransaction = await lockTransactionRow(
+      m,
+      parentTransactionId,
+      userId,
+    );
 
     if (parentTransaction) {
       const allSplits = await m.find(TransactionSplit, {
@@ -2281,59 +2383,73 @@ export class TransactionsService {
       ];
 
       if (linkedIds.length > 0) {
-        const linkedTxs = await m.find(Transaction, {
-          where: { id: In(linkedIds), userId },
-        });
+        // Locked in ascending id order: these amounts become balance deltas,
+        // and an unlocked read can be stale by the time the delete lands.
+        const linkedTxs = await lockTransactionRows(m, linkedIds, userId);
 
-        for (const linkedTx of linkedTxs) {
+        for (const linkedTx of [...linkedTxs.values()]) {
           const linkedAccId = linkedTx.accountId;
           const linkedIsFuture = isTransactionInFuture(
             linkedTx.transactionDate,
           );
-          if (!linkedIsFuture) {
+          const removed = await m.delete(Transaction, {
+            id: linkedTx.id,
+            userId,
+          });
+          if ((removed.affected ?? 0) === 0) continue;
+          if (linkedIsFuture) {
+            await this.accountsService.recalculateCurrentBalance(
+              userId,
+              linkedAccId,
+            );
+          } else if (linkedTx.status !== TransactionStatus.VOID) {
             await this.accountsService.updateBalance(
               linkedAccId,
-              -Number(linkedTx.amount),
+              -linkedTx.amount,
             );
-          }
-          await m.remove(linkedTx);
-          if (linkedIsFuture) {
-            await this.accountsService.recalculateCurrentBalance(linkedAccId);
           }
         }
       }
 
       await m.remove(allSplits);
 
+      const parentRemoved = await m.delete(Transaction, {
+        id: parentTransaction.id,
+        userId,
+      });
+      if ((parentRemoved.affected ?? 0) === 0) return;
+
       if (parentTransaction.status !== TransactionStatus.VOID) {
         if (isTransactionInFuture(parentTransaction.transactionDate)) {
-          await m.remove(parentTransaction);
           await this.accountsService.recalculateCurrentBalance(
+            userId,
             parentTransaction.accountId,
           );
           return;
         }
         await this.accountsService.updateBalance(
           parentTransaction.accountId,
-          -Number(parentTransaction.amount),
+          -parentTransaction.amount,
         );
       }
-      await m.remove(parentTransaction);
     }
   }
 
   // Delegated methods
 
+  // These four pass the transaction *id*, not a loaded entity: the status a
+  // guard refuses on and the status a balance delta is derived from are the
+  // same value, and it has to be read under the write's own lock. See
+  // `applyStatusTransition`.
   async updateStatus(
     userId: string,
     id: string,
     status: TransactionStatus,
   ): Promise<Transaction> {
-    const transaction = await this.findOne(userId, id);
     return this.reconciliationService.updateStatus(
-      transaction,
-      status,
       userId,
+      id,
+      status,
       (accountId: string, userId: string) =>
         this.netWorthService.triggerDebouncedRecalc(accountId, userId),
       this.findOne.bind(this),
@@ -2345,11 +2461,10 @@ export class TransactionsService {
     id: string,
     isCleared: boolean,
   ): Promise<Transaction> {
-    const transaction = await this.findOne(userId, id);
     return this.reconciliationService.markCleared(
-      transaction,
-      isCleared,
       userId,
+      id,
+      isCleared,
       (accountId: string, userId: string) =>
         this.netWorthService.triggerDebouncedRecalc(accountId, userId),
       this.findOne.bind(this),
@@ -2357,10 +2472,9 @@ export class TransactionsService {
   }
 
   async reconcile(userId: string, id: string): Promise<Transaction> {
-    const transaction = await this.findOne(userId, id);
     return this.reconciliationService.reconcile(
-      transaction,
       userId,
+      id,
       (accountId: string, userId: string) =>
         this.netWorthService.triggerDebouncedRecalc(accountId, userId),
       this.findOne.bind(this),
@@ -2368,10 +2482,9 @@ export class TransactionsService {
   }
 
   async unreconcile(userId: string, id: string): Promise<Transaction> {
-    const transaction = await this.findOne(userId, id);
     return this.reconciliationService.unreconcile(
-      transaction,
       userId,
+      id,
       this.findOne.bind(this),
     );
   }

--- a/backend/test/integration/transfers.integration.spec.ts
+++ b/backend/test/integration/transfers.integration.spec.ts
@@ -170,4 +170,132 @@ describe("TransactionsService transfers (integration)", () => {
       expect(remaining).toHaveLength(0);
     });
   });
+
+  /**
+   * Lock ordering across the paths that touch a split parent and its legs
+   * (audit RV4-005).
+   *
+   * This is a liveness property of PostgreSQL, not of the service: two
+   * transactions that acquire the same two rows in opposite orders get `40P01`
+   * and one of them is aborted. The ids are chosen so the leg sorts *before* the
+   * parent, which is the case a single sorted batch over parent-plus-legs gets
+   * wrong -- `removeSplit` cannot know a leg id before reading the split, so it
+   * necessarily locks the parent first, and the rule has to be "parent before
+   * legs" rather than "ascending id".
+   */
+  describe("split parent and leg lock ordering", () => {
+    /**
+     * A split parent whose transfer leg's UUID sorts before its own, so
+     * ascending-id order and parent-first order genuinely disagree.
+     */
+    const PARENT_ID = "ffffffff-0000-4000-8000-000000000001";
+    const LEG_ID = "00000000-0000-4000-8000-000000000001";
+    const SPLIT_ID = "aaaaaaaa-1111-4000-8000-000000000001";
+
+    beforeEach(async () => {
+      // Built with raw SQL: the service would allocate its own UUIDs, and the
+      // adversarial ordering is the whole point of the fixture.
+      await dataSource.query(
+        `INSERT INTO transactions
+           (id, user_id, account_id, transaction_date, amount, currency_code,
+            exchange_rate, is_split, is_transfer, status)
+         VALUES ($1, $2, $3, DATE '2026-01-15', -100, 'USD', 1, true, false,
+                 'UNRECONCILED')`,
+        [PARENT_ID, userId, fromAccountId],
+      );
+      await dataSource.query(
+        `INSERT INTO transactions
+           (id, user_id, account_id, transaction_date, amount, currency_code,
+            exchange_rate, is_split, is_transfer, status, linked_transaction_id)
+         VALUES ($1, $2, $3, DATE '2026-01-15', 100, 'USD', 1, false, true,
+                 'UNRECONCILED', $4)`,
+        [LEG_ID, userId, toAccountId, PARENT_ID],
+      );
+      await dataSource.query(
+        `INSERT INTO transaction_splits
+           (id, transaction_id, kind, amount, transfer_account_id,
+            linked_transaction_id)
+         VALUES ($1, $2, 'TRANSFER', -100, $3, $4)`,
+        [SPLIT_ID, PARENT_ID, toAccountId, LEG_ID],
+      );
+    });
+
+    it("removes the split and the counterpart concurrently without deadlocking", async () => {
+      // Both directions at once. Before the ordering fix one of these took the
+      // parent then the leg while the other took the leg then the parent, and
+      // PostgreSQL aborted whichever it picked.
+      const outcomes = await Promise.allSettled([
+        withUserContext(userId, () =>
+          service.removeSplit(userId, PARENT_ID, SPLIT_ID),
+        ),
+        withUserContext(userId, () => service.removeTransfer(userId, LEG_ID)),
+      ]);
+
+      for (const outcome of outcomes) {
+        if (outcome.status !== "rejected") continue;
+        const message = String(
+          (outcome.reason as { message?: string })?.message ?? outcome.reason,
+        );
+        // Losing the race is legitimate -- the row may already be gone, and a
+        // 404 is the honest answer. A deadlock is not.
+        expect(message).not.toMatch(/deadlock/i);
+        expect((outcome.reason as { code?: string })?.code).not.toBe("40P01");
+      }
+    });
+
+    it("does not deadlock when both directions are run repeatedly", async () => {
+      // One pass can pass by luck: whichever request happens to finish before the
+      // other starts never contends at all. Several rounds over fresh fixtures
+      // make the interleaving actually happen.
+      for (let round = 0; round < 5; round += 1) {
+        if (round > 0) {
+          await dataSource.query(
+            `DELETE FROM transactions WHERE id IN ($1, $2)`,
+            [PARENT_ID, LEG_ID],
+          );
+          await dataSource.query(
+            `INSERT INTO transactions
+               (id, user_id, account_id, transaction_date, amount, currency_code,
+                exchange_rate, is_split, is_transfer, status)
+             VALUES ($1, $2, $3, DATE '2026-01-15', -100, 'USD', 1, true, false,
+                     'UNRECONCILED')`,
+            [PARENT_ID, userId, fromAccountId],
+          );
+          await dataSource.query(
+            `INSERT INTO transactions
+               (id, user_id, account_id, transaction_date, amount, currency_code,
+                exchange_rate, is_split, is_transfer, status,
+                linked_transaction_id)
+             VALUES ($1, $2, $3, DATE '2026-01-15', 100, 'USD', 1, false, true,
+                     'UNRECONCILED', $4)`,
+            [LEG_ID, userId, toAccountId, PARENT_ID],
+          );
+          await dataSource.query(
+            `INSERT INTO transaction_splits
+               (id, transaction_id, kind, amount, transfer_account_id,
+                linked_transaction_id)
+             VALUES ($1, $2, 'TRANSFER', -100, $3, $4)`,
+            [SPLIT_ID, PARENT_ID, toAccountId, LEG_ID],
+          );
+        }
+
+        const outcomes = await Promise.allSettled([
+          withUserContext(userId, () =>
+            service.removeSplit(userId, PARENT_ID, SPLIT_ID),
+          ),
+          withUserContext(userId, () => service.removeTransfer(userId, LEG_ID)),
+        ]);
+
+        for (const outcome of outcomes) {
+          if (outcome.status !== "rejected") continue;
+          expect(
+            String(
+              (outcome.reason as { message?: string })?.message ??
+                outcome.reason,
+            ),
+          ).not.toMatch(/deadlock/i);
+        }
+      }
+    });
+  });
 });

--- a/docs/cron-jobs.md
+++ b/docs/cron-jobs.md
@@ -17,6 +17,7 @@ One row per `@Cron` handler. The Cron column is the decorator's expression verba
 | `scheduled-transactions.service` | `25 17 * * 1-5` (America/New_York) | 5:25 PM ET weekdays | Re-derive the account-currency estimate on foreign-currency schedules from the rates the 5:05 PM refresh just stored |
 | `exchange-rate.service` | `5 17 * * 1-5` (America/New_York) | 5:05 PM ET weekdays | Fetch exchange rates (staggered after price refresh) |
 | `accounts.service` | `0 * * * *` | Hourly | Fold future-dated transactions into account balances as their date arrives in each user's local timezone |
+| `net-worth.service` | `0 */30 * * * *` | Every 30 minutes | Recompute current-month net-worth snapshots for accounts whose balance moved since the snapshot was taken (owner-scoped, idempotent across replicas) |
 | `mortgage-reminder.service` | `0 08 * * *` | Daily 8 AM | Mortgage payment reminders |
 | `bill-reminder.service` | `0 08 * * *` | Daily 8 AM | Bill payment reminders |
 | `budget-period-cron.service` | `0 0 1 * *` | 1st of month, midnight | Create new budget periods |


### PR DESCRIPTION
> **Stacked on `pr/04-01-concurrency-foundations`, which is itself stacked on #1078.**
> This branch is exactly one commit above Phase 4 PR 1 (`187b555236fdc3d577dab7f397867994736763e2`).
> Until the lower PRs land, GitHub's combined diff will contain their commits too. Review the unique
> commit `fb20158618888a0c5f3c9f42c7d14c26344f62f3` for this PR's own work.
>
> After the prerequisite PRs merge, rebase this branch onto the resulting `main` before final review.

**Phase 4 merge order: 2**, after `pr/04-01-concurrency-foundations`. Targets `main`.

## What this fixes

This PR applies the Phase 4 lock and transaction contract to the core financial writers. The goal is not to change financial formulas; it is to ensure that the value committed to derived state is based on the row version the write actually replaces.

### Transaction update and delete use locked committed state

Transaction edit/delete paths now lock and re-read the transaction before deriving an old amount, account, date or status from it.

Previously two requests could both act from the same stale snapshot. For example, with an opening balance of `100.00` and one `-10.00` transaction, concurrent edits to `-20.00` and `-30.00` could both reverse the original `-10.00`; the ledger could finish at `-30.00` while the stored balance finished at `60.00` instead of `70.00`.

The write paths now derive reversals from the `FOR UPDATE` row that is actually being replaced.

Deletion follows the same rule. `removeLockedTransactionLeg` conditionally deletes the locked row and reverses its balance contribution only when that delete actually removed a row. A second concurrent delete therefore cannot reverse the same amount twice.

### Absolute balance recomputation composes with atomic deltas

`AccountsService.recalculateCurrentBalance` now locks the account row **before** reading the ledger and writing an absolute total.

That closes the `READ COMMITTED` window where:

1. the recomputation reads the ledger;
2. another request commits an ordinary balance delta;
3. the recomputation writes an older absolute total and erases the committed delta.

The same account-lock protocol is used by other absolute derived-state writers added in this PR, including action-history balance rebuilds and net-worth snapshot recomputation.

### Closed accounts cannot receive a late balance mutation

`AccountsService.updateBalance` now performs the arithmetic and the `is_closed = false` check in the same guarded SQL `UPDATE`.

A transaction mutation that waited behind `close()` can no longer read the account as open and then add a delta after the close committed. A zero-row result is distinguished inside the same transaction as "account gone" versus "account closed", and the exception rolls the surrounding ledger mutation back.

### Holdings updates share one account-level exclusion

Holdings are derived from investment transactions, so a holdings-row lock alone cannot serialize a new trade against a rebuild that deletes and recreates holdings.

All holdings read-modify-write and rebuild paths now use the shared holdings advisory-lock namespace before reading the state they will replace. That covers ordinary quantity/cost-basis updates, stock splits, share adjustments, deletion, rebuilds and account-wide wipes.

### Transfers, splits, bulk operations and reconciliation use locked rows

The same stale-read rule is applied to the surrounding transaction machinery:

- transfer updates/removals lock both legs and compare against the committed pair;
- split parent/leg operations use the parent-before-leg ordering and include regression coverage for the prior deadlock shape;
- split-linked transaction removal uses the single conditional delete-and-reverse path;
- bulk status updates lock every affected transaction before deriving VOID balance movements;
- bulk deletes lock primary and linked rows before deriving reversals and count rows actually deleted;
- reconciliation transitions resolve their guards and VOID balance effects against the locked current status, not a pre-transaction snapshot.

### Net-worth snapshot repair is recoverable

Net-worth recalculation now locks the account before reading the source ledger and replacing snapshots. The process-memory debounce remains a latency optimization, but a periodic stale-snapshot sweep derives missed work from durable database timestamps so a killed pod or failed timer does not leave stale snapshots indefinitely.

### Existing account-service coverage is preserved

The earlier split of this work accidentally deleted a large portion of `accounts.service.spec.ts`. This branch keeps the existing behavior suite and adds the new concurrency cases instead; the file's diff is additive overall rather than replacing the suite with a small subset.

## User-visible errors and localization

New refusal/error messages are carried through the backend i18n catalogs for all supported translated locales, and the pseudo-locale is regenerated. The localization change is included here so this behavioral PR can satisfy the repository's merge-time parity rule independently of later Phase 4 PRs.

## Why

These races are financially material because the authoritative ledger and its derived values could disagree even though every individual request returned success. The failures were not floating-point noise: they were whole committed deltas, duplicated reversals or stale holdings state.

The required invariant is:

> A read-modify-write or delete-and-reverse operation must derive its side effects from the row version it owns under the same transaction and lock as the mutation.

This PR applies that invariant across the financial write paths that share balances, holdings and transaction state.

## Review focus

The highest-value review points are:

1. every reversal comes from a locked current transaction row, not a caller snapshot;
2. a delete reverses only when that request actually deleted the row;
3. absolute balance/snapshot recomputation locks before its source read;
4. closed-account refusal is part of the balance write, not a preceding check;
5. multi-row locks are deterministic and split parent/leg ordering is consistent;
6. holdings writers share one advisory-lock namespace before read-modify-write;
7. rejected operations roll back the ledger mutation and all derived-state changes together;
8. existing account/transaction behavior tests remain present alongside the new concurrency coverage.

## Test evidence

The branch commit records the following as green on its Phase 4 PR 1 base:

- backend typecheck;
- backend lint;
- balance/transaction unit specs: **1,860 tests**;
- backend i18n parity: **212 tests**;
- transfer integration spec: **15 tests**.

The branch also contains explicit integration regression coverage for the split parent/counterpart deadlock scenario.

The PR has not yet produced GitHub Actions status checks because it has not been opened. The numbers above are therefore the branch author's reported local verification and should be confirmed by PR CI before merge.

## Risk

**High.** This PR deliberately touches the core transaction, balance, holdings and net-worth write paths. The changes are defensive and transactional rather than formula changes, but a mistake in this layer can affect stored balances or portfolio state. The focused concurrency tests and separation from the later cron/import/attachment work are intended to keep that risk reviewable.

## What this PR does not do

- no database migration or schema change;
- no change to tax, gain, FX or rounding formulas beyond preserving existing monetary precision at the write boundary;
- no Phase 4 cron/job-claim protocol;
- no MNY import lifecycle changes;
- no attachment lifecycle changes;
- no emergency-access changes.

Those concerns remain in later Phase 4 PRs.

## Linked discussion / issue

Approved in: <!-- Add the maintainer-approved Phase 4 discussion or issue carrying the required approval label. -->

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses one concern: concurrency safety of core financial writes and their derived state.
- [x] New behavior has regression tests; the branch author reports the test sets above as green.
- [x] New backend user-facing errors are localized and the pseudo-locale is regenerated.
- [ ] Shared/core-area scope has maintainer sign-off in the linked discussion or issue.
- [ ] The branch is rebased on the latest `main`. This becomes actionable after the prerequisite stacked PRs merge.
- [x] AI assistance is disclosed below, and the submitted result remains the contributor's responsibility.

## AI assistance disclosure

Implemented with Claude Code from findings produced by the Phase 4 repository audit. The branch was subsequently reviewed for stack ancestry, transaction boundaries, stale-read/double-reversal failure modes, lock ordering, holdings exclusion, reconciliation/bulk behavior, preservation of the existing account-service test suite and localization completeness before this PR description was prepared.
