### PR TITLE
Make import job reaping demand-driven to end user lockouts

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -377,3 +377,27 @@ previous backups are encrypted and silently downgrading is worse than failing).
 Cron jobs use `@Cron()` from `@nestjs/schedule` and run **in the API process** -- `ScheduleModule.forRoot()` is registered in `app.module.ts`; there is no separate scheduler process (on k8s with more than one backend replica, every replica fires every cron). For the full schedule, see `docs/cron-jobs.md` or grep `@Cron(`.
 
 Every `@Cron` handler is an out-of-request entry point, so its body must seed its own RLS context (tasks C2-C4): the cross-user fan-out under `withSystemContext`, each per-user body under `withUserContext(userId)`. A handler that reaches the DB with no ambient context throws `DB access outside request/user/system context` in every `RLS_MODE`, including `off` -- the per-module `rls-context-smoke.spec.ts` specs are the pattern for proving a cron runs clean.
+
+### Cleanup somebody is blocked on belongs on the request path
+
+Before choosing an interval, ask what the stale row *does* while it sits there.
+If it is only untidy, a schedule is the whole answer. If it **refuses the user's
+next request** -- a slot, a lock, a uniqueness guard -- then the interval is a
+lockout the user cannot end, and picking a smaller number only makes the outage
+shorter. Run the cleanup inside the transaction of the request that is about to
+be refused by it, scoped to that caller, and leave the cron as a cross-user
+backstop for whoever never comes back. `MnyImportJobService` is the worked
+example: `reapStaleJobsForUser` runs in `create` and in the poll's `findOne`, so
+a dead import clears itself within one 1.5s poll instead of within ten minutes,
+and `reapStaleJobs` dropped from every five minutes to hourly.
+
+Two things that path has to get right, both of which have a test rather than a
+paragraph. The staleness predicate is **one exported constant** used by the reap
+and negated by the advisory pre-check -- an advisory check that still counts what
+the reap would clear throws the refusal before the request ever reaches the
+transaction that would have cleared it, which reinstates the lockout through the
+back door and looks correct at every individual site. And a per-user cleanup
+whose predicate is a disjunction needs its own parentheses inside the
+`user_id = $n AND (...)`, or the trailing arm escapes the tenant restriction
+entirely; assert the composed clause, not an `"AND ("` prefix, since a condition
+that opens with its own paren satisfies that prefix while ungrouped.

--- a/backend/src/import/mny/entities/import-job.entity.ts
+++ b/backend/src/import/mny/entities/import-job.entity.ts
@@ -31,7 +31,9 @@ export const ONE_ACTIVE_JOB_INDEX = "idx_import_jobs_one_active_per_user";
  * The row is the coordination point: `POST /import/mny/start` inserts it
  * `pending`, exactly one worker claims it by moving it to `running`, the running
  * job writes `progress` and `heartbeat_at` in their own short transactions so a
- * poller can see them, and a reaper cron fails jobs whose heartbeat went stale.
+ * poller can see them, and a job whose heartbeat went stale is failed by the
+ * next request that reads or competes for the slot -- with an hourly cron as the
+ * backstop for a user who never asks again.
  * A failed job keeps `stagedFileId`, so Retry is a new job over the same bytes.
  *
  * The partial unique index is what makes "one import at a time per user" true:

--- a/backend/src/import/mny/mny-import-job.service.spec.ts
+++ b/backend/src/import/mny/mny-import-job.service.spec.ts
@@ -12,7 +12,9 @@ import {
   JOB_STALE_AFTER_MS,
   JOB_STALLED_ERROR_KEY,
   MnyImportJobService,
+  STALE_ACTIVE_JOB_CONDITION,
   isActiveJobConflict,
+  reapStatement,
   returnedRows,
 } from "./mny-import-job.service";
 
@@ -83,12 +85,69 @@ describe("returnedRows", () => {
   });
 });
 
+/**
+ * SQL with its formatting normalized away, including the whitespace either side
+ * of a parenthesis -- so an assertion compares grouping and not indentation.
+ */
+const flat = (statement: string): string =>
+  statement
+    .replace(/\s+/g, " ")
+    .replace(/\(\s+/g, "(")
+    .replace(/\s+\)/g, ")")
+    .trim();
+
+describe("reapStatement", () => {
+  it("groups the user restriction against the whole staleness condition", () => {
+    // The condition is `(A) OR (B)`, so `user_id = $3 AND (A) OR (B)` reaps
+    // this user's stale running jobs *and everybody else's stale pending ones*
+    // -- one request retiring another tenant's import. An enclosing paren is
+    // the only thing between those two statements, and it is invisible in a
+    // template literal. Asserted against the composed clause and not against a
+    // `"AND ("` prefix, because the condition opens with a paren of its own and
+    // would satisfy that prefix while ungrouped.
+    expect(flat(reapStatement(true))).toContain(
+      flat(`WHERE user_id = $3 AND (${STALE_ACTIVE_JOB_CONDITION})`),
+    );
+  });
+
+  it("restricts nothing when it is the cross-user sweep", () => {
+    expect(flat(reapStatement(false))).toContain(
+      flat(`WHERE (${STALE_ACTIVE_JOB_CONDITION})`),
+    );
+    expect(reapStatement(false)).not.toContain("user_id");
+  });
+
+  it("differs between its two forms only by that restriction", () => {
+    // Proof the predicate really is written once: strip the scope clause and
+    // the two statements are byte-identical. A hand-maintained second copy
+    // would drift here first.
+    expect(flat(reapStatement(true)).replace("user_id = $3 AND ", "")).toBe(
+      flat(reapStatement(false)),
+    );
+  });
+
+  it("treats a running job with no heartbeat at all as stale", () => {
+    // `NULL < timestamp` is NULL, so without this arm such a row matches
+    // neither the reap nor `hasActiveJob`'s negation of it -- the one state
+    // nothing can ever clear.
+    expect(flat(STALE_ACTIVE_JOB_CONDITION)).toContain(
+      "heartbeat_at IS NULL OR heartbeat_at <",
+    );
+  });
+
+  it("measures a pending job from creation, since it never heartbeated", () => {
+    expect(flat(STALE_ACTIVE_JOB_CONDITION)).toContain(
+      "status = 'pending' AND created_at <",
+    );
+  });
+});
+
 describe("MnyImportJobService", () => {
   let repo: Record<string, jest.Mock>;
   let query: jest.Mock;
   let service: MnyImportJobService;
 
-  const sql = (call: unknown[]): string => String(call[0]).replace(/\s+/g, " ");
+  const sql = (call: unknown[]): string => flat(String(call[0]));
   const lastCall = (): unknown[] =>
     query.mock.calls[query.mock.calls.length - 1] as unknown[];
 
@@ -168,6 +227,40 @@ describe("MnyImportJobService", () => {
         service.create("user-1", "staged-1", DEFAULT_MNY_IMPORT_OPTIONS),
       ).rejects.toBe(boom);
     });
+
+    it("reaps this user's stale jobs before attempting the insert", async () => {
+      // The regression: with no reap here, a job whose pod died refuses every
+      // import the user ever starts again, and `discard` cannot reach it once
+      // it is `running`.
+      await service.create("user-1", "staged-1", DEFAULT_MNY_IMPORT_OPTIONS);
+
+      expect(sql(query.mock.calls[0])).toContain("UPDATE import_jobs");
+      expect(query.mock.calls[0][1]).toEqual([
+        String(JOB_STALE_AFTER_MS),
+        JOB_STALLED_ERROR_KEY,
+        "user-1",
+      ]);
+    });
+
+    it("reaps in the same transaction the insert runs in", async () => {
+      // In a transaction of its own the reap settles nothing: the row could be
+      // re-read as active before the INSERT, which is the same defect as
+      // counting active jobs in a separate transaction beforehand.
+      await service.create("user-1", "staged-1", DEFAULT_MNY_IMPORT_OPTIONS);
+
+      expect(mockedScopedDb).toHaveBeenCalledTimes(1);
+      expect(query.mock.invocationCallOrder[0]).toBeLessThan(
+        repo.save.mock.invocationCallOrder[0],
+      );
+    });
+
+    it("reaps only rows belonging to the caller", async () => {
+      await service.create("user-1", "staged-1", DEFAULT_MNY_IMPORT_OPTIONS);
+
+      expect(sql(query.mock.calls[0])).toContain(
+        sql([`WHERE user_id = $3 AND (${STALE_ACTIVE_JOB_CONDITION})`]),
+      );
+    });
   });
 
   describe("isActiveJobConflict", () => {
@@ -215,24 +308,50 @@ describe("MnyImportJobService", () => {
     it("returns null for another user's job", async () => {
       expect(await service.findOne("user-1", "job-1")).toBeNull();
     });
+
+    it("reaps before reading, so the poller never sees the stale row", async () => {
+      // This endpoint is polled every 1.5s by the wizard. Reading first would
+      // hand back `running` for a worker that is gone, and the progress bar
+      // would sit there until the hourly cron happened to fire.
+      await service.findOne("user-1", "job-1");
+
+      expect(mockedScopedDb).toHaveBeenCalledTimes(1);
+      expect(sql(query.mock.calls[0])).toContain("UPDATE import_jobs");
+      expect(query.mock.invocationCallOrder[0]).toBeLessThan(
+        repo.findOne.mock.invocationCallOrder[0],
+      );
+    });
   });
 
   describe("hasActiveJob", () => {
-    it("counts both pending and running jobs", async () => {
+    it("looks for a pending or running job belonging to the caller", async () => {
       expect(await service.hasActiveJob("user-1")).toBe(false);
 
-      expect(repo.count).toHaveBeenCalledWith({
-        where: [
-          { userId: "user-1", status: "pending" },
-          { userId: "user-1", status: "running" },
-        ],
-      });
+      const statement = sql(query.mock.calls[0]);
+      expect(statement).toContain("FROM import_jobs");
+      expect(statement).toContain("status IN ('pending', 'running')");
+      expect(query.mock.calls[0][1]).toEqual([
+        String(JOB_STALE_AFTER_MS),
+        "user-1",
+      ]);
     });
 
-    it("is true once one exists", async () => {
-      repo.count.mockResolvedValue(1);
+    it("is true once a live one exists", async () => {
+      query.mockResolvedValue([{ id: "job-1" }]);
 
       expect(await service.hasActiveJob("user-1")).toBe(true);
+    });
+
+    it("does not count a job the very next statement would reap", async () => {
+      // The regression this guards is subtle and total: `start` calls this
+      // before `create`, so a stale row counted here throws the 409 and the
+      // request never reaches the transaction that would have reaped it. The
+      // demand-driven reap would be unreachable on its main path.
+      await service.hasActiveJob("user-1");
+
+      expect(sql(query.mock.calls[0])).toContain(
+        flat(`AND NOT (${STALE_ACTIVE_JOB_CONDITION})`),
+      );
     });
   });
 
@@ -499,6 +618,69 @@ describe("MnyImportJobService", () => {
       query.mockRejectedValue(new Error("connection reset"));
 
       await expect(service.reapStaleJobs()).resolves.toBeUndefined();
+    });
+
+    it("sweeps every user, so it carries no user restriction", async () => {
+      await service.reapStaleJobs();
+
+      expect(sql(query.mock.calls[0])).not.toContain("user_id");
+    });
+  });
+
+  describe("reapStaleJobsForUser", () => {
+    const managerOf = (): EntityManager =>
+      ({
+        query,
+        getRepository: jest.fn(() => repo),
+      }) as unknown as EntityManager;
+
+    it("runs on the manager it was handed, not on a transaction of its own", async () => {
+      // The signature is the safety property: taking an EntityManager forces
+      // the reap into the caller's transaction, where its outcome is still
+      // true when the caller acts on it.
+      await service.reapStaleJobsForUser(managerOf(), "user-1");
+
+      expect(mockedScopedDb).not.toHaveBeenCalled();
+      expect(query).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns the ids it cleared", async () => {
+      query.mockResolvedValue([[{ id: "job-1" }, { id: "job-2" }], 2]);
+
+      expect(await service.reapStaleJobsForUser(managerOf(), "user-1")).toEqual(
+        ["job-1", "job-2"],
+      );
+    });
+
+    it("names the user in the log, since it is one tenant's lockout", async () => {
+      query.mockResolvedValue([[{ id: "job-1" }], 1]);
+      const warn = jest.spyOn(service["logger"], "warn");
+
+      await service.reapStaleJobsForUser(managerOf(), "user-1");
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("for user user-1"),
+      );
+    });
+
+    it("says nothing and returns nothing when there was nothing to reap", async () => {
+      const warn = jest.spyOn(service["logger"], "warn");
+
+      expect(await service.reapStaleJobsForUser(managerOf(), "user-1")).toEqual(
+        [],
+      );
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("propagates a failure rather than letting the caller commit regardless", async () => {
+      // Unlike the cron, this runs inside a request's transaction. Swallowing
+      // the error would let `create` insert against an unreaped slot, or let
+      // the poller return the row the reap was meant to correct.
+      query.mockRejectedValue(new Error("connection reset"));
+
+      await expect(
+        service.reapStaleJobsForUser(managerOf(), "user-1"),
+      ).rejects.toThrow("connection reset");
     });
   });
 

--- a/backend/src/import/mny/mny-import-job.service.ts
+++ b/backend/src/import/mny/mny-import-job.service.ts
@@ -29,6 +29,15 @@ import { MnyImportOptions } from "./model/mny-import-options";
  * racing over that one job produce one winner; and a running job heartbeats, so
  * a job whose pod died is reaped into `failed` + retryable instead of appearing
  * to run forever.
+ *
+ * Reaping is demand-driven. A stale row is not a tidiness problem -- the partial
+ * unique index makes it refuse every future import that user starts, and
+ * `discard` cannot touch it once it reached `running` -- so the two requests that
+ * care clear it in their own transaction before deciding: `create`, which is
+ * about to be refused by it, and `findOne`, which the wizard polls and which
+ * would otherwise keep rendering a progress bar for a worker that is gone.
+ * `reapStaleJobs` remains as an hourly cross-user backstop for the user who
+ * closed the tab and never asked again.
  */
 
 /** A job with no heartbeat for this long is presumed dead. */
@@ -59,6 +68,62 @@ export class MnyImportSlotLostError extends Error {
 
 /** PostgreSQL SQLSTATE for a unique violation. */
 const UNIQUE_VIOLATION = "23505";
+
+/**
+ * The condition deciding that a job's worker is gone, in terms of `$1` -- the
+ * staleness threshold in milliseconds.
+ *
+ * Written once because three callers ask the same question and have to agree:
+ * the per-user reap inside `create`, the same reap inside the poller's
+ * `findOne`, and `hasActiveJob`, which must consider *inactive* exactly what
+ * those two would clear. A fourth copy of these clauses, drifted by one, is a
+ * user told an import is already running by a row the very next statement would
+ * have reaped -- and no test would see it, because each site would still be
+ * self-consistent.
+ *
+ * A `running` row with no heartbeat at all counts as stale. `claim` stamps one
+ * in the same UPDATE that sets the status, so it should be unreachable; without
+ * the null arm it is the one state nothing can ever clear, because `NULL <
+ * timestamp` is NULL and the row matches neither the reap nor its negation.
+ */
+export const STALE_ACTIVE_JOB_CONDITION = `(
+              status = 'running'
+          AND (
+                heartbeat_at IS NULL
+             OR heartbeat_at < CURRENT_TIMESTAMP - ($1::text || ' milliseconds')::interval
+              )
+            )
+            OR (
+              status = 'pending'
+          AND created_at < CURRENT_TIMESTAMP - ($1::text || ' milliseconds')::interval
+            )`;
+
+/**
+ * The reap, in terms of `$1` (staleness threshold, ms) and `$2` (the i18n key);
+ * `scopedToUser` restricts it to `$3` and is how the per-request reap stays
+ * inside the caller's own rows.
+ *
+ * The `AND` binds tighter than the condition's `OR`, so the parenthesis around
+ * it is the whole difference between "this user's stale jobs" and "this user's
+ * jobs, plus everybody's stale pending ones". `reapStatement` is exported so a
+ * test can assert that grouping rather than trusting the reader to see it.
+ */
+export const reapStatement = (scopedToUser: boolean): string => `
+    UPDATE import_jobs
+        SET status = 'failed',
+            error_key = $2,
+            error_detail = CASE
+              WHEN status = 'running'
+                THEN 'Import worker stopped reporting progress'
+              ELSE 'Import was never picked up by a worker'
+            END,
+            retryable = true,
+            progress = NULL,
+            completed_at = CURRENT_TIMESTAMP
+      WHERE ${scopedToUser ? "user_id = $3 AND " : ""}(
+            ${STALE_ACTIVE_JOB_CONDITION}
+          )
+      RETURNING id`;
 
 /**
  * True when this error is the one-active-import-per-user index refusing an
@@ -133,6 +198,11 @@ export class MnyImportJobService {
    * twice, with fresh transaction UUIDs each time so nothing deduplicated the
    * second run. The partial unique index makes the loser block on the winner
    * and then fail, so the check and the write are one atomic act.
+   *
+   * The stale reap runs first, in that same transaction, because only a row
+   * whose worker is still alive has any business refusing this request. Reaped
+   * in a separate transaction it would settle nothing: the answer could change
+   * between the two, which is the same defect as counting before inserting.
    */
   async create(
     userId: string,
@@ -141,6 +211,7 @@ export class MnyImportJobService {
   ): Promise<ImportJob> {
     try {
       return await withScopedDb(this.dataSource, async (manager) => {
+        await this.reapStaleJobsForUser(manager, userId);
         const repo = manager.getRepository(ImportJob);
         return repo.save(
           repo.create({
@@ -180,32 +251,92 @@ export class MnyImportJobService {
     );
   }
 
-  /** The job, or null when it never existed or belongs to another user. */
+  /**
+   * The job, or null when it never existed or belongs to another user.
+   *
+   * This is what the wizard polls, every 1.5s, which makes it the first place a
+   * dead worker can be noticed. Reaping this user's stale jobs first -- in the
+   * transaction that then reads the row, so the caller cannot see the pre-reap
+   * state -- is what turns a progress bar frozen at 40% into the retryable
+   * failure it has actually been since the pod died. Without it the wizard
+   * renders `running` forever, because nothing in the request path ever
+   * contradicts the row.
+   */
   async findOne(userId: string, jobId: string): Promise<ImportJob | null> {
-    return withScopedDb(this.dataSource, (manager) =>
-      manager
+    return withScopedDb(this.dataSource, async (manager) => {
+      await this.reapStaleJobsForUser(manager, userId);
+      return manager
         .getRepository(ImportJob)
-        .findOne({ where: { id: jobId, userId } }),
-    );
+        .findOne({ where: { id: jobId, userId } });
+    });
   }
 
   /**
-   * True when this user already has an import in flight.
+   * True when this user has an import in flight *and still alive*.
    *
    * Advisory only: it answers the question a moment before the answer can
    * change, so it buys a friendly 409 without an INSERT attempt and nothing
    * more. The guarantee lives in `create`'s unique index.
+   *
+   * The staleness exclusion is not an optimization, it is what makes the
+   * advisory answer agree with the authoritative one. This runs *before*
+   * `create`, so counting a stale row as active would throw the 409 from here
+   * and the request would never reach the transaction that was about to reap
+   * it -- restoring, through the pre-check, exactly the lockout the reap
+   * exists to end. Hence the shared `STALE_ACTIVE_JOB_CONDITION`: negated here,
+   * asserted there, one definition.
    */
   async hasActiveJob(userId: string): Promise<boolean> {
-    const count = await withScopedDb(this.dataSource, (manager) =>
-      manager.getRepository(ImportJob).count({
-        where: [
-          { userId, status: "pending" },
-          { userId, status: "running" },
-        ],
-      }),
+    const rows = await withScopedDb(this.dataSource, (manager) =>
+      manager.query(
+        `SELECT id FROM import_jobs
+          WHERE user_id = $2
+            AND status IN ('pending', 'running')
+            AND NOT (${STALE_ACTIVE_JOB_CONDITION})
+          LIMIT 1`,
+        [String(JOB_STALE_AFTER_MS), userId],
+      ),
     );
-    return count > 0;
+    return returnedRows<{ id: string }>(rows).length > 0;
+  }
+
+  /**
+   * Fails this user's stale jobs **inside the caller's transaction**, and
+   * returns what it cleared.
+   *
+   * This is the reap that matters to a person waiting. A stale row locks its
+   * user out of importing entirely: the partial unique index refuses the next
+   * start, `discard` is restricted to `pending` so a dead `running` job is
+   * beyond the client's reach, and no other request path clears it. Running the
+   * reap in the transaction that is about to need the answer means the lockout
+   * ends the moment the user next asks, instead of whenever the cron happens to
+   * fire.
+   *
+   * Scoped to one user deliberately. It runs under the caller's own identity,
+   * so it can only reach rows they own -- no bypass, and no way for one user's
+   * request to retire another's live import. The cross-user sweep stays on the
+   * cron, under a system context.
+   *
+   * @param manager the EntityManager of the ACTIVE transaction whose decision
+   *   this clears the way for. Reaped in a separate transaction it guarantees
+   *   nothing, because the row can be re-read as active before the caller acts.
+   */
+  async reapStaleJobsForUser(
+    manager: EntityManager,
+    userId: string,
+  ): Promise<string[]> {
+    const result = await manager.query(reapStatement(true), [
+      String(JOB_STALE_AFTER_MS),
+      JOB_STALLED_ERROR_KEY,
+      userId,
+    ]);
+    const reaped = returnedRows<{ id: string }>(result).map((row) => row.id);
+    if (reaped.length > 0) {
+      this.logger.warn(
+        `Reaped ${reaped.length} stalled import job(s) for user ${userId}: ${reaped.join(", ")}`,
+      );
+    }
+    return reaped;
   }
 
   /**
@@ -410,49 +541,32 @@ export class MnyImportJobService {
   }
 
   /**
-   * Fails jobs whose worker stopped heartbeating -- a killed pod, an OOM, a
-   * rolling restart mid-import.
+   * The cross-user backstop for jobs whose worker stopped heartbeating -- a
+   * killed pod, an OOM, a rolling restart mid-import -- and for `pending` rows
+   * no worker ever claimed, reaped on the same rule measured from creation.
    *
-   * A `pending` job is reaped on the same rule, measured from creation. Nothing
-   * else would ever clear one: `start` inserts the row and then claims it from an
-   * unawaited task, so a pod that dies in between -- or a claim that throws --
-   * leaves the row pending forever. `hasActiveJob` counts pending, so that one
-   * row would refuse every future import this user ever starts, with no way back
-   * short of a DBA. Five minutes is far longer than the microseconds the real
-   * gap takes.
+   * Hourly, because it is no longer what any waiting user depends on.
+   * `reapStaleJobsForUser` runs on the two requests that care, so the person
+   * whose import died sees it fail on their next poll -- about 1.5 seconds after
+   * the job goes stale -- and can start another immediately. Firing this every
+   * five minutes bought a worst case of ten minutes for a lockout that the
+   * request path now ends by itself; what is left for a schedule is the user who
+   * closed the tab and never asked again, whose row would otherwise sit
+   * `running` in the table indefinitely and misreport the import history.
    *
    * Marked retryable: the staged file is untouched, so the wizard can offer Retry
    * rather than making the user upload 200 MB again. Idempotent across replicas,
    * because the predicate only matches rows still in the state being reaped.
    */
-  @Cron(CronExpression.EVERY_5_MINUTES)
+  @Cron(CronExpression.EVERY_HOUR)
   async reapStaleJobs(): Promise<void> {
     try {
       const reaped = await withSystemContext(() =>
         withScopedDb(this.dataSource, async (manager) => {
-          const result = await manager.query(
-            `UPDATE import_jobs
-                SET status = 'failed',
-                    error_key = $2,
-                    error_detail = CASE
-                      WHEN status = 'running'
-                        THEN 'Import worker stopped reporting progress'
-                      ELSE 'Import was never picked up by a worker'
-                    END,
-                    retryable = true,
-                    progress = NULL,
-                    completed_at = CURRENT_TIMESTAMP
-              WHERE (
-                      status = 'running'
-                  AND heartbeat_at < CURRENT_TIMESTAMP - ($1::text || ' milliseconds')::interval
-                    )
-                 OR (
-                      status = 'pending'
-                  AND created_at < CURRENT_TIMESTAMP - ($1::text || ' milliseconds')::interval
-                    )
-              RETURNING id`,
-            [String(JOB_STALE_AFTER_MS), JOB_STALLED_ERROR_KEY],
-          );
+          const result = await manager.query(reapStatement(false), [
+            String(JOB_STALE_AFTER_MS),
+            JOB_STALLED_ERROR_KEY,
+          ]);
           return returnedRows<{ id: string }>(result).map((row) => row.id);
         }),
       );

--- a/backend/src/import/mny/mny-import.service.spec.ts
+++ b/backend/src/import/mny/mny-import.service.spec.ts
@@ -470,8 +470,8 @@ describe("MnyImportService", () => {
 
     it("gives the import slot back when the wipe is refused", async () => {
       // Otherwise the pending row it took blocks every import this user starts
-      // until the reaper sweeps it five minutes later -- for a job that will
-      // never run, over a request that already returned an error.
+      // until it has been stale long enough for the next start to reap it --
+      // for a job that will never run, over a request that already errored.
       usersService.deleteData.mockRejectedValue(new Error("bad password"));
 
       await expect(
@@ -515,9 +515,9 @@ describe("MnyImportService", () => {
     });
 
     it("fails the job when the background start never got going", async () => {
-      // Otherwise the row sits pending until the reaper's five-minute sweep,
-      // and `hasActiveJob` counts pending -- so the user could start nothing at
-      // all in the meantime, with no error to explain why.
+      // Otherwise the row sits pending until it goes stale, and the wizard
+      // polls a row that says `pending` for the whole staleness window with no
+      // error to explain why nothing is happening.
       jobs.runClaimed.mockRejectedValue(new Error("pool exhausted"));
 
       await service.start("user-1", { stagedFileId: "staged-1" });

--- a/backend/src/import/mny/mny-import.service.ts
+++ b/backend/src/import/mny/mny-import.service.ts
@@ -170,9 +170,10 @@ export class MnyImportService {
           "import-wipe",
         );
       } catch (error) {
-        // The request is refused, so the slot it took must go back: leaving the
-        // row pending would block every import this user starts for the five
-        // minutes until the reaper sweeps it.
+        // The request is refused, so the slot it took must go back. The stale
+        // reap in `create` would clear it on the next start anyway, but only
+        // after it has been stale for JOB_STALE_AFTER_MS -- and the user is
+        // looking at the failed wipe now, so the retry is immediate.
         await this.jobs.discard(userId, job.id).catch(() => undefined);
         throw error;
       }
@@ -193,9 +194,9 @@ export class MnyImportService {
       this.logger.error(`Import job ${job.id} could not be started: ${detail}`);
       // `runClaimed` reports its own body's failures; reaching here means the
       // claim or the status write itself failed, which would otherwise leave the
-      // row pending until the reaper's five-minute sweep -- and `hasActiveJob`
-      // counts pending, so the user could start nothing in the meantime. Failing
-      // it now turns that into an immediate, retryable error in the wizard.
+      // row pending until something reaped it -- and the wizard would poll a row
+      // that says `pending` for JOB_STALE_AFTER_MS first. Failing it now turns
+      // that wait into an immediate, retryable error.
       await withUserContext(userId, () =>
         this.jobs.fail(job.id, JOB_FAILED_ERROR_KEY, detail, true),
       ).catch(() => undefined);

--- a/backend/test/integration/mny-import-job.integration.spec.ts
+++ b/backend/test/integration/mny-import-job.integration.spec.ts
@@ -732,6 +732,24 @@ describe("MnyImportJobService (integration)", () => {
       expect(job!.stagedFileId).not.toBeNull();
     });
 
+    it("reaps a running job that somehow has no heartbeat at all", async () => {
+      // `claim` stamps one in the same UPDATE that sets the status, so this
+      // should be unreachable -- but `NULL < timestamp` is NULL, so without the
+      // explicit null arm it is the one state nothing can ever clear, and the
+      // user is locked out permanently by a row no sweep will touch.
+      const jobId = await newJob();
+      await asUser(userA, () => jobs.claim(jobId));
+      await dataSource.query(
+        "UPDATE import_jobs SET heartbeat_at = NULL WHERE id = $1",
+        [jobId],
+      );
+
+      await jobs.reapStaleJobs();
+
+      const job = await asUser(userA, () => jobs.findOne(userA, jobId));
+      expect(job).toMatchObject({ status: "failed", retryable: true });
+    });
+
     it("is idempotent: a second sweep changes nothing", async () => {
       const jobId = await newJob();
       await asUser(userA, () => jobs.claim(jobId));
@@ -746,6 +764,28 @@ describe("MnyImportJobService (integration)", () => {
       const second = await asUser(userA, () => jobs.findOne(userA, jobId));
 
       expect(second!.completedAt).toEqual(first!.completedAt);
+    });
+
+    it("still reaps for a user who never comes back, which is all it is for", async () => {
+      // The request-path reap only fires when the user asks. Somebody who
+      // closed the tab never asks, so their row would sit `running` in the
+      // table indefinitely and misreport their import history. That is what is
+      // left for a schedule -- at an hour, not five minutes, because nobody is
+      // waiting on it.
+      const jobId = await newJob();
+      await asUser(userA, () => jobs.claim(jobId));
+      await dataSource.query(
+        "UPDATE import_jobs SET heartbeat_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes' WHERE id = $1",
+        [jobId],
+      );
+
+      await jobs.reapStaleJobs();
+
+      const row = await dataSource.query(
+        "SELECT status FROM import_jobs WHERE id = $1",
+        [jobId],
+      );
+      expect(row[0].status).toBe("failed");
     });
 
     it("reaps across users, since it runs under a system context", async () => {
@@ -765,6 +805,212 @@ describe("MnyImportJobService (integration)", () => {
       expect(
         (await asUser(userB, () => jobs.findOne(userB, jobB)))!.status,
       ).toBe("failed");
+    });
+  });
+
+  /**
+   * The reap that a waiting person actually depends on. A stale row is a
+   * lockout, not litter: the partial unique index refuses their next start, and
+   * `discard` is restricted to `pending`, so a dead `running` job cannot be
+   * cleared from the client at all. These assert that the request which needs
+   * the answer produces it, rather than waiting for a schedule.
+   */
+  describe("demand-driven reaping", () => {
+    /** A job of this user's, claimed and then aged past the staleness window. */
+    async function abandonedJob(userId = userA): Promise<string> {
+      const jobId = await newJob(userId);
+      await asUser(userId, () => jobs.claim(jobId));
+      await dataSource.query(
+        "UPDATE import_jobs SET heartbeat_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes' WHERE id = $1",
+        [jobId],
+      );
+      return jobId;
+    }
+
+    const statusOf = async (jobId: string): Promise<string> => {
+      const rows = await dataSource.query(
+        "SELECT status FROM import_jobs WHERE id = $1",
+        [jobId],
+      );
+      return rows[0].status;
+    };
+
+    it("lets the next start through, without any sweep having run", async () => {
+      // The whole point. Before this, the user waited out the cron: up to five
+      // minutes of staleness plus up to five more until it fired.
+      const stale = await abandonedJob();
+
+      const fresh = await newJob();
+
+      expect(await statusOf(stale)).toBe("failed");
+      expect(await statusOf(fresh)).toBe("pending");
+    });
+
+    it("marks what it reaped retryable, with the stalled key and its bytes", async () => {
+      // Retry has to be one click, so the reap must leave the row in the same
+      // state the cron would have -- otherwise the demand path is a second,
+      // subtly different reaper.
+      const stale = await abandonedJob();
+
+      await newJob();
+
+      const job = await asUser(userA, () => jobs.findOne(userA, stale));
+      expect(job).toMatchObject({
+        status: "failed",
+        errorKey: JOB_STALLED_ERROR_KEY,
+        retryable: true,
+      });
+      expect(job!.stagedFileId).not.toBeNull();
+    });
+
+    it("does not touch another user's stale running job", async () => {
+      const theirs = await abandonedJob(userB);
+
+      await newJob(userA);
+
+      expect(await statusOf(theirs)).toBe("running");
+    });
+
+    it("does not touch another user's stale pending job", async () => {
+      // Not a duplicate of the case above, and the ordering of the clauses is
+      // why. The reap is `user_id = $3 AND (running-stale OR pending-stale)`;
+      // drop the parenthesis and it becomes `(user_id = $3 AND running-stale)
+      // OR pending-stale`, so the *pending* arm escapes the user restriction
+      // entirely and one tenant's start retires another tenant's import. The
+      // running arm still looks correct throughout, which is exactly why a
+      // fixture that claims the job first proves nothing here.
+      const theirs = await newJob(userB);
+      await dataSource.query(
+        "UPDATE import_jobs SET created_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes' WHERE id = $1",
+        [theirs],
+      );
+
+      await newJob(userA);
+
+      expect(await statusOf(theirs)).toBe("pending");
+    });
+
+    it("still refuses a start when the existing job is alive", async () => {
+      // The reap must not become a way to steal your own live slot: a second
+      // tab starting an import has to lose, exactly as before.
+      const alive = await newJob();
+      await asUser(userA, () => jobs.claim(alive));
+
+      await expect(asUser(userA, () => newJob())).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(await statusOf(alive)).toBe("running");
+    });
+
+    it("has exactly one winner when two starts race over a stale row", async () => {
+      // Both reap the same row. The loser blocks on it, re-reads it as already
+      // failed, matches nothing, and then loses the INSERT to the unique index
+      // -- one new job, not two, and no deadlock between the two statements.
+      const stale = await abandonedJob();
+      const stagedFileId = (
+        await asUser(userA, () =>
+          staging.stage(userA, {
+            filename: "money.mny",
+            data: Buffer.from("bytes"),
+          }),
+        )
+      ).id;
+
+      const results = await Promise.allSettled([
+        asUser(userA, () =>
+          jobs.create(userA, stagedFileId, DEFAULT_MNY_IMPORT_OPTIONS),
+        ),
+        asUser(userA, () =>
+          jobs.create(userA, stagedFileId, DEFAULT_MNY_IMPORT_OPTIONS),
+        ),
+      ]);
+
+      expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+      expect(results.filter((r) => r.status === "rejected")).toHaveLength(1);
+      expect(await statusOf(stale)).toBe("failed");
+      const active = await dataSource.query(
+        `SELECT COUNT(*)::int AS count FROM import_jobs
+          WHERE user_id = $1 AND status IN ('pending', 'running')`,
+        [userA],
+      );
+      expect(active[0].count).toBe(1);
+    });
+
+    it("turns the wizard's next poll into a retryable failure", async () => {
+      // The frozen-progress-bar case: the user is watching, so the row has to
+      // stop claiming to be running the moment it is asked, not whenever the
+      // cron fires.
+      const stale = await abandonedJob();
+
+      const polled = await asUser(userA, () => jobs.findOne(userA, stale));
+
+      expect(polled).toMatchObject({
+        status: "failed",
+        errorKey: JOB_STALLED_ERROR_KEY,
+        retryable: true,
+      });
+    });
+
+    it("never hands the poller the row as it was before the reap", async () => {
+      // Reaping and reading in one transaction is what makes this true. Split
+      // across two, the poll can return `running` for a job it has just
+      // retired, and the wizard renders a progress bar for it until the next
+      // tick.
+      const stale = await abandonedJob();
+
+      const first = await asUser(userA, () => jobs.findOne(userA, stale));
+
+      expect(first!.status).not.toBe("running");
+    });
+
+    it("leaves a live job alone when the poller asks about it", async () => {
+      const alive = await newJob();
+      await asUser(userA, () => jobs.claim(alive));
+
+      const polled = await asUser(userA, () => jobs.findOne(userA, alive));
+
+      expect(polled!.status).toBe("running");
+    });
+
+    it("does not report a stale job as active, so the pre-check cannot block", async () => {
+      // `start` calls `hasActiveJob` before `create`. Counting a stale row here
+      // throws the 409 from the pre-check and the request never reaches the
+      // transaction that would have reaped it -- restoring the exact lockout,
+      // through the advisory check, that the reap exists to end.
+      await abandonedJob();
+
+      expect(await asUser(userA, () => jobs.hasActiveJob(userA))).toBe(false);
+    });
+
+    it("still reports a live job as active", async () => {
+      const alive = await newJob();
+      await asUser(userA, () => jobs.claim(alive));
+
+      expect(await asUser(userA, () => jobs.hasActiveJob(userA))).toBe(true);
+    });
+
+    it("reaps a pending job that no worker ever claimed", async () => {
+      // The pod that died between the INSERT and the unawaited claim. Measured
+      // from creation, since a pending row has never heartbeated.
+      const jobId = await newJob();
+      await dataSource.query(
+        "UPDATE import_jobs SET created_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes' WHERE id = $1",
+        [jobId],
+      );
+
+      expect(await asUser(userA, () => jobs.hasActiveJob(userA))).toBe(false);
+      const fresh = await newJob();
+      expect(await statusOf(jobId)).toBe("failed");
+      expect(await statusOf(fresh)).toBe("pending");
+    });
+
+    it("leaves a freshly pending job alone -- its worker is about to claim it", async () => {
+      const jobId = await newJob();
+
+      expect(await asUser(userA, () => jobs.hasActiveJob(userA))).toBe(true);
+      expect(
+        (await asUser(userA, () => jobs.findOne(userA, jobId)))!.status,
+      ).toBe("pending");
     });
   });
 });

--- a/backend/test/integration/mny-import.integration.spec.ts
+++ b/backend/test/integration/mny-import.integration.spec.ts
@@ -1344,8 +1344,8 @@ describe("mny writers (integration)", () => {
 
     it("releases the import slot when the wipe is refused", async () => {
       // A rejected start must not leave the user holding a slot for a job that
-      // will never run -- the reaper would take five minutes to clear it, and
-      // every import started in between would be refused.
+      // will never run -- the stale reap only clears it once it has been stale
+      // for JOB_STALE_AFTER_MS, and every import started in between is refused.
       const usersService = module.get(UsersService) as unknown as {
         deleteData: jest.Mock;
       };

--- a/docs/cron-jobs.md
+++ b/docs/cron-jobs.md
@@ -25,7 +25,7 @@ One row per `@Cron` handler. The Cron column is the decorator's expression verba
 | `budget-alert.service` | `0 3 * * *` | Daily 3 AM | Purge sent alerts older than 30 days |
 | `security-price.service` | `0 17 * * 1-5` (America/New_York) | 5 PM ET weekdays | Fetch security prices |
 | `mny-staging.service` | `0 0-23/1 * * *` | Hourly | Delete expired staged import files (24 h TTL) |
-| `mny-import-job.service` | `0 */5 * * * *` | Every 5 min | Fail import jobs whose worker stopped heartbeating |
+| `mny-import-job.service` | `0 0-23/1 * * *` | Hourly | Backstop sweep for import jobs whose worker stopped heartbeating; the reap that a waiting user depends on runs on their own next request, not here |
 | `auto-backup.service` | `0 * * * *` | Hourly | Enrol every non-admin user on the default backup policy, then write each user's due automatic backup, promote weekly/monthly copies, enforce retention |
 | `action-history.service` | `0 3 * * *` | Daily 3 AM | Delete undo-log entries past their retention window |
 | `holdings.service` | `30 * * * *` | Hourly at :30 | Apply matured fixed-term investment holdings |

--- a/docs/future-plans/mny-import.md
+++ b/docs/future-plans/mny-import.md
@@ -242,9 +242,18 @@ are deleted on completion and swept by a TTL cron (24 h).
 `heartbeat_at`), claims it atomically (`UPDATE ... WHERE id = $1 AND status = 'pending'`), and
 runs the import as an unawaited in-process task wrapped in `withUserContext`. The wizard polls
 `GET /import/mny/jobs/:id` (~1.5 s). Progress updates are written in their own short `withScopedDb`
-(writes inside the import transaction would be invisible to pollers). A reaper cron marks jobs
-with a stale heartbeat (> 5 min) failed-retryable; the staged file survives, so retry is
+(writes inside the import transaction would be invisible to pollers). A job with a stale
+heartbeat (> 5 min) is marked failed-retryable; the staged file survives, so retry is
 one click (new job, same staged file). No queue library, no Redis, no new process.
+
+Reaping is demand-driven, because a stale row is a *lockout*, not litter: the partial unique
+index refuses the user's next start, and `discard` is restricted to `pending`, so a dead
+`running` job cannot be cleared from the client at all. `reapStaleJobsForUser` therefore runs
+inside the transaction of the two requests that care -- `create`, which the row is about to
+refuse, and the poll's `findOne`, which would otherwise keep rendering a progress bar for a
+worker that is gone. `hasActiveJob` negates the same shared condition, so the advisory 409 and
+the authoritative one cannot disagree. `reapStaleJobs` stays on an hourly cron as the
+cross-user backstop for a user who closed the tab and never asked again.
 
 **ADR-4 — Parsing layers** (each its own file, spec-covered):
 `msisam/msisam-decrypt.ts` -> `vendor/mdb-reader/` -> `msisam/open-mny.ts` (wrapper exposing

--- a/frontend/src/hooks/useMnyImport.ts
+++ b/frontend/src/hooks/useMnyImport.ts
@@ -122,8 +122,11 @@ export function useMnyImport(): UseMnyImportResult {
               stopPolling();
             }
           })
-          // A dropped poll is not a failed import: the next tick tries again,
-          // and the reaper is what decides a job is really dead.
+          // A dropped poll is not a failed import: the next tick tries again.
+          // The server decides a job is really dead -- the poll endpoint reaps
+          // this user's stale jobs before it reads, so a worker that died comes
+          // back as `failed` + retryable on a subsequent tick, not as a
+          // progress bar that never moves.
           .catch(() => undefined);
       }, MNY_POLL_INTERVAL_MS);
     },


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

Moves import job reaping from a 5-minute cron to the request path, so users whose import workers die are no longer locked out waiting for the schedule to fire. A stale job row blocks all future imports via a partial unique index and cannot be cleared by the client (since `discard` only works on `pending` jobs), making it a lockout rather than litter.

**Demand-driven reaping:** `reapStaleJobsForUser` now runs inside the transactions of the two requests that care:
- `create` (POST /import/mny/start): clears stale jobs before attempting the insert, so the user can immediately retry
- `findOne` (GET /import/mny/jobs/:id): clears stale jobs before reading, so the wizard's poll shows the failure instead of a frozen progress bar

**Advisory check fixed:** `hasActiveJob` now excludes stale jobs from its count, so it agrees with what `create` will actually allow (previously it could throw a 409 for a row the very next statement would reap).

**Cron reduced to hourly backstop:** `reapStaleJobs` still runs cross-user on a schedule, but now hourly instead of every 5 minutes, since the request path handles the waiting user. It catches jobs abandoned by users who closed the tab and never asked again.

**Shared staleness logic:** Extracted `STALE_ACTIVE_JOB_CONDITION` and `reapStatement` so the three callers (`create`, `findOne`, `hasActiveJob`) all use the same predicate—a single source of truth for what counts as stale, preventing subtle drifts that would let one path see a job as active while another reaped it.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (demand-driven reaping to end lockouts).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (no new user-facing strings added).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_01WHdq5aJFiggMiwJteLYDP7