### PR TITLE
03: Record the shipped OIDC restore re-auth and pin its ordering (F3RB-007)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -278,10 +278,15 @@ them:
   `INTENTIONALLY_EXCLUDED_TABLES` with a reason, and classified in the support
   backup rules.
 
-And one that no test can catch: the destructive restore's step-up for OIDC users
-accepts any truthy header value. It is an open defect with a written plan, not a
-design choice -- see section 5 of the contract before touching
-`verifyAuthentication`.
+And one thing about `verifyAuthentication` that is easy to undo by accident. An
+OIDC restore is authorized by a single-use `OidcReauthService` artifact, and the
+round trip that mints one loses the user's file selection -- so the restore
+validates everything free (decrypt, decompress, envelope) *before* spending it,
+and a wrong backup password costs no identity-provider round trip. That makes it
+the one refusal in the path that is deliberately not first; it still precedes
+every write. Do not reorder it forward to match section 3's list, and do not
+reorder it backward past a `DELETE FROM`. Section 5 of the contract has the
+reasoning, and `backup.service.spec.ts` pins both edges.
 
 ### `BackupService` is a facade; put new code in the component that owns it
 

--- a/backend/src/backup/backup.service.spec.ts
+++ b/backend/src/backup/backup.service.spec.ts
@@ -9,6 +9,7 @@ import {
 import { gzipSync, gunzipSync } from "zlib";
 import { PassThrough } from "stream";
 import { createHash, randomUUID } from "crypto";
+import * as jwt from "jsonwebtoken";
 import * as fs from "fs";
 import * as path from "path";
 import { getRequestContext } from "../common/request-context";
@@ -530,9 +531,10 @@ describe("BackupService", () => {
   // Signing key for the re-authentication artifacts below. The service reads it
   // fresh from the environment, so a spec that mints one has to supply it.
   const ORIGINAL_JWT_SECRET = process.env.JWT_SECRET;
+  const SPEC_JWT_SECRET = "spec-jwt-secret-of-at-least-32-characters";
 
   beforeAll(() => {
-    process.env.JWT_SECRET = "spec-jwt-secret-of-at-least-32-characters";
+    process.env.JWT_SECRET = SPEC_JWT_SECRET;
   });
 
   afterAll(() => {
@@ -2743,6 +2745,16 @@ describe("BackupService", () => {
       await expect(
         service.restoreData(userId, makeInput({ password: "wrong-password" })),
       ).rejects.toThrow(UnauthorizedException);
+
+      // Same obligation the OIDC forgery table carries: the backup file itself is
+      // valid, so the refusal is the only thing between this request and an
+      // erased account. The local path is where re-authentication has always
+      // worked, which is exactly why a reordering would be noticed here last.
+      const deletes = mockQueryRunner.query.mock.calls.filter(
+        ([sql]: [unknown]) =>
+          typeof sql === "string" && sql.includes("DELETE FROM"),
+      );
+      expect(deletes).toEqual([]);
     });
 
     it("should throw UnauthorizedException if OIDC token is missing for OIDC user", async () => {
@@ -4040,10 +4052,11 @@ describe("BackupService", () => {
       }
     });
 
-    it("accepts the session-confirmed sentinel for OIDC users (soft re-auth)", async () => {
-      // OIDC restore mirrors account deletion: the live JWT session is the
-      // re-authentication, so any present confirmation token is accepted -- the
-      // frontend sends a non-JWT sentinel it cannot cryptographically sign.
+    it("accepts a genuine re-authentication artifact for OIDC users", async () => {
+      // The one shape that may restore an OIDC account: signed with JWT_SECRET,
+      // minted for this user and for "restore-backup", unspent, unexpired. Every
+      // rejection below is a near miss of this, so this case is what proves they
+      // fail for the reason claimed rather than because the path is broken.
       const oidcModule = {
         ...mockUser,
         authProvider: "oidc",
@@ -4060,26 +4073,117 @@ describe("BackupService", () => {
       expect(result.message).toBe("Backup restored successfully");
     });
 
-    // P2-005. Restore is the most destructive action in the product: it deletes
-    // everything the user has and writes the file's contents in its place. Each
-    // of these used to be accepted, because the check was only whether the field
-    // was non-empty.
-    it.each([
-      ["the sentinel the client used to send", "oidc-session-confirmed"],
-      ["any non-empty string", "x"],
-      ["an unsigned JWT-shaped value", "a.b.c"],
-    ])("refuses %s as re-authentication for restore", async (_label, token) => {
-      mockUserRepo.findOne.mockResolvedValue({
-        ...mockUser,
-        authProvider: "oidc",
-        passwordHash: null,
-        oidcSubject: "sub-1",
-      });
+    // P2-005 / F3RB-007. Restore is the most destructive action in the product:
+    // it deletes everything the user has and writes the file's contents in its
+    // place. Every one of these used to be accepted, because the check was only
+    // whether the field was non-empty -- and the first entry is the exact string
+    // the shipped frontend sent, so it is the one a regression reaches first.
+    //
+    // Each case is a *near miss* of the artifact the test above accepts: one
+    // property wrong and nothing else. That is what makes them evidence about
+    // the individual checks rather than about the path being broken.
+    //
+    // Minted lazily. Signing at table-construction time would run before the
+    // beforeAll that installs JWT_SECRET.
+    const REAUTH_FORGERIES: ReadonlyArray<readonly [string, () => string]> = [
+      ["the sentinel the client used to send", () => "oidc-session-confirmed"],
+      ["any non-empty string", () => "x"],
+      ["an unsigned JWT-shaped value", () => "a.b.c"],
+      [
+        "an alg=none token carrying every correct claim",
+        () =>
+          jwt.sign(
+            {
+              sub: userId,
+              type: "oidc_reauth",
+              purpose: "restore-backup",
+              jti: randomUUID(),
+            },
+            "",
+            { algorithm: "none" },
+          ),
+      ],
+      [
+        "a correct payload signed with a foreign key",
+        () =>
+          jwt.sign(
+            {
+              sub: userId,
+              type: "oidc_reauth",
+              purpose: "restore-backup",
+              jti: randomUUID(),
+            },
+            "a-different-secret-of-at-least-32-characters",
+            { algorithm: "HS256", expiresIn: 300 },
+          ),
+      ],
+      [
+        "an artifact that has expired",
+        () =>
+          jwt.sign(
+            {
+              sub: userId,
+              type: "oidc_reauth",
+              purpose: "restore-backup",
+              jti: randomUUID(),
+            },
+            SPEC_JWT_SECRET,
+            { algorithm: "HS256", expiresIn: -10 },
+          ),
+      ],
+      [
+        // A session token is the factor the artifact exists to be independent
+        // of. Accepting one collapses the second proof into the first, which is
+        // precisely the defect.
+        "an ordinary access token for the same user",
+        () =>
+          jwt.sign({ sub: userId, type: "access" }, SPEC_JWT_SECRET, {
+            algorithm: "HS256",
+            expiresIn: 900,
+          }),
+      ],
+      [
+        // Signed by us, bound to this user and this purpose -- but minted by the
+        // step-up service, which for an OIDC account issues on the strength of a
+        // re-auth artifact. Spending one here would let a single round trip be
+        // laundered into a second authorization.
+        "a step-up token for the same user and purpose",
+        () =>
+          jwt.sign(
+            { sub: userId, type: "step_up", purpose: "restore-backup" },
+            SPEC_JWT_SECRET,
+            { algorithm: "HS256", expiresIn: 300 },
+          ),
+      ],
+    ];
 
-      await expect(
-        service.restoreData(userId, makeInput({ oidcIdToken: token })),
-      ).rejects.toThrow(UnauthorizedException);
-    });
+    it.each(REAUTH_FORGERIES)(
+      "refuses %s as re-authentication for restore",
+      async (_label, mint) => {
+        mockUserRepo.findOne.mockResolvedValue({
+          ...mockUser,
+          authProvider: "oidc",
+          passwordHash: null,
+          oidcSubject: "sub-1",
+        });
+
+        await expect(
+          service.restoreData(userId, makeInput({ oidcIdToken: mint() })),
+        ).rejects.toThrow(UnauthorizedException);
+
+        // The half that matters more than the status code. The file here is a
+        // perfectly valid backup, so everything ahead of the check succeeds and
+        // the only thing standing between this request and an erased account is
+        // `verifyAuthentication`. A 401 the client sees cannot un-delete a row,
+        // so assert the database was never touched -- not merely that the call
+        // threw. (A transaction *is* open by this point; the user lookup runs in
+        // one. The claim is that no data was destroyed.)
+        const deletes = mockQueryRunner.query.mock.calls.filter(
+          ([sql]) => typeof sql === "string" && sql.includes("DELETE FROM"),
+        );
+        expect(deletes).toEqual([]);
+      },
+    );
 
     it("refuses an artifact minted to delete data rather than restore", async () => {
       mockUserRepo.findOne.mockResolvedValue({

--- a/docs/backup-restore-contract.md
+++ b/docs/backup-restore-contract.md
@@ -100,11 +100,18 @@ A restore deletes everything the user owns and then inserts the backup, in one
 transaction. Everything that can refuse the request must refuse it before the
 delete:
 
-- credential/step-up verification (section 5);
 - decryption;
 - decompression, under a hard expanded-size ceiling (section 6);
 - version and envelope validation;
+- re-authentication (section 5);
 - **staging of external attachment objects** (section 4).
+
+That list is in execution order, and the position of re-authentication is a
+decision rather than an accident: it is last among the refusals because the OIDC
+artifact is single-use and minting a replacement costs the user their file
+selection, so nothing that can fail for free may fail *after* it. Section 5 has
+the reasoning. What the ordering must never become is re-authentication after any
+write — the check precedes every `DELETE FROM` on every path.
 
 Any SQL or foreign-key error rolls the whole transaction back. The one effect
 that is not transactional is the object store; that is what makes staging-first
@@ -304,44 +311,79 @@ the module routes its key through the validator, and names the database
 provider's exemption (a parameterised primary-key lookup) rather than assuming
 it.
 
-## 5. Confirming a destructive restore — known gap
+## 5. Confirming a destructive restore
 
-A restore requires the user's password (local accounts, bcrypt-checked). For OIDC
-accounts it requires `x-restore-oidc-token`, and **`verifyAuthentication` checks
-only that the value is truthy.** `x-restore-oidc-token: x` passes. The header is
-documentation, not a control, so anything holding a live OIDC session can erase
-and replace a user's entire financial history with no barrier.
+`verifyAuthentication` in `backend/src/backup/backup-restore.service.ts` decides
+this, and it has exactly three branches — there is no fall-through that proves
+nothing:
 
-This is a known open defect (audit P3-009), not a design decision.
+| Account | Second proof |
+|---------|--------------|
+| Local, password set | `password`, bcrypt-checked against `passwordHash`. |
+| Local, no `passwordHash` (admin-provisioned, reset never completed) | **Refused.** No proof is available, so the restore is not offered — this branch used to fall off the end of the `else if` and require nothing. |
+| OIDC | A signed, action-bound, single-use re-authentication artifact from `OidcReauthService`, consumed for the purpose `"restore-backup"`. |
 
-The repository already contains the right mechanism, used by emergency access:
+### The OIDC artifact, and what it replaced
 
-- `STEP_UP_PURPOSES` in `backend/src/auth/step-up/dto/verify-step-up.dto.ts`
-- `@RequireStepUp(purpose)` + `StepUpGuard` — JWT-signed, purpose-scoped,
-  expiring, with attempt lockout
-- `StepUpAuthModal` and `useStepUpTokenStore` on the frontend, which already
-  handle local password, TOTP, and the OIDC redirect
+Until #1060 this branch read `if (!input.oidcIdToken) reject` and nothing else.
+The frontend sent the literal `"oidc-session-confirmed"`, so `x` passed just as
+well: the second proof for the most destructive action in the product was
+possession of the session that was already required (audit P3-009 / F3RB-007).
 
-The fix is therefore small and should reuse that mechanism rather than invent a
-second one:
+What is there now is `OidcReauthService`
+(`backend/src/auth/oidc/oidc-reauth.service.ts`), shared by every destructive
+surface rather than reimplemented per caller. `GET /auth/oidc/reauth?purpose=…`
+sends the user to the identity provider with `prompt=login` and `max_age=0`; the
+callback — after `openid-client` has verified state, nonce, issuer, audience and
+signature — mints an artifact signed with `JWT_SECRET`, carrying the user id, the
+purpose, a one-time `jti`, and a five-minute expiry. `consume(userId, purpose,
+token)` checks all of it: signature, type, subject, action, freshness, single
+use. Every rejection is the same `401` with the same message, because which check
+failed is a fact about the server's state.
 
-1. Add `"backup-restore"` to `STEP_UP_PURPOSES`.
-2. Put `@UseGuards(StepUpGuard)` and `@RequireStepUp("backup-restore")` on the
-   restore handler.
-3. Delete the `oidcIdToken` branch from `verifyAuthentication`.
-4. Open `StepUpAuthModal` in `BackupRestoreSection` before restoring and send the
-   resulting token as `x-step-up-token`.
+Two bindings matter and are easy to lose:
 
-Note when doing it: the step-up mechanism's own OIDC branch is also a
-session-based soft check (`oidcConfirmed`), so this makes the proof signed,
-expiring and action-scoped without making it a *fresh* identity-provider
-authentication. Closing that remaining half needs a real step-up transaction
-(`prompt=login`, `max_age=0`, an `auth_time` freshness check) and a browser round
-trip that survives having a large file selected. Account deletion shares the same
-sentinel and should be converted in the same change.
+- **Purpose.** `"restore-backup"` is not `"delete-data"`. An artifact minted to
+  empty an account must not authorize overwriting it with someone else's file.
+- **The round trip.** The pending marker carries a hash of the `state` it was
+  issued alongside, so an artifact is bound to *its own* challenge and not merely
+  to the fact that one was started. Without that, an ordinary `GET /auth/oidc`
+  answered silently from a live SSO session minted a valid artifact for a
+  challenge nobody ever answered (FV-001).
 
-Steps 1–4 change the restore path for every user, so they need exercising in a
-browser: the failure mode is "the user cannot restore their backup".
+`STEP_UP_PURPOSES` is a different mechanism for a different question, and this
+path deliberately does not route through it: a step-up token is a second proof,
+but for an OIDC account it was itself issued on a client-asserted
+`oidcConfirmed: true`. That branch now consumes the same artifact
+(`backend/src/auth/step-up/step-up.service.ts`), so there is one implementation of
+cryptographic step-up in the repository rather than two.
+
+### Naming: the header does not carry an ID token
+
+The wire names are historical. The header is `X-Restore-OIDC-Token` and the field
+is `oidcIdToken` (`backend/src/backup/backup-format.ts`,
+`frontend/src/lib/backupApi.ts`), but the value is a Monize-minted
+re-authentication artifact, **not** an OIDC ID token — nothing verifies it against
+the provider's JWKS, and it would fail if it did. Do not add ID-token claim
+checks here on the strength of the name.
+
+### The artifact is spent last, and that is a requirement
+
+The round trip that mints the artifact navigates away from the settings page,
+which loses the user's file selection. So a restore that fails for a reason
+having nothing to do with identity — a wrong backup password, a truncated file,
+a foreign JSON document — must not cost one: the user would have to re-select a
+large file *and* re-authenticate, and the retry's honest failure would read as a
+spent artifact.
+
+`restoreData` therefore runs everything free first — decrypt, decompress under
+the expanded-size ceiling, validate the envelope — and calls
+`verifyAuthentication` only once the file is known to be restorable. This is the
+one place where section 3's "refuse before the destruction" ordering is refined
+rather than simply followed: the check still precedes every write, but it no
+longer precedes the checks that cost nothing. `backup.service.spec.ts` pins both
+halves — a bad file leaves the artifact spendable, and no `DELETE FROM` reaches
+the database on any path where the artifact is refused.
 
 ## 6. Size ceilings
 


### PR DESCRIPTION
## Linked discussion / issue

Closes #1071
Approved in: #1071 (labelled `approved-to-build`)

## Summary

**This PR contains no production code.** Read that first, because the issue it closes is a security defect and the natural assumption is that the fix is here. It is not — it shipped in #1060, which merged on 2026-08-05. This is the documentation and test follow-up that #1060 did not do.

Issue #1071 declared itself blocked on #1060 by choice, listing four code items to do once that landed. All four are already in `main`:

| Issue item | Where it landed |
|---|---|
| Add a restore purpose to `OIDC_REAUTH_PURPOSES` | `"restore-backup"`, `backend/src/auth/oidc/oidc-reauth.service.ts` |
| Consume the artifact in the restore path; delete the sentinel | `backup-restore.service.ts` `verifyAuthentication`; the frontend sends a real artifact via `takeOidcReauthArtifact` |
| Same for the step-up service's `oidcConfirmed` branch | `auth/step-up/step-up.service.ts` |
| Validate everything free before spending the artifact | `restoreData` decrypts, decompresses and validates the envelope first |

So the vulnerability is closed. What was left open was the documentation, and on this particular defect that is not a cosmetic remainder.

### The docs still told a reader to build the wrong thing

Three places described the defect as live:

- **Contract §5** stated that `verifyAuthentication` "checks only that the value is truthy" and that `x-restore-oidc-token: x` passes — then prescribed a four-step `StepUpGuard` plan that was deliberately *not* the path taken. A reader following it would have produced the second implementation of cryptographic step-up that #1071 exists to prevent, and conflicted with shipped code.
- **Contract §3** listed credential verification *first* among the refusals. It is now last among them, on purpose. A reader "correcting" the code to match the doc would have reintroduced the full identity-provider round trip that a mistyped backup password costs — the exact regression #1060's ordering rule was written to stop.
- **`backend/CLAUDE.md`** repeated the open-defect claim verbatim.

§5 is rewritten to describe the three branches, the artifact, its two bindings (purpose, and the `state` hash tying it to its own round trip), why the path deliberately does not route through `STEP_UP_PURPOSES`, and why the header and DTO still carry ID-token names for a value that is not one — nothing checks it against the provider's JWKS, and a future reader must not add that on the strength of the name.

### Tests

The issue named ten rejections; the restore spec covered six (sentinel, arbitrary string, unsigned value, wrong purpose, wrong user, replay). The four missing are added — `alg=none`, foreign signing key, expired artifact, and tokens of another type — each written as a near miss of the accepted artifact, one property wrong and nothing else, so each is evidence about an individual check rather than about the path being broken.

The two token-type cases earn their place: an **access token** is the factor the artifact exists to be independent of, and a **step-up token** is signed by us and bound to this user *and* this purpose, so accepting either collapses the second proof back into the first.

Every case now also asserts no `DELETE FROM` reached the database — including the local-password path, which had no such check. The file in these tests is a valid backup, so re-authentication is the only thing between the request and an erased account, and a 401 the client sees cannot un-delete a row. That assertion is what makes a future reordering past a write fail instead of pass.

Also retitles a spec that read "accepts the session-confirmed sentinel for OIDC users (soft re-auth)" and carried a comment asserting that any present token is accepted. Its body had already been changed to mint a real artifact, so the name documented the removed behaviour as current.

### Verification

Per the repo's rule that a green suite after a behaviour change is a finding: the new assertions were confirmed non-vacuous by reverting the fix in the working tree — **8 of the 10 turn red**, green again once restored. Backup suite 496 passed, auth/oidc + step-up 85 passed, `doc-paths` guard passed, backend typecheck and lint clean.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (documentation and test follow-up for #1060).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity) — n/a, no user-facing strings are added or changed.
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written by Claude Code (Claude Opus 5), including the contract rewrite and the added test cases. Reviewed and owned by the PR author.