### PR TITLE
Fix blur-without-edit reporting false changes in currency fields

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -104,6 +104,10 @@ Both components take a *number*, not the field's text: `value: number | undefine
 
 Give each field an explicit `id` when two on the same screen share a label. Both components derive `id` from the label text, so a "Years"/"Months" pair rendered twice (term and amortization) collides and every label points at the first input.
 
+**A field that hands back its own value has not been edited.** Both components re-parse whatever text is on screen on blur (and `CurrencyInput` on every keystroke and on Enter), and for a field nobody touched that text *is* the parent's value formatted to two decimals. Reporting it is invisible to a parent that only stores the number and destructive to one that does more: the FX panels derive an exchange rate from the converted total and mark it user-overridden, so tabbing through the field replaced the fetched 10dp rate with one reverse-engineered from the cents-rounded total (`1.365234` became `54.61 / 40 = 1.365250`) and stopped the date effect re-fetching -- a rate the user never chose, posted against a date it was never quoted for. Both components now notify only when the value actually moved (`notifyIfChanged`), and both carry a blurred-untouched regression test.
+
+The general rule that follows: **an `onChange` that does more than store the number must also be idempotent**, because a controlled field can legitimately re-report the same value. Guard the side effect on the value having changed at the handler too -- `handleConvertedTotalChange` and `handleConvertedTotalOverride` both return early when the incoming total already equals the derived one -- rather than trusting the field to be the only caller.
+
 ### A clickable table row -- `useLongPress({ onClick })`
 
 `useLongPress` takes an `onClick` alongside `onLongPress` for exactly this: a plain click runs the row's primary action, a 750ms press (or right-click) opens the mobile action sheet, and a click that followed a long-press is suppressed. Spread `getRowHandlers(item)` on the `<tr>` and add `cursor-pointer`. The accounts, payees, tags, categories and securities lists all do this.
@@ -415,6 +419,18 @@ await waitFor(() => expect(screen.getByText('Error message')).toBeInTheDocument(
 ```
 
 Never use synchronous `act(() => {...})` for calls that trigger async side-effects — always `await act(async () => {...})`.
+
+**`vitest run` does not show you the warnings.** The default reporter buffers console output and prints it only for failing tests, so a suite full of act warnings looks spotless locally and prints eighty of them in CI. Use `npx vitest run --reporter=verbose` when checking for them, and grep for `not wrapped in act`.
+
+**A store reset in a file's `afterEach` runs while the tree is still mounted.** Testing Library registers its `cleanup` at import time and vitest runs after-hooks in reverse registration order, so the file's own hook goes first. Writing to a Zustand store there re-renders the mounted component outside act, once per selector it reads through -- `SecurityDetailHeader` emitted three warnings in every one of its tests for exactly this. Call `cleanup()` at the top of the hook; a second cleanup afterwards is a no-op. `src/test/test-hygiene.test.ts` scans for it.
+
+**Three quieter sources of the same warning**, all of which show up as "an update to X inside a test was not wrapped in act":
+
+- A **synchronous `render(...)` of a component that fetches on mount** -- even in a test that only asserts on static copy, and even when the fetch is a stubbed `mockResolvedValue([])`. `GemStrategyHeader`'s tests were clean-looking for this reason; the switcher beside the title loads saved reports. Give the file one `await act(async () => { render(...) })` helper and use it everywhere, not only in the tests that await something.
+- An **awaited handler behind a click**: `fireEvent.click` is act-wrapped, but the `finally { setBusy(false) }` after an `await` lands in a later microtask. Wrap that click in `await act(async () => ...)`.
+- A **bare `await new Promise(r => setTimeout(r, n))`** used to let a `requestAnimationFrame` run. Whatever rAF you were waiting on is inside act; the ones beside it are not. Put the wait inside `await act(async () => { ... })`.
+
+**A mocked hook must return a stable object if the real one does.** `useRouter()` returns the same router every render; a mock written as `useRouter: () => ({ push: vi.fn(), ... })` returns a new one per call. Every `useCallback([router])` then changes identity each render, every effect depending on such a callback re-runs each render, and an effect that also sets state loops forever. The Transactions page made **83 `transactions.getAll` calls in 300ms** under its own local mock -- invisible except as a slow test file and sixteen act warnings from updates still landing after the test had ended. The mock in `src/test/setup.ts` builds one router for the run; a file overriding it to observe `push` must do the same (build it lazily inside the factory -- `vi.mock` is hoisted above the `const mockPush` it closes over). The same reasoning applies to any mocked hook returning an object or array.
 
 ## Testing Conventions
 

--- a/frontend/src/app/transactions/page.test.tsx
+++ b/frontend/src/app/transactions/page.test.tsx
@@ -6,17 +6,28 @@ import TransactionsPage from './page';
 // observed. This one keeps a stable `push` for the navigation assertions; the
 // rest matches the global mock (this file never reads search params).
 const mockPush = vi.fn();
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({
+vi.mock('next/navigation', () => {
+  // One stable object, as the real hook returns. A fresh router per call makes
+  // every `useCallback([router])` change identity each render, and this page's
+  // filter effect depends on one of those -- so it re-ran on every render,
+  // re-fetched, set state, and looped. See the note in `src/test/setup.ts`.
+  // Built on first use rather than here: the factory is hoisted above
+  // `mockPush`'s declaration, so reading it eagerly is a temporal-dead-zone
+  // error.
+  let router: ReturnType<typeof buildRouter> | null = null;
+  const buildRouter = () => ({
     push: mockPush,
     replace: vi.fn(),
     back: vi.fn(),
     prefetch: vi.fn(),
     refresh: vi.fn(),
-  }),
-  usePathname: () => '/transactions',
-  useSearchParams: () => new URLSearchParams(),
-}));
+  });
+  return {
+    useRouter: () => (router ??= buildRouter()),
+    usePathname: () => '/transactions',
+    useSearchParams: () => new URLSearchParams(),
+  };
+});
 
 // Mock next/image
 vi.mock('next/image', () => ({

--- a/frontend/src/components/accounts/OverpaymentRecognitionFields.test.tsx
+++ b/frontend/src/components/accounts/OverpaymentRecognitionFields.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@/test/render';
+import { render, screen, waitFor, act, fireEvent } from '@/test/render';
 import { OverpaymentRecognitionFields } from './OverpaymentRecognitionFields';
 import type { Category } from '@/types/category';
 
@@ -47,7 +47,9 @@ const categories: Category[] = [
   { id: 'c1', name: 'Loan Overpayment', parentId: null } as Category,
 ];
 
-function renderFields(overrides = {}) {
+// Payees are fetched on mount, so the render has async work behind it -- act
+// keeps that state update wrapped even in the tests that never await it.
+async function renderFields(overrides = {}) {
   const props = {
     categories,
     selectedInterestCategoryId: '',
@@ -62,11 +64,13 @@ function renderFields(overrides = {}) {
     errors: {},
     ...overrides,
   };
-  render(
-    <OverpaymentRecognitionFields
-      {...(props as unknown as Parameters<typeof OverpaymentRecognitionFields>[0])}
-    />,
-  );
+  await act(async () => {
+    render(
+      <OverpaymentRecognitionFields
+        {...(props as unknown as Parameters<typeof OverpaymentRecognitionFields>[0])}
+      />,
+    );
+  });
   return props;
 }
 
@@ -74,7 +78,7 @@ describe('OverpaymentRecognitionFields', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('renders the category and payee pickers and loads payees', async () => {
-    renderFields();
+    await renderFields();
     expect(screen.getByText('Overpayment recognition')).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByRole('option', { name: 'Bank Overpayment' })).toBeInTheDocument();
@@ -84,11 +88,10 @@ describe('OverpaymentRecognitionFields', () => {
   });
 
   it('reports the chosen payee', async () => {
-    const props = renderFields();
+    const props = await renderFields();
     await waitFor(() =>
       expect(screen.getByRole('option', { name: 'Bank Overpayment' })).toBeInTheDocument(),
     );
-    const { fireEvent } = await import('@testing-library/react');
     fireEvent.change(screen.getByLabelText('Overpayment payee'), {
       target: { value: 'p1' },
     });
@@ -96,8 +99,7 @@ describe('OverpaymentRecognitionFields', () => {
   });
 
   it('reports the chosen interest booking mode', async () => {
-    const props = renderFields();
-    const { fireEvent } = await import('@testing-library/react');
+    const props = await renderFields();
     fireEvent.change(screen.getByLabelText('How is interest recorded?'), {
       target: { value: 'SEPARATE' },
     });

--- a/frontend/src/components/accounts/shared/AccountDetailShell.test.tsx
+++ b/frontend/src/components/accounts/shared/AccountDetailShell.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/render';
+import { render, screen, fireEvent, act } from '@/test/render';
 import { AccountDetailShell } from './AccountDetailShell';
 import type { Account } from '@/types/account';
 
@@ -45,7 +45,7 @@ describe('AccountDetailShell', () => {
     expect(screen.queryByText('Export')).not.toBeInTheDocument();
   });
 
-  it('fires the standard action handlers', () => {
+  it('fires the standard action handlers', async () => {
     const onViewTransactions = vi.fn();
     const onReconcile = vi.fn();
     const onEdit = vi.fn();
@@ -67,7 +67,11 @@ describe('AccountDetailShell', () => {
     fireEvent.click(screen.getByText('View Transactions'));
     fireEvent.click(screen.getByText('Reconcile'));
     fireEvent.click(screen.getByText('Edit Account'));
-    fireEvent.click(screen.getByText('Export PDF'));
+    // Export awaits its handler, so clearing the busy flag lands in a later
+    // microtask -- act, not a bare fireEvent.
+    await act(async () => {
+      fireEvent.click(screen.getByText('Export PDF'));
+    });
     fireEvent.click(screen.getByText('Back to Accounts'));
 
     expect(onViewTransactions).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
@@ -1896,17 +1896,29 @@ describe('PostTransactionDialog - editing the converted total', () => {
     });
   };
 
+  /**
+   * `renderDialog` only waits for the lookup to be *called*, so every test
+   * after it starts with the rate either applied or still in flight -- and a
+   * test that types into the total behaves differently in each. Wait for the
+   * fetched rate to reach the field, so the state under test is the one the
+   * user sees rather than whichever the scheduler happened to produce.
+   */
+  const awaitFetchedRate = async () => {
+    await waitFor(() =>
+      expect((screen.getByLabelText('Total in CAD') as HTMLInputElement).value).toContain('56'),
+    );
+  };
+
   it('shows both the foreign amount and the account-currency total', async () => {
     await renderDialog();
     expect(screen.getByLabelText('Amount in USD')).toBeInTheDocument();
     // The lookup is debounced, so the total fills in once it resolves.
-    await waitFor(() =>
-      expect((screen.getByLabelText('Total in CAD') as HTMLInputElement).value).toContain('56'),
-    );
+    await awaitFetchedRate();
   });
 
   it('re-derives the total when the foreign amount changes', async () => {
     await renderDialog();
+    await awaitFetchedRate();
     const amountInput = screen.getByLabelText('Amount in USD');
     await act(async () => {
       fireEvent.change(amountInput, { target: { value: '-50' } });
@@ -1918,6 +1930,7 @@ describe('PostTransactionDialog - editing the converted total', () => {
 
   it('derives the rate when the converted total is edited directly', async () => {
     await renderDialog();
+    await awaitFetchedRate();
     const total = screen.getByLabelText('Total in CAD');
     await act(async () => {
       fireEvent.change(total, { target: { value: '-60' } });
@@ -1930,6 +1943,55 @@ describe('PostTransactionDialog - editing the converted total', () => {
     expect(mockPostApi).toHaveBeenCalledWith(
       's-fx2',
       expect.objectContaining({ originalAmount: -40, exchangeRate: 1.5 }),
+    );
+  });
+
+  it('does not treat a blur that changed nothing as an override', async () => {
+    // Tabbing through the total field hands its own displayed figure back. The
+    // field reports it, the dialog derived a rate from it -- one
+    // reverse-engineered from a cents-rounded number rather than the 10dp rate
+    // the server gave -- and marked it user-overridden, which also stops the
+    // date effect re-fetching. Merely looking at the field must post the
+    // schedule exactly as an untouched one does.
+    mockGetRateForDate.mockResolvedValue(1.365234);
+    await renderDialog();
+    const total = screen.getByLabelText('Total in CAD') as HTMLInputElement;
+    // -40 x 1.365234 = -54.6094, shown to the cent as -54.61.
+    await waitFor(() => expect(total.value).toContain('54.61'));
+
+    await act(async () => {
+      fireEvent.focus(total);
+      fireEvent.blur(total);
+    });
+    await post();
+
+    await waitFor(() => expect(mockPostApi).toHaveBeenCalled());
+    // No override, so no rate is sent and the backend resolves the real one for
+    // the posting date -- rather than 54.61 / 40 = 1.36525, which is not it.
+    expect(mockPostApi.mock.calls[0][1].exchangeRate).toBeUndefined();
+  });
+
+  it('keeps re-fetching for a new date after a blur that changed nothing', async () => {
+    // The other half of the same defect: a spurious override latches, so every
+    // later date kept the rate reverse-engineered from the first one.
+    mockGetRateForDate.mockResolvedValue(1.365234);
+    await renderDialog();
+    const total = screen.getByLabelText('Total in CAD') as HTMLInputElement;
+    await waitFor(() => expect(total.value).toContain('54.61'));
+
+    await act(async () => {
+      fireEvent.focus(total);
+      fireEvent.blur(total);
+    });
+
+    mockGetRateForDate.mockClear();
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Transaction Date'), {
+        target: { value: '2026-03-15' },
+      });
+    });
+    await waitFor(() =>
+      expect(mockGetRateForDate).toHaveBeenCalledWith('USD', 'CAD', '2026-03-15'),
     );
   });
 
@@ -1993,6 +2055,7 @@ describe('PostTransactionDialog - editing the converted total', () => {
 
   it('keeps a hand-typed rate when the posting date moves', async () => {
     await renderDialog();
+    await awaitFetchedRate();
     const total = screen.getByLabelText('Total in CAD');
     await act(async () => {
       fireEvent.change(total, { target: { value: '-60' } });
@@ -2017,17 +2080,20 @@ describe('PostTransactionDialog - editing the converted total', () => {
       accounts: [{ id: 'a1', name: 'Checking', currentBalance: 5000, fxFeePercent: 2.5 }],
     });
     const total = screen.getByLabelText('Total in CAD');
+    // -40 x 1.4 = -56.00 base, plus the 2.5% fee, is -57.40 on screen. Type a
+    // different figure: handing the field its own total back is not an edit.
+    await waitFor(() => expect((total as HTMLInputElement).value).toBe('-57.4'));
     await act(async () => {
-      fireEvent.change(total, { target: { value: '-57.4' } });
+      fireEvent.change(total, { target: { value: '-71.75' } });
       fireEvent.blur(total);
     });
     await post();
 
     await waitFor(() => expect(mockPostApi).toHaveBeenCalled());
-    // -57.40 total with a 2.5% fee is a -56.00 base, so the rate is 1.4 --
-    // not -57.40 / -40 = 1.435, which would double-count the fee when the
+    // -71.75 total with a 2.5% fee is a -70.00 base, so the rate is 1.75 --
+    // not -71.75 / -40 = 1.794, which would double-count the fee when the
     // backend reapplies it.
-    expect(mockPostApi.mock.calls[0][1].exchangeRate).toBeCloseTo(1.4, 6);
+    expect(mockPostApi.mock.calls[0][1].exchangeRate).toBeCloseTo(1.75, 6);
   });
 });
 

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -272,6 +272,12 @@ export function PostTransactionDialog({
   // backend re-deriving the fee lands on the same total the user typed.
   const handleConvertedTotalChange = (total: number | undefined) => {
     if (total === undefined || !foreignAmount) return;
+    // A total that already equals the one the fetched rate produces is not an
+    // override -- it is the field handing back what it was displaying. Deriving
+    // from it would replace the fetched 10dp rate with one reverse-engineered
+    // from a cents-rounded total and stop the date effect re-fetching, so the
+    // posted row would carry a rate the user never chose.
+    if (foreignConversion && total === foreignConversion.total) return;
     let base = total;
     if (postFxFeePercent && postFxFeePercent > 0) {
       // total = base - |base| * p; solve for base by its (matching) sign.

--- a/frontend/src/components/securities/detail/SecurityDetailHeader.test.tsx
+++ b/frontend/src/components/securities/detail/SecurityDetailHeader.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { cleanup, screen } from '@testing-library/react';
 import { render } from '@/test/render';
 import { SecurityDetailHeader, type SecurityQuote } from './SecurityDetailHeader';
 import { usePreferencesStore } from '@/store/preferencesStore';
@@ -87,6 +87,12 @@ describe('SecurityDetailHeader', () => {
   });
 
   afterEach(() => {
+    // Unmount first. Testing Library's own cleanup is registered at import
+    // time, and after-hooks run in reverse registration order, so it lands
+    // *after* this one -- leaving the header mounted and subscribed while the
+    // store is reset below. Each of its preference reads then re-renders it
+    // outside act, which is where this file's act warnings came from.
+    cleanup();
     vi.useRealTimers();
     usePreferencesStore.setState({ preferences: null, isLoaded: false } as never);
   });

--- a/frontend/src/components/settings/AutoBackupSection.test.tsx
+++ b/frontend/src/components/settings/AutoBackupSection.test.tsx
@@ -77,12 +77,15 @@ describe('AutoBackupSection', () => {
     expect(screen.getByLabelText('Backup Frequency')).toHaveValue('daily');
   });
 
-  it('shows loading state initially', () => {
+  it('shows loading state initially', async () => {
     (backupApi.getAutoBackupSettings as ReturnType<typeof vi.fn>).mockReturnValue(
       new Promise(() => {}),
     );
 
-    render(<AutoBackupSection />);
+    // Rendered inside act even though the assertion is about the first paint:
+    // the capability probe beside the settings load *does* resolve, and a bare
+    // render leaves its state update outside act.
+    await renderAutoBackupSection();
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });

--- a/frontend/src/components/strategies/GemStrategyHeader.test.tsx
+++ b/frontend/src/components/strategies/GemStrategyHeader.test.tsx
@@ -38,8 +38,26 @@ describe("GemStrategyHeader", () => {
     daysUntilNextEvaluation: 28,
   };
 
-  it("shows the way back, title, cadence and days remaining", () => {
-    render(<GemStrategyHeader {...baseProps} onEditSettings={vi.fn()} />);
+  /**
+   * `ReportSwitcher` beside the title loads the user's saved reports on mount,
+   * so every render here has async work behind it -- even the tests that only
+   * assert on static copy. Rendering outside act leaves those state updates
+   * unwrapped.
+   */
+  const renderHeader = async (props: Record<string, unknown> = {}) => {
+    await act(async () => {
+      render(
+        <GemStrategyHeader
+          {...baseProps}
+          onEditSettings={vi.fn()}
+          {...props}
+        />,
+      );
+    });
+  };
+
+  it("shows the way back, title, cadence and days remaining", async () => {
+    await renderHeader();
 
     // The same back link the other report pages carry, above the title.
     expect(
@@ -65,14 +83,8 @@ describe("GemStrategyHeader", () => {
    * Minimal mutation: hardcode 12 in the `explainer` catalog string.
    * Test that fails under it: this one.
    */
-  it("explains the strategy with the window it is actually run on", () => {
-    render(
-      <GemStrategyHeader
-        {...baseProps}
-        lookbackMonths={6}
-        onEditSettings={vi.fn()}
-      />,
-    );
+  it("explains the strategy with the window it is actually run on", async () => {
+    await renderHeader({ lookbackMonths: 6 });
 
     // The tooltip's text is on the trigger, so it is readable without hover.
     const explainer = screen.getByLabelText(/Global Equities Momentum/);
@@ -84,26 +96,14 @@ describe("GemStrategyHeader", () => {
     );
   });
 
-  it("omits the day count when it is unknown", () => {
-    render(
-      <GemStrategyHeader
-        {...baseProps}
-        daysUntilNextEvaluation={null}
-        onEditSettings={vi.fn()}
-      />,
-    );
+  it("omits the day count when it is unknown", async () => {
+    await renderHeader({ daysUntilNextEvaluation: null });
     expect(screen.getByText(/Next evaluation:/)).toBeInTheDocument();
     expect(screen.queryByText(/in 28 days/)).not.toBeInTheDocument();
   });
 
-  it("says the evaluation is unscheduled without a date", () => {
-    render(
-      <GemStrategyHeader
-        {...baseProps}
-        nextEvaluationOn={null}
-        onEditSettings={vi.fn()}
-      />,
-    );
+  it("says the evaluation is unscheduled without a date", async () => {
+    await renderHeader({ nextEvaluationOn: null });
     expect(
       screen.getByText("Next evaluation not scheduled"),
     ).toBeInTheDocument();
@@ -123,9 +123,7 @@ describe("GemStrategyHeader", () => {
     ];
 
     it("switches reports from the caret beside the title", async () => {
-      await act(async () => {
-        render(<GemStrategyHeader {...baseProps} onEditSettings={vi.fn()} />);
-      });
+      await renderHeader();
       await act(async () => {
         fireEvent.click(
           screen.getByRole("button", { name: "Switch to another report" }),
@@ -140,9 +138,7 @@ describe("GemStrategyHeader", () => {
     });
 
     it("does not offer this report as a destination", async () => {
-      await act(async () => {
-        render(<GemStrategyHeader {...baseProps} onEditSettings={vi.fn()} />);
-      });
+      await renderHeader();
       await act(async () => {
         fireEvent.click(
           screen.getByRole("button", { name: "Switch to another report" }),
@@ -153,16 +149,7 @@ describe("GemStrategyHeader", () => {
 
     it("names the scenario control, so the second caret is not a mystery", async () => {
       const onSelectScenario = vi.fn();
-      await act(async () => {
-        render(
-          <GemStrategyHeader
-            {...baseProps}
-            scenarios={twoScenarios}
-            onSelectScenario={onSelectScenario}
-            onEditSettings={vi.fn()}
-          />,
-        );
-      });
+      await renderHeader({ scenarios: twoScenarios, onSelectScenario });
       const scenarioTrigger = screen.getByRole("button", {
         name: "Switch scenario",
       });
@@ -175,11 +162,9 @@ describe("GemStrategyHeader", () => {
     });
   });
 
-  it("reports the settings request", () => {
+  it("reports the settings request", async () => {
     const onEditSettings = vi.fn();
-    render(
-      <GemStrategyHeader {...baseProps} onEditSettings={onEditSettings} />,
-    );
+    await renderHeader({ onEditSettings });
     fireEvent.click(screen.getByRole("button", { name: /Edit settings/ }));
     expect(onEditSettings).toHaveBeenCalledOnce();
   });

--- a/frontend/src/components/tours/TourTooltip.test.tsx
+++ b/frontend/src/components/tours/TourTooltip.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, cleanup } from '@/test/render';
+import { render, screen, fireEvent, waitFor, cleanup, act } from '@/test/render';
 import { TourTooltip, type TourTooltipLabels } from './TourTooltip';
 
 const LABELS: TourTooltipLabels = {
@@ -242,8 +242,11 @@ describe('TourTooltip', () => {
     document.body.appendChild(input);
     input.focus();
     setup({ leaveFocusToForm: true });
-    // Give the focus rAF a chance to (not) run.
-    await new Promise((r) => setTimeout(r, 30));
+    // Give the focus rAF a chance to (not) run. Inside act, because the
+    // measuring rAF beside it *does* run and sets the card's size.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
     expect(document.activeElement).toBe(input);
   });
 });

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -3668,6 +3668,43 @@ describe('TransactionForm', () => {
       );
     });
 
+    it('does not re-derive the rate when the converted total is blurred untouched', async () => {
+      // The converted total is shown to the cent, so re-deriving a rate from it
+      // loses the digits the server sent: 54.61 / 40 is 1.365250, not 1.365234.
+      // Tabbing through the field is not an override, and treating it as one
+      // also pinned the rate against the date, so later dates never refetched.
+      mockGetRateForDate.mockResolvedValue(1.365234);
+      render(
+        <TransactionForm
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+          defaultAccountId="acc-1"
+        />,
+      );
+      await waitFor(() => expect(mockAccountsGetAll).toHaveBeenCalled());
+      await pickEuro();
+      await waitFor(() => expect(mockGetRateForDate).toHaveBeenCalled());
+
+      const amountInput = screen.getAllByPlaceholderText('0.00')[0];
+      await act(async () => {
+        fireEvent.change(amountInput, { target: { value: '40' } });
+        fireEvent.blur(amountInput);
+      });
+      await waitFor(() =>
+        expect(screen.getByText(/1 EUR = 1\.365234 CAD/)).toBeInTheDocument(),
+      );
+
+      const convertedTotal = screen.getAllByPlaceholderText('0.00')[1];
+      expect((convertedTotal as HTMLInputElement).value).toBe('54.61');
+      await act(async () => {
+        fireEvent.focus(convertedTotal);
+        fireEvent.blur(convertedTotal);
+      });
+
+      expect(screen.getByText(/1 EUR = 1\.365234 CAD/)).toBeInTheDocument();
+      expect(screen.queryByText(/1\.365250/)).not.toBeInTheDocument();
+    });
+
     it('folds the bank fee into the amount without creating a split', async () => {
       // acc-1 configured with a 2.5% foreign-transaction fee.
       const feeAccount = { ...mockAccounts[0], fxFeePercent: 2.5 };

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -868,6 +868,12 @@ function TransactionFormFields({ transaction, duplicateFrom, defaultAccountId, d
   // round-trips, mark the rate overridden, and recompute.
   const handleConvertedTotalOverride = (total: number | undefined) => {
     if (total === undefined || !foreignAmount) return;
+    // A total equal to the one the fetched rate already produces is the field
+    // handing back what it was displaying, not an override. Deriving from it
+    // would replace the fetched 10dp rate with one reverse-engineered from a
+    // cents-rounded total and pin it against the date. Mirrors the same guard
+    // in PostTransactionDialog's `handleConvertedTotalChange`.
+    if (fxTotal !== undefined && total === fxTotal) return;
     const feePercent = selectedAccount?.fxFeePercent;
     let base = total;
     if (feePercent && feePercent > 0) {

--- a/frontend/src/components/ui/AppVersion.test.tsx
+++ b/frontend/src/components/ui/AppVersion.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
-import { fireEvent } from '@testing-library/react';
+import { cleanup, fireEvent } from '@testing-library/react';
 import { render, screen } from '@/test/render';
 import { AppVersion } from './AppVersion';
 import { useWhatsNewStore } from '@/store/whatsNewStore';
@@ -10,6 +10,10 @@ describe('AppVersion', () => {
   });
 
   afterEach(() => {
+    // Unmount before touching shared state: Testing Library's cleanup is
+    // registered at import time and after-hooks run in reverse order, so it
+    // runs after this one. See `test-hygiene.test.ts`.
+    cleanup();
     vi.unstubAllEnvs();
     useWhatsNewStore.setState({ isOpen: false });
   });

--- a/frontend/src/components/ui/CurrencyInput.test.tsx
+++ b/frontend/src/components/ui/CurrencyInput.test.tsx
@@ -1,6 +1,35 @@
+import { useState } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@/test/render';
 import { CurrencyInput } from './CurrencyInput';
+
+/**
+ * A parent that actually stores what the field reports, which is what every
+ * real call site is. A `vi.fn()` on its own leaves `value` frozen, so the
+ * field's own re-sync effect pulls the display back to the stale number and
+ * hides whatever the interaction did.
+ */
+function Controlled({
+  label,
+  initial,
+  onChange,
+}: {
+  label: string;
+  initial: number | undefined;
+  onChange: (value: number | undefined) => void;
+}) {
+  const [value, setValue] = useState<number | undefined>(initial);
+  return (
+    <CurrencyInput
+      label={label}
+      value={value}
+      onChange={(next) => {
+        onChange(next);
+        setValue(next);
+      }}
+    />
+  );
+}
 
 describe('CurrencyInput', () => {
   it('renders with label', () => {
@@ -77,10 +106,9 @@ describe('CurrencyInput', () => {
 
   it('formats value on blur', () => {
     const onChange = vi.fn();
-    render(<CurrencyInput label="Amount" value={50} onChange={onChange} />);
+    render(<Controlled label="Amount" initial={0} onChange={onChange} />);
     const input = screen.getByLabelText('Amount');
     fireEvent.focus(input);
-    // After focus, "50.00" becomes "50.00" stripped of commas -> "50.00", then since it's not zero it stays
     fireEvent.change(input, { target: { value: '50' } });
     fireEvent.blur(input);
     // Should format to 2 decimal places
@@ -102,15 +130,82 @@ describe('CurrencyInput', () => {
 
   it('evaluates calculator expression on blur', () => {
     const onChange = vi.fn();
-    render(<CurrencyInput label="Amount" value={113} onChange={onChange} />);
+    render(<Controlled label="Amount" initial={0} onChange={onChange} />);
     const input = screen.getByLabelText('Amount');
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: '100*1.13' } });
     fireEvent.blur(input);
     // Should evaluate 100 * 1.13 = 113.00 and format
-    // onChange is called with 113 and display re-syncs with value prop (113)
     expect(onChange).toHaveBeenCalledWith(113);
     expect(input).toHaveValue('113.00');
+  });
+
+  // A field the user tabbed through, or one whose text round-trips to the value
+  // it was already showing, has not been edited. Reporting it as a change is
+  // invisible to a parent that only stores the number and destructive to one
+  // that does more: the FX panels derive an exchange rate from the converted
+  // total and mark it user-overridden, so a bare blur replaced the fetched 10dp
+  // rate with one reverse-engineered from the cents-rounded total on screen.
+  describe('a blur that changes nothing does not report a change', () => {
+    it('stays silent when the field is blurred untouched', () => {
+      const onChange = vi.fn();
+      render(<CurrencyInput label="Total" value={-54.61} onChange={onChange} />);
+      const input = screen.getByLabelText('Total');
+      fireEvent.focus(input);
+      fireEvent.blur(input);
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('-54.61');
+    });
+
+    it('stays silent when the typed text parses back to the same value', () => {
+      const onChange = vi.fn();
+      render(<CurrencyInput label="Total" value={-54.61} onChange={onChange} />);
+      const input = screen.getByLabelText('Total');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '-54.610' } });
+      fireEvent.blur(input);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('stays silent when an expression evaluates to the value already held', () => {
+      const onChange = vi.fn();
+      render(<CurrencyInput label="Total" value={113} onChange={onChange} />);
+      const input = screen.getByLabelText('Total');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '100*1.13' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('113.00');
+    });
+
+    it('stays silent when an empty field is blurred while the value is undefined', () => {
+      const onChange = vi.fn();
+      render(<CurrencyInput label="Total" value={undefined} onChange={onChange} />);
+      const input = screen.getByLabelText('Total');
+      fireEvent.focus(input);
+      fireEvent.blur(input);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('still reports a real edit', () => {
+      const onChange = vi.fn();
+      render(<CurrencyInput label="Total" value={-54.61} onChange={onChange} />);
+      const input = screen.getByLabelText('Total');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '-60' } });
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenLastCalledWith(-60);
+    });
+
+    it('still reports a field the user cleared', () => {
+      const onChange = vi.fn();
+      render(<CurrencyInput label="Total" value={-54.61} onChange={onChange} />);
+      const input = screen.getByLabelText('Total');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '' } });
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenLastCalledWith(undefined);
+    });
   });
 
   it('evaluates calculator expression on Enter without submitting form', () => {

--- a/frontend/src/components/ui/CurrencyInput.tsx
+++ b/frontend/src/components/ui/CurrencyInput.tsx
@@ -105,6 +105,23 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
     const inputPaddingRight =
       rightButtonCount === 0 ? undefined : rightButtonCount === 1 ? '2.25rem' : '3.75rem';
 
+    /**
+     * Report a value only when it differs from the one the parent already
+     * holds. Every path here re-parses whatever text is on screen, and for a
+     * field nobody edited -- one tabbed through, or typed back to the same
+     * number -- that text is the parent's own value formatted to two decimals.
+     * Handing it back is not an edit. It is invisible to a parent that only
+     * stores the number and destructive to one that does more: the FX panels
+     * derive an exchange rate from the converted total and mark it
+     * user-overridden, so a bare blur replaced a fetched 10dp rate with one
+     * reverse-engineered from the cents-rounded total (1.365234 -> 1.365250)
+     * and stopped the date effect re-fetching.
+     */
+    const notifyIfChanged = (next: number | undefined) => {
+      if (next === value) return;
+      onChange(next);
+    };
+
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       // Use calculator filter if calculator is enabled, otherwise standard currency filter
       let filtered = allowCalculator
@@ -121,8 +138,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
       // Only notify parent immediately if not a calculator expression
       // (expressions are evaluated on blur)
       if (!allowCalculator || !hasCalculatorOperators(filtered)) {
-        const parsed = parseAmount(filtered);
-        onChange(parsed);
+        notifyIfChanged(parseAmount(filtered));
       }
     };
 
@@ -155,11 +171,11 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
           setDisplayValue(formatAmountWithCommas(value));
         } else {
           setDisplayValue(formatAmountWithCommas(finalValue));
-          onChange(finalValue);
+          notifyIfChanged(finalValue);
         }
       } else if (displayValue.trim() === '') {
         setDisplayValue('');
-        onChange(undefined);
+        notifyIfChanged(undefined);
       } else {
         // Invalid input - reset to last valid value
         setDisplayValue(formatAmountWithCommas(value));
@@ -185,7 +201,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
             result = Math.abs(result);
           }
           setDisplayValue(formatAmountWithCommas(result));
-          onChange(result);
+          notifyIfChanged(result);
         }
       }
     };

--- a/frontend/src/components/ui/NumericInput.test.tsx
+++ b/frontend/src/components/ui/NumericInput.test.tsx
@@ -153,6 +153,21 @@ describe('NumericInput', () => {
     expect(onChange).toHaveBeenLastCalledWith(15);
   });
 
+  it('stays silent when the field is blurred untouched', () => {
+    // Blur re-parses what the field is showing, which for an unedited field is
+    // the parent's own value. Reporting that as a change is invisible to a
+    // parent that only stores the number and destructive to one that does more
+    // -- the same defect CurrencyInput carried, where a bare blur on the
+    // converted total re-derived the exchange rate from a rounded figure.
+    const onChange = vi.fn();
+    render(<NumericInput label="Rate" value={3.14} onChange={onChange} />);
+    const input = screen.getByLabelText('Rate');
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input).toHaveValue('3.14');
+  });
+
   it('calls onFocus callback', () => {
     const onFocus = vi.fn();
     render(<NumericInput label="Qty" value={0} onChange={vi.fn()} onFocus={onFocus} />);

--- a/frontend/src/components/ui/NumericInput.tsx
+++ b/frontend/src/components/ui/NumericInput.tsx
@@ -140,7 +140,12 @@ export const NumericInput = forwardRef<HTMLInputElement, NumericInputProps>(
         // Apply min/max validation
         const finalValue = clampToRange(parsed);
         setDisplayValue(formatValue(finalValue, decimalPlaces));
-        onChange(finalValue);
+        // Blur re-parses what the field is showing, which for an unedited field
+        // is the parent's own value formatted to `decimalPlaces`. Handing that
+        // back is not an edit, and a parent whose `onChange` does more than
+        // store the number cannot tell the two apart. Same rule as
+        // `CurrencyInput.notifyIfChanged`.
+        if (finalValue !== value) onChange(finalValue);
       } else if (displayValue.trim() === '') {
         setDisplayValue('');
       } else {

--- a/frontend/src/components/whats-new/WhatsNewHost.test.tsx
+++ b/frontend/src/components/whats-new/WhatsNewHost.test.tsx
@@ -152,10 +152,14 @@ describe('WhatsNewHost', () => {
 
     // Same tab, same session, same unacknowledged version: the second mount
     // stands in for the refresh.
-    useWhatsNewStore.setState({
-      isOpen: false,
-      pausedForTour: false,
-      backendVersion: undefined,
+    // The first host is still mounted and subscribed, so this store write
+    // re-renders it -- it belongs inside act.
+    act(() => {
+      useWhatsNewStore.setState({
+        isOpen: false,
+        pausedForTour: false,
+        backendVersion: undefined,
+      });
     });
     await renderHost();
 
@@ -231,10 +235,14 @@ describe('WhatsNewHost', () => {
 
     // Still unacknowledged, but this browser has already had its one
     // announcement for 1.13.0.
-    useWhatsNewStore.setState({
-      isOpen: false,
-      pausedForTour: false,
-      backendVersion: undefined,
+    // The first host is still mounted and subscribed, so this store write
+    // re-renders it -- it belongs inside act.
+    act(() => {
+      useWhatsNewStore.setState({
+        isOpen: false,
+        pausedForTour: false,
+        backendVersion: undefined,
+      });
     });
     await renderHost();
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -43,15 +43,24 @@ console.info = (...args: unknown[]) => {
   originalConsoleInfo(...args);
 };
 
-// Mock next/navigation
+// Mock next/navigation.
+//
+// One router object for the whole run, because that is what the real hook
+// returns. A fresh object per call gives every `useCallback([router])` a new
+// identity on every render, and any effect depending on such a callback then
+// re-runs on every render -- which, when the effect also sets state, is an
+// endless loop. The Transactions page did exactly that: 83 `transactions.getAll`
+// calls in 300ms, and act warnings from the updates still landing after the test
+// had ended. Nothing in production behaves that way; only the mock did.
+const routerMock = {
+  push: vi.fn(),
+  replace: vi.fn(),
+  back: vi.fn(),
+  prefetch: vi.fn(),
+  refresh: vi.fn(),
+};
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: vi.fn(),
-    replace: vi.fn(),
-    back: vi.fn(),
-    prefetch: vi.fn(),
-    refresh: vi.fn(),
-  }),
+  useRouter: () => routerMock,
   usePathname: () => '/',
   useSearchParams: () => new URLSearchParams(),
 }));

--- a/frontend/src/test/test-hygiene.test.ts
+++ b/frontend/src/test/test-hygiene.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Guard tests for the testing conventions in `frontend/CLAUDE.md`.
+ *
+ * Sibling of `ui-conventions.test.ts`, for mistakes in the *tests* rather than
+ * in the components. Each one here produced act warnings that a green suite
+ * happily printed and nobody read, so the rule needs a failing test rather than
+ * a paragraph.
+ */
+const sources = import.meta.glob('/src/**/*.{test,spec}.{ts,tsx}', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+/** The body of every `afterEach(...)` callback in a file, braces balanced. */
+function afterEachBodies(content: string): string[] {
+  const bodies: string[] = [];
+  const opener = /afterEach\(\s*(?:async\s*)?\(\s*\)\s*=>\s*\{/g;
+  let match: RegExpExecArray | null;
+  while ((match = opener.exec(content)) !== null) {
+    const start = content.indexOf('{', match.index);
+    let depth = 0;
+    for (let i = start; i < content.length; i += 1) {
+      if (content[i] === '{') depth += 1;
+      else if (content[i] === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          bodies.push(content.slice(start, i + 1));
+          break;
+        }
+      }
+    }
+  }
+  return bodies;
+}
+
+describe('a shared store is reset only after the tree is unmounted', () => {
+  /**
+   * Testing Library registers its `cleanup` at import time, and vitest runs
+   * after-hooks in reverse registration order -- so a file's own `afterEach`
+   * runs *first*, while the component it rendered is still mounted and still
+   * subscribed. Writing to a Zustand store there re-renders that component
+   * outside act, once per selector it reads through. `SecurityDetailHeader`
+   * produced three such warnings in every one of its tests for exactly this.
+   *
+   * Call `cleanup()` at the top of the hook. A second cleanup afterwards is a
+   * no-op, so this costs nothing where the hazard does not apply.
+   */
+  it('has no afterEach that writes a store before calling cleanup()', () => {
+    const offenders = Object.entries(sources)
+      .filter(([, content]) =>
+        afterEachBodies(content).some(
+          (body) => /\w+\.setState\(/.test(body) && !body.includes('cleanup('),
+        ),
+      )
+      .map(([path]) => path);
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

Fixes a defect where `CurrencyInput` and `NumericInput` report a change when blurred without being edited. When a field is tabbed through or its text is typed back to the same value, the blur handler re-parses the displayed text and calls `onChange` with the same value the parent already holds. This is invisible to parents that only store the number but destructive to those that do more: the FX panels derive an exchange rate from the converted total and mark it user-overridden, replacing a fetched 10-decimal-place rate with one reverse-engineered from the cents-rounded display (`1.365234` → `54.61 / 40 = 1.365250`) and stopping the date effect from re-fetching.

Both components now call `onChange` only when the value actually changes, via a new `notifyIfChanged` helper. The fix includes regression tests for blurred-untouched scenarios in both components and in the FX workflows that depend on them (`PostTransactionDialog`, `TransactionForm`).

## Changes

### Source code
- **`CurrencyInput.tsx`**: Added `notifyIfChanged` helper that compares the parsed value to the current prop before calling `onChange`. Applied to blur, keystroke, and Enter handlers.
- **`NumericInput.tsx`**: Added same `notifyIfChanged` pattern to the blur handler.
- **`PostTransactionDialog.tsx`**: Added guard in `handleConvertedTotalChange` to skip rate derivation when the total equals the one the fetched rate already produces.
- **`TransactionForm.tsx`**: Added same guard in `handleConvertedTotalOverride`.

### Tests
- **`CurrencyInput.test.tsx`**: Added `Controlled` wrapper component to properly test stateful behavior. Added comprehensive test suite "a blur that changes nothing does not report a change" with five scenarios: untouched blur, typed-back value, expression that evaluates to current value, empty field with undefined value, and confirmation that real edits and clears still report.
- **`NumericInput.test.tsx`**: Added regression test for blurred-untouched scenario.
- **`PostTransactionDialog.test.tsx`**: Added two tests for the FX override defect: one confirming no override is posted when the total is blurred untouched, another confirming the date effect continues to re-fetch after such a blur.
- **`TransactionForm.test.tsx`**: Added test confirming the rate is not re-derived when the converted total is blurred untouched.
- **`test-hygiene.test.ts`**: New guard test that scans all test files for `afterEach` hooks that write to a Zustand store before calling `cleanup()`, which causes re-renders outside act.

### Test infrastructure
- **`setup.ts`**: Changed `useRouter` mock to return a single stable router object for the entire test run, rather than a fresh one per call. A new router per call makes every `useCallback([router])` change identity on each render, causing effects that depend on such callbacks to re-run and re-fetch, creating act warnings and test flakiness.
- **`GemStrategyHeader.test.tsx`**: Wrapped all renders in `act` via new `renderHeader` helper, since `ReportSwitcher` loads async data on mount.
- **`OverpaymentRecognitionFields.test.tsx`**: Wrapped render in `act` since payees are fetched on mount.
- **`WhatsNewHost.test.tsx`**: Wrapped store writes in `act` to avoid re-rendering mounted components outside act.
- **`TransactionsPage.test.tsx`**: Updated router mock to use a stable object built on first use.
- **`SecurityDetailHeader.test.tsx`**, **`AppVersion.test.tsx`**, **`TourTooltip.test.tsx`**, **`AccountDetailShell.test.tsx`**, **`AutoBackupSection.test.tsx`**: Added `cleanup()` calls in `afterEach` hooks before store writes, or wrapped renders in `act` where async work happens on mount.

### Documentation
- **`

https://claude.ai/code/session_01KRRSz3MN3jJEEsnCKvCdTd