### PR TITLE
04: Coordinate cron jobs with durable claims and owned leases (v1.15.0)

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -35,6 +35,10 @@ const WITH_CONTEXT_ALLOWLIST = [
   "src/budgets/budget-alert.service.ts",
   "src/budgets/budget-period-cron.service.ts",
   "src/common/interceptors/request-context.interceptor.ts",
+  // Cross-replica job coordination: claimOnce/claimLease write to a global
+  // claims table that belongs to no single user, from cron entry points with no
+  // request to inherit an identity from -- system context by construction.
+  "src/common/jobs/job-claim.service.ts",
   "src/currencies/currencies.service.ts",
   "src/currencies/exchange-rate.service.ts",
   "src/database/demo-reset.service.ts",

--- a/backend/src/accounts/mortgage-reminder.service.spec.ts
+++ b/backend/src/accounts/mortgage-reminder.service.spec.ts
@@ -12,8 +12,16 @@ import { Account, AccountType } from "./entities/account.entity";
 import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { EmailService } from "../notifications/email.service";
+import {
+  createJobClaimMock,
+  TEST_LEASE_TOKEN,
+  JobClaimMock,
+  jobClaimProvider,
+} from "../test-helpers/job-claim-testing";
 
 describe("MortgageReminderService", () => {
+  /** Wins every claim, matching the pre-claim behaviour these specs describe. */
+  const jobClaims: JobClaimMock = createJobClaimMock();
   let service: MortgageReminderService;
   let accountsRepository: Record<string, jest.Mock>;
   let usersRepository: Record<string, jest.Mock>;
@@ -51,6 +59,15 @@ describe("MortgageReminderService", () => {
   };
 
   beforeEach(async () => {
+    // The claim double is shared across tests, so recorded calls and any queued
+    // `...Once` would leak forward -- invisible until a spec asserts a claim was
+    // *not* taken, and then it reads as a product bug.
+    jobClaims.claimOnce.mockReset().mockResolvedValue(true);
+    jobClaims.claimLease.mockReset().mockResolvedValue(TEST_LEASE_TOKEN);
+    jobClaims.releaseLease.mockReset().mockResolvedValue(undefined);
+    jobClaims.markDelivered.mockReset().mockResolvedValue(undefined);
+    jobClaims.wasDelivered.mockReset().mockResolvedValue(false);
+
     accountsRepository = {
       find: jest.fn().mockResolvedValue([]),
     };
@@ -83,6 +100,7 @@ describe("MortgageReminderService", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MortgageReminderService,
+        jobClaimProvider(jobClaims),
         { provide: DataSource, useValue: dataSource },
         { provide: EmailService, useValue: emailService },
         { provide: ConfigService, useValue: configService },
@@ -151,6 +169,84 @@ describe("MortgageReminderService", () => {
   });
 
   describe("checkMortgageRenewals", () => {
+    /**
+     * Coordination and delivery are two different facts (audit RV4-006). A
+     * permanent claim taken before the send was consumed by a replica killed in
+     * between, and every later run then read it as "already handled" -- the
+     * renewal notice was never sent and nothing could notice.
+     */
+    describe("the claim is a lease, and delivery is recorded separately", () => {
+      beforeEach(() => {
+        accountsRepository.find.mockResolvedValue([mockMortgage]);
+        preferencesRepository.findOne.mockResolvedValue(mockPrefsEmailEnabled);
+        usersRepository.findOne.mockResolvedValue(mockUser);
+      });
+
+      it("takes a bounded lease rather than a permanent claim", async () => {
+        await service.checkMortgageRenewals();
+
+        expect(jobClaims.claimLease).toHaveBeenCalledWith(
+          "mortgage_reminder",
+          mockUser.id,
+          expect.any(String),
+          expect.any(Number),
+        );
+        expect(jobClaims.claimOnce).not.toHaveBeenCalled();
+      });
+
+      it("records the delivery only after the send succeeds", async () => {
+        await service.checkMortgageRenewals();
+
+        expect(jobClaims.markDelivered).toHaveBeenCalledWith(
+          "mortgage_reminder",
+          mockUser.id,
+          expect.any(String),
+          // The token, so the record is written against *this* attempt's lease: a
+          // stalled worker whose lease was retaken must not stamp a delivery for
+          // the new holder's unfinished send (audit DR-RRV4-01).
+          TEST_LEASE_TOKEN,
+        );
+        expect(emailService.sendMail.mock.invocationCallOrder[0]).toBeLessThan(
+          jobClaims.markDelivered.mock.invocationCallOrder[0],
+        );
+      });
+
+      it("does not record a delivery when the send fails", async () => {
+        emailService.sendMail.mockRejectedValue(new Error("smtp down"));
+
+        await service.checkMortgageRenewals();
+
+        expect(jobClaims.markDelivered).not.toHaveBeenCalled();
+        expect(jobClaims.releaseLease).toHaveBeenCalled();
+      });
+
+      it("stands down when the work is already recorded as delivered", async () => {
+        jobClaims.wasDelivered.mockResolvedValue(true);
+
+        await service.checkMortgageRenewals();
+
+        expect(emailService.sendMail).not.toHaveBeenCalled();
+        expect(jobClaims.releaseLease).toHaveBeenCalled();
+      });
+
+      it("sends when another holder's lease expired without delivering", async () => {
+        jobClaims.claimLease.mockResolvedValue(TEST_LEASE_TOKEN);
+        jobClaims.wasDelivered.mockResolvedValue(false);
+
+        await service.checkMortgageRenewals();
+
+        expect(emailService.sendMail).toHaveBeenCalledTimes(1);
+      });
+
+      it("does not send while another replica holds the lease", async () => {
+        jobClaims.claimLease.mockResolvedValue(null);
+
+        await service.checkMortgageRenewals();
+
+        expect(emailService.sendMail).not.toHaveBeenCalled();
+      });
+    });
+
     it("runs without error when no renewals found", async () => {
       accountsRepository.find.mockResolvedValue([]);
 

--- a/backend/src/accounts/mortgage-reminder.service.ts
+++ b/backend/src/accounts/mortgage-reminder.service.ts
@@ -13,6 +13,11 @@ import { emailTranslator } from "../i18n/email-translator";
 import { DEFAULT_LOCALE } from "../i18n/config";
 import { withSystemContext, withUserContext } from "../common/db/with-context";
 import { withScopedDb } from "../common/db/scoped-db";
+import {
+  JobClaimService,
+  JobClaimType,
+} from "../common/jobs/job-claim.service";
+import { createHash } from "node:crypto";
 
 /**
  * Service for handling mortgage term renewal reminders
@@ -22,6 +27,21 @@ import { withScopedDb } from "../common/db/scoped-db";
  * notificationEmail preference). Also logs each detected renewal so ops
  * can see what was processed even when SMTP is unavailable.
  */
+/**
+ * How long one replica holds the right to send this user's mortgage renewal notice.
+ *
+ * A lease, so a replica killed between claiming and sending costs a retry window
+ * rather than the delivery. It only has to outlast an SMTP round trip; whether the
+ * work is still owed is decided by the delivery record, not by the lease
+ * (audit RV4-006).
+ *
+ * The resulting contract is at-least-once: a process killed after SMTP accepted
+ * but before the record committed re-sends next run. For a reminder that is the
+ * right trade -- a duplicate nudge is an annoyance, a missed mortgage renewal is
+ * not. See docs/cron-jobs.md.
+ */
+const REMINDER_LEASE_MS = 10 * 60 * 1000;
+
 @Injectable()
 export class MortgageReminderService {
   private readonly logger = new Logger(MortgageReminderService.name);
@@ -31,7 +51,29 @@ export class MortgageReminderService {
     private emailService: EmailService,
     private configService: ConfigService,
     private readonly i18n: I18nService,
+    private readonly jobClaims: JobClaimService,
   ) {}
+
+  /**
+   * Release a lease a send did not use, so the next run can retry.
+   *
+   * Addressed by the lease token, not only by the work: a stalled worker must not
+   * delete a lease another replica has retaken (audit DR-RRV4-01).
+   */
+  private async releaseClaim(
+    userId: string,
+    claimKey: string,
+    leaseToken: string,
+  ): Promise<void> {
+    await this.jobClaims
+      .releaseLease(JobClaimType.MortgageReminder, userId, claimKey, leaseToken)
+      .catch((error: unknown) =>
+        this.logger.warn(
+          `Failed to release mortgage-reminder claim for user ${userId}: ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
+  }
 
   /**
    * Run daily at 8:00 AM to check for upcoming mortgage renewals
@@ -85,6 +127,44 @@ export class MortgageReminderService {
     let skipCount = 0;
 
     for (const [userId, mortgages] of mortgagesByUser) {
+      // Claim before sending -- see BillReminderService for the reasoning. Every
+      // replica fires this cron, so without a durable record two healthy pods
+      // both email the same renewal notice (audit P4-018).
+      const claimKey = buildMortgageReminderClaimKey(mortgages);
+      // A **lease**, not a permanent claim, plus a durable delivery record.
+      //
+      // `claimOnce` was taken before the send and was the only record that the
+      // send was owed, so a replica killed in between left a permanent row that
+      // every later run read as "already handled" -- the mortgage reminder was never
+      // sent and nothing could notice, because the row could not tell "I sent
+      // this" from "I intended to" (audit RV4-006). The lease bounds *doing* the
+      // work; `delivered_at`, written after the send and re-read here, is what
+      // says it was done.
+      const claimed = await this.jobClaims.claimLease(
+        JobClaimType.MortgageReminder,
+        userId,
+        claimKey,
+        REMINDER_LEASE_MS,
+      );
+      if (!claimed) {
+        skipCount++;
+        continue;
+      }
+      const leaseToken = claimed;
+      if (
+        await this.jobClaims.wasDelivered(
+          JobClaimType.MortgageReminder,
+          userId,
+          claimKey,
+        )
+      ) {
+        // Already sent, durably. Hand the lease back rather than holding it for
+        // its whole TTL.
+        skipCount++;
+        await this.releaseClaim(userId, claimKey, leaseToken);
+        continue;
+      }
+
       try {
         // RLS (task C2): per-user reads run under the user's own context.
         const prefs = await withUserContext(userId, () =>
@@ -96,6 +176,7 @@ export class MortgageReminderService {
         );
         if (prefs && !prefs.notificationEmail) {
           skipCount++;
+          await this.releaseClaim(userId, claimKey, leaseToken);
           continue;
         }
 
@@ -108,6 +189,7 @@ export class MortgageReminderService {
         );
         if (!user || !user.email) {
           skipCount++;
+          await this.releaseClaim(userId, claimKey, leaseToken);
           continue;
         }
 
@@ -138,8 +220,17 @@ export class MortgageReminderService {
               );
 
         await this.emailService.sendMail(user.email, subject, html);
+        // The delivery record, after the side effect and never before it.
+        await this.jobClaims.markDelivered(
+          JobClaimType.MortgageReminder,
+          userId,
+          claimKey,
+          leaseToken,
+        );
         sentCount++;
       } catch (error) {
+        // A transient SMTP failure returns the day rather than consuming it.
+        await this.releaseClaim(userId, claimKey, leaseToken);
         this.logger.error(
           `Failed to send mortgage reminder to user ${userId}`,
           error instanceof Error ? error.stack : error,
@@ -216,4 +307,28 @@ export class MortgageReminderService {
       })),
     };
   }
+}
+
+/**
+ * The delivery key for one user's mortgage-renewal notice: today's date plus a
+ * digest of which mortgages and which term-end dates it names.
+ *
+ * Same shape as the bill reminder's key, and for the same reason: the date alone
+ * suppresses a legitimate second notice when another mortgage enters the window
+ * today, and the digest alone would let the same notice repeat tomorrow.
+ */
+export function buildMortgageReminderClaimKey(
+  mortgages: readonly Account[],
+): string {
+  const today = new Date();
+  const date = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+  const fingerprint = [...mortgages]
+    .map((m) => `${m.id}:${formatDateYMD(m.termEndDate!)}`)
+    .sort()
+    .join("|");
+  const digest = createHash("sha256")
+    .update(fingerprint)
+    .digest("hex")
+    .slice(0, 32);
+  return `${date}#${digest}`;
 }

--- a/backend/src/accounts/rls-context-smoke.spec.ts
+++ b/backend/src/accounts/rls-context-smoke.spec.ts
@@ -14,6 +14,11 @@ import { PortfolioService } from "../securities/portfolio.service";
 import { LoanMortgageAccountService } from "./loan-mortgage-account.service";
 import { ActionHistoryService } from "../action-history/action-history.service";
 import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
+import {
+  createJobClaimMock,
+  JobClaimMock,
+  jobClaimProvider,
+} from "../test-helpers/job-claim-testing";
 
 /**
  * RLS smoke for the accounts module's out-of-request entry points (task R1).
@@ -27,6 +32,8 @@ import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
  */
 
 describe("accounts module RLS context smoke (real withScopedDb)", () => {
+  /** Wins every claim, matching the pre-claim behaviour these specs describe. */
+  const jobClaims: JobClaimMock = createJobClaimMock();
   const OWNER_ID = "3f1f8a52-2f0e-4b6d-9a56-0d6a3f1c2b4e";
 
   it("applyDueTransactionBalances runs its withScopedDb work under the system context", async () => {
@@ -78,6 +85,16 @@ describe("accounts module RLS context smoke (real withScopedDb)", () => {
           c[0].includes("UPDATE accounts SET current_balance"),
       ),
     ).toBe(true);
+    // And the accounts were locked before the balances were read.
+    const lockIndex = manager.query.mock.calls.findIndex(
+      (c) => typeof c[0] === "string" && c[0].includes("FOR UPDATE"),
+    );
+    const sumIndex = manager.query.mock.calls.findIndex(
+      (c) =>
+        typeof c[0] === "string" && c[0].includes("COALESCE(SUM(t.amount)"),
+    );
+    expect(lockIndex).toBeGreaterThanOrEqual(0);
+    expect(lockIndex).toBeLessThan(sumIndex);
   });
 
   it("checkMortgageRenewals runs fan-out and per-user reads under their contexts", async () => {
@@ -117,6 +134,7 @@ describe("accounts module RLS context smoke (real withScopedDb)", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MortgageReminderService,
+        jobClaimProvider(jobClaims),
         { provide: DataSource, useValue: dataSource },
         {
           provide: EmailService,

--- a/backend/src/ai/insights/ai-insights.service.spec.ts
+++ b/backend/src/ai/insights/ai-insights.service.spec.ts
@@ -12,6 +12,11 @@ import {
 import { ConfigService } from "@nestjs/config";
 import { UserPreference } from "../../users/entities/user-preference.entity";
 import { createScopedDbMocks } from "../../test-helpers/scoped-db-testing";
+import {
+  createJobClaimMock,
+  JobClaimMock,
+  jobClaimProvider,
+} from "../../test-helpers/job-claim-testing";
 
 jest.mock("../../common/db/scoped-db", () =>
   jest
@@ -20,6 +25,8 @@ jest.mock("../../common/db/scoped-db", () =>
 );
 
 describe("AiInsightsService", () => {
+  /** Wins every claim, matching the pre-claim behaviour these specs describe. */
+  const jobClaims: JobClaimMock = createJobClaimMock();
   let service: AiInsightsService;
 
   let mockInsightRepo: Record<string, any>;
@@ -160,6 +167,7 @@ describe("AiInsightsService", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AiInsightsService,
+        jobClaimProvider(jobClaims),
         {
           provide: DataSource,
           useValue: scoped.dataSource,
@@ -289,10 +297,19 @@ describe("AiInsightsService", () => {
       qb.getRawOne.mockResolvedValue({ lastGenerated: now.toISOString() });
       mockInsightRepo.createQueryBuilder.mockReturnValue(qb);
 
+      const leasesBefore = jobClaims.claimLease.mock.calls.length;
       const result = await service.generateInsights(userId);
 
       expect(mockAggregatorService.computeAggregates).not.toHaveBeenCalled();
       expect(result.insights).toHaveLength(1);
+      // The cooldown fires before the lease, not after. That order is what
+      // coordinates with a previous-release pod during the claim protocol's
+      // first rollout: that binary takes no lease, but the insights it commits
+      // are visible to this durable read, so the new pod converges on them
+      // instead of generating twice (REMAINING-004). Only the simultaneous
+      // start remains uncovered, which is exactly the exposure two
+      // previous-release replicas already have with each other today.
+      expect(jobClaims.claimLease.mock.calls.length).toBe(leasesBefore);
     });
 
     it("generates insights when no recent insights exist", async () => {

--- a/backend/src/ai/insights/ai-insights.service.ts
+++ b/backend/src/ai/insights/ai-insights.service.ts
@@ -3,6 +3,10 @@ import { tr } from "../../i18n/translate";
 import { ConfigService } from "@nestjs/config";
 import { DataSource, LessThan } from "typeorm";
 import { withScopedDb } from "../../common/db/scoped-db";
+import {
+  JobClaimService,
+  JobClaimType,
+} from "../../common/jobs/job-claim.service";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import {
   AiInsight,
@@ -29,6 +33,22 @@ import { AiInsightResponse, InsightsListResponse } from "./dto/ai-insights.dto";
 const INSIGHT_EXPIRY_DAYS = 7;
 const MAX_INSIGHTS_PER_USER = 50;
 const MIN_GENERATION_INTERVAL_HOURS = 12;
+
+/**
+ * The lease key. One per user -- there is only ever one generation in flight for
+ * a user, so the key names the activity rather than a window.
+ */
+const INSIGHT_GENERATION_CLAIM_KEY = "generation";
+
+/**
+ * How long a generation lease survives its holder.
+ *
+ * Long enough to cover aggregate computation plus a slow provider call, short
+ * enough that a killed replica does not block the user until someone intervenes.
+ * The lease is released on the happy path, so this only ever matters after a
+ * crash.
+ */
+const INSIGHT_GENERATION_LEASE_MS = 15 * 60 * 1000;
 // Number of users whose insights are generated concurrently in the daily cron.
 // Each generation makes LLM calls, so keep this modest to respect provider
 // rate limits and cost while still being faster than fully sequential.
@@ -53,6 +73,7 @@ export class AiInsightsService {
     private readonly usageService: AiUsageService,
     private readonly aggregatorService: InsightsAggregatorService,
     private readonly configService: ConfigService,
+    private readonly jobClaims: JobClaimService,
   ) {}
 
   async getInsights(
@@ -159,6 +180,32 @@ export class AiInsightsService {
       return this.getInsights(userId);
     }
 
+    // A durable lease, because `generatingUsers` is per process.
+    //
+    // Every backend replica fires the daily cron, and each has its own Set -- so
+    // both replicas observed no recent insight, both added the user to their own
+    // in-memory guard, both computed aggregates, both called the provider and
+    // both saved. Duplicate insights, double the provider spend and double the
+    // usage accounting (audit P4-013). The in-memory Set stays as a cheap local
+    // short-circuit; the lease is the actual exclusion.
+    //
+    // A lease rather than a permanent claim, so a replica killed mid-generation
+    // does not lock the user out until someone notices. It is released on the way
+    // out, which keeps the real cooldown where it already was: the recent-insight
+    // query above.
+    const leased = await this.jobClaims.claimLease(
+      JobClaimType.AiInsightGeneration,
+      userId,
+      INSIGHT_GENERATION_CLAIM_KEY,
+      INSIGHT_GENERATION_LEASE_MS,
+    );
+    if (!leased) {
+      this.logger.log(
+        `Insights generation already leased elsewhere user=${userId}; returning current list`,
+      );
+      return this.getInsights(userId);
+    }
+
     this.generatingUsers.add(userId);
     const startTime = Date.now();
     this.logger.log(`Insights generation start user=${userId}`);
@@ -257,6 +304,21 @@ export class AiInsightsService {
       return this.getInsights(userId);
     } finally {
       this.generatingUsers.delete(userId);
+      await this.jobClaims
+        .releaseLease(
+          JobClaimType.AiInsightGeneration,
+          userId,
+          INSIGHT_GENERATION_CLAIM_KEY,
+          // By token, so a generation that outran its own lease releases nothing
+          // rather than freeing a lease another replica now holds (DR-RRV4-01).
+          leased,
+        )
+        .catch((error: unknown) =>
+          this.logger.warn(
+            `Failed to release insight generation lease for user ${userId}: ` +
+              `${error instanceof Error ? error.message : String(error)}`,
+          ),
+        );
     }
   }
 

--- a/backend/src/ai/rls-context-smoke.spec.ts
+++ b/backend/src/ai/rls-context-smoke.spec.ts
@@ -4,6 +4,7 @@ import { AiUsageLog } from "./entities/ai-usage-log.entity";
 import { AiInsight } from "./entities/ai-insight.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
+import { createJobClaimMock } from "../test-helpers/job-claim-testing";
 
 /**
  * RLS smoke for the AI module's cron entry points (task R6).
@@ -65,6 +66,7 @@ describe("ai module RLS context smoke (real withScopedDb)", () => {
       {} as never,
       {} as never,
       { get: jest.fn().mockReturnValue(undefined) } as never,
+      createJobClaimMock() as never,
     );
     jest
       .spyOn(service, "generateInsights")

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { CsrfRefreshInterceptor } from "./common/interceptors/csrf-refresh.inter
 import { RequestContextInterceptor } from "./common/interceptors/request-context.interceptor";
 import { parseRlsMode, resolveRlsDatabaseAuth } from "./common/db/rls-config";
 import { DemoModeModule } from "./common/demo-mode.module";
+import { JobClaimModule } from "./common/jobs/job-claim.module";
 
 import { AuthModule } from "./auth/auth.module";
 import { UsersModule } from "./users/users.module";
@@ -122,6 +123,7 @@ import { I18nModule } from "./i18n/i18n.module";
 
     // Demo mode (global — available to all modules)
     DemoModeModule,
+    JobClaimModule,
 
     // i18n (global — exception messages, validation, email content)
     I18nModule,

--- a/backend/src/auth/rls-context-smoke.spec.ts
+++ b/backend/src/auth/rls-context-smoke.spec.ts
@@ -59,6 +59,7 @@ describe("R7 modules RLS context smoke (real withScopedDb)", () => {
       {} as never,
       {} as never,
       { isDemo: false } as never,
+      { isUnderMaintenance: jest.fn().mockResolvedValue(false) } as never,
       { get: jest.fn() } as never,
     );
 

--- a/backend/src/backup/auto-backup.service.spec.ts
+++ b/backend/src/backup/auto-backup.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { DataSource } from "typeorm";
 import { ConfigService } from "@nestjs/config";
-import { BadRequestException } from "@nestjs/common";
+import { BadRequestException, ConflictException } from "@nestjs/common";
 import {
   promises as fs,
   mkdtempSync,
@@ -23,6 +23,11 @@ import { AutoBackupSettings } from "./entities/auto-backup-settings.entity";
 import { User } from "../users/entities/user.entity";
 import { DemoModeService } from "../common/demo-mode.service";
 import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
+import {
+  createUserMaintenanceMock,
+  userMaintenanceProvider,
+  type UserMaintenanceMock,
+} from "../test-helpers/job-claim-testing";
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
@@ -69,6 +74,9 @@ describe("AutoBackupService", () => {
   let mockUsersRepo: Record<string, jest.Mock>;
   let mockBackupService: Record<string, jest.Mock>;
   let mockBackupEncryption: Record<string, jest.Mock>;
+  let updateBuilder: Record<string, jest.Mock>;
+  let scoped: ReturnType<typeof createScopedDbMocks>;
+  let maintenance: UserMaintenanceMock;
 
   /** A real directory, standing in for the operator's mounted backup volume. */
   let root: string;
@@ -138,20 +146,29 @@ describe("AutoBackupService", () => {
   async function createService(
     env: Record<string, string> = {},
   ): Promise<AutoBackupService> {
+    scoped = createScopedDbMocks([
+      [AutoBackupSettings, mockSettingsRepo as never],
+      [User, mockUsersRepo as never],
+    ]);
+    // The cron claims each due window with a guarded
+    // `UPDATE ... RETURNING`, which the pg driver answers as
+    // `[rows, rowCount]`. Winning by default preserves the behaviour every test
+    // written before the claim existed expects; the loser path is asserted
+    // explicitly below.
+    scoped.manager.query.mockResolvedValue([[{ id: "settings-1" }], 1]);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         {
           provide: DataSource,
-          useValue: createScopedDbMocks([
-            [AutoBackupSettings, mockSettingsRepo as never],
-            [User, mockUsersRepo as never],
-          ]).dataSource,
+          useValue: scoped.dataSource,
         },
         AutoBackupService,
         {
           provide: BackupService,
           useValue: mockBackupService,
         },
+        userMaintenanceProvider(maintenance),
         {
           provide: BackupEncryptionService,
           useValue: mockBackupEncryption,
@@ -213,6 +230,14 @@ describe("AutoBackupService", () => {
         return s;
       }),
       save: jest.fn().mockImplementation((entity) => Promise.resolve(entity)),
+      createQueryBuilder: jest.fn(() => updateBuilder),
+    };
+
+    updateBuilder = {
+      update: jest.fn(() => updateBuilder),
+      set: jest.fn(() => updateBuilder),
+      where: jest.fn(() => updateBuilder),
+      execute: jest.fn().mockResolvedValue({ affected: 1 }),
     };
 
     mockUsersRepo = {
@@ -227,6 +252,8 @@ describe("AutoBackupService", () => {
       // default, so the cron tests below exercise only the due-backup path.
       find: jest.fn().mockResolvedValue([]),
     };
+
+    maintenance = createUserMaintenanceMock();
 
     mockBackupService = {
       // The service now returns the buffer alongside a completeness report; the
@@ -1147,6 +1174,23 @@ describe("AutoBackupService", () => {
       expect(await listBackups(root)).toEqual([]);
     });
 
+    it("refuses rather than writing an empty file mid-maintenance", async () => {
+      // The cron defers silently; a manual run has someone watching, so it says
+      // why. Writing the file anyway would produce an empty backup and then
+      // rotate the last good one out to keep the retention count.
+      mockSettingsRepo.findOne.mockResolvedValue(
+        createSettings({ enabled: true, folderPath: root }),
+      );
+      maintenance.isUnderMaintenance.mockResolvedValue(true);
+
+      await expect(service.runManualBackup(userId)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(mockBackupService.exportToBuffer).not.toHaveBeenCalled();
+      // Nothing reached the disk: the user's folder holds no backup file.
+      expect(await listBackups(folderFor())).toEqual([]);
+    });
+
     it("should run backup and update status on success", async () => {
       mockSettingsRepo.findOne.mockResolvedValue(
         createSettings({ enabled: true, folderPath: root }),
@@ -1308,13 +1352,19 @@ describe("AutoBackupService", () => {
 
       await service.handleAutoBackupCron();
 
-      expect(mockSettingsRepo.save).toHaveBeenCalledWith(
+      expect(updateBuilder.set).toHaveBeenCalledWith(
         expect.objectContaining({
           lastBackupStatus: "success",
-          nextBackupAt: expect.any(Date),
+          lastBackupError: null,
         }),
       );
       expect(await listBackups(folderFor())).toHaveLength(1);
+      // The schedule was advanced by the claim, not by re-saving the snapshot.
+      const claim = scoped.manager.query.mock.calls.find((call) =>
+        String(call[0]).includes("UPDATE auto_backup_settings"),
+      );
+      expect(claim).toBeDefined();
+      expect(claim![1]![0]).toBeInstanceOf(Date);
     });
 
     it("should write under BACKUP_CONTAINER_DIR when a due row has no folder path", async () => {
@@ -1393,13 +1443,125 @@ describe("AutoBackupService", () => {
 
       await service.handleAutoBackupCron();
 
-      expect(mockSettingsRepo.save).toHaveBeenCalledWith(
+      expect(updateBuilder.set).toHaveBeenCalledWith(
         expect.objectContaining({
           lastBackupStatus: "failed",
           lastBackupError: expect.any(String),
-          nextBackupAt: expect.any(Date),
         }),
       );
+    });
+
+    describe("multi-replica coordination", () => {
+      function dueSettings() {
+        return createSettings({
+          enabled: true,
+          folderPath: root,
+          nextBackupAt: new Date(Date.now() - 3600000),
+        });
+      }
+
+      it("claims the window by advancing next_backup_at, guarded on it still being due", async () => {
+        mockSettingsRepo.find.mockResolvedValue([dueSettings()]);
+
+        await service.handleAutoBackupCron();
+
+        const [sql, params] = scoped.manager.query.mock.calls.find((call) =>
+          String(call[0]).includes("UPDATE auto_backup_settings"),
+        )!;
+        expect(sql).toContain("next_backup_at <= $3");
+        expect(sql).toContain("enabled = true");
+        expect(sql).toContain("RETURNING id");
+        expect(params).toHaveLength(3);
+      });
+
+      it("exports nothing when another replica claimed the window", async () => {
+        // The regression: every replica fires this cron, so with no claim a
+        // two-replica cluster writes each user's backup twice -- and one
+        // replica's retention sweep can delete the file the other is writing.
+        mockSettingsRepo.find.mockResolvedValue([dueSettings()]);
+        scoped.manager.query.mockResolvedValue([[], 0]);
+
+        await service.handleAutoBackupCron();
+
+        expect(mockBackupService.exportToBuffer).not.toHaveBeenCalled();
+        expect(updateBuilder.execute).not.toHaveBeenCalled();
+      });
+
+      it("does not read a claim result as a win just because the driver returned a tuple", async () => {
+        // `[rows, rowCount]` has length 2 whatever happened, so an open-coded
+        // `result.length > 0` would make every replica a winner.
+        mockSettingsRepo.find.mockResolvedValue([dueSettings()]);
+        scoped.manager.query.mockResolvedValue([[], 0]);
+
+        await service.handleAutoBackupCron();
+
+        expect(mockBackupService.exportToBuffer).not.toHaveBeenCalled();
+      });
+
+      it("defers, without claiming, while the user's data is being replaced", async () => {
+        // A `.mny` import with "start fresh" commits its wipe and then writes
+        // rows for minutes. Backing up in that window saves the empty dataset as
+        // today's file and then enforces retention -- rotating the last good
+        // backup out to make room for one containing nothing (DR-04-02).
+        mockSettingsRepo.find.mockResolvedValue([dueSettings()]);
+        maintenance.isUnderMaintenance.mockResolvedValue(true);
+
+        await service.handleAutoBackupCron();
+
+        expect(mockBackupService.exportToBuffer).not.toHaveBeenCalled();
+        // Not claimed, so next_backup_at stays in the past and the next hour
+        // retries rather than skipping the whole period.
+        const claim = scoped.manager.query.mock.calls.find((call) =>
+          String(call[0]).includes("UPDATE auto_backup_settings"),
+        );
+        expect(claim).toBeUndefined();
+      });
+
+      it("does not enforce retention while deferring", async () => {
+        // Retention runs inside the backup path, so deferring has to skip it
+        // too: pruning to N files without having written a new one loses a
+        // generation for nothing.
+        mockSettingsRepo.find.mockResolvedValue([
+          createSettings({
+            enabled: true,
+            folderPath: root,
+            nextBackupAt: new Date(Date.now() - 3600000),
+            retentionDaily: 1,
+          }),
+        ]);
+        await fs.mkdir(folderFor(), { recursive: true });
+        const existing = [
+          "monize-backup-daily-2026-04-01.json.gz",
+          "monize-backup-daily-2026-04-02.json.gz",
+        ];
+        for (const name of existing) {
+          await fs.writeFile(join(folderFor(), name), "x");
+        }
+        maintenance.isUnderMaintenance.mockResolvedValue(true);
+
+        await service.handleAutoBackupCron();
+
+        // retentionDaily=1 would prune to a single file if the backup path had
+        // run; deferring skips it, so both pre-existing dailies survive.
+        expect((await listBackups(folderFor())).sort()).toEqual(existing);
+      });
+
+      it("writes only the outcome columns, never the whole snapshot", async () => {
+        // `repo.save(settings)` would write back the folder, frequency and
+        // retention this sweep read minutes ago, reverting anything the user
+        // changed in the meantime.
+        mockSettingsRepo.find.mockResolvedValue([dueSettings()]);
+
+        await service.handleAutoBackupCron();
+
+        expect(mockSettingsRepo.save).not.toHaveBeenCalled();
+        const written = Object.keys(updateBuilder.set.mock.calls[0][0]);
+        expect(written.sort()).toEqual([
+          "lastBackupAt",
+          "lastBackupError",
+          "lastBackupStatus",
+        ]);
+      });
     });
   });
 
@@ -1529,7 +1691,9 @@ describe("AutoBackupService", () => {
 
       await service.handleAutoBackupCron();
 
-      expect(mockSettingsRepo.save).toHaveBeenCalledWith(
+      // The cron records the outcome with a targeted UPDATE (recordBackupOutcome),
+      // not a whole-row repo.save, so a concurrent settings edit is never reverted.
+      expect(updateBuilder.set).toHaveBeenCalledWith(
         expect.objectContaining({ lastBackupStatus: "partial" }),
       );
       const remaining = await listBackups(folderFor());

--- a/backend/src/backup/auto-backup.service.ts
+++ b/backend/src/backup/auto-backup.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, BadRequestException } from "@nestjs/common";
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  ConflictException,
+} from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import {
   DataSource,
@@ -10,6 +15,7 @@ import {
   Repository,
 } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
+import { affectedRowCount } from "../common/db/query-result";
 import { Cron } from "@nestjs/schedule";
 import { promises as fs, readdirSync, unlinkSync } from "fs";
 import { randomUUID } from "crypto";
@@ -33,6 +39,7 @@ import { User } from "../users/entities/user.entity";
 import { DemoModeService } from "../common/demo-mode.service";
 import { isShardableId, shardedSegments } from "../common/shard-path.util";
 import { withSystemContext, withUserContext } from "../common/db/with-context";
+import { UserMaintenanceService } from "../common/jobs/user-maintenance.service";
 import {
   UpdateAutoBackupSettingsDto,
   AutoBackupFrequency,
@@ -193,6 +200,7 @@ export class AutoBackupService {
     private readonly backupService: BackupService,
     private readonly backupEncryption: BackupEncryptionService,
     private readonly demoMode: DemoModeService,
+    private readonly maintenance: UserMaintenanceService,
     config: ConfigService,
   ) {
     this.defaultFolderPath = this.resolveConfiguredFolderPath(
@@ -598,6 +606,18 @@ export class AutoBackupService {
   async runManualBackup(
     userId: string,
   ): Promise<{ message: string; filename: string }> {
+    // The cron defers in this state; a manual run has a user watching, so it says
+    // so instead. Writing the file anyway would produce an empty backup and then
+    // rotate the last good one out to keep the retention count.
+    if (await this.maintenance.isUnderMaintenance(userId)) {
+      throw new ConflictException(
+        tr(
+          "errors.maintenance.inProgress",
+          "Another operation is currently replacing this account's data. Wait for it to finish and try again.",
+        ),
+      );
+    }
+
     // A user who has never opened the auto-backup settings still gets a working
     // manual run: the row is seeded with defaults here and persisted by the
     // save at the end of this method.
@@ -693,6 +713,74 @@ export class AutoBackupService {
     );
   }
 
+  /**
+   * Claim one due backup by advancing its own schedule.
+   *
+   * Every replica fires this cron, so without a claim a two-replica cluster
+   * writes every user's backup twice -- and worse, one replica's
+   * `enforceRetention` can delete the file the other is still writing.
+   *
+   * The claim is the schedule advance itself: `next_backup_at` is a column this
+   * job owns, so `UPDATE ... WHERE next_backup_at <= now RETURNING` re-evaluates
+   * the predicate after taking the row lock and exactly one replica gets a row
+   * back. No claim table and no lease to expire -- the row already carries the
+   * fact. Advancing *before* the export also means a crash mid-backup skips this
+   * window rather than retrying forever, which is the behaviour the failure path
+   * already had.
+   */
+  private async claimDueBackup(
+    settings: AutoBackupSettings,
+    now: Date,
+    nextBackupAt: Date,
+  ): Promise<boolean> {
+    const rows = await withUserContext(settings.userId, () =>
+      withScopedDb(this.dataSource, (manager) =>
+        manager.query(
+          `UPDATE auto_backup_settings
+              SET next_backup_at = $1
+            WHERE user_id = $2
+              AND enabled = true
+              AND next_backup_at IS NOT NULL
+              AND next_backup_at <= $3
+            RETURNING id`,
+          [nextBackupAt, settings.userId, now],
+        ),
+      ),
+    );
+    return affectedRowCount(rows) > 0;
+  }
+
+  /**
+   * Write only the columns describing how the run went.
+   *
+   * `repo.save(settings)` would write back every column of the snapshot this
+   * sweep read at the top, so a user who changed their folder, frequency or
+   * retention through the UI while the sweep was running would find those edits
+   * reverted. The outcome columns are the only ones this job is entitled to
+   * write; `next_backup_at` was already set by the claim.
+   */
+  private async recordBackupOutcome(
+    userId: string,
+    at: Date,
+    status: "success" | "partial" | "failed",
+    error: string | null,
+  ): Promise<void> {
+    await withUserContext(userId, () =>
+      this.scoped(AutoBackupSettings, (repo) =>
+        repo
+          .createQueryBuilder()
+          .update(AutoBackupSettings)
+          .set({
+            lastBackupAt: at,
+            lastBackupStatus: status,
+            lastBackupError: error,
+          })
+          .where("user_id = :userId", { userId })
+          .execute(),
+      ),
+    );
+  }
+
   @Cron("0 * * * *")
   async handleAutoBackupCron(): Promise<void> {
     const now = new Date();
@@ -714,6 +802,35 @@ export class AutoBackupService {
     this.logger.log(`Auto-backup cron: ${dueSettings.length} backup(s) due`);
 
     for (const settings of dueSettings) {
+      const nextBackupAt = this.calculateNextBackupAt(
+        settings.frequency as AutoBackupFrequency,
+        settings.backupTime,
+        settings.timezone,
+        now,
+      );
+
+      // Never back up a dataset that is mid-replacement. A `.mny` import with
+      // "start fresh" commits its wipe and then writes rows for minutes, so an
+      // hourly backup landing in that window would export the empty dataset,
+      // save it as today's file, and enforce retention -- rotating the last good
+      // backup out to make room for one containing nothing. Skipping without
+      // claiming leaves `next_backup_at` in the past, so the next hour retries
+      // (audit DR-04-02).
+      if (await this.maintenance.isUnderMaintenance(settings.userId)) {
+        this.logger.log(
+          `Auto-backup deferred for user ${settings.userId}: their data is being replaced`,
+        );
+        continue;
+      }
+
+      const claimed = await this.claimDueBackup(settings, now, nextBackupAt);
+      if (!claimed) {
+        // Either another replica took this window, or the user disabled or
+        // rescheduled the backup after this sweep read its snapshot. Both mean
+        // "not ours to run".
+        continue;
+      }
+
       try {
         settings.folderPath = this.resolveFolderPath(settings.folderPath);
         const userFolder = await this.resolveUserFolder(
@@ -737,15 +854,16 @@ export class AutoBackupService {
           timezone,
         );
 
-        settings.lastBackupAt = now;
-        settings.nextBackupAt = this.calculateNextBackupAt(
-          settings.frequency as AutoBackupFrequency,
-          settings.backupTime,
-          settings.timezone,
+        // applyBackupOutcome set lastBackupStatus/Error to reflect a complete
+        // ("success") or incomplete ("partial") artifact; record exactly that,
+        // never a hardcoded success, so a partial backup is not persisted as a
+        // full one (F3R7-001). The write is the targeted outcome UPDATE, not a
+        // whole-row save, so it cannot revert a concurrent settings edit.
+        await this.recordBackupOutcome(
+          settings.userId,
           now,
-        );
-        await withUserContext(settings.userId, () =>
-          this.scoped(AutoBackupSettings, (repo) => repo.save(settings)),
+          report.complete ? "success" : "partial",
+          settings.lastBackupError,
         );
 
         this.logger.log(
@@ -755,17 +873,11 @@ export class AutoBackupService {
         this.logger.error(
           `Auto-backup failed for user ${settings.userId}: ${error.message}`,
         );
-        settings.lastBackupAt = now;
-        settings.lastBackupStatus = "failed";
-        settings.lastBackupError = String(error.message).slice(0, 1024);
-        settings.nextBackupAt = this.calculateNextBackupAt(
-          settings.frequency as AutoBackupFrequency,
-          settings.backupTime,
-          settings.timezone,
+        await this.recordBackupOutcome(
+          settings.userId,
           now,
-        );
-        await withUserContext(settings.userId, () =>
-          this.scoped(AutoBackupSettings, (repo) => repo.save(settings)),
+          "failed",
+          String(error.message).slice(0, 1024),
         );
       }
     }

--- a/backend/src/backup/backup-export.service.ts
+++ b/backend/src/backup/backup-export.service.ts
@@ -61,6 +61,20 @@ import { tr } from "../i18n/translate";
  * The irreducible part is one row: a 10 MiB attachment is 13.6 MiB of base64 no
  * matter what the budget says. Everything else is a constant.
  */
+
+/**
+ * How long an export may sit idle inside its snapshot transaction before the
+ * database aborts it.
+ *
+ * The streaming export writes to the client between table reads, so a client
+ * that stops draining holds the snapshot open -- and a long-lived
+ * `REPEATABLE READ` transaction blocks vacuum from reclaiming dead tuples for
+ * the whole database, not just this user's tables. Bounding the idle time turns
+ * that from an operational problem into a failed download the user can retry
+ * (audit DR-04).
+ */
+const EXPORT_IDLE_TIMEOUT_MS = 60_000;
+
 @Injectable()
 export class BackupExportService {
   private readonly logger = new Logger(BackupExportService.name);
@@ -341,7 +355,20 @@ export class BackupExportService {
   ): Promise<T> {
     return withScopedDb(
       this.dataSource,
-      (manager) => fn(createExportReader(manager, userId)),
+      async (manager) => {
+        // Bound how long this REPEATABLE READ snapshot may sit idle. The
+        // streaming export holds the transaction open for as long as the client
+        // takes to drain, and a long-lived transaction blocks vacuum from
+        // reclaiming dead tuples across the whole database, not just this user's
+        // tables. EXPORT_IDLE_TIMEOUT_MS turns a stalled download into an aborted
+        // transaction the user can retry rather than an operational problem
+        // (audit DR-04). `true` scopes the setting to this transaction.
+        await manager.query(
+          "SELECT set_config('idle_in_transaction_session_timeout', $1, true)",
+          [String(EXPORT_IDLE_TIMEOUT_MS)],
+        );
+        return fn(createExportReader(manager, userId));
+      },
       "REPEATABLE READ",
     );
   }

--- a/backend/src/backup/backup-restore.service.ts
+++ b/backend/src/backup/backup-restore.service.ts
@@ -12,6 +12,7 @@ import { gunzip } from "zlib";
 import { promisify } from "util";
 import { withScopedDb } from "../common/db/scoped-db";
 import { withPreserveTimestamps } from "../common/db/with-context";
+import { UserMaintenanceService } from "../common/jobs/user-maintenance.service";
 import { AiEncryptionService } from "../ai/ai-encryption.service";
 import { OidcReauthService } from "../auth/oidc/oidc-reauth.service";
 import { User } from "../users/entities/user.entity";
@@ -65,6 +66,7 @@ export class BackupRestoreService {
     private readonly oidcReauth: OidcReauthService,
     private readonly attachments: BackupAttachmentTransferService,
     private readonly db: BackupRestoreDatabaseService,
+    private readonly maintenance: UserMaintenanceService,
   ) {}
 
   /**
@@ -183,47 +185,58 @@ export class BackupRestoreService {
       // timestamps through the Phase-3 deferred-FK UPDATEs -- replacing the old
       // trigger-disabling ALTER TABLE DDL, which the unprivileged runtime role
       // cannot execute under enforcement (task C5).
-      return withPreserveTimestamps(() =>
-        withScopedDb(this.dataSource, async (manager) => {
-          // Phase 1: Delete all existing user data (same order as deleteData in users.service)
-          await this.db.deleteAllUserData(userId, manager);
+      // The delete-and-reinsert runs under this user's maintenance lease, taken
+      // only now -- after authentication, before the first delete. A concurrent
+      // restore, delete-my-data, or `.mny` import already replacing this
+      // account's data makes the lease refuse with a 409, and because the refusal
+      // precedes `fn`, nothing here has run: no row deleted, the account left
+      // exactly as the other operation will leave it (audit DR-04-02). Staged
+      // attachment bytes are discarded by the `.catch` below, since they were
+      // written before the lease and this request no longer owns the restore.
+      return this.maintenance
+        .withMaintenanceLease(userId, "backup restore", () =>
+          withPreserveTimestamps(() =>
+            withScopedDb(this.dataSource, async (manager) => {
+              // Phase 1: Delete all existing user data (same order as deleteData in users.service)
+              await this.db.deleteAllUserData(userId, manager);
 
-          // Phase 2a: ensure every referenced currency code exists before
-          // restoring the tables with FK references to currencies(code).
-          await this.db.ensureCurrenciesExist(manager, data, userId);
+              // Phase 2a: ensure every referenced currency code exists before
+              // restoring the tables with FK references to currencies(code).
+              await this.db.ensureCurrenciesExist(manager, data, userId);
 
-          // Phase 2b: insert every backed-up table in FK-safe order. The order,
-          // the row-count key and whether user_id is forced live in
-          // RESTORE_PLAN, which restore-plan.spec.ts checks against the schema's
-          // foreign keys -- so a new table or a new FK cannot quietly land in the
-          // wrong position.
-          for (const { table, countKey, scopeToUser } of RESTORE_PLAN) {
-            restored[countKey] = await this.db.insertRows(
-              manager,
-              table,
-              backupTables(data)[table],
-              scopeToUser ? userId : null,
-            );
-          }
-
-          // Phase 3: Restore deferred FK columns that were stripped during insert
-          // to avoid circular/forward reference violations.
-          await this.db.restoreDeferredFkColumns(manager, data);
-
-          this.logger.log(`Backup restore completed for user ${userId}`);
-          // `skippedAttachments` is reported beside `restored`, never inside it:
-          // the client sums `restored`'s values to show a row total, and a count
-          // of rows that were deliberately not written does not belong in that
-          // sum.
-          return skippedAttachments > 0
-            ? {
-                message: "Backup restored successfully",
-                restored,
-                skippedAttachments,
+              // Phase 2b: insert every backed-up table in FK-safe order. The order,
+              // the row-count key and whether user_id is forced live in
+              // RESTORE_PLAN, which restore-plan.spec.ts checks against the schema's
+              // foreign keys -- so a new table or a new FK cannot quietly land in the
+              // wrong position.
+              for (const { table, countKey, scopeToUser } of RESTORE_PLAN) {
+                restored[countKey] = await this.db.insertRows(
+                  manager,
+                  table,
+                  backupTables(data)[table],
+                  scopeToUser ? userId : null,
+                );
               }
-            : { message: "Backup restored successfully", restored };
-        }),
-      )
+
+              // Phase 3: Restore deferred FK columns that were stripped during insert
+              // to avoid circular/forward reference violations.
+              await this.db.restoreDeferredFkColumns(manager, data);
+
+              this.logger.log(`Backup restore completed for user ${userId}`);
+              // `skippedAttachments` is reported beside `restored`, never inside it:
+              // the client sums `restored`'s values to show a row total, and a count
+              // of rows that were deliberately not written does not belong in that
+              // sum.
+              return skippedAttachments > 0
+                ? {
+                    message: "Backup restored successfully",
+                    restored,
+                    skippedAttachments,
+                  }
+                : { message: "Backup restored successfully", restored };
+            }),
+          ),
+        )
         .then(async (result) => {
           // After the commit, never before: until it lands, the metadata that
           // references these objects may come back with a rollback.

--- a/backend/src/backup/backup.service.spec.ts
+++ b/backend/src/backup/backup.service.spec.ts
@@ -6,6 +6,7 @@ import {
   BadRequestException,
   Logger,
   NotFoundException,
+  ConflictException,
 } from "@nestjs/common";
 import { gzipSync, gunzipSync } from "zlib";
 import { PassThrough } from "stream";
@@ -33,6 +34,11 @@ import {
   ATTACHMENT_STORAGE_PROVIDER,
   AttachmentStorageProvider,
 } from "../attachments/storage/attachment-storage.interface";
+import {
+  createUserMaintenanceMock,
+  userMaintenanceProvider,
+  type UserMaintenanceMock,
+} from "../test-helpers/job-claim-testing";
 
 /**
  * A `PassThrough` standing in for an express `Response`, carrying the header
@@ -121,6 +127,7 @@ function insertColumnMap(call: unknown[]): Record<string, unknown> {
 describe("BackupService", () => {
   let service: BackupService;
   let mockUserRepo: Record<string, jest.Mock>;
+  let maintenance: UserMaintenanceMock;
   let mockDataSource: Record<string, jest.Mock>;
   let mockQueryRunner: Record<string, jest.Mock>;
   // Typed rather than Record<string, jest.Mock>: this is one of our own
@@ -569,6 +576,7 @@ describe("BackupService", () => {
     // EntityManager -- `mockQueryRunner.query` and `mockDataSource.query` are
     // the same jest.fn the manager exposes, keeping the assertions below
     // pointed at the same statements.
+    maintenance = createUserMaintenanceMock();
     const scoped = createScopedDbMocks([[User, mockUserRepo as never]]);
     scoped.manager.query.mockImplementation(mockQueryHandler);
     // The export reads large tables through a database cursor, so what reaches
@@ -619,6 +627,7 @@ describe("BackupService", () => {
         // re-authentication assertion vacuous -- which is how the sentinel
         // survived (P2-005).
         OidcReauthService,
+        userMaintenanceProvider(maintenance),
         {
           provide: AiEncryptionService,
           useValue: {
@@ -1371,6 +1380,49 @@ describe("BackupService", () => {
       const result = await resultPromise;
 
       expect(result.investment_reports).toEqual(mockInvestmentReports);
+    });
+
+    it("reads every table inside one REPEATABLE READ transaction", async () => {
+      // The regression: each table used to be read in its own autocommit
+      // transaction, so a concurrent write could land between two reads and the
+      // file could hold a split whose parent transaction is missing. The
+      // restore inserts with ON CONFLICT DO NOTHING, so that orphan is dropped
+      // silently rather than failing -- a backup that is quietly incomplete.
+      mockDataSource.query.mockResolvedValue([]);
+
+      const mockRes = new PassThrough();
+      const resultPromise = collectGzipOutput(mockRes);
+      await service.streamExport(userId, mockRes as any);
+      await resultPromise;
+
+      const isolations = mockDataSource.transaction.mock.calls
+        .map((call) => call[0])
+        .filter((arg) => typeof arg === "string");
+      expect(isolations).toEqual(["REPEATABLE READ"]);
+      // One transaction for the whole export, not one per table.
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it("bounds how long the snapshot may sit idle waiting on the client", async () => {
+      // The cost of holding one snapshot across a streamed download is that a
+      // client which stops draining keeps a REPEATABLE READ transaction open,
+      // and that blocks vacuum database-wide. The timeout turns that into a
+      // failed download instead.
+      mockDataSource.query.mockResolvedValue([]);
+
+      const mockRes = new PassThrough();
+      const resultPromise = collectGzipOutput(mockRes);
+      await service.streamExport(userId, mockRes as any);
+      await resultPromise;
+
+      const idleGuard = mockDataSource.query.mock.calls.find((call) =>
+        String(call[0]).includes("idle_in_transaction_session_timeout"),
+      );
+      expect(idleGuard).toBeDefined();
+      // Transaction-local (`set_config(..., true)`), so it cannot leak onto the
+      // pooled connection and shorten an unrelated request's allowance.
+      expect(idleGuard![1]).toEqual([expect.any(String)]);
+      expect(String(idleGuard![0])).toContain("true");
     });
 
     it("writes an encrypted envelope when a password is provided", async () => {
@@ -3273,6 +3325,53 @@ describe("BackupService", () => {
 
       expect(mockDataSource.transaction).toHaveBeenCalled();
       expect(mockDataSource.transaction).toHaveBeenCalled();
+    });
+
+    it("runs the restore under the maintenance lease", async () => {
+      mockUserRepo.findOne.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.restoreData(userId, makeInput({ password: "test" }));
+
+      expect(maintenance.withMaintenanceLease).toHaveBeenCalledWith(
+        userId,
+        expect.stringContaining("restore"),
+        expect.any(Function),
+      );
+    });
+
+    it("deletes nothing when another operation is already replacing the data", async () => {
+      // A restore landing mid-`.mny`-import wipes the rows that import's worker
+      // is still writing, and the worker then writes the rest into the restored
+      // dataset. The lease refuses before the delete phase, so the account is
+      // left exactly as the other operation will leave it (DR-04-02).
+      mockUserRepo.findOne.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      maintenance.withMaintenanceLease.mockRejectedValue(
+        new ConflictException("busy"),
+      );
+
+      await expect(
+        service.restoreData(userId, makeInput({ password: "test" })),
+      ).rejects.toThrow(ConflictException);
+
+      const deletes = mockQueryRunner.query.mock.calls.filter(
+        (call: string[]) => String(call[0]).includes("DELETE FROM"),
+      );
+      expect(deletes).toHaveLength(0);
+    });
+
+    it("takes the lease only after authentication succeeds", async () => {
+      // A wrong password must not consume the lease and lock the real restore
+      // out for the length of its TTL.
+      mockUserRepo.findOne.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      await expect(
+        service.restoreData(userId, makeInput({ password: "wrong" })),
+      ).rejects.toThrow();
+
+      expect(maintenance.withMaintenanceLease).not.toHaveBeenCalled();
     });
 
     it("should override user_id in restored data to match current user", async () => {

--- a/backend/src/budgets/budget-alert.service.spec.ts
+++ b/backend/src/budgets/budget-alert.service.spec.ts
@@ -102,6 +102,8 @@ function makeAlert(overrides: Partial<BudgetAlert> = {}): BudgetAlert {
 
 describe("BudgetAlertService", () => {
   let scopedDataSource: DataSourceMock;
+  /** Rows the conflict-safe INSERT accepted, in order. */
+  let insertedAlerts: Record<string, unknown>[];
   let service: BudgetAlertService;
   let budgetsRepository: Record<string, jest.Mock>;
   let alertsRepository: Record<string, jest.Mock>;
@@ -139,6 +141,8 @@ describe("BudgetAlertService", () => {
           Promise.resolve({ ...data, id: data.id || "new-alert-id" }),
         ),
       delete: jest.fn().mockResolvedValue({ affected: 0 }),
+      // Reads back the row the conflict-safe INSERT accepted.
+      findOne: jest.fn().mockResolvedValue(null),
     };
 
     transactionsRepository = {
@@ -185,15 +189,48 @@ describe("BudgetAlertService", () => {
       }),
     };
 
-    ({ dataSource: scopedDataSource } = createScopedDbMocks([
-      [Budget, budgetsRepository as never],
-      [BudgetAlert, alertsRepository as never],
-      [Transaction, transactionsRepository as never],
-      [TransactionSplit, splitsRepository as never],
-      [User, usersRepository as never],
-      [UserPreference, preferencesRepository as never],
-      [ScheduledTransaction, scheduledTransactionsRepository as never],
-    ]));
+    let scopedManager: Record<string, jest.Mock>;
+    ({ manager: scopedManager, dataSource: scopedDataSource } =
+      createScopedDbMocks([
+        [Budget, budgetsRepository as never],
+        [BudgetAlert, alertsRepository as never],
+        [Transaction, transactionsRepository as never],
+        [TransactionSplit, splitsRepository as never],
+        [User, usersRepository as never],
+        [UserPreference, preferencesRepository as never],
+        [ScheduledTransaction, scheduledTransactionsRepository as never],
+      ]));
+
+    // Alerts are inserted with `ON CONFLICT DO NOTHING RETURNING id`, and what
+    // that statement returns is what decides whether an alert is new -- the
+    // unique fingerprint from migration 139 is the de-duplication rule now, not
+    // the in-memory comparison (audit P4-015). So the double has to behave like
+    // the real insert: record the row, hand back an id, and let the follow-up
+    // read find it.
+    insertedAlerts = [];
+    scopedManager.query.mockImplementation(
+      async (sql: string, params: unknown[]) => {
+        if (!sql.includes("INSERT INTO budget_alerts")) return [];
+        const row = {
+          id: `alert-${insertedAlerts.length + 1}`,
+          userId: params[0],
+          budgetId: params[1],
+          budgetCategoryId: params[2],
+          alertType: params[3],
+          severity: params[4],
+          title: params[5],
+          message: params[6],
+          data: JSON.parse(String(params[7])),
+          periodStart: params[8],
+        };
+        insertedAlerts.push(row);
+        return [[{ id: row.id }], 1];
+      },
+    );
+    alertsRepository.findOne.mockImplementation(
+      async ({ where }: { where: { id: string } }) =>
+        insertedAlerts.find((row) => row.id === where.id) ?? null,
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -978,10 +1015,8 @@ describe("BudgetAlertService", () => {
       const result = await service.processAlerts(budget);
 
       expect(result.alertsCreated).toBeGreaterThan(0);
-      expect(alertsRepository.save).toHaveBeenCalled();
-
-      const savedAlert = alertsRepository.create.mock.calls[0][0];
-      expect(savedAlert.alertType).toBe(AlertType.OVER_BUDGET);
+      expect(insertedAlerts.length).toBeGreaterThan(0);
+      expect(insertedAlerts[0].alertType).toBe(AlertType.OVER_BUDGET);
     });
 
     it("sends immediate email for critical alerts", async () => {
@@ -1119,11 +1154,11 @@ describe("BudgetAlertService", () => {
       await service.processAlerts(budget);
 
       // The OVER_BUDGET candidate has CRITICAL severity which is higher than the
-      // existing WARNING, so severity escalation allows it through
-      const createdAlerts = alertsRepository.create.mock.calls.map(
-        (call: any[]) => call[0].alertType,
+      // existing WARNING, so severity escalation allows it through -- and the
+      // unique fingerprint includes severity precisely so that it can.
+      expect(insertedAlerts.map((row) => row.alertType)).toContain(
+        AlertType.OVER_BUDGET,
       );
-      expect(createdAlerts).toContain(AlertType.OVER_BUDGET);
     });
 
     it("suppresses alert when existing alert has same or higher severity", async () => {

--- a/backend/src/budgets/budget-alert.service.ts
+++ b/backend/src/budgets/budget-alert.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { Cron } from "@nestjs/schedule";
 import { LessThan, IsNull, DataSource } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
+import { returnedRows } from "../common/db/query-result";
 import { ConfigService } from "@nestjs/config";
 import { I18nService } from "nestjs-i18n";
 import { emailTranslator } from "../i18n/email-translator";
@@ -322,27 +323,52 @@ export class BudgetAlertService {
       return { alertsCreated: 0, emailsSent: 0 };
     }
 
-    // Save new alerts
+    // Save new alerts. What the INSERT returns -- not what the candidate list
+    // hoped to save -- decides which alerts are new.
+    //
+    // The in-memory de-duplication above is a check-then-act, and every backend
+    // replica runs this cron: two processors both read no existing OVER_BUDGET
+    // alert for the period, both inserted one, and both sent the critical email
+    // (audit P4-015). The unique fingerprint from migration 139 arbitrates
+    // instead, and `ON CONFLICT DO NOTHING RETURNING` reports the outcome
+    // honestly: the loser gets no row and therefore sends nothing.
     const savedAlerts: BudgetAlert[] = [];
     for (const candidate of newCandidates) {
-      savedAlerts.push(
-        await withScopedDb(this.dataSource, (m) => {
-          const repo = m.getRepository(BudgetAlert);
-          return repo.save(
-            repo.create({
-              userId: budget.userId,
-              budgetId: candidate.budgetId,
-              budgetCategoryId: candidate.budgetCategoryId,
-              alertType: candidate.alertType,
-              severity: candidate.severity,
-              title: candidate.title,
-              message: candidate.message,
-              data: candidate.data,
-              periodStart,
-            }),
-          );
-        }),
+      const inserted = await withScopedDb(this.dataSource, (m) =>
+        m.query(
+          `INSERT INTO budget_alerts
+             (user_id, budget_id, budget_category_id, alert_type, severity,
+              title, message, data, period_start)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
+           ON CONFLICT (budget_id, period_start, alert_type,
+                        COALESCE(budget_category_id, '00000000-0000-0000-0000-000000000000'::uuid),
+                        severity)
+             DO NOTHING
+           RETURNING id`,
+          [
+            budget.userId,
+            candidate.budgetId,
+            candidate.budgetCategoryId,
+            candidate.alertType,
+            candidate.severity,
+            candidate.title,
+            candidate.message,
+            JSON.stringify(candidate.data ?? {}),
+            periodStart,
+          ],
+        ),
       );
+      const rows = returnedRows<{ id: string }>(inserted);
+      if (rows.length === 0) continue;
+
+      const saved = await withScopedDb(this.dataSource, (m) =>
+        m.getRepository(BudgetAlert).findOne({ where: { id: rows[0].id } }),
+      );
+      if (saved) savedAlerts.push(saved);
+    }
+
+    if (savedAlerts.length === 0) {
+      return { alertsCreated: 0, emailsSent: 0 };
     }
 
     // Send immediate emails for critical alerts

--- a/backend/src/budgets/budget-period-lifecycle.spec.ts
+++ b/backend/src/budgets/budget-period-lifecycle.spec.ts
@@ -35,6 +35,8 @@ describe("Budget Period Lifecycle Integration", () => {
   let periodService: BudgetPeriodService;
   let cronService: BudgetPeriodCronService;
   let periodsRepository: Record<string, jest.Mock>;
+  /** Period rows the guarded insert created, in order. */
+  let insertedPeriodRows: BudgetPeriod[];
   let periodCategoriesRepository: Record<string, jest.Mock>;
   let transactionsRepository: Record<string, jest.Mock>;
   let splitsRepository: Record<string, jest.Mock>;
@@ -132,6 +134,7 @@ describe("Budget Period Lifecycle Integration", () => {
   });
   beforeEach(async () => {
     const savedPeriods: BudgetPeriod[] = [];
+    insertedPeriodRows = [];
 
     periodsRepository = {
       create: jest.fn().mockImplementation((data) => ({
@@ -149,6 +152,7 @@ describe("Budget Period Lifecycle Integration", () => {
         return saved;
       }),
       findOne: jest.fn(),
+      findOneOrFail: jest.fn(),
       find: jest.fn().mockResolvedValue([]),
     };
 
@@ -191,6 +195,40 @@ describe("Budget Period Lifecycle Integration", () => {
     // EntityManager directly (it used to be queryRunner.manager.save).
     scopedManager.save.mockImplementation(
       (entity: unknown, data: unknown) => data ?? entity,
+    );
+    // The period insert is one `INSERT ... ON CONFLICT DO NOTHING RETURNING id`
+    // so a lost race is a no-op rather than a transaction-aborting 23505.
+    // Winning by default; the read-back returns the row the insert claimed.
+    let insertedPeriods = 0;
+    let lastInserted: BudgetPeriod | null = null;
+    scopedManager.query.mockImplementation(
+      async (sql: string, params?: unknown[]) => {
+        if (
+          typeof sql === "string" &&
+          sql.includes("INSERT INTO budget_periods")
+        ) {
+          insertedPeriods += 1;
+          const [budgetId, periodStart, periodEnd, totalBudgeted, status] =
+            params as [string, string, string, number, PeriodStatus];
+          // Hand back the row the statement wrote, the way the read-back would.
+          lastInserted = {
+            id: `period-${insertedPeriods}`,
+            budgetId,
+            periodStart,
+            periodEnd,
+            totalBudgeted,
+            status,
+            actualIncome: 0,
+            actualExpenses: 0,
+          } as BudgetPeriod;
+          insertedPeriodRows.push(lastInserted);
+          return [{ id: lastInserted.id }];
+        }
+        return [];
+      },
+    );
+    periodsRepository.findOneOrFail.mockImplementation(
+      async () => lastInserted,
     );
 
     const module: TestingModule = await Test.createTestingModule({
@@ -468,9 +506,9 @@ describe("Budget Period Lifecycle Integration", () => {
       // the closing period's categories + 1 for the period itself...
       expect(scopedDataSource.transaction).toHaveBeenCalled();
       expect(scopedManager.save).toHaveBeenCalledTimes(5);
-      // ...and the next period is created on the same manager: 1 save for the
-      // period + 1 batch save for its categories.
-      expect(periodsRepository.save).toHaveBeenCalledTimes(1);
+      // ...and the next period is created on the same manager: one guarded
+      // insert for the period plus one batch save for its categories.
+      expect(insertedPeriodRows).toHaveLength(1);
       expect(periodCategoriesRepository.save).toHaveBeenCalledTimes(1);
     });
 
@@ -812,18 +850,15 @@ describe("Budget Period Lifecycle Integration", () => {
 
     it("handles getOrCreateCurrentPeriod when no period exists", async () => {
       periodsRepository.findOne.mockResolvedValue(null);
-      periodsRepository.save.mockImplementation((data) => ({
-        ...data,
-        id: "new-period",
-      }));
 
       const result = await periodService.getOrCreateCurrentPeriod(
         "11111111-1111-1111-1111-111111111111",
         "budget-1",
       );
 
-      expect(result.id).toBe("new-period");
-      expect(periodsRepository.create).toHaveBeenCalled();
+      expect(insertedPeriodRows).toHaveLength(1);
+      expect(result.id).toBe(insertedPeriodRows[0].id);
+      expect(result.status).toBe(PeriodStatus.OPEN);
     });
 
     it("income categories do not receive rollover", async () => {

--- a/backend/src/budgets/budget-period.service.spec.ts
+++ b/backend/src/budgets/budget-period.service.spec.ts
@@ -132,6 +132,7 @@ describe("BudgetPeriodService", () => {
         id: data.id || "new-period",
       })),
       findOne: jest.fn(),
+      findOneOrFail: jest.fn(),
       find: jest.fn().mockResolvedValue([]),
     };
 
@@ -168,6 +169,17 @@ describe("BudgetPeriodService", () => {
     scopedManager.save.mockImplementation(
       (entity: unknown, data: unknown) => data ?? entity,
     );
+    // The period insert is now `INSERT ... ON CONFLICT DO NOTHING RETURNING id`
+    // so a lost race is a no-op instead of a transaction-aborting 23505. Default
+    // to winning; the loser path is asserted explicitly.
+    scopedManager.query.mockImplementation(async (sql: string) =>
+      typeof sql === "string" && sql.includes("INSERT INTO budget_periods")
+        ? [{ id: "new-period" }]
+        : [],
+    );
+    periodsRepository.findOneOrFail.mockImplementation(async () => ({
+      id: "new-period",
+    }));
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -248,6 +260,62 @@ describe("BudgetPeriodService", () => {
     });
   });
 
+  describe("closePeriod -- serialization", () => {
+    it("locks the period and reads the actuals inside the same transaction", async () => {
+      // The regression: the open period, the ledger the actuals come from, and
+      // the write that freezes them were three separate transactions. A
+      // transaction committing into the period's date range between the second
+      // and the third was left out of the closing figures for good -- a closed
+      // period is never recomputed. And the monthly cron fires on every replica,
+      // so two of them found the same OPEN period.
+      const budgetWithCategories = {
+        ...mockBudget,
+        categories: [{ ...mockBudgetCategory }],
+      };
+      budgetsService.findOne.mockResolvedValue(budgetWithCategories);
+      periodsRepository.findOne.mockResolvedValue({
+        ...mockPeriod,
+        status: PeriodStatus.OPEN,
+        periodCategories: [],
+      });
+
+      await service.closePeriod("user-1", "budget-1");
+
+      // The period row is taken with a write lock, and taken *before* the ledger
+      // the actuals are computed from is read -- that ordering is what makes
+      // "these figures were computed from rows a concurrent close cannot have
+      // moved" true rather than intended.
+      expect(
+        periodsRepository.findOne.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        transactionsRepository.createQueryBuilder.mock.invocationCallOrder[0],
+      );
+      expect(periodsRepository.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { budgetId: "budget-1", status: PeriodStatus.OPEN },
+          lock: { mode: "pessimistic_write" },
+        }),
+      );
+    });
+
+    it("refuses when another close already took the period", async () => {
+      // The loser of the lock finds no OPEN period and must not write anything;
+      // the cron reports it as a skip.
+      budgetsService.findOne.mockResolvedValue(mockBudget);
+      periodsRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.closePeriod("user-1", "budget-1")).rejects.toThrow(
+        /No open period/,
+      );
+      expect(scopedManager.save).not.toHaveBeenCalled();
+      expect(
+        scopedManager.query.mock.calls.some((call: unknown[]) =>
+          String(call[0]).includes("INSERT INTO budget_periods"),
+        ),
+      ).toBe(false);
+    });
+  });
+
   describe("closePeriod", () => {
     it("closes the open period and creates next period", async () => {
       const budgetWithCategories = {
@@ -324,10 +392,6 @@ describe("BudgetPeriodService", () => {
       };
       budgetsService.findOne.mockResolvedValue(budgetWithCategories);
       periodsRepository.findOne.mockResolvedValue(null);
-      periodsRepository.save.mockImplementation((data) => ({
-        ...data,
-        id: "new-period",
-      }));
 
       const result = await service.getOrCreateCurrentPeriod(
         "user-1",
@@ -335,8 +399,39 @@ describe("BudgetPeriodService", () => {
       );
 
       expect(result.id).toBe("new-period");
-      expect(periodsRepository.create).toHaveBeenCalled();
+      expect(
+        scopedManager.query.mock.calls.some((call: unknown[]) =>
+          String(call[0]).includes("INSERT INTO budget_periods"),
+        ),
+      ).toBe(true);
       expect(periodCategoriesRepository.create).toHaveBeenCalled();
+    });
+
+    it("adopts the period another request created rather than failing", async () => {
+      // Opening the Budgets screen for the first time this month fires several
+      // requests; they all find no open period and they all try to insert.
+      // `UNIQUE(budget_id, period_start)` stops the duplicate row, and inside a
+      // transaction a unique violation aborts everything -- so the loser has to
+      // find out by getting no row back, not by throwing.
+      const budgetWithCategories = {
+        ...mockBudget,
+        categories: [{ ...mockBudgetCategory }],
+      };
+      budgetsService.findOne.mockResolvedValue(budgetWithCategories);
+      const winner = { id: "their-period", periodCategories: [] };
+      periodsRepository.findOne
+        .mockResolvedValueOnce(null) // no open period when we looked
+        .mockResolvedValue(winner); // ...but one exists by the time we insert
+      scopedManager.query.mockImplementation(async () => []); // conflict: no row
+
+      const result = await service.getOrCreateCurrentPeriod(
+        "user-1",
+        "budget-1",
+      );
+
+      expect(result).toBe(winner);
+      // And it must not write category rows on top of the winner's.
+      expect(periodCategoriesRepository.save).not.toHaveBeenCalled();
     });
   });
 
@@ -350,19 +445,19 @@ describe("BudgetPeriodService", () => {
           { ...mockBudgetCategory, id: "bc-3", amount: 3000, isIncome: true },
         ],
       };
-      periodsRepository.save.mockImplementation((data) => ({
-        ...data,
-        id: "new-period",
-      }));
-
       await service.createPeriodForBudget(budgetWithCategories);
 
-      expect(periodsRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          totalBudgeted: 800,
-          status: PeriodStatus.OPEN,
-        }),
+      // The period row is inserted with one guarded statement, so the totals are
+      // checked on its parameters rather than on a `create()` call.
+      const insert = scopedManager.query.mock.calls.find((call: unknown[]) =>
+        String(call[0]).includes("INSERT INTO budget_periods"),
+      )!;
+      expect(String(insert[0])).toContain(
+        "ON CONFLICT (budget_id, period_start) DO NOTHING",
       );
+      // budget_id, period_start, period_end, total_budgeted, status
+      expect((insert[1] as unknown[])[3]).toBe(800);
+      expect((insert[1] as unknown[])[4]).toBe(PeriodStatus.OPEN);
       expect(periodCategoriesRepository.create).toHaveBeenCalledTimes(3);
     });
 

--- a/backend/src/budgets/budget-period.service.ts
+++ b/backend/src/budgets/budget-period.service.ts
@@ -6,6 +6,7 @@ import {
 import { tr } from "../i18n/translate";
 import { DataSource, EntityManager } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
+import { returnedRows } from "../common/db/query-result";
 import { Budget } from "./entities/budget.entity";
 import { RolloverType } from "./entities/budget-category.entity";
 import { BudgetPeriod, PeriodStatus } from "./entities/budget-period.entity";
@@ -68,29 +69,40 @@ export class BudgetPeriodService {
   async closePeriod(userId: string, budgetId: string): Promise<BudgetPeriod> {
     const budget = await this.budgetsService.findOne(userId, budgetId);
 
-    const openPeriod = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(BudgetPeriod).findOne({
-        where: { budgetId, status: PeriodStatus.OPEN },
-        relations: ["periodCategories"],
-      }),
-    );
-
-    if (!openPeriod) {
-      throw new BadRequestException(
-        tr("errors.budgets.noOpenPeriod", "No open period to close"),
-      );
-    }
-
-    const actuals = await this.computePeriodActuals(
-      userId,
-      budget,
-      openPeriod.periodStart,
-      openPeriod.periodEnd,
-    );
-
     // M26: the whole period close is one transaction, so a partial failure can
     // never leave a period half-closed.
+    //
+    // And it is one transaction from the *read* onwards, not just from the write.
+    // The open period, the ledger the actuals come from, and the write that
+    // freezes them used to be three separate transactions: a transaction
+    // committing into the period's date range between the second and the third
+    // was left out of the closing figures for good, since a closed period is
+    // never recomputed. The period row is locked first so a second close cannot
+    // interleave -- the monthly cron fires on every replica, and both replicas
+    // find the same OPEN period.
     return withScopedDb(this.dataSource, async (manager) => {
+      const openPeriod = await manager.getRepository(BudgetPeriod).findOne({
+        where: { budgetId, status: PeriodStatus.OPEN },
+        relations: ["periodCategories"],
+        lock: { mode: "pessimistic_write" },
+      });
+
+      if (!openPeriod) {
+        // Either there never was one, or another replica closed it while this
+        // call was waiting for the lock. Both are "nothing to do here", and the
+        // caller reports it as a skip rather than an error.
+        throw new BadRequestException(
+          tr("errors.budgets.noOpenPeriod", "No open period to close"),
+        );
+      }
+
+      const actuals = await this.computePeriodActuals(
+        userId,
+        budget,
+        openPeriod.periodStart,
+        openPeriod.periodEnd,
+      );
+
       let totalIncome = 0;
       let totalExpenses = 0;
 
@@ -131,18 +143,25 @@ export class BudgetPeriodService {
   ): Promise<BudgetPeriod> {
     const budget = await this.budgetsService.findOne(userId, budgetId);
 
-    const existingOpen = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(BudgetPeriod).findOne({
+    // "Find one, and create it if absent" is a check-then-act, and this one is
+    // reached by an ordinary page load: opening the Budgets screen for the first
+    // time this month fires several requests, they all find no open period, and
+    // they all insert. `UNIQUE(budget_id, period_start)` stops the duplicate row,
+    // but the loser used to surface as a 500 on a screen that was simply being
+    // opened. One transaction, and the insert tolerates losing.
+    return withScopedDb(this.dataSource, async (manager) => {
+      const repo = manager.getRepository(BudgetPeriod);
+      const existingOpen = await repo.findOne({
         where: { budgetId, status: PeriodStatus.OPEN },
         relations: ["periodCategories"],
-      }),
-    );
+      });
 
-    if (existingOpen) {
-      return existingOpen;
-    }
+      if (existingOpen) {
+        return existingOpen;
+      }
 
-    return this.createPeriodForBudget(budget);
+      return this.createPeriodForBudget(budget, undefined, manager);
+    });
   }
 
   /**
@@ -168,15 +187,38 @@ export class BudgetPeriodService {
       const periodsRepo = m.getRepository(BudgetPeriod);
       const periodCatsRepo = m.getRepository(BudgetPeriodCategory);
 
-      const period = periodsRepo.create({
-        budgetId: budget.id,
-        periodStart,
-        periodEnd,
-        totalBudgeted,
-        status: PeriodStatus.OPEN,
-      });
+      // `UNIQUE(budget_id, period_start)` decides who creates this month's
+      // period, and the loser must be able to carry on: inside a transaction a
+      // unique violation aborts everything, so a plain insert would turn a lost
+      // race into a failed request rather than into "somebody else made it".
+      const claimed: unknown = await m.query(
+        `INSERT INTO budget_periods
+           (budget_id, period_start, period_end, total_budgeted, status)
+         VALUES ($1, $2::DATE, $3::DATE, $4, $5)
+         ON CONFLICT (budget_id, period_start) DO NOTHING
+         RETURNING id`,
+        [budget.id, periodStart, periodEnd, totalBudgeted, PeriodStatus.OPEN],
+      );
 
-      const savedPeriod = await periodsRepo.save(period);
+      if (returnedRows<{ id: string }>(claimed).length === 0) {
+        // Somebody else created it. Return theirs, categories included, rather
+        // than a period this call believes it made -- and do not write category
+        // rows, which they have already written.
+        const existing = await periodsRepo.findOne({
+          where: { budgetId: budget.id, periodStart },
+          relations: ["periodCategories"],
+        });
+        if (!existing) {
+          throw new Error(
+            `budget_periods insert for budget ${budget.id} conflicted but no row exists for ${periodStart}`,
+          );
+        }
+        return existing;
+      }
+
+      const savedPeriod = await periodsRepo.findOneOrFail({
+        where: { budgetId: budget.id, periodStart },
+      });
 
       const periodCategories = budgetCategories.map((bc) => {
         const rolloverIn = rolloverMap?.get(bc.id) || 0;

--- a/backend/src/common/db/derived-state-writers.guard.spec.ts
+++ b/backend/src/common/db/derived-state-writers.guard.spec.ts
@@ -3,15 +3,15 @@ import { join } from "node:path";
 import { globSync } from "glob";
 
 /**
- * Source-scanning guards for two of the mistakes the Phase 4 concurrency audit
- * found over and over, in different files, each time looking locally reasonable.
+ * Source-scanning guards for the two mistakes the Phase 4 concurrency audit found
+ * over and over, in different files, each time looking locally reasonable.
  *
  * A rule in prose gets read, agreed with, and violated anyway -- so these are
  * tests. They scan the source rather than exercising behaviour, because both
  * mistakes are mechanical: not "this calculation is wrong" but "this shape is the
  * wrong shape", and the next instance will be in a file nobody thought to check.
  *
- * Each list below is an allowlist of *reviewed* exceptions. An entry needs a
+ * Both lists below are allowlists of *reviewed* exceptions. An entry needs a
  * reason, and the list may only shrink.
  */
 const SRC = join(__dirname, "..", "..");
@@ -33,6 +33,83 @@ function relative(file: string): string {
 }
 
 describe("derived financial state has one set of writers", () => {
+  /**
+   * `accounts.current_balance` is written by exactly two protocols -- an atomic
+   * delta and an absolute recomputation -- and they only compose because every
+   * writer takes the account lock before reading the inputs it writes back.
+   *
+   * A new site that assembles its own `UPDATE accounts SET current_balance`
+   * bypasses that agreement, which is how a recomputation silently overwrote a
+   * committed delta (audit P4-005). Route it through `AccountsService`.
+   */
+  it("writes current_balance only from the sanctioned services", () => {
+    const ALLOWED = new Set([
+      // The two protocols themselves, and the lock that makes them compose.
+      "accounts/accounts.service.ts",
+      // Post-import recomputation: bulk, and locked through the shared helper.
+      "import/import-post-processing.service.ts",
+      // Demo-mode seeding writes balances alongside the rows it invents.
+      "database/demo-seed.service.ts",
+      "database/seed.service.ts",
+      // A restore replaces whole rows, balances included, under preserved
+      // timestamps -- it is restoring a snapshot, not maintaining a balance.
+      "backup/backup.service.ts",
+      // The `.mny` importer writes balances inside its one import transaction.
+      "import/mny/writers/write-transactions.ts",
+      // Undo/redo recomputes the accounts its replay touched, under the shared
+      // account lock.
+      "action-history/action-history.service.ts",
+      // Delete-my-data resets every account to its opening balance; there is no
+      // ledger left to recompute from.
+      "users/users.service.ts",
+      // Demo mode's daily reset owns the whole dataset it invents.
+      "database/demo-reset.service.ts",
+      // The protocol note itself quotes the statement it is describing.
+      "common/db/locks.ts",
+    ]);
+
+    const offenders = sourceFiles()
+      .filter((file) => /current_balance\s*=/.test(read(file)))
+      .map(relative)
+      .filter((file) => !ALLOWED.has(file));
+
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * A balance delta must be derived from the ledger version the write replaces.
+   *
+   * The shape that breaks it is a read *before* the transaction whose values are
+   * then used to adjust a balance *inside* it -- two concurrent requests each
+   * held that snapshot and the second reversed an amount the first had already
+   * replaced (audit P4-003). The locked readers in `common/db/locks.ts` are how a
+   * service reads those values instead.
+   */
+  it("derives balance deltas from locked reads, not entity snapshots", () => {
+    const ALLOWED = new Set([
+      // The helper that performs the locked read.
+      "common/db/locks.ts",
+    ]);
+
+    const offenders = sourceFiles()
+      .filter((file) => {
+        const source = read(file);
+        // A service that adjusts balances at all must have a locked reader, or a
+        // documented reason not to.
+        const adjustsBalances = /accountsService\.updateBalance\(/.test(source);
+        if (!adjustsBalances) return false;
+        return !/lockTransactionRow|lockTransactionRows|lockAccountsForBalanceWrite/.test(
+          source,
+        );
+      })
+      .map(relative)
+      .filter((file) => !ALLOWED.has(file));
+
+    // Every remaining balance-adjusting service reads its old values under a
+    // lock. A new one that does not is the P4-003 shape again.
+    expect(offenders).toEqual([]);
+  });
+
   /**
    * A balance reversal must be gated on the row this call actually removed.
    *
@@ -74,6 +151,112 @@ describe("derived financial state has one set of writers", () => {
       })
       .map(relative)
       .filter((file) => !ALLOWED.has(file));
+
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * Every backend replica fires every cron (`docs/cron-jobs.md`), so a guard held
+   * in process memory is not a guard: each replica has its own.
+   *
+   * A `Set` or `Map` of user ids beside an `@Cron` handler is the shape that
+   * produced duplicate AI provider calls and duplicate emails (P4-013, P4-018).
+   * Use `JobClaimService`.
+   */
+  it("does not guard cron work with process-local state", () => {
+    const ALLOWED = new Map([
+      [
+        "ai/insights/ai-insights.service.ts",
+        "generatingUsers is a cheap local short-circuit ONLY; the exclusion is a durable lease",
+      ],
+      [
+        "net-worth/net-worth.service.ts",
+        "recalcTimers is a debounce registry, not a guard: it coordinates nothing " +
+          "and duplicate work is harmless (the recalc is an absolute recomputation " +
+          "under the account lock). Losing a timer is made recoverable by " +
+          "sweepStaleSnapshots, which derives the staleness from accounts.updated_at " +
+          "rather than from anything held in memory",
+      ],
+    ]);
+
+    const offenders = sourceFiles()
+      .filter((file) => {
+        const source = read(file);
+        if (!/@Cron\(/.test(source)) return false;
+        // A field holding a Set/Map of ids at class scope, beside a cron.
+        return /^\s*private\s+(?:readonly\s+)?\w+\s*[:=]\s*(?:new\s+)?(?:Set|Map)\b/m.test(
+          source,
+        );
+      })
+      .map(relative)
+      .filter((file) => !ALLOWED.has(file));
+
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * TypeORM returns `[rows, rowCount]` for `UPDATE` and `DELETE` -- with or
+   * without a `RETURNING` clause -- and bare rows for everything else. So a
+   * `length` check on an `UPDATE ... RETURNING` result is not merely fragile: it
+   * is testing 2 against 0 and can only ever take one branch.
+   *
+   * That is not a hypothetical. `TourService.saveProgress` had a
+   * `updated.length === 0` guard whose whole job was to materialize a missing
+   * preferences row, and it could not fire; the row stayed missing and the tour
+   * progress went nowhere while the endpoint answered `{ saved: true }`. Nothing
+   * about the call site shows the shape, so this is a scan, not a review note.
+   */
+  it("never reads an UPDATE/DELETE result with an open-coded length check", () => {
+    /**
+     * `.query(...)` calls whose result is bound to a name, paren-matched so a
+     * multi-line SQL template is captured whole.
+     */
+    function boundQueryCalls(
+      source: string,
+    ): Array<{ line: number; sql: string; variable: string }> {
+      const calls: Array<{ line: number; sql: string; variable: string }> = [];
+      for (const match of source.matchAll(
+        /(?:const|let|var)\s+(\w+)(?:\s*:\s*[^=]+)?=\s*(?:await\s+)?[\w.]*\.query\s*\(/g,
+      )) {
+        let depth = 0;
+        let i = match.index! + match[0].length - 1;
+        const start = i;
+        while (i < source.length) {
+          if (source[i] === "(") depth++;
+          else if (source[i] === ")" && --depth === 0) break;
+          i++;
+        }
+        calls.push({
+          line: source.slice(0, match.index!).split("\n").length,
+          sql: source.slice(start, i),
+          variable: match[1],
+        });
+      }
+      return calls;
+    }
+
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const source = read(file);
+      const lines = source.split("\n");
+      for (const { line, sql, variable } of boundQueryCalls(source)) {
+        // The statement's first word, read from the literal the call passes. A
+        // call that passes a variable (`query(sql, params)`) shows nothing here
+        // and is skipped -- a scan can only see what is written inline.
+        const firstWord = sql.match(/[`"']\s*(\w+)/)?.[1] ?? "";
+        // Only the tuple-shaped commands can mislead a length check.
+        if (!/^(UPDATE|DELETE)$/i.test(firstWord)) continue;
+
+        // How that specific binding is consumed, a little way past the call.
+        const after = lines.slice(line - 1, line + 20).join("\n");
+        const lengthCheck = new RegExp(
+          `\\b${variable}\\s*\\.length\\s*(?:===|!==|==|>|<|>=|<=)`,
+        );
+        if (lengthCheck.test(after)) {
+          offenders.push(`${relative(file)}:${line}`);
+        }
+      }
+    }
 
     expect(offenders).toEqual([]);
   });

--- a/backend/src/common/jobs/entities/job-claim.entity.ts
+++ b/backend/src/common/jobs/entities/job-claim.entity.ts
@@ -1,0 +1,92 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import { User } from "../../../users/entities/user.entity";
+
+/**
+ * One durable claim on a piece of per-user work that must happen at most once.
+ *
+ * `ScheduleModule.forRoot()` lives in the API process, so **every backend
+ * replica fires every cron** (`docs/cron-jobs.md`). A guard held in process
+ * memory -- a `Set` of user ids, a boolean -- is therefore not a guard at all:
+ * each replica has its own. Nor is "query for a row like the one I am about to
+ * write": that is a check-then-act, and both replicas pass it.
+ *
+ * This table is the coordination point those jobs were missing. The unique key
+ * `(claim_type, user_id, claim_key)` makes the claim itself the atomic
+ * operation, so exactly one replica may send the email, call the AI provider or
+ * issue the token, and the loser learns it lost from the database rather than
+ * from its own memory.
+ */
+@Entity("job_claims")
+@Index(["claimType", "userId", "claimKey"], { unique: true })
+export class JobClaim {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  /** Which job this claim belongs to, e.g. `bill_reminder`. */
+  @Column({ type: "varchar", name: "claim_type", length: 64 })
+  claimType: string;
+
+  @Column({ type: "uuid", name: "user_id" })
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
+  user?: User;
+
+  /**
+   * What within that job is being claimed -- a local delivery date, a window
+   * hash, a generation bucket. Two claims with the same key are the same work.
+   */
+  @Column({ type: "varchar", name: "claim_key", length: 200 })
+  claimKey: string;
+
+  @CreateDateColumn({ name: "claimed_at" })
+  claimedAt: Date;
+
+  /**
+   * When a lease claim stops protecting the work. `null` means the claim is
+   * permanent: a "once per user per day" delivery, which nothing may retake.
+   * A lease whose holder died is retaken once this passes.
+   */
+  @Column({ type: "timestamp", name: "expires_at", nullable: true })
+  expiresAt: Date | null;
+
+  /**
+   * When the side effect this claim coordinates actually happened.
+   *
+   * The lease above answers "may I do this now"; this answers "has this been
+   * done", and they are different facts because the second has to outlive the
+   * process that asked the first. A claim taken before a send and read as proof of
+   * it is consumed by a replica killed in between, and the delivery is then owed
+   * forever with nothing able to notice (audit RV4-006).
+   *
+   * Written after the side effect succeeds, and re-read under the lease. A
+   * delivered row is never retaken, which is what keeps "once per window" true.
+   */
+  @Column({ type: "timestamp", name: "delivered_at", nullable: true })
+  deliveredAt: Date | null;
+
+  /**
+   * Which attempt owns the current lease.
+   *
+   * The unique key identifies the *work*; this identifies the holder. Without it
+   * `release` and `markDelivered` address the row by work alone, so a worker
+   * delayed past its own expiry can delete a lease another replica has since
+   * retaken -- leaving the replica that is actually sending with no exclusion --
+   * or record a delivery for a send that replica has not finished, so a genuine
+   * failure there is never retried (audit DR-RRV4-01).
+   *
+   * Minted per successful `claimLease`. NULL for a permanent `claimOnce` row,
+   * which has no attempt to identify: its claim is the fact itself.
+   */
+  @Column({ type: "uuid", name: "lease_token", nullable: true })
+  leaseToken: string | null;
+}

--- a/backend/src/common/jobs/job-claim.module.ts
+++ b/backend/src/common/jobs/job-claim.module.ts
@@ -1,0 +1,15 @@
+import { Global, Module } from "@nestjs/common";
+import { JobClaimService } from "./job-claim.service";
+import { UserMaintenanceService } from "./user-maintenance.service";
+
+/**
+ * Global so any cron can claim its work without every feature module
+ * re-declaring the provider -- and so there is exactly one claim mechanism to
+ * find when the next multi-replica job needs one.
+ */
+@Global()
+@Module({
+  providers: [JobClaimService, UserMaintenanceService],
+  exports: [JobClaimService, UserMaintenanceService],
+})
+export class JobClaimModule {}

--- a/backend/src/common/jobs/job-claim.service.spec.ts
+++ b/backend/src/common/jobs/job-claim.service.spec.ts
@@ -1,0 +1,317 @@
+import { DataSource, IsNull } from "typeorm";
+import {
+  JOB_CLAIM_RETENTION_DAYS,
+  JobClaimService,
+  JobClaimType,
+} from "./job-claim.service";
+import { JobClaim } from "./entities/job-claim.entity";
+import {
+  createScopedDbMocks,
+  DataSourceMock,
+} from "../../test-helpers/scoped-db-testing";
+
+jest.mock("../db/scoped-db", () =>
+  jest
+    .requireActual("../../test-helpers/scoped-db-testing")
+    .scopedDbMockModule(),
+);
+
+jest.mock("../db/with-context", () => ({
+  withSystemContext: jest.fn((fn: () => unknown) => fn()),
+}));
+
+/**
+ * The claim's whole value is that the *database* decides who won, so these specs
+ * pin down the statements and how their results are read.
+ *
+ * The result-reading is not incidental. A data-modifying `query` with `RETURNING`
+ * comes back as `[rows, rowCount]`, and on that tuple `result.length > 0` is
+ * always true -- so a naive reading makes every replica a winner and every
+ * replica sends. That is precisely the bug the claim exists to prevent, which is
+ * why the tuple shape is exercised here rather than assumed.
+ */
+describe("JobClaimService", () => {
+  let service: JobClaimService;
+  let manager: Record<string, jest.Mock>;
+  let dataSource: DataSourceMock;
+  let claimsRepo: Record<string, jest.Mock>;
+
+  const USER = "11111111-1111-4111-8111-111111111111";
+  /** A lease token as `claimLease` would have returned it. */
+  const LEASE = "22222222-2222-4222-8222-222222222222";
+
+  beforeEach(() => {
+    claimsRepo = { delete: jest.fn().mockResolvedValue({ affected: 1 }) };
+    const mocks = createScopedDbMocks([[JobClaim, claimsRepo]]);
+    manager = mocks.manager;
+    dataSource = mocks.dataSource;
+    service = new JobClaimService(dataSource as unknown as DataSource);
+  });
+
+  describe("claimOnce", () => {
+    it("inserts with ON CONFLICT DO NOTHING and no expiry", async () => {
+      manager.query.mockResolvedValue([[{ id: "claim-1" }], 1]);
+
+      const won = await service.claimOnce(
+        JobClaimType.BillReminder,
+        USER,
+        "2026-08-03#abc",
+      );
+
+      const [sql, params] = manager.query.mock.calls[0];
+      expect(sql).toContain("INSERT INTO job_claims");
+      expect(sql).toContain("ON CONFLICT (claim_type, user_id, claim_key)");
+      expect(sql).toContain("DO NOTHING");
+      expect(sql).toContain("RETURNING id");
+      expect(params).toEqual(["bill_reminder", USER, "2026-08-03#abc"]);
+      expect(won).toBe(true);
+    });
+
+    it("reports the loser correctly through the RETURNING tuple", async () => {
+      // `[[], 0]` -- the shape the driver hands back when nothing was inserted.
+      // Read as a bare array its length is 2, i.e. "won", which is the failure
+      // this assertion exists to prevent.
+      manager.query.mockResolvedValue([[], 0]);
+
+      expect(
+        await service.claimOnce(JobClaimType.BillReminder, USER, "k"),
+      ).toBe(false);
+    });
+
+    it("reports the winner when the driver returns bare rows", async () => {
+      manager.query.mockResolvedValue([{ id: "claim-1" }]);
+
+      expect(
+        await service.claimOnce(JobClaimType.BillReminder, USER, "k"),
+      ).toBe(true);
+    });
+  });
+
+  describe("claimLease", () => {
+    it("retakes a lease only once its own expiry has passed", async () => {
+      manager.query.mockResolvedValue([[{ id: "claim-1" }], 1]);
+
+      const won = await service.claimLease(
+        JobClaimType.AiInsightGeneration,
+        USER,
+        "generation",
+        60_000,
+      );
+
+      const [sql, params] = manager.query.mock.calls[0];
+      expect(sql).toContain("DO UPDATE");
+      // Both halves matter: a live lease must not be retaken, and a lease with no
+      // expiry (a permanent delivery claim) must never be retaken at all.
+      expect(sql).toContain("job_claims.expires_at IS NOT NULL");
+      expect(sql).toContain("job_claims.expires_at < CURRENT_TIMESTAMP");
+      expect(params.slice(0, 4)).toEqual([
+        "ai_insight_generation",
+        USER,
+        "generation",
+        "60000",
+      ]);
+      // The fifth parameter is the attempt's lease token, and it is what comes
+      // back: `release` and `markDelivered` compare it, so a worker delayed past
+      // its own expiry cannot write against a lease another replica retook
+      // (audit DR-RRV4-01).
+      expect(params[4]).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(sql).toContain("lease_token = EXCLUDED.lease_token");
+      expect(won).toBe(params[4]);
+    });
+
+    it("mints a distinct token per attempt", async () => {
+      manager.query.mockResolvedValue([[{ lease_token: "x" }], 1]);
+
+      const first = await service.claimLease(
+        JobClaimType.BillReminder,
+        USER,
+        "k",
+        60_000,
+      );
+      const second = await service.claimLease(
+        JobClaimType.BillReminder,
+        USER,
+        "k",
+        60_000,
+      );
+
+      // Two attempts on the same work are two holders, so the tokens have to
+      // differ -- a shared constant would let either write against the other's
+      // lease and the column would prove nothing.
+      expect(first).not.toBe(second);
+    });
+
+    it("stands down when a live lease exists", async () => {
+      manager.query.mockResolvedValue([[], 0]);
+
+      expect(
+        await service.claimLease(
+          JobClaimType.AiInsightGeneration,
+          USER,
+          "generation",
+          60_000,
+        ),
+      ).toBeNull();
+    });
+
+    it("never asks for a non-positive lease", async () => {
+      manager.query.mockResolvedValue([[{ id: "c" }], 1]);
+
+      await service.claimLease(JobClaimType.AiInsightGeneration, USER, "g", 0);
+
+      expect(manager.query.mock.calls[0][1][3]).toBe("1");
+    });
+
+    it("never retakes a lease whose work was already delivered", async () => {
+      manager.query.mockResolvedValue([[{ id: "c" }], 1]);
+
+      await service.claimLease(JobClaimType.BillReminder, USER, "k", 60_000);
+
+      // The expiry bounds *doing* the work; it says nothing about what has been
+      // done. Without this clause a lease that expired long ago would let a later
+      // run re-send something already delivered (audit RV4-006).
+      expect(manager.query.mock.calls[0][0]).toContain(
+        "job_claims.delivered_at IS NULL",
+      );
+    });
+  });
+
+  /**
+   * A claim answers "may I do this now"; the delivery record answers "has this
+   * been done". The second has to outlive the process that asked the first, which
+   * is exactly what a pre-send `claimOnce` could not express (audit RV4-006).
+   */
+  describe("markDelivered", () => {
+    it("records the delivery and ends the lease", async () => {
+      manager.query.mockResolvedValue([[], 1]);
+
+      await service.markDelivered(JobClaimType.BillReminder, USER, "k", LEASE);
+
+      // The lease token is declared into the transaction GUC first, so the
+      // migration-141 trigger admits this write and a previous binary's cannot.
+      const [declareSql, declareParams] = manager.query.mock.calls[0];
+      expect(declareSql).toContain("set_config('app.job_claim_lease_token'");
+      expect(declareParams).toEqual([LEASE]);
+      const [sql, params] = manager.query.mock.calls[1];
+      expect(sql).toContain("SET delivered_at = CURRENT_TIMESTAMP");
+      // Nothing left to protect: from here the row's job is to say the work is
+      // done, and `claimLease` refuses to retake a delivered row.
+      expect(sql).toContain("expires_at = NULL");
+      // And it is this attempt's row, not merely this work's.
+      expect(sql).toContain("lease_token = $4::uuid");
+      expect(params).toEqual(["bill_reminder", USER, "k", LEASE]);
+    });
+
+    it("records nothing and says so when the lease was retaken", async () => {
+      // The DR-RRV4-01 interleaving: this attempt stalled past its expiry, another
+      // replica retook the lease, and this one has just finished sending. Stamping
+      // `delivered_at` here would claim a delivery for the *new* holder's send, so
+      // a genuine failure there would never be retried. The work stays owed
+      // instead, and the log is what makes the re-send explicable.
+      manager.query.mockResolvedValue([[], 0]);
+      const warn = jest
+        .spyOn(service["logger"], "warn")
+        .mockImplementation(() => undefined);
+
+      await service.markDelivered(JobClaimType.BillReminder, USER, "k", LEASE);
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("lease was retaken"),
+      );
+    });
+  });
+
+  describe("wasDelivered", () => {
+    it("is true only for a row carrying a delivery timestamp", async () => {
+      manager.query.mockResolvedValue([{ "1": 1 }]);
+
+      expect(
+        await service.wasDelivered(JobClaimType.BillReminder, USER, "k"),
+      ).toBe(true);
+      expect(manager.query.mock.calls[0][0]).toContain(
+        "delivered_at IS NOT NULL",
+      );
+    });
+
+    it("is false for a claimed-but-unsent window", async () => {
+      // The state the fix exists for: a replica claimed and died before sending.
+      // The row is there, the delivery is not, so the work is still owed.
+      manager.query.mockResolvedValue([]);
+
+      expect(
+        await service.wasDelivered(JobClaimType.BillReminder, USER, "k"),
+      ).toBe(false);
+    });
+  });
+
+  describe("release", () => {
+    it("deletes a permanent claim so a failed send can be retried", async () => {
+      // No token: a `claimOnce` caller's claim *is* the fact, so there is no
+      // attempt to identify and the row is addressed by the work alone -- and
+      // the IS NULL predicate keeps this method off tokenized leases entirely.
+      await service.releasePermanentClaim(
+        JobClaimType.MortgageReminder,
+        USER,
+        "k",
+      );
+
+      expect(claimsRepo.delete).toHaveBeenCalledWith({
+        claimType: "mortgage_reminder",
+        userId: USER,
+        claimKey: "k",
+        leaseToken: IsNull(),
+      });
+    });
+
+    it("releases only its own lease when the caller holds a token", async () => {
+      await service.releaseLease(
+        JobClaimType.MortgageReminder,
+        USER,
+        "k",
+        LEASE,
+      );
+
+      // A stalled attempt releasing by work alone would free the lease the
+      // replica now sending holds, leaving it with no exclusion at all
+      // (audit DR-RRV4-01).
+      expect(claimsRepo.delete).not.toHaveBeenCalled();
+      // The token is declared into the GUC first (migration-141 trigger), then the
+      // delete filters on it too.
+      const [declareSql, declareParams] = manager.query.mock.calls[0];
+      expect(declareSql).toContain("set_config('app.job_claim_lease_token'");
+      expect(declareParams).toEqual([LEASE]);
+      const [sql, params] = manager.query.mock.calls[1];
+      expect(sql).toContain("DELETE FROM job_claims");
+      expect(sql).toContain("lease_token = $4::uuid");
+      expect(params).toEqual(["mortgage_reminder", USER, "k", LEASE]);
+    });
+  });
+
+  describe("sweepOldClaims", () => {
+    it("deletes only claims past the retention window", async () => {
+      manager.query.mockResolvedValue([[], 3]);
+
+      await service.sweepOldClaims();
+
+      const [sql, params] = manager.query.mock.calls[0];
+      expect(sql).toContain("DELETE FROM job_claims");
+      expect(sql).toContain("claimed_at <");
+      expect(params).toEqual([String(JOB_CLAIM_RETENTION_DAYS)]);
+    });
+
+    it("logs and swallows a sweep failure rather than crashing the cron", async () => {
+      manager.query.mockRejectedValue(new Error("connection reset"));
+      const warn = jest
+        .spyOn(service["logger"], "warn")
+        .mockImplementation(() => undefined);
+
+      await expect(service.sweepOldClaims()).resolves.toBeUndefined();
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("connection reset"),
+      );
+    });
+  });
+});

--- a/backend/src/common/jobs/job-claim.service.ts
+++ b/backend/src/common/jobs/job-claim.service.ts
@@ -1,0 +1,339 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { randomUUID } from "crypto";
+import { DataSource, EntityManager, IsNull } from "typeorm";
+import { withScopedDb } from "../db/scoped-db";
+import { withSystemContext } from "../db/with-context";
+import { affectedRowCount, returnedRows } from "../db/query-result";
+import { JobClaim } from "./entities/job-claim.entity";
+
+/**
+ * The one durable claim mechanism for work that must happen at most once per
+ * user, however many backend replicas fire the same cron.
+ *
+ * The multi-replica jobs in this codebase need three things, and they used to
+ * invent a different ad hoc guard for each (audit DR-04-04):
+ *
+ * - `claimLease` -- an **exclusion**. Only one replica may do this now. Expires,
+ *   so a replica killed mid-run does not lock the user out until someone notices;
+ *   `releaseLease` returns it early. Returns a **lease token** identifying the
+ *   winning attempt, which `markDelivered` and `releaseLease` require: the unique key names the
+ *   work, not the holder, so without the token a worker delayed past its own expiry
+ *   could delete a lease another replica had retaken, or record a delivery for a
+ *   send that replica had not finished (audit DR-RRV4-01).
+ *
+ * - `markDelivered` / `wasDelivered` -- the **delivery record**. Written after the
+ *   side effect succeeded, re-read under the lease to decide whether the work is
+ *   still owed. A delivered row is never retaken.
+ *
+ * - `claimOnce` -- a permanent claim, for work where the claim row itself *is* the
+ *   fact and nothing leaves the database: a posted occurrence, an alert
+ *   fingerprint. `releasePermanentClaim` hands it back on failure.
+ *
+ * **A claim is not a record that the work was done**, and reaching for `claimOnce`
+ * as though it were is how a delivery gets lost: the claim commits, the process
+ * dies, and the permanent row now says a send happened that never did (audit
+ * FV4-004, FV4-005, RV4-006). So anything with a crash window between claiming and
+ * sending takes the lease *and* keeps a delivery record -- either on this table via
+ * `markDelivered`, as the bill and mortgage reminders do, or in a column of its own
+ * where the domain already has one (`emergency_access_settings
+ * .last_reminder_sent_at`, `emergency_access_contacts.claim_notified_at`).
+ *
+ * That makes those jobs **at-least-once**: a process killed after the provider
+ * accepted but before the record committed re-sends next run. For a reminder that
+ * is the right trade, and it is a decision rather than an oversight -- see
+ * `docs/cron-jobs.md`, which states the contract per job.
+ *
+ * Both are a single statement, so the claim is the serialization point: there is
+ * no window between deciding and recording. Every call must sit inside an
+ * ambient identity context (`withUserContext` / `withSystemContext`) like any
+ * other database access.
+ */
+
+/** How long claim rows are kept before the sweep removes them. */
+export const JOB_CLAIM_RETENTION_DAYS = 30;
+
+/** Claim types in use. Spelled out so a typo is a compile error, not a duplicate email. */
+export const JobClaimType = {
+  BillReminder: "bill_reminder",
+  MortgageReminder: "mortgage_reminder",
+  EmergencyAccessReminder: "emergency_access_reminder",
+  EmergencyAccessGrantNotify: "emergency_access_grant_notify",
+  AiInsightGeneration: "ai_insight_generation",
+  UserMaintenance: "user_maintenance",
+  DemoReset: "demo_reset",
+  DemoIntraday: "demo_intraday",
+} as const;
+
+export type JobClaimType = (typeof JobClaimType)[keyof typeof JobClaimType];
+
+@Injectable()
+export class JobClaimService {
+  private readonly logger = new Logger(JobClaimService.name);
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  /**
+   * Claim `(type, userId, key)` permanently. True for the one caller that won.
+   *
+   * `ON CONFLICT DO NOTHING` with `RETURNING` is what makes this safe across
+   * replicas: the loser gets an empty result from the database, not a stale
+   * "nothing exists yet" from its own read.
+   */
+  async claimOnce(
+    claimType: JobClaimType,
+    userId: string,
+    claimKey: string,
+  ): Promise<boolean> {
+    const rows = await withScopedDb(this.dataSource, (manager) =>
+      manager.query(
+        `INSERT INTO job_claims (claim_type, user_id, claim_key, expires_at)
+         VALUES ($1, $2, $3, NULL)
+         ON CONFLICT (claim_type, user_id, claim_key) DO NOTHING
+         RETURNING id`,
+        [claimType, userId, claimKey],
+      ),
+    );
+    return affectedRowCount(rows) > 0;
+  }
+
+  /**
+   * Claim `(type, userId, key)` for `ttlMs`. Returns the winning attempt's lease
+   * token, or `null` for a caller that lost.
+   *
+   * The `DO UPDATE ... WHERE` arm is the lease: an existing row is only retaken
+   * when its own expiry has passed, which is how a worker killed mid-run stops
+   * blocking the next one without a human. A live lease returns no row, so the
+   * loser knows to stand down rather than doing the work twice.
+   *
+   * `delivered_at IS NULL` is also in that arm, so a lease whose work is already
+   * done is never retaken however long ago it expired. Without it the expiry alone
+   * would let a later run re-do delivered work -- the lease is a bound on *doing*,
+   * not a statement about what has been done.
+   *
+   * The token is what makes "the lease" a thing a caller can *hold*. Retaking
+   * overwrites it, so a previous holder that comes back after its expiry can no
+   * longer write against the row: `release` and `markDelivered` both compare it
+   * (audit DR-RRV4-01).
+   */
+  async claimLease(
+    claimType: JobClaimType,
+    userId: string,
+    claimKey: string,
+    ttlMs: number,
+  ): Promise<string | null> {
+    const leaseToken = randomUUID();
+    const rows = await withScopedDb(this.dataSource, (manager) =>
+      manager.query(
+        `INSERT INTO job_claims (claim_type, user_id, claim_key, expires_at, lease_token)
+         VALUES ($1, $2, $3,
+                 CURRENT_TIMESTAMP + ($4::text || ' milliseconds')::interval,
+                 $5::uuid)
+         ON CONFLICT (claim_type, user_id, claim_key) DO UPDATE
+            SET claimed_at = CURRENT_TIMESTAMP,
+                expires_at = CURRENT_TIMESTAMP + ($4::text || ' milliseconds')::interval,
+                lease_token = EXCLUDED.lease_token
+          WHERE job_claims.delivered_at IS NULL
+            AND job_claims.expires_at IS NOT NULL
+            AND job_claims.expires_at < CURRENT_TIMESTAMP
+         RETURNING lease_token`,
+        [
+          claimType,
+          userId,
+          claimKey,
+          String(Math.max(1, Math.round(ttlMs))),
+          leaseToken,
+        ],
+      ),
+    );
+    return affectedRowCount(rows) > 0 ? leaseToken : null;
+  }
+
+  /**
+   * Give a lease back, as the attempt that holds it.
+   *
+   * On the happy path this ends a lease early. After a failure it un-consumes a
+   * delivery, so a transient SMTP outage costs a retry rather than the whole
+   * day's reminder -- which is the behaviour the pre-claim code had by accident
+   * and which claiming first would otherwise take away.
+   *
+   * `leaseToken` is **required by the signature**: it refuses the delete when the
+   * row belongs to a different attempt, because a worker delayed past its own
+   * expiry would otherwise remove a live lease and leave the replica actually
+   * sending with no exclusion at all (audit DR-RRV4-01). A permanent `claimOnce`
+   * row, which has no attempt to identify, goes through
+   * `releasePermanentClaim` instead -- two methods, so the compiler decides
+   * which contract a call site is under rather than an optional argument
+   * silently bypassing the ownership predicate (stack review, DR-04).
+   *
+   * The token goes both in the statement's `WHERE` and, via `set_config`, into the
+   * transaction-local `app.job_claim_lease_token` GUC the migration-141 trigger
+   * checks. The `WHERE` protects new code from new code; the GUC is what lets the
+   * database refuse a *previous-release* pod's untokenized delete of a live lease
+   * this deployment now holds (audit V4R3-004).
+   *
+   * A delivered row is deliberately **not** protected from this: the only callers
+   * that release are the ones that just failed or just declined, and both hold the
+   * lease. A caller that has recorded a delivery has nothing to release.
+   */
+  async releaseLease(
+    claimType: JobClaimType,
+    userId: string,
+    claimKey: string,
+    leaseToken: string,
+  ): Promise<void> {
+    await withScopedDb(this.dataSource, async (manager) => {
+      await this.declareLeaseToken(manager, leaseToken);
+      await manager.query(
+        `DELETE FROM job_claims
+          WHERE claim_type = $1 AND user_id = $2 AND claim_key = $3
+            AND lease_token = $4::uuid`,
+        [claimType, userId, claimKey, leaseToken],
+      );
+    });
+  }
+
+  /**
+   * Give back a permanent `claimOnce` claim.
+   *
+   * Its own method rather than an optional-token arm of `releaseLease`: a lease
+   * caller that forgot its token would otherwise compile, silently skip the
+   * ownership predicate and the GUC the migration-141 trigger checks, and delete
+   * whatever attempt currently holds the row. The compiler now refuses that call
+   * shape outright. A permanent claim has no attempt to identify -- the trigger
+   * leaves NULL-token rows alone -- so this is the only untokenized delete.
+   */
+  async releasePermanentClaim(
+    claimType: JobClaimType,
+    userId: string,
+    claimKey: string,
+  ): Promise<void> {
+    await withScopedDb(this.dataSource, async (manager) => {
+      // `IsNull()` is part of the contract, not decoration: it makes this method
+      // structurally incapable of deleting a tokenized lease, even if a caller
+      // reaches it with a lease's work key by mistake.
+      await manager.getRepository(JobClaim).delete({
+        claimType,
+        userId,
+        claimKey,
+        leaseToken: IsNull(),
+      });
+    });
+  }
+
+  /**
+   * Announce, for this transaction only, which lease this session is acting on.
+   *
+   * The migration-141 trigger compares it against a live tokenized row's own token
+   * and rejects a mismatch, so a previous-release binary -- which never sets it --
+   * cannot mutate a lease new code holds. `is_local = true` scopes it to the
+   * surrounding `withScopedDb` transaction.
+   */
+  private async declareLeaseToken(
+    manager: EntityManager,
+    leaseToken: string,
+  ): Promise<void> {
+    await manager.query(
+      `SELECT set_config('app.job_claim_lease_token', $1, true)`,
+      [leaseToken],
+    );
+  }
+
+  /**
+   * Record that the side effect this claim coordinates actually happened.
+   *
+   * Called **after** the send, and it clears the lease: there is nothing left to
+   * protect, and the row's job from here on is to say the work is done. Together
+   * with `wasDelivered` this is what makes a claimed-but-unsent window recoverable
+   * -- the failure the permanent `claimOnce` could not express (audit RV4-006).
+   *
+   * `lease_token` is a predicate, so this records a delivery only for the attempt
+   * that is still the holder. A worker whose lease was retaken while it was stalled
+   * writes nothing and logs it: the send it just made is real but unrecordable, so
+   * the work stays owed and the next run re-sends. That is the at-least-once side
+   * of the trade, and it is strictly better than the alternative -- stamping
+   * `delivered_at` for a send the *current* holder has not finished, which would
+   * make a genuine failure there permanent (audit DR-RRV4-01).
+   */
+  async markDelivered(
+    claimType: JobClaimType,
+    userId: string,
+    claimKey: string,
+    leaseToken: string,
+  ): Promise<void> {
+    const updated = await withScopedDb(this.dataSource, async (manager) => {
+      // The GUC lets the trigger admit this write; the WHERE makes it apply only to
+      // the row this attempt still holds (audit V4R3-004, DR-RRV4-01).
+      await this.declareLeaseToken(manager, leaseToken);
+      return manager.query(
+        `UPDATE job_claims
+            SET delivered_at = CURRENT_TIMESTAMP,
+                expires_at = NULL
+          WHERE claim_type = $1 AND user_id = $2 AND claim_key = $3
+            AND lease_token = $4::uuid`,
+        [claimType, userId, claimKey, leaseToken],
+      );
+    });
+    if (affectedRowCount(updated) === 0) {
+      this.logger.warn(
+        `Delivery of ${claimType}/${claimKey} for user ${userId} could not be ` +
+          `recorded: the lease was retaken by another attempt. The work stays owed ` +
+          `and will be re-sent.`,
+      );
+    }
+  }
+
+  /**
+   * Has this exact work already been delivered?
+   *
+   * Read under the lease, because that is the only order in which the answer is
+   * stable: a claim says somebody intended to send, and only this says somebody
+   * did. A lease holder that finds `true` stands down and hands the lease back.
+   */
+  async wasDelivered(
+    claimType: JobClaimType,
+    userId: string,
+    claimKey: string,
+  ): Promise<boolean> {
+    const rows = await withScopedDb(this.dataSource, (manager) =>
+      manager.query(
+        `SELECT 1 FROM job_claims
+          WHERE claim_type = $1
+            AND user_id = $2
+            AND claim_key = $3
+            AND delivered_at IS NOT NULL`,
+        [claimType, userId, claimKey],
+      ),
+    );
+    return returnedRows(rows).length > 0;
+  }
+
+  /**
+   * Drop claim rows older than the retention window.
+   *
+   * Idempotent by construction -- the predicate is "already old" -- so two
+   * replicas racing the sweep delete the same rows and the loser deletes none.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_4AM)
+  async sweepOldClaims(): Promise<void> {
+    try {
+      const removed = await withSystemContext(() =>
+        withScopedDb(this.dataSource, async (manager) => {
+          const result = await manager.query(
+            `DELETE FROM job_claims
+              WHERE claimed_at < CURRENT_TIMESTAMP - ($1::text || ' days')::interval`,
+            [String(JOB_CLAIM_RETENTION_DAYS)],
+          );
+          return Array.isArray(result) ? (result[1] as number) : 0;
+        }),
+      );
+      if (removed > 0) {
+        this.logger.log(`Swept ${removed} expired job claim(s)`);
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Job claim sweep failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}

--- a/backend/src/common/jobs/user-maintenance.service.spec.ts
+++ b/backend/src/common/jobs/user-maintenance.service.spec.ts
@@ -1,0 +1,177 @@
+import { ConflictException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+import {
+  USER_MAINTENANCE_CLAIM_KEY,
+  USER_MAINTENANCE_LEASE_MS,
+  UserMaintenanceService,
+} from "./user-maintenance.service";
+import { JobClaimType } from "./job-claim.service";
+import { createScopedDbMocks } from "../../test-helpers/scoped-db-testing";
+import {
+  createJobClaimMock,
+  jobClaimProvider,
+  TEST_LEASE_TOKEN,
+  type JobClaimMock,
+} from "../../test-helpers/job-claim-testing";
+
+jest.mock("../db/scoped-db", () =>
+  jest
+    .requireActual("../../test-helpers/scoped-db-testing")
+    .scopedDbMockModule(),
+);
+
+/**
+ * Three operations replace a user's whole dataset -- a backup restore, delete my
+ * data, and a `.mny` import with "start fresh". Each is internally consistent;
+ * two of them overlapping is not, and the import is not one transaction at all,
+ * so for its duration the dataset is legitimately empty. The hourly auto-backup
+ * fired into that window would save the empty dataset as today's file and then
+ * rotate the last good one out to satisfy retention -- unrecoverable, and
+ * nothing flags it.
+ */
+describe("UserMaintenanceService", () => {
+  const userId = "11111111-1111-1111-1111-111111111111";
+
+  let service: UserMaintenanceService;
+  let scoped: ReturnType<typeof createScopedDbMocks>;
+  let jobClaims: JobClaimMock;
+
+  /** No import in flight and no live lease. */
+  function quiet() {
+    scoped.manager.query.mockResolvedValue([{ present: false }]);
+  }
+
+  beforeEach(async () => {
+    scoped = createScopedDbMocks([]);
+    jobClaims = createJobClaimMock();
+    quiet();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserMaintenanceService,
+        { provide: DataSource, useValue: scoped.dataSource },
+        jobClaimProvider(jobClaims),
+      ],
+    }).compile();
+
+    service = module.get(UserMaintenanceService);
+  });
+
+  describe("isUnderMaintenance", () => {
+    it("counts an active import job and a live lease, in one query", async () => {
+      scoped.manager.query.mockResolvedValue([{ present: true }]);
+
+      expect(await service.isUnderMaintenance(userId)).toBe(true);
+
+      const [sql, params] = scoped.manager.query.mock.calls[0];
+      expect(sql).toContain("FROM import_jobs");
+      expect(sql).toContain("status IN ('pending', 'running')");
+      expect(sql).toContain("FROM job_claims");
+      // An expired lease is not maintenance -- otherwise a replica killed
+      // mid-restore would lock the user out of their own backups forever.
+      expect(sql).toContain("expires_at > CURRENT_TIMESTAMP");
+      expect(params).toEqual([
+        userId,
+        JobClaimType.UserMaintenance,
+        USER_MAINTENANCE_CLAIM_KEY,
+      ]);
+    });
+
+    it("is false when nothing is replacing the data", async () => {
+      expect(await service.isUnderMaintenance(userId)).toBe(false);
+    });
+
+    it("does not read a missing row as maintenance", async () => {
+      // A read that returned nothing is not "everything is fine": it would make
+      // every backup skip forever. `EXISTS` always returns a row, so an empty
+      // result means something else went wrong -- and reporting false there
+      // matches the failure mode the callers already tolerate (they proceed).
+      scoped.manager.query.mockResolvedValue([]);
+
+      expect(await service.isUnderMaintenance(userId)).toBe(false);
+    });
+  });
+
+  describe("withMaintenanceLease", () => {
+    it("holds the lease across the body and gives it back", async () => {
+      const order: string[] = [];
+      jobClaims.claimLease.mockImplementation(async () => {
+        order.push("claim");
+        return TEST_LEASE_TOKEN;
+      });
+      jobClaims.releaseLease.mockImplementation(async () => {
+        order.push("release");
+      });
+
+      const result = await service.withMaintenanceLease(
+        userId,
+        "backup restore",
+        async () => {
+          order.push("body");
+          return "done";
+        },
+      );
+
+      expect(result).toBe("done");
+      expect(order).toEqual(["claim", "body", "release"]);
+      expect(jobClaims.claimLease).toHaveBeenCalledWith(
+        JobClaimType.UserMaintenance,
+        userId,
+        USER_MAINTENANCE_CLAIM_KEY,
+        USER_MAINTENANCE_LEASE_MS,
+      );
+    });
+
+    it("refuses with a 409 when another operation holds the lease", async () => {
+      jobClaims.claimLease.mockResolvedValue(null);
+      const body = jest.fn();
+
+      await expect(
+        service.withMaintenanceLease(userId, "restore", body),
+      ).rejects.toThrow(ConflictException);
+      // A refused command must not already have written.
+      expect(body).not.toHaveBeenCalled();
+    });
+
+    it("refuses while an import is in flight, before taking a lease", async () => {
+      // The import holds no lease of its own -- its `import_jobs` row is the
+      // fact -- so the check has to be separate, and it has to come first.
+      scoped.manager.query.mockResolvedValue([{ present: true }]);
+      const body = jest.fn();
+
+      await expect(
+        service.withMaintenanceLease(userId, "restore", body),
+      ).rejects.toThrow(ConflictException);
+      expect(jobClaims.claimLease).not.toHaveBeenCalled();
+      expect(body).not.toHaveBeenCalled();
+    });
+
+    it("gives the lease back when the body throws", async () => {
+      await expect(
+        service.withMaintenanceLease(userId, "restore", async () => {
+          throw new Error("restore failed");
+        }),
+      ).rejects.toThrow("restore failed");
+
+      expect(jobClaims.releaseLease).toHaveBeenCalledWith(
+        JobClaimType.UserMaintenance,
+        userId,
+        USER_MAINTENANCE_CLAIM_KEY,
+        // With the token: a restore that outran its own lease must not release the
+        // lease whoever holds it now is relying on (audit DR-RRV4-01).
+        TEST_LEASE_TOKEN,
+      );
+    });
+
+    it("does not fail a completed operation because the release failed", async () => {
+      // The lease expires anyway, so a failed release costs a delay -- turning a
+      // finished restore into an error would be the worse outcome.
+      jobClaims.releaseLease.mockRejectedValue(new Error("connection reset"));
+
+      await expect(
+        service.withMaintenanceLease(userId, "restore", async () => "done"),
+      ).resolves.toBe("done");
+    });
+  });
+});

--- a/backend/src/common/jobs/user-maintenance.service.ts
+++ b/backend/src/common/jobs/user-maintenance.service.ts
@@ -1,0 +1,164 @@
+import { ConflictException, Injectable, Logger } from "@nestjs/common";
+import { DataSource } from "typeorm";
+import { withScopedDb } from "../db/scoped-db";
+import { returnedRows } from "../db/query-result";
+import { JobClaimService, JobClaimType } from "./job-claim.service";
+import { tr } from "../../i18n/translate";
+
+/**
+ * Exclusion between the operations that replace a user's whole dataset and
+ * anything that would read or derive from it while they run (audit DR-04-02).
+ *
+ * Three operations rewrite everything a user owns: a backup restore, the
+ * self-service "delete my data", and a `.mny` import started with
+ * `wipeExistingData`. Each is internally consistent -- restore and delete are
+ * one transaction apiece, so a concurrent reader sees the before or the after and
+ * never a half -- but they are not consistent with *each other*, and the `.mny`
+ * import is not one transaction at all: its wipe commits and the rows then
+ * arrive over the following minutes, so for the length of the import the user's
+ * dataset is legitimately empty.
+ *
+ * That window is where the damage is. The hourly auto-backup fired into it would
+ * export the empty dataset, write it as today's file, and then enforce retention
+ * -- rotating the last good backup out to make room for a file containing
+ * nothing. Nothing in the system flags that, and it is not recoverable.
+ *
+ * So: a lease the destructive operations hold, and an `isUnderMaintenance` read
+ * everything derived consults. An active `import_jobs` row counts as
+ * maintenance without a lease of its own -- the row already *is* the fact, and
+ * inventing a second parallel truth for it is how the two drift.
+ */
+
+/** One maintenance operation per user, so the key names the fact, not the window. */
+export const USER_MAINTENANCE_CLAIM_KEY = "maintenance";
+
+/**
+ * How long a maintenance lease survives without its holder.
+ *
+ * Long enough for a large restore, short enough that a replica killed mid-restore
+ * does not lock the user out of their own backups for a working day. The happy
+ * path releases explicitly, so this only matters after a crash.
+ */
+export const USER_MAINTENANCE_LEASE_MS = 60 * 60 * 1000;
+
+@Injectable()
+export class UserMaintenanceService {
+  private readonly logger = new Logger(UserMaintenanceService.name);
+
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly jobClaims: JobClaimService,
+  ) {}
+
+  /**
+   * True while this user's dataset is being replaced.
+   *
+   * A hint, not a guarantee: a caller that must not *overlap* takes the lease
+   * instead. This is for work that is merely pointless or harmful during the
+   * window and can simply happen later -- a scheduled backup, a derived
+   * recomputation -- where skipping is the whole remedy.
+   */
+  async isUnderMaintenance(userId: string): Promise<boolean> {
+    return withScopedDb(this.dataSource, async (manager) => {
+      const rows = returnedRows<{ present: boolean }>(
+        await manager.query(
+          `SELECT EXISTS (
+             SELECT 1 FROM import_jobs
+              WHERE user_id = $1 AND status IN ('pending', 'running')
+           ) OR EXISTS (
+             SELECT 1 FROM job_claims
+              WHERE claim_type = $2 AND user_id = $1 AND claim_key = $3
+                AND expires_at IS NOT NULL
+                AND expires_at > CURRENT_TIMESTAMP
+           ) AS present`,
+          [userId, JobClaimType.UserMaintenance, USER_MAINTENANCE_CLAIM_KEY],
+        ),
+      );
+      return rows[0]?.present === true;
+    });
+  }
+
+  /**
+   * Run `fn` holding this user's maintenance lease, refusing to start if
+   * anything else is already replacing their data.
+   *
+   * The refusal is a `409`, which is the honest answer: the request was
+   * well-formed and is being declined because of the account's current state,
+   * and retrying once the other operation finishes will work. It happens before
+   * `fn` does anything, so a refused maintenance operation has written nothing --
+   * the rule in the root `CLAUDE.md`.
+   */
+  async withMaintenanceLease<T>(
+    userId: string,
+    operation: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    // An import in flight is maintenance too, and it has no lease to collide
+    // with, so it is checked separately. This read is not a guarantee against an
+    // import starting a moment later -- that side is guarded by the import's own
+    // slot claim, which this lease makes it lose.
+    if (await this.hasActiveImport(userId)) {
+      throw this.busy();
+    }
+
+    const leased = await this.jobClaims.claimLease(
+      JobClaimType.UserMaintenance,
+      userId,
+      USER_MAINTENANCE_CLAIM_KEY,
+      USER_MAINTENANCE_LEASE_MS,
+    );
+    if (!leased) {
+      throw this.busy();
+    }
+
+    this.logger.log(`Maintenance lease taken for user ${userId}: ${operation}`);
+    try {
+      return await fn();
+    } finally {
+      await this.jobClaims
+        .releaseLease(
+          JobClaimType.UserMaintenance,
+          userId,
+          USER_MAINTENANCE_CLAIM_KEY,
+          // By token, so a restore that outran its own lease does not release the
+          // one the operation now running holds (DR-RRV4-01).
+          leased,
+        )
+        .catch((error) =>
+          // The lease expires on its own, so a failed release costs a delay, not
+          // a permanent lockout -- but it must not turn a completed restore into
+          // a failed request.
+          this.logger.warn(
+            `Failed to release the maintenance lease for user ${userId}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          ),
+        );
+    }
+  }
+
+  /** True while an import job for this user is pending or running. */
+  private async hasActiveImport(userId: string): Promise<boolean> {
+    return withScopedDb(this.dataSource, async (manager) => {
+      const rows = returnedRows<{ present: boolean }>(
+        await manager.query(
+          `SELECT EXISTS (
+             SELECT 1 FROM import_jobs
+              WHERE user_id = $1 AND status IN ('pending', 'running')
+           ) AS present`,
+          [userId],
+        ),
+      );
+      return rows[0]?.present === true;
+    });
+  }
+
+  private busy(): ConflictException {
+    return new ConflictException(
+      tr(
+        "errors.maintenance.inProgress",
+        "Another operation is currently replacing this account's data. Wait for it to finish and try again.",
+      ),
+    );
+  }
+}

--- a/backend/src/currencies/currency-references.spec.ts
+++ b/backend/src/currencies/currency-references.spec.ts
@@ -278,16 +278,31 @@ describe("currency global liveness", () => {
     );
   });
 
-  it("is the only SECURITY DEFINER function in the schema", () => {
-    // The RLS design relies on invoker functions everywhere else; a second
-    // definer function is a privilege decision that needs its own review, not
-    // something to notice later.
+  it("declares only the known, reviewed SECURITY DEFINER functions", () => {
+    // The RLS design relies on invoker functions everywhere else; a definer
+    // function bypasses the caller's policies, so each one is a privilege
+    // decision that needs its own review -- this list is that review. A new
+    // definer function must be added here deliberately, not noticed later.
     // Counted over function definitions only -- COMMENT ON bodies are string
     // literals that survive comment stripping and mention the attribute in prose.
     const definitions =
       uncommented.match(/CREATE (?:OR REPLACE )?FUNCTION[\s\S]*?\$\$/g) ?? [];
     const definers = definitions.filter((d) => /SECURITY DEFINER/.test(d));
-    expect(definers).toHaveLength(1);
+    const names = definers.map((d) => /FUNCTION\s+(\w+)/.exec(d)?.[1]).sort();
+    expect(names).toEqual([
+      // The global currency-liveness answer, evaluated across every tenant.
+      "currency_code_in_use_globally",
+      // Records an attachment-blob tombstone as the table owner, so the deletion
+      // is captured under RLS whichever tenant's DELETE fired the trigger
+      // (migration 139).
+      "record_attachment_blob_tombstone",
+    ]);
+    // Every definer function pins its search_path: without it, a definer can be
+    // redirected at objects the caller controls -- the escalation this allowlist
+    // exists to keep reviewed.
+    for (const d of definers) {
+      expect(d).toMatch(/SET search_path = /);
+    }
   });
 
   /**

--- a/backend/src/currencies/exchange-rate.service.spec.ts
+++ b/backend/src/currencies/exchange-rate.service.spec.ts
@@ -19,6 +19,13 @@ jest.mock("../common/db/scoped-db", () =>
 describe("ExchangeRateService", () => {
   let service: ExchangeRateService;
   let exchangeRateRepository: Record<string, jest.Mock>;
+  /** Rows the single-rate upsert wrote, in order, as the service supplied them. */
+  let upsertedRates: Array<{
+    fromCurrency: string;
+    toCurrency: string;
+    rate: number;
+    source: string;
+  }>;
   let currencyRepository: Record<string, jest.Mock>;
   let userPreferenceRepository: Record<string, jest.Mock>;
   let dataSource: Record<string, jest.Mock>;
@@ -58,7 +65,58 @@ describe("ExchangeRateService", () => {
     ...overrides,
   });
 
+  /**
+   * Answer `manager.query` by statement instead of with one blanket value.
+   *
+   * The single-rate save is now `INSERT ... ON CONFLICT DO UPDATE RETURNING id`,
+   * so a test that also needs the currency-list query cannot use one
+   * `mockResolvedValue` for both. This records what the upsert wrote -- which is
+   * what the assertions are about -- and answers the currency list from
+   * `codes`.
+   */
+  function routeRateQueries(codes: string[]): void {
+    dataSource.query.mockImplementation(
+      async (sql: string, params?: unknown[]) => {
+        if (
+          typeof sql === "string" &&
+          sql.includes("INSERT INTO exchange_rates") &&
+          sql.includes("RETURNING id")
+        ) {
+          const [fromCurrency, toCurrency, , rate] = params as [
+            string,
+            string,
+            Date,
+            number,
+          ];
+          const id = upsertedRates.length + 1;
+          upsertedRates.push({
+            fromCurrency,
+            toCurrency,
+            rate,
+            source: "yahoo_finance",
+          });
+          return [{ id }];
+        }
+        if (typeof sql === "string" && sql.includes("SELECT DISTINCT code")) {
+          return codes.map((code) => ({ code }));
+        }
+        return [];
+      },
+    );
+    // The service reads the upserted row back by id.
+    exchangeRateRepository.findOne.mockImplementation(
+      async ({ where }: { where: { id?: number } }) =>
+        where?.id === undefined
+          ? null
+          : { id: where.id, ...upsertedRates[where.id - 1] },
+    );
+  }
+
   beforeEach(async () => {
+    // The single-rate save is now one `INSERT ... ON CONFLICT DO UPDATE
+    // RETURNING id` through the manager, so the spec records the statement and
+    // hands back the row it wrote. `findOne` still answers the by-id read-back.
+    upsertedRates = [];
     exchangeRateRepository = {
       findOne: jest.fn(),
       find: jest.fn(),
@@ -226,17 +284,10 @@ describe("ExchangeRateService", () => {
         { code: "EUR" },
       ]);
 
-      // Mock fetchQuote via yahooFinanceService
+      routeRateQueries(["USD", "CAD", "EUR"]);
       yahooFinanceService.fetchQuote.mockResolvedValue({
         regularMarketPrice: 1.365,
       });
-
-      // saveRate: no existing rate found, then save
-      exchangeRateRepository.findOne.mockResolvedValue(null);
-      exchangeRateRepository.save.mockImplementation((data) => ({
-        ...data,
-        id: 1,
-      }));
 
       const result = await service.refreshAllRates();
 
@@ -288,53 +339,69 @@ describe("ExchangeRateService", () => {
       expect(result.updated).toBe(0);
     });
 
-    it("updates existing rate when one already exists for the date", async () => {
-      dataSource.query.mockResolvedValue([{ code: "USD" }, { code: "CAD" }]);
+    it("upserts both directions rather than reading first and then writing", async () => {
+      // The rate cron fires on every replica, so two processes routinely fetch
+      // the same pair for the same day. The old shape read the row and then
+      // either saved it or inserted -- a check-then-act whose loser hit
+      // `UNIQUE(from_currency, to_currency, rate_date)` and, because the two
+      // directions share a transaction, lost the inverse rate with it.
+      routeRateQueries(["USD", "CAD"]);
 
       yahooFinanceService.fetchQuote.mockResolvedValue({
         regularMarketPrice: 1.4,
       });
 
-      // Return a fresh copy for each findOne call so mutations don't bleed
-      exchangeRateRepository.findOne.mockImplementation(() => ({
-        ...mockExchangeRate,
-      }));
-      exchangeRateRepository.save.mockImplementation((data) => data);
-
       const result = await service.refreshAllRates();
 
       expect(result.updated).toBe(1);
-      // Save should be called with both forward and inverse rates
-      expect(exchangeRateRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({ rate: 1.4, source: "yahoo_finance" }),
+      const upserts = dataSource.query.mock.calls.filter(
+        (call: unknown[]) =>
+          typeof call[0] === "string" &&
+          call[0].includes("INSERT INTO exchange_rates") &&
+          call[0].includes("RETURNING id"),
       );
+      expect(upserts).toHaveLength(2);
+      expect(upserts[0][0]).toContain(
+        "ON CONFLICT (from_currency, to_currency, rate_date) DO UPDATE",
+      );
+      // Forward, then the inverse.
+      expect(upsertedRates[0]).toMatchObject({
+        fromCurrency: "USD",
+        toCurrency: "CAD",
+        rate: 1.4,
+      });
       // The inverse is stored at the rate column's ten decimal places, not at
       // money precision: rounding it to four (0.7143) inverts back to 1.39997,
       // which a statement quoting six decimals reconciles against by cents.
-      expect(exchangeRateRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          rate: roundFxRate(1 / 1.4),
-          source: "yahoo_finance",
-        }),
-      );
-      const inverseSave = exchangeRateRepository.save.mock.calls
-        .map((call) => call[0])
-        .find((row) => row.rate !== 1.4);
-      expect(inverseSave.rate).not.toBe(0.7143);
-      expect(roundFxRate(1 / inverseSave.rate)).toBeCloseTo(1.4, 6);
+      expect(upsertedRates[1]).toMatchObject({
+        fromCurrency: "CAD",
+        toCurrency: "USD",
+        rate: roundFxRate(1 / 1.4),
+        source: "yahoo_finance",
+      });
+      expect(upsertedRates[1].rate).not.toBe(0.7143);
+      expect(roundFxRate(1 / upsertedRates[1].rate)).toBeCloseTo(1.4, 6);
     });
 
-    it("handles saveRate failure gracefully", async () => {
-      dataSource.query.mockResolvedValue([{ code: "USD" }, { code: "CAD" }]);
-
+    it("handles a rate write failure gracefully", async () => {
+      routeRateQueries(["USD", "CAD"]);
       yahooFinanceService.fetchQuote.mockResolvedValue({
         regularMarketPrice: 1.365,
       });
-
-      exchangeRateRepository.findOne.mockResolvedValue(null);
-      exchangeRateRepository.save.mockRejectedValue(
-        new Error("DB write failed"),
-      );
+      // The upsert itself fails: one pair is reported failed and the sweep
+      // carries on.
+      dataSource.query.mockImplementation(async (sql: string) => {
+        if (
+          typeof sql === "string" &&
+          sql.includes("INSERT INTO exchange_rates")
+        ) {
+          throw new Error("DB write failed");
+        }
+        if (typeof sql === "string" && sql.includes("SELECT DISTINCT code")) {
+          return [{ code: "USD" }, { code: "CAD" }];
+        }
+        return [];
+      });
 
       const result = await service.refreshAllRates();
 
@@ -345,22 +412,10 @@ describe("ExchangeRateService", () => {
     });
 
     it("builds correct number of pairs from 4 currencies", async () => {
-      dataSource.query.mockResolvedValue([
-        { code: "USD" },
-        { code: "CAD" },
-        { code: "EUR" },
-        { code: "GBP" },
-      ]);
-
+      routeRateQueries(["USD", "CAD", "EUR", "GBP"]);
       yahooFinanceService.fetchQuote.mockResolvedValue({
         regularMarketPrice: 1.0,
       });
-
-      exchangeRateRepository.findOne.mockResolvedValue(null);
-      exchangeRateRepository.save.mockImplementation((data) => ({
-        ...data,
-        id: 1,
-      }));
 
       const result = await service.refreshAllRates();
 

--- a/backend/src/currencies/exchange-rate.service.ts
+++ b/backend/src/currencies/exchange-rate.service.ts
@@ -20,6 +20,7 @@ import { YahooFinanceService } from "../securities/yahoo-finance.service";
 import { mapWithConcurrency } from "../common/concurrency.util";
 import { roundFxRate } from "../common/fx-entry.util";
 import { withScopedDb } from "../common/db/scoped-db";
+import { returnedRows } from "../common/db/query-result";
 import { withSystemContext, withUserContext } from "../common/db/with-context";
 
 // Cap concurrent Yahoo FX fetches so the daily refresh does not burst every
@@ -234,29 +235,41 @@ export class ExchangeRateService implements OnModuleInit {
     rate: number,
     date: Date,
   ): Promise<ExchangeRate> {
-    const repo = manager.getRepository(ExchangeRate);
-    const existing = await repo.findOne({
-      where: {
-        fromCurrency: from,
-        toCurrency: to,
-        rateDate: date,
-      },
-    });
+    // One statement, arbitrated by `UNIQUE(from_currency, to_currency,
+    // rate_date)`. This used to be a `findOne` and then either a save of the
+    // found row or an insert -- a check-then-act, and one every replica runs:
+    // the exchange-rate cron fires everywhere at 5:05 PM ET, so two processes
+    // routinely fetch the same pair for the same day, both find no row, and both
+    // insert. The loser got a unique violation, which inside `saveRate`'s
+    // transaction also lost the inverse direction written beside it.
+    //
+    // `persistRateSeries` a few lines below already did it this way; the two are
+    // now consistent, which matters because they write the same rows.
+    const rows: unknown = await manager.query(
+      `INSERT INTO exchange_rates (from_currency, to_currency, rate_date, rate, source)
+       VALUES ($1, $2, $3::DATE, $4, 'yahoo_finance')
+       ON CONFLICT (from_currency, to_currency, rate_date) DO UPDATE SET
+         rate = EXCLUDED.rate,
+         source = EXCLUDED.source
+       RETURNING id`,
+      [from, to, date, rate],
+    );
 
-    if (existing) {
-      existing.rate = rate;
-      existing.source = "yahoo_finance";
-      return repo.save(existing);
+    // `DO UPDATE` always returns the row, so a read-back is only needed to hand
+    // the caller an entity. Scoped by the id just written rather than by the
+    // triple, so it cannot pick up a different row.
+    const id = returnedRows<{ id: number }>(rows)[0]?.id;
+    const saved = id
+      ? await manager.getRepository(ExchangeRate).findOne({ where: { id } })
+      : null;
+    if (!saved) {
+      // Nothing else can make an upsert return no row, so this is a real fault
+      // rather than a state to paper over with a synthesized entity.
+      throw new Error(
+        `Failed to persist exchange rate ${from}/${to} for ${date.toISOString().slice(0, 10)}`,
+      );
     }
-
-    const newRate = repo.create({
-      fromCurrency: from,
-      toCurrency: to,
-      rate,
-      rateDate: date,
-      source: "yahoo_finance",
-    });
-    return repo.save(newRate);
+    return saved;
   }
 
   /**

--- a/backend/src/database/demo-reset.service.spec.ts
+++ b/backend/src/database/demo-reset.service.spec.ts
@@ -5,6 +5,13 @@ import { DemoSeedService } from "./demo-seed.service";
 import { DemoModeService } from "../common/demo-mode.service";
 import { getRequestContext } from "../common/request-context";
 import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
+import {
+  createJobClaimMock,
+  TEST_LEASE_TOKEN,
+  jobClaimProvider,
+  type JobClaimMock,
+} from "../test-helpers/job-claim-testing";
+import { JobClaimType } from "../common/jobs/job-claim.service";
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
@@ -20,6 +27,7 @@ describe("DemoResetService", () => {
   let demoSeedService: { seedDemoData: jest.Mock };
   let demoModeService: { isDemo: boolean };
   let queryRunner: Record<string, jest.Mock>;
+  let jobClaims: JobClaimMock;
 
   beforeEach(async () => {
     queryRunner = {
@@ -44,6 +52,7 @@ describe("DemoResetService", () => {
     };
 
     demoModeService = { isDemo: true };
+    jobClaims = createJobClaimMock();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -51,6 +60,7 @@ describe("DemoResetService", () => {
         { provide: DataSource, useValue: dataSource },
         { provide: DemoSeedService, useValue: demoSeedService },
         { provide: DemoModeService, useValue: demoModeService },
+        jobClaimProvider(jobClaims),
       ],
     }).compile();
 
@@ -189,8 +199,12 @@ describe("DemoResetService", () => {
       const callOrder: string[] = [];
       const runTransaction = dataSource.transaction.getMockImplementation()!;
       dataSource.transaction.mockImplementation(async (...args: unknown[]) => {
+        const before = queryRunner.query.mock.calls.length;
         const result = await runTransaction(...args);
-        callOrder.push("commit");
+        const wrote = queryRunner.query.mock.calls
+          .slice(before)
+          .some((call: string[]) => call[0].includes("DELETE FROM"));
+        if (wrote) callOrder.push("commit");
         return result;
       });
       demoSeedService.seedDemoData.mockImplementation(() => {
@@ -201,6 +215,74 @@ describe("DemoResetService", () => {
       await service.resetDemoData();
 
       expect(callOrder).toEqual(["commit", "reseed"]);
+    });
+  });
+
+  describe("multi-replica coordination of the reset", () => {
+    beforeEach(() => {
+      queryRunner.query.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT id FROM users")) {
+          return Promise.resolve([{ id: "demo-user-id" }]);
+        }
+        return Promise.resolve([]);
+      });
+    });
+
+    it("takes a lease before wiping anything", async () => {
+      await service.resetDemoData();
+
+      expect(jobClaims.claimLease).toHaveBeenCalledWith(
+        JobClaimType.DemoReset,
+        "demo-user-id",
+        expect.any(String),
+        expect.any(Number),
+      );
+    });
+
+    it("wipes nothing when another replica holds the lease", async () => {
+      // A wipe-and-reseed is the one job a duplicate run cannot repair by
+      // repeating: the second replica's DELETE lands inside the first
+      // replica's seed and both finish with a partial demo.
+      jobClaims.claimLease.mockResolvedValue(null);
+
+      await service.resetDemoData();
+
+      const deletes = queryRunner.query.mock.calls.filter((call: string[]) =>
+        call[0].includes("DELETE FROM"),
+      );
+      expect(deletes).toHaveLength(0);
+      expect(demoSeedService.seedDemoData).not.toHaveBeenCalled();
+    });
+
+    it("hands the lease back even when the reset throws", async () => {
+      queryRunner.query.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT id FROM users")) {
+          return Promise.resolve([{ id: "demo-user-id" }]);
+        }
+        if (sql.includes("DELETE FROM investment_transactions")) {
+          throw new Error("Database error");
+        }
+        return Promise.resolve([]);
+      });
+
+      await service.resetDemoData();
+
+      expect(jobClaims.releaseLease).toHaveBeenCalledWith(
+        JobClaimType.DemoReset,
+        "demo-user-id",
+        expect.any(String),
+        // With the token: a reset that outran its own lease must not release the
+        // one the replica now reseeding holds (audit DR-RRV4-01).
+        TEST_LEASE_TOKEN,
+      );
+    });
+
+    it("does not claim anything when there is no demo user", async () => {
+      queryRunner.query.mockResolvedValue([]);
+
+      await service.resetDemoData();
+
+      expect(jobClaims.claimLease).not.toHaveBeenCalled();
     });
   });
 
@@ -292,20 +374,12 @@ describe("DemoResetService", () => {
         }
       });
 
-      it("skips duplicate transactions", async () => {
-        dataSource.query.mockImplementation((sql: string) => {
-          if (sql.includes("SELECT id FROM users")) {
-            return Promise.resolve([{ id: "demo-user-id" }]);
-          }
-          if (sql.includes("SELECT id FROM accounts")) {
-            return Promise.resolve([{ id: "account-123" }]);
-          }
-          if (sql.includes("SELECT COUNT")) {
-            // Simulate existing transaction
-            return Promise.resolve([{ count: "1" }]);
-          }
-          return Promise.resolve([]);
-        });
+      it("generates nothing when another replica already claimed the window", async () => {
+        // The regression: the generator is seeded by the window, so every
+        // replica computes the SAME transactions. The old guard was a
+        // `SELECT COUNT(*)` for an identical row -- a check-then-act that two
+        // replicas both pass, producing the demo transaction twice.
+        jobClaims.claimOnce.mockResolvedValue(false);
 
         await service.generateIntradayTransactions();
 
@@ -313,6 +387,61 @@ describe("DemoResetService", () => {
           (call: string[]) => call[0].includes("INSERT INTO transactions"),
         );
         expect(insertCalls.length).toBe(0);
+      });
+
+      it("claims the window durably, keyed on the date and the hour", async () => {
+        await service.generateIntradayTransactions();
+
+        expect(jobClaims.claimOnce).toHaveBeenCalledTimes(1);
+        const [type, userId, key] = jobClaims.claimOnce.mock.calls[0];
+        expect(type).toBe(JobClaimType.DemoIntraday);
+        expect(userId).toBe("demo-user-id");
+        expect(key).toMatch(/^\d{4}-\d{2}-\d{2}-\d{2}$/);
+      });
+
+      it("does not count a row-existence check as coordination", async () => {
+        // A `SELECT COUNT(*) ... WHERE the row I am about to insert` is the
+        // shape this fix removed; leaving it in would read as a guard.
+        await service.generateIntradayTransactions();
+
+        const countChecks = dataSource.query.mock.calls.filter(
+          (call: string[]) =>
+            call[0].includes("SELECT COUNT(*) as count FROM transactions"),
+        );
+        expect(countChecks).toHaveLength(0);
+      });
+
+      it("writes the ledger row and its balance in one transaction", async () => {
+        // Split across two transactions, a crash between them leaves a demo
+        // whose account balance disagrees with its own ledger.
+        const perTransaction: string[][] = [];
+        const runTransaction = dataSource.transaction.getMockImplementation()!;
+        dataSource.transaction.mockImplementation(
+          async (...args: unknown[]) => {
+            const before = dataSource.query.mock.calls.length;
+            const result = await runTransaction(...args);
+            perTransaction.push(
+              dataSource.query.mock.calls
+                .slice(before)
+                .map((call: string[]) => call[0]),
+            );
+            return result;
+          },
+        );
+
+        await service.generateIntradayTransactions();
+
+        const writeGroups = perTransaction.filter((sqls) =>
+          sqls.some((sql) => sql.includes("INSERT INTO transactions")),
+        );
+        expect(writeGroups.length).toBeGreaterThanOrEqual(1);
+        for (const group of writeGroups) {
+          expect(
+            group.some((sql) =>
+              sql.includes("UPDATE accounts SET current_balance"),
+            ),
+          ).toBe(true);
+        }
       });
 
       it("skips when account not found", async () => {
@@ -335,37 +464,24 @@ describe("DemoResetService", () => {
       });
 
       it("produces deterministic output for the same time window", async () => {
-        await service.generateIntradayTransactions();
-        const firstRunInserts = dataSource.query.mock.calls
-          .filter((call: string[]) =>
-            call[0].includes("INSERT INTO transactions"),
-          )
-          .map((call: unknown[]) => (call[1] as unknown[])[4]); // payee_name
+        // Determinism is exactly why the claim is needed rather than a
+        // row-existence check: two replicas in the same window pick the same
+        // templates, so the only thing distinguishing them is who claimed.
+        const payeeNames = () =>
+          dataSource.query.mock.calls
+            .filter((call: string[]) =>
+              call[0].includes("INSERT INTO transactions"),
+            )
+            .map((call: unknown[]) => (call[1] as unknown[])[4]);
 
-        // Reset and run again — dedup will skip, but the template selection is the same
-        // Verify by checking the dedup queries use the same payee names
+        await service.generateIntradayTransactions();
+        const firstRun = payeeNames();
+
         dataSource.query.mockClear();
-        dataSource.query.mockImplementation((sql: string) => {
-          if (sql.includes("SELECT id FROM users")) {
-            return Promise.resolve([{ id: "demo-user-id" }]);
-          }
-          if (sql.includes("SELECT id FROM accounts")) {
-            return Promise.resolve([{ id: "account-123" }]);
-          }
-          if (sql.includes("SELECT COUNT")) {
-            return Promise.resolve([{ count: "1" }]); // Already exists
-          }
-          return Promise.resolve([]);
-        });
-
         await service.generateIntradayTransactions();
 
-        const dedupPayees = dataSource.query.mock.calls
-          .filter((call: string[]) => call[0].includes("SELECT COUNT"))
-          .map((call: unknown[]) => (call[1] as unknown[])[2]); // payee_name
-
-        // Same templates should be selected both times
-        expect(dedupPayees).toEqual(firstRunInserts);
+        expect(payeeNames()).toEqual(firstRun);
+        expect(firstRun.length).toBeGreaterThan(0);
       });
     });
 

--- a/backend/src/database/demo-reset.service.ts
+++ b/backend/src/database/demo-reset.service.ts
@@ -8,6 +8,23 @@ import { DemoModeService } from "../common/demo-mode.service";
 import { DemoSeedService } from "./demo-seed.service";
 import { INTRADAY_TEMPLATES } from "./demo-seed-data/intraday-templates";
 import { withSystemContext } from "../common/db/with-context";
+import {
+  JobClaimService,
+  JobClaimType,
+} from "../common/jobs/job-claim.service";
+
+/**
+ * How long one replica may hold the demo reset before another may retake it.
+ *
+ * A wipe-and-reseed is not idempotent while it is running: a second replica
+ * starting halfway through deletes the rows the first is still seeding and both
+ * finish with a partial demo. The lease expires so a replica killed mid-reset
+ * does not leave the demo un-resettable until someone restarts the cluster.
+ */
+export const DEMO_RESET_LEASE_MS = 30 * 60 * 1000;
+
+/** Lease and claim keys; one demo user, so the key names the window instead. */
+export const DEMO_RESET_CLAIM_KEY = "reset";
 
 @Injectable()
 export class DemoResetService {
@@ -17,6 +34,7 @@ export class DemoResetService {
     private dataSource: DataSource,
     private demoSeedService: DemoSeedService,
     private demoModeService: DemoModeService,
+    private readonly jobClaims: JobClaimService,
   ) {}
 
   @Cron("0 4 * * *") // 4:00 AM daily
@@ -30,27 +48,73 @@ export class DemoResetService {
     return withSystemContext(() => this.resetDemoDataWithinContext());
   }
 
+  /** The demo user's id, or null when the demo user has not been created. */
+  private async findDemoUserId(): Promise<string | null> {
+    const [demoUser] = await withScopedDb(this.dataSource, (manager) =>
+      manager.query("SELECT id FROM users WHERE email = 'demo@monize.com'"),
+    );
+    return demoUser?.id ?? null;
+  }
+
   private async resetDemoDataWithinContext(): Promise<void> {
+    // The cron must not reject: an unhandled rejection from a scheduled handler
+    // takes the process down, and this reset is best-effort.
+    try {
+      const demoUserId = await this.findDemoUserId();
+      if (!demoUserId) {
+        this.logger.warn("Demo user not found, skipping reset");
+        return;
+      }
+
+      // Every replica fires this cron. A wipe-and-reseed is the one shape a
+      // duplicate run cannot repair by repeating: the second replica's DELETE
+      // lands in the middle of the first replica's seed and both finish with a
+      // partial demo. The lease is the exclusion; it expires so a killed replica
+      // does not leave the demo un-resettable.
+      const leased = await this.jobClaims.claimLease(
+        JobClaimType.DemoReset,
+        demoUserId,
+        DEMO_RESET_CLAIM_KEY,
+        DEMO_RESET_LEASE_MS,
+      );
+      if (!leased) {
+        this.logger.log(
+          "Another replica is already resetting the demo data; skipping",
+        );
+        return;
+      }
+
+      try {
+        await this.performDemoReset(demoUserId);
+      } finally {
+        await this.jobClaims
+          // By token: a reset that outran its lease must not free the one the
+          // replica now reseeding holds (DR-RRV4-01).
+          .releaseLease(
+            JobClaimType.DemoReset,
+            demoUserId,
+            DEMO_RESET_CLAIM_KEY,
+            leased,
+          )
+          .catch(() => undefined);
+      }
+    } catch (error) {
+      this.logger.error(
+        "Demo reset failed",
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
+  }
+
+  private async performDemoReset(demoUserId: string): Promise<void> {
     try {
       // The clear runs in one transaction and must COMMIT before the re-seed:
       // seedDemoData opens its own scoped transactions, and the seeded rows
       // have to land on a database the clear has already emptied.
-      const userId = await withScopedDb(this.dataSource, async (manager) => {
-        // 1. Get demo user ID
-        const [demoUser] = await manager.query(
-          "SELECT id FROM users WHERE email = 'demo@monize.com'",
-        );
+      await withScopedDb(this.dataSource, async (manager) => {
+        const userId: string = demoUserId;
 
-        if (!demoUser) {
-          this.logger.warn("Demo user not found, skipping reset");
-          // Nothing written yet, so returning commits an empty transaction --
-          // the same net effect as the old explicit rollback.
-          return null;
-        }
-
-        const userId: string = demoUser.id;
-
-        // 2. Delete all user data in FK-safe order
+        // 1. Delete all user data in FK-safe order
         await manager.query(
           "DELETE FROM investment_transactions WHERE user_id = $1",
           [userId],
@@ -119,7 +183,7 @@ export class DemoResetService {
           userId,
         ]);
 
-        // 3. Reset user record
+        // 2. Reset user record
         const hashedPassword = await bcrypt.hash("Demo123!", 10);
         await manager.query(
           `UPDATE users SET
@@ -134,14 +198,12 @@ export class DemoResetService {
         WHERE id = $2`,
           [hashedPassword, userId],
         );
-
-        return userId;
       });
 
-      if (!userId) return;
+      const userId = demoUserId;
       this.logger.log("Demo data cleared successfully");
 
-      // 4. Re-seed demo data
+      // 3. Re-seed demo data
       // seedDemoData runs outside the transaction because it uses
       // this.dataSource directly. If seeding fails, retry once before
       // giving up so the database is not left empty.
@@ -189,14 +251,31 @@ export class DemoResetService {
 
   private async generateIntradayTransactionsWithinContext(): Promise<void> {
     try {
-      const [demoUser] = await withScopedDb(this.dataSource, (manager) =>
-        manager.query("SELECT id FROM users WHERE email = 'demo@monize.com'"),
-      );
-      if (!demoUser) return;
+      const userId = await this.findDemoUserId();
+      if (!userId) return;
 
-      const userId = demoUser.id;
       const now = new Date();
       const today = now.toISOString().split("T")[0];
+
+      // The generator is seeded by the window, so every replica computes the
+      // SAME transactions -- which means the "does this exact row exist yet"
+      // check below is a check-then-act two replicas both pass, and the demo
+      // gets each transaction twice. The claim is what decides; it is permanent
+      // because a window that has been generated must never be generated again,
+      // and it is not released on failure because a partial window is better
+      // than a doubled one (the next window generates fresh rows anyway).
+      const windowKey = `${today}-${String(now.getUTCHours()).padStart(2, "0")}`;
+      const claimed = await this.jobClaims.claimOnce(
+        JobClaimType.DemoIntraday,
+        userId,
+        windowKey,
+      );
+      if (!claimed) {
+        this.logger.log(
+          `Intra-day demo window ${windowKey} was already generated; skipping`,
+        );
+        return;
+      }
 
       // Deterministic RNG seeded by date + hour (same window = same output)
       const seedStr = `${today}-${now.getUTCHours()}`;
@@ -228,85 +307,69 @@ export class DemoResetService {
               100,
           ) / 100;
 
-        // Look up account
         const accountName = accountNameMap[template.accountKey];
-        const [account] = await withScopedDb(this.dataSource, (manager) =>
-          manager.query(
-            "SELECT id FROM accounts WHERE user_id = $1 AND name = $2",
-            [userId, accountName],
-          ),
-        );
-        if (!account) continue;
 
-        // Deduplicate: skip if this exact transaction already exists
-        const [existing] = await withScopedDb(this.dataSource, (manager) =>
-          manager.query(
-            `SELECT COUNT(*) as count FROM transactions
-           WHERE user_id = $1 AND transaction_date = $2
-             AND payee_name = $3 AND amount = $4`,
-            [userId, today, template.payeeName, amount],
-          ),
-        );
-        if (parseInt(existing.count) > 0) continue;
+        // One transaction for the ledger row and the balance it moves. Split
+        // across two, a crash between them leaves a transaction the account
+        // balance does not account for -- and the demo then shows a balance that
+        // disagrees with its own ledger, which is the exact defect this
+        // codebase's balance rules exist to prevent.
+        const inserted = await withScopedDb(
+          this.dataSource,
+          async (manager) => {
+            const [account] = await manager.query(
+              "SELECT id FROM accounts WHERE user_id = $1 AND name = $2",
+              [userId, accountName],
+            );
+            if (!account) return null;
 
-        // Look up payee
-        const [payee] = await withScopedDb(this.dataSource, (manager) =>
-          manager.query(
-            "SELECT id FROM payees WHERE user_id = $1 AND name = $2",
-            [userId, template.payeeName],
-          ),
-        );
+            const [payee] = await manager.query(
+              "SELECT id FROM payees WHERE user_id = $1 AND name = $2",
+              [userId, template.payeeName],
+            );
 
-        // Look up category (handle "Parent > Child" path)
-        let categoryId: string | null = null;
-        const parts = template.categoryPath.split(" > ");
-        if (parts.length === 2) {
-          const [cat] = await withScopedDb(this.dataSource, (manager) =>
-            manager.query(
-              `SELECT c.id FROM categories c
-             JOIN categories p ON c.parent_id = p.id
-             WHERE c.user_id = $1 AND p.name = $2 AND c.name = $3`,
-              [userId, parts[0], parts[1]],
-            ),
-          );
-          categoryId = cat?.id || null;
-        } else {
-          const [cat] = await withScopedDb(this.dataSource, (manager) =>
-            manager.query(
-              "SELECT id FROM categories WHERE user_id = $1 AND name = $2 AND parent_id IS NULL",
-              [userId, parts[0]],
-            ),
-          );
-          categoryId = cat?.id || null;
-        }
+            // Category may be given as "Parent > Child".
+            const parts = template.categoryPath.split(" > ");
+            const [cat] =
+              parts.length === 2
+                ? await manager.query(
+                    `SELECT c.id FROM categories c
+                       JOIN categories p ON c.parent_id = p.id
+                      WHERE c.user_id = $1 AND p.name = $2 AND c.name = $3`,
+                    [userId, parts[0], parts[1]],
+                  )
+                : await manager.query(
+                    "SELECT id FROM categories WHERE user_id = $1 AND name = $2 AND parent_id IS NULL",
+                    [userId, parts[0]],
+                  );
 
-        // Insert transaction
-        await withScopedDb(this.dataSource, (manager) =>
-          manager.query(
-            `INSERT INTO transactions (
-            user_id, account_id, transaction_date, payee_id, payee_name,
-            category_id, amount, currency_code, description, status
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, 'CAD', $8, 'UNRECONCILED')`,
-            [
-              userId,
-              account.id,
-              today,
-              payee?.id || null,
-              template.payeeName,
-              categoryId,
-              amount,
-              template.description,
-            ],
-          ),
+            await manager.query(
+              `INSERT INTO transactions (
+                user_id, account_id, transaction_date, payee_id, payee_name,
+                category_id, amount, currency_code, description, status
+              ) VALUES ($1, $2, $3, $4, $5, $6, $7, 'CAD', $8, 'UNRECONCILED')`,
+              [
+                userId,
+                account.id,
+                today,
+                payee?.id || null,
+                template.payeeName,
+                cat?.id || null,
+                amount,
+                template.description,
+              ],
+            );
+
+            await manager.query(
+              "UPDATE accounts SET current_balance = ROUND(CAST(current_balance AS numeric) + $1, 4) WHERE id = $2",
+              [amount, account.id],
+            );
+
+            return account.id as string;
+          },
         );
 
-        // Update account balance
-        await withScopedDb(this.dataSource, (manager) =>
-          manager.query(
-            "UPDATE accounts SET current_balance = current_balance + $1 WHERE id = $2",
-            [amount, account.id],
-          ),
-        );
+        if (!inserted) continue;
 
         this.logger.log(
           `Added intra-day transaction: ${template.payeeName} $${Math.abs(amount).toFixed(2)}`,

--- a/backend/src/notifications/bill-reminder.service.spec.ts
+++ b/backend/src/notifications/bill-reminder.service.spec.ts
@@ -9,12 +9,20 @@ import { ScheduledTransactionOverride } from "../scheduled-transactions/entities
 import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
+import {
+  createJobClaimMock,
+  TEST_LEASE_TOKEN,
+  JobClaimMock,
+  jobClaimProvider,
+} from "../test-helpers/job-claim-testing";
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
 );
 
 describe("BillReminderService", () => {
+  /** Wins every claim, matching the pre-claim behaviour these specs describe. */
+  const jobClaims: JobClaimMock = createJobClaimMock();
   let service: BillReminderService;
   let scheduledTransactionsRepo: Record<string, jest.Mock>;
   let usersRepo: Record<string, jest.Mock>;
@@ -23,6 +31,15 @@ describe("BillReminderService", () => {
   let configService: Record<string, jest.Mock>;
 
   beforeEach(async () => {
+    // The claim double is shared across tests, so recorded calls and any queued
+    // `...Once` would leak forward -- invisible until a spec asserts a claim was
+    // *not* taken, and then it reads as a product bug.
+    jobClaims.claimOnce.mockReset().mockResolvedValue(true);
+    jobClaims.claimLease.mockReset().mockResolvedValue(TEST_LEASE_TOKEN);
+    jobClaims.releaseLease.mockReset().mockResolvedValue(undefined);
+    jobClaims.markDelivered.mockReset().mockResolvedValue(undefined);
+    jobClaims.wasDelivered.mockReset().mockResolvedValue(false);
+
     scheduledTransactionsRepo = {
       find: jest.fn(),
     };
@@ -53,6 +70,7 @@ describe("BillReminderService", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BillReminderService,
+        jobClaimProvider(jobClaims),
         { provide: DataSource, useValue: dataSource },
         { provide: EmailService, useValue: emailService },
         { provide: ConfigService, useValue: configService },
@@ -158,6 +176,100 @@ describe("BillReminderService", () => {
         emailService.getStatus.mockReturnValue({ configured: true });
         configService.get.mockReturnValue("https://app.monize.com");
         emailService.sendMail.mockResolvedValue(undefined);
+      });
+
+      /**
+       * Coordination and delivery are two different facts (audit RV4-006).
+       *
+       * `claimOnce` was taken before the send and was the only record that the
+       * send was owed, so a replica killed in between left a permanent row that
+       * every later run read as "already handled" -- the reminder was never sent
+       * and nothing could notice.
+       */
+      describe("the claim is a lease, and delivery is recorded separately", () => {
+        const dueBill = () =>
+          makeBill({
+            userId: userId1,
+            nextDueDate: daysFromNow(0),
+            reminderDaysBefore: 3,
+            name: "Electric Bill",
+          });
+
+        beforeEach(() => {
+          scheduledTransactionsRepo.find.mockResolvedValue([dueBill()]);
+          preferencesRepo.findOne.mockResolvedValue(mockPrefsEmailEnabled);
+          usersRepo.findOne.mockResolvedValue(mockUser1);
+        });
+
+        it("takes a bounded lease rather than a permanent claim", async () => {
+          await service.sendBillReminders();
+
+          expect(jobClaims.claimLease).toHaveBeenCalledWith(
+            "bill_reminder",
+            userId1,
+            expect.any(String),
+            expect.any(Number),
+          );
+          expect(jobClaims.claimOnce).not.toHaveBeenCalled();
+        });
+
+        it("records the delivery only after the send succeeds", async () => {
+          await service.sendBillReminders();
+
+          expect(jobClaims.markDelivered).toHaveBeenCalledWith(
+            "bill_reminder",
+            userId1,
+            expect.any(String),
+            // The token, so the record is written against *this* attempt's lease:
+            // a stalled worker whose lease was retaken must not stamp a delivery
+            // for the new holder's unfinished send (audit DR-RRV4-01).
+            TEST_LEASE_TOKEN,
+          );
+          expect(
+            emailService.sendMail.mock.invocationCallOrder[0],
+          ).toBeLessThan(jobClaims.markDelivered.mock.invocationCallOrder[0]);
+        });
+
+        it("does not record a delivery when the send fails", async () => {
+          emailService.sendMail.mockRejectedValue(new Error("smtp down"));
+
+          await service.sendBillReminders();
+
+          // The notice stays owed, and the lease goes back so the next run can
+          // retry immediately.
+          expect(jobClaims.markDelivered).not.toHaveBeenCalled();
+          expect(jobClaims.releaseLease).toHaveBeenCalled();
+        });
+
+        it("stands down when the work is already recorded as delivered", async () => {
+          // The lease was won -- an earlier holder let it expire -- but the send
+          // had already happened. Only the delivery record can say so.
+          jobClaims.wasDelivered.mockResolvedValue(true);
+
+          await service.sendBillReminders();
+
+          expect(emailService.sendMail).not.toHaveBeenCalled();
+          expect(jobClaims.releaseLease).toHaveBeenCalled();
+        });
+
+        it("sends when another holder's lease expired without delivering", async () => {
+          // The recovery the permanent claim made impossible: the lease is
+          // retakeable and nothing was delivered, so this replica sends.
+          jobClaims.claimLease.mockResolvedValue(TEST_LEASE_TOKEN);
+          jobClaims.wasDelivered.mockResolvedValue(false);
+
+          await service.sendBillReminders();
+
+          expect(emailService.sendMail).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not send while another replica holds the lease", async () => {
+          jobClaims.claimLease.mockResolvedValue(null);
+
+          await service.sendBillReminders();
+
+          expect(emailService.sendMail).not.toHaveBeenCalled();
+        });
       });
 
       it("returns early when no manual bills exist", async () => {

--- a/backend/src/notifications/bill-reminder.service.ts
+++ b/backend/src/notifications/bill-reminder.service.ts
@@ -12,6 +12,26 @@ import { emailTranslator } from "../i18n/email-translator";
 import { DEFAULT_LOCALE } from "../i18n/config";
 import { withSystemContext, withUserContext } from "../common/db/with-context";
 import { withScopedDb } from "../common/db/scoped-db";
+import {
+  JobClaimService,
+  JobClaimType,
+} from "../common/jobs/job-claim.service";
+import { createHash } from "node:crypto";
+
+/**
+ * How long one replica holds the right to send this user's bill reminder.
+ *
+ * A lease, so a replica killed between claiming and sending costs a retry window
+ * rather than the delivery. It only has to outlast an SMTP round trip; whether the
+ * work is still owed is decided by the delivery record, not by the lease
+ * (audit RV4-006).
+ *
+ * The resulting contract is at-least-once: a process killed after SMTP accepted
+ * but before the record committed re-sends next run. For a reminder that is the
+ * right trade -- a duplicate nudge is an annoyance, a missed mortgage renewal is
+ * not. See docs/cron-jobs.md.
+ */
+const REMINDER_LEASE_MS = 10 * 60 * 1000;
 
 @Injectable()
 export class BillReminderService {
@@ -22,7 +42,29 @@ export class BillReminderService {
     private emailService: EmailService,
     private configService: ConfigService,
     private readonly i18n: I18nService,
+    private readonly jobClaims: JobClaimService,
   ) {}
+
+  /**
+   * Release a lease a send did not use, so the next run can retry.
+   *
+   * Addressed by the lease token, not only by the work: a stalled worker must not
+   * delete a lease another replica has retaken (audit DR-RRV4-01).
+   */
+  private async releaseClaim(
+    userId: string,
+    claimKey: string,
+    leaseToken: string,
+  ): Promise<void> {
+    await this.jobClaims
+      .releaseLease(JobClaimType.BillReminder, userId, claimKey, leaseToken)
+      .catch((error: unknown) =>
+        this.logger.warn(
+          `Failed to release bill-reminder claim for user ${userId}: ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
+  }
 
   @Cron(CronExpression.EVERY_DAY_AT_8AM)
   async sendBillReminders(): Promise<void> {
@@ -90,6 +132,52 @@ export class BillReminderService {
     let skipCount = 0;
 
     for (const [userId, bills] of billsByUser) {
+      // Claim this user's reminder for today before doing anything that leaves
+      // the process.
+      //
+      // Every backend replica fires this cron (docs/cron-jobs.md), and nothing
+      // here recorded that a reminder had been sent -- so two healthy replicas
+      // both selected the same due bills and both emailed them. Not a rare race:
+      // the *normal* outcome of running more than one replica (audit P4-018).
+      //
+      // The key is the local date plus a hash of what the email says, so a bill
+      // that becomes due later the same day still produces a reminder while an
+      // identical run does not.
+      const claimKey = buildReminderClaimKey(bills);
+      // A **lease**, not a permanent claim, plus a durable delivery record.
+      //
+      // `claimOnce` was taken before the send and was the only record that the
+      // send was owed, so a replica killed in between left a permanent row that
+      // every later run read as "already handled" -- the bill reminder was never
+      // sent and nothing could notice, because the row could not tell "I sent
+      // this" from "I intended to" (audit RV4-006). The lease bounds *doing* the
+      // work; `delivered_at`, written after the send and re-read here, is what
+      // says it was done.
+      const claimed = await this.jobClaims.claimLease(
+        JobClaimType.BillReminder,
+        userId,
+        claimKey,
+        REMINDER_LEASE_MS,
+      );
+      if (!claimed) {
+        skipCount++;
+        continue;
+      }
+      const leaseToken = claimed;
+      if (
+        await this.jobClaims.wasDelivered(
+          JobClaimType.BillReminder,
+          userId,
+          claimKey,
+        )
+      ) {
+        // Already sent, durably. Hand the lease back rather than holding it for
+        // its whole TTL.
+        skipCount++;
+        await this.releaseClaim(userId, claimKey, leaseToken);
+        continue;
+      }
+
       try {
         // Check if user has email notifications enabled.
         // RLS (task C2): per-user reads run under the user's own context.
@@ -102,6 +190,7 @@ export class BillReminderService {
         );
         if (prefs && !prefs.notificationEmail) {
           skipCount++;
+          await this.releaseClaim(userId, claimKey, leaseToken);
           continue;
         }
 
@@ -112,6 +201,7 @@ export class BillReminderService {
         );
         if (!user || !user.email) {
           skipCount++;
+          await this.releaseClaim(userId, claimKey, leaseToken);
           continue;
         }
 
@@ -151,8 +241,20 @@ export class BillReminderService {
               );
 
         await this.emailService.sendMail(user.email, subject, html);
+        // The delivery record, after the side effect and never before it.
+        await this.jobClaims.markDelivered(
+          JobClaimType.BillReminder,
+          userId,
+          claimKey,
+          leaseToken,
+        );
         sentCount++;
       } catch (error) {
+        // Hand the claim back. Claiming first is what makes the send
+        // exactly-once, but it must not turn a transient SMTP outage into a
+        // silently skipped day -- which is what the pre-claim code got for free
+        // by never recording anything.
+        await this.releaseClaim(userId, claimKey, leaseToken);
         this.logger.error(
           `Failed to send bill reminder to user ${userId}`,
           error instanceof Error ? error.stack : error,
@@ -164,4 +266,29 @@ export class BillReminderService {
       `Bill reminders complete: ${sentCount} sent, ${skipCount} skipped`,
     );
   }
+}
+
+/**
+ * The delivery key for one user's bill reminder: today's date plus a digest of
+ * exactly what the email will say.
+ *
+ * The date alone would suppress a legitimate second reminder when another bill
+ * falls due later the same day. The digest alone would let the same set be
+ * re-sent tomorrow. Together they mean "this reminder, today", which is what the
+ * claim is asserting.
+ */
+export function buildReminderClaimKey(
+  bills: readonly ScheduledTransaction[],
+): string {
+  const today = new Date();
+  const date = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+  const fingerprint = [...bills]
+    .map((b) => `${b.id}:${String(b.nextDueDate).split("T")[0]}:${b.amount}`)
+    .sort()
+    .join("|");
+  const digest = createHash("sha256")
+    .update(fingerprint)
+    .digest("hex")
+    .slice(0, 32);
+  return `${date}#${digest}`;
 }

--- a/backend/src/scheduled-transactions/entities/scheduled-transaction-posting.entity.ts
+++ b/backend/src/scheduled-transactions/entities/scheduled-transaction-posting.entity.ts
@@ -1,0 +1,74 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import { ScheduledTransaction } from "./scheduled-transaction.entity";
+
+/**
+ * One posted occurrence of a scheduled transaction.
+ *
+ * The occurrence -- not the schedule -- is the thing that must happen once.
+ * Before this table existed there was no name for it: the hourly cron fires in
+ * every replica, `post()` read the due row without a claim, and the financial
+ * transaction committed in its own transaction *before* `nextDueDate` advanced.
+ * Two replicas, or a manual post racing the cron, or a crash between the two
+ * commits, each produced the same result -- one bill paid twice (audit P4-004).
+ *
+ * `(scheduled_transaction_id, original_due_date)` is that name. Manual and
+ * automatic posting both insert it, inside the same transaction as the money
+ * they create, so the unique key arbitrates and the loser writes nothing.
+ * `original_due_date` is the schedule's own `next_due_date` at the moment of
+ * posting -- the occurrence's identity -- not the date the row was booked on,
+ * which an override or an inline `transactionDate` can move.
+ */
+@Entity("scheduled_transaction_postings")
+@Index(["scheduledTransactionId", "originalDueDate"], { unique: true })
+export class ScheduledTransactionPosting {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column({ type: "uuid", name: "scheduled_transaction_id" })
+  scheduledTransactionId: string;
+
+  @ManyToOne(() => ScheduledTransaction, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "scheduled_transaction_id" })
+  scheduledTransaction?: ScheduledTransaction;
+
+  /** The occurrence's identity: the schedule's due date when it was posted. */
+  @Column({
+    type: "date",
+    name: "original_due_date",
+    transformer: {
+      from: (value: string | Date): string => {
+        if (!value) return value as string;
+        if (typeof value === "string") return value;
+        return `${value.getFullYear()}-${String(value.getMonth() + 1).padStart(2, "0")}-${String(value.getDate()).padStart(2, "0")}`;
+      },
+      to: (value: string | Date): string | Date => value,
+    },
+  })
+  originalDueDate: string;
+
+  /** The date the money was actually booked on, after overrides. */
+  @Column({
+    type: "date",
+    name: "posted_date",
+    transformer: {
+      from: (value: string | Date): string => {
+        if (!value) return value as string;
+        if (typeof value === "string") return value;
+        return `${value.getFullYear()}-${String(value.getMonth() + 1).padStart(2, "0")}-${String(value.getDate()).padStart(2, "0")}`;
+      },
+      to: (value: string | Date): string | Date => value,
+    },
+  })
+  postedDate: string;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+}

--- a/backend/src/scheduled-transactions/rls-context-smoke.spec.ts
+++ b/backend/src/scheduled-transactions/rls-context-smoke.spec.ts
@@ -120,8 +120,16 @@ describe("scheduled-transactions module RLS context smoke (real withScopedDb)", 
       scheduledRepo,
       overridesRepo,
     );
-    // The timezone fan-out now runs through its own withScopedDb.
-    manager.query.mockResolvedValue([{ user_id: OWNER_ID, timezone: "UTC" }]);
+    // The timezone fan-out now runs through its own withScopedDb, and `post`
+    // locks the schedule and claims the occurrence before creating any money
+    // (audit P4-004) -- so the manager answers a locked read and a claim insert
+    // as well as the fan-out.
+    manager.findOne.mockResolvedValue(dueRow);
+    manager.query.mockImplementation(async (sql: string) =>
+      String(sql).includes("scheduled_transaction_postings")
+        ? [[{ id: "posting-1" }], 1]
+        : [{ user_id: OWNER_ID, timezone: "UTC" }],
+    );
     manager.createQueryBuilder.mockImplementation(() => ({
       delete: jest.fn().mockReturnThis(),
       from: jest.fn().mockReturnThis(),

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -1,5 +1,9 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { NotFoundException, BadRequestException } from "@nestjs/common";
+import {
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+} from "@nestjs/common";
 import { DataSource } from "typeorm";
 import { ScheduledTransactionsService } from "./scheduled-transactions.service";
 import { ScheduledTransaction } from "./entities/scheduled-transaction.entity";
@@ -37,6 +41,8 @@ describe("ScheduledTransactionsService", () => {
   // The withScopedDb manager, exposed under the legacy name so the pre-RLS
   // queryRunner.manager assertions keep reading naturally.
   let mockQueryRunner: Record<string, any>;
+  /** Whether the occurrence-claim insert returns a row this run. */
+  let postingClaimWins: boolean;
   let mockDataSource: DataSourceMock;
   let mockActionHistoryService: Record<string, jest.Mock>;
   let mockExchangeRateService: Record<string, jest.Mock>;
@@ -199,12 +205,32 @@ describe("ScheduledTransactionsService", () => {
       execute: jest.fn().mockResolvedValue({ affected: 0 }),
     }));
     mockQueryRunner = { manager: txManager };
+    /**
+     * `post` locks the schedule row and claims the occurrence before it creates
+     * any money.
+     *
+     * The financial transaction used to commit in its own transaction and
+     * `nextDueDate` advance in a second one, so two replicas firing the same
+     * hourly cron -- or a manual post racing it, or a crash between the two
+     * commits -- posted the same bill twice (audit P4-004). The locked read and
+     * the occurrence claim are what the doubles below answer.
+     */
+    postingClaimWins = true;
+    txManager.findOne.mockImplementation((_entity: unknown, options: unknown) =>
+      scheduledRepo.findOne(options as never),
+    );
+
     // Default to a single UTC user so cron logic that buckets by timezone
     // continues to operate against legacy tests that pre-date the cron
     // refactor and assume a one-user world.
-    mockDataSource.query.mockResolvedValue([
-      { user_id: "11111111-1111-1111-1111-111111111111", timezone: "UTC" },
-    ]);
+    mockDataSource.query.mockImplementation(async (sql: string) => {
+      if (String(sql).includes("scheduled_transaction_postings")) {
+        return postingClaimWins ? [[{ id: "posting-1" }], 1] : [[], 0];
+      }
+      return [
+        { user_id: "11111111-1111-1111-1111-111111111111", timezone: "UTC" },
+      ];
+    });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -1474,6 +1500,70 @@ describe("ScheduledTransactionsService", () => {
       );
     });
 
+    it("claims the occurrence before creating any money", async () => {
+      // The regression guard for P4-004. The claim, the money and the schedule
+      // advancement are one transaction keyed on
+      // (scheduled_transaction_id, original_due_date), so two replicas firing the
+      // same hourly cron cannot both post: opening 100.00 with one due -50.00
+      // ended at 0.00 instead of 50.00.
+      const scheduled = makeScheduled({ nextDueDate: "2026-02-01" });
+      stubFindOne(scheduled);
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await service.post(userId, stId);
+
+      const claim = mockQueryRunner.manager.query.mock.calls.find(
+        (c: unknown[]) =>
+          String(c[0]).includes("scheduled_transaction_postings"),
+      );
+      expect(claim).toBeDefined();
+      expect(String(claim![0])).toContain("ON CONFLICT");
+      // The occurrence's identity is the due date, not the date it was booked on.
+      expect(claim![1]).toEqual([stId, "2026-02-01", "2026-02-01"]);
+      expect(
+        mockQueryRunner.manager.query.mock.invocationCallOrder[
+          mockQueryRunner.manager.query.mock.calls.indexOf(claim!)
+        ],
+      ).toBeLessThan(transactionsService.create.mock.invocationCallOrder[0]);
+    });
+
+    it("posts nothing when another replica claimed the occurrence", async () => {
+      postingClaimWins = false;
+      const scheduled = makeScheduled({ nextDueDate: "2026-02-01" });
+      stubFindOne(scheduled);
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await expect(service.post(userId, stId)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+
+      expect(transactionsService.create).not.toHaveBeenCalled();
+      expect(scheduledRepo.update).not.toHaveBeenCalled();
+    });
+
+    it("refuses when the schedule has already been advanced past this occurrence", async () => {
+      // A manual post racing the cron: the caller computed the payload for
+      // 2026-02-01, but the committed row has moved on. Posting anyway would
+      // duplicate the occurrence the winner already booked.
+      const scheduled = makeScheduled({ nextDueDate: "2026-02-01" });
+      scheduledRepo.findOne
+        .mockResolvedValueOnce(scheduled)
+        .mockResolvedValueOnce({ ...scheduled, nextDueDate: "2026-03-01" });
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await expect(service.post(userId, stId)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+
+      expect(transactionsService.create).not.toHaveBeenCalled();
+    });
+
     it("should not call findOne after deleting a ONCE (would 404)", async () => {
       const scheduled = makeScheduled({ frequency: "ONCE" });
       stubFindOne(scheduled);
@@ -1485,11 +1575,14 @@ describe("ScheduledTransactionsService", () => {
         .fn()
         .mockResolvedValue({ affected: 1 });
 
-      // findOne is called once at the start of post() to load the entity.
-      // It must NOT be called a second time after the row is deleted.
+      // Twice: once outside the transaction to build the payload, and once
+      // inside it under the row lock -- that second read is what confirms the
+      // occurrence is still the due one before any money is created (P4-004).
+      // What must NOT happen is a read *after* the row is deleted, which would
+      // 404 on a posting that succeeded.
       await service.post(userId, stId);
 
-      expect(scheduledRepo.findOne).toHaveBeenCalledTimes(1);
+      expect(scheduledRepo.findOne).toHaveBeenCalledTimes(2);
     });
 
     it("should advance nextDueDate for recurring frequency", async () => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  ConflictException,
   NotFoundException,
   BadRequestException,
   Inject,
@@ -40,6 +41,7 @@ import { ActionHistoryService } from "../action-history/action-history.service";
 import { getUsersByEffectiveTimezone } from "../common/users-by-timezone.util";
 import { withSystemContext, withUserContext } from "../common/db/with-context";
 import { withScopedDb } from "../common/db/scoped-db";
+import { affectedRowCount } from "../common/db/query-result";
 import { validateSplitAmountSum } from "../common/split-amount.util";
 import { roundMoney, sumMoney } from "../common/round.util";
 import {
@@ -165,6 +167,7 @@ export class ScheduledTransactionsService {
 
       let totalSuccess = 0;
       let totalError = 0;
+      let totalSkipped = 0;
 
       for (const [tz, userIds] of userIdsByTz) {
         const today = todayInTimezone(tz);
@@ -240,6 +243,14 @@ export class ScheduledTransactionsService {
             );
             totalSuccess++;
           } catch (error) {
+            if (error instanceof ConflictException) {
+              // Another replica -- or a manual post -- claimed this occurrence
+              // first. Every backend replica fires this cron, so losing the
+              // claim is the normal outcome for all but one of them, not a
+              // failure: the money was posted exactly once, by the winner.
+              totalSkipped++;
+              continue;
+            }
             totalError++;
             this.logger.error(
               `Failed to auto-post "${scheduled.name}" (ID: ${scheduled.id}): ${error.message}`,
@@ -250,7 +261,8 @@ export class ScheduledTransactionsService {
       }
 
       this.logger.log(
-        `Auto-post processing complete: ${totalSuccess} succeeded, ${totalError} failed`,
+        `Auto-post processing complete: ${totalSuccess} succeeded, ` +
+          `${totalSkipped} already claimed elsewhere, ${totalError} failed`,
       );
     } catch (error) {
       this.logger.error("Auto-post processing failed", error.stack);
@@ -1618,66 +1630,126 @@ export class ScheduledTransactionsService {
       transactionPayload.categoryId = finalCategoryId || undefined;
     }
 
-    if (scheduled.isInvestment) {
-      await this.postInvestment(
-        userId,
-        scheduled,
-        postDto,
-        postDate,
-        storedOverride,
-      );
-    } else if (scheduled.isTransfer && scheduled.transferAccountId) {
-      // Carry the schedule's category onto the posted transfer (both legs), so
-      // a categorized scheduled transfer behaves like a one-off one (#743).
-      // Same precedence as the non-transfer branch: inline override > stored
-      // occurrence override > the schedule's own category.
-      const transferCategoryId = hasInlineCategoryId
-        ? postDto.categoryId
-        : storedOverride?.categoryId !== null &&
-            storedOverride?.categoryId !== undefined
-          ? storedOverride.categoryId
-          : scheduled.categoryId || undefined;
-      await this.transactionsService.createTransfer(userId, {
-        fromAccountId: scheduled.accountId,
-        toAccountId: scheduled.transferAccountId,
-        amount: Math.abs(finalAmount),
-        transactionDate: postDate,
-        fromCurrencyCode: scheduled.currencyCode,
-        description: finalDescription || undefined,
-        referenceNumber: postDto?.referenceNumber || undefined,
-        payeeId: scheduled.payeeId || undefined,
-        payeeName: scheduled.payeeName || undefined,
-        categoryId: transferCategoryId || undefined,
-        tagIds:
-          scheduled.tagIds && scheduled.tagIds.length > 0
-            ? scheduled.tagIds
-            : undefined,
-      });
-    } else {
-      await this.transactionsService.create(userId, transactionPayload);
-    }
-
-    // Wrap all bookkeeping in a transaction for atomicity. The posted
-    // transaction/transfer/investment above has already committed in its own
-    // withScopedDb, matching the pre-RLS boundary.
+    // ONE transaction from here down: the occurrence claim, the money it
+    // creates, the override it consumes and the schedule advancement.
+    //
+    // Before this, the financial transaction committed in its own transaction
+    // and `nextDueDate` advanced in a second one. Every way of getting between
+    // the two produced the same bill paid twice -- two replicas firing the same
+    // hourly cron, a manual post racing it, or a crash after the money
+    // committed. Opening balance 100.00 and one due -50.00: the account ends at
+    // 0.00 instead of 50.00 (audit P4-004).
+    //
+    // Nested service calls join this transaction, so a refusal below rolls the
+    // money back with it. Everything that reaches outside PostgreSQL -- the FX
+    // rate lookup in particular -- has already run above.
     const removedAfterOnce = await withScopedDb(this.dataSource, async (m) => {
+      // Lock the schedule and confirm this occurrence is still the due one. A
+      // poster that lost the race finds next_due_date already advanced.
+      const current = await m.findOne(ScheduledTransaction, {
+        where: { id, userId },
+        lock: { mode: "pessimistic_write" },
+      });
+      if (!current) {
+        throw new NotFoundException(
+          tr(
+            "errors.scheduled.notFound",
+            `Scheduled transaction with ID ${id} not found`,
+            { id },
+          ),
+        );
+      }
+      if (ensureYMD(current.nextDueDate) !== nextDueDateStr) {
+        throw new ConflictException(
+          tr(
+            "errors.scheduled.occurrenceAlreadyPosted",
+            "This occurrence has already been posted.",
+          ),
+        );
+      }
+
+      // Claim the occurrence. The unique key on
+      // (scheduled_transaction_id, original_due_date) is what makes the claim
+      // the serialization point rather than the lock alone: it survives a
+      // crash, and manual and automatic posting both go through it.
+      const claim: unknown = await m.query(
+        `INSERT INTO scheduled_transaction_postings
+           (scheduled_transaction_id, original_due_date, posted_date)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (scheduled_transaction_id, original_due_date) DO NOTHING
+         RETURNING id`,
+        [id, nextDueDateStr, postDate],
+      );
+      if (affectedRowCount(claim) === 0) {
+        throw new ConflictException(
+          tr(
+            "errors.scheduled.occurrenceAlreadyPosted",
+            "This occurrence has already been posted.",
+          ),
+        );
+      }
+
+      if (scheduled.isInvestment) {
+        await this.postInvestment(
+          userId,
+          scheduled,
+          postDto,
+          postDate,
+          storedOverride,
+        );
+      } else if (scheduled.isTransfer && scheduled.transferAccountId) {
+        // Carry the schedule's category onto the posted transfer (both legs),
+        // so a categorized scheduled transfer behaves like a one-off one
+        // (#743). Same precedence as the non-transfer branch: inline override >
+        // stored occurrence override > the schedule's own category.
+        const transferCategoryId = hasInlineCategoryId
+          ? postDto.categoryId
+          : storedOverride?.categoryId !== null &&
+              storedOverride?.categoryId !== undefined
+            ? storedOverride.categoryId
+            : scheduled.categoryId || undefined;
+        await this.transactionsService.createTransfer(userId, {
+          fromAccountId: scheduled.accountId,
+          toAccountId: scheduled.transferAccountId,
+          amount: Math.abs(finalAmount),
+          transactionDate: postDate,
+          fromCurrencyCode: scheduled.currencyCode,
+          description: finalDescription || undefined,
+          referenceNumber: postDto?.referenceNumber || undefined,
+          payeeId: scheduled.payeeId || undefined,
+          payeeName: scheduled.payeeName || undefined,
+          categoryId: transferCategoryId || undefined,
+          tagIds:
+            scheduled.tagIds && scheduled.tagIds.length > 0
+              ? scheduled.tagIds
+              : undefined,
+        });
+      } else {
+        await this.transactionsService.create(userId, transactionPayload);
+      }
+
       if (storedOverride) {
         await m.remove(storedOverride);
       }
 
-      if (scheduled.frequency === "ONCE") {
+      if (current.frequency === "ONCE") {
         // One-time bill or deposit: remove the scheduled transaction entirely
         // after posting so it disappears from the Bills & Deposits page.
-        // Splits and overrides are cleaned up via ON DELETE CASCADE.
+        // Splits, overrides and the posting claim are cleaned up via
+        // ON DELETE CASCADE.
         await m.delete(ScheduledTransaction, id);
         return true;
       }
 
       // Recurring frequency: advance nextDueDate, prune stale overrides,
       // decrement occurrencesRemaining, deactivate if past endDate.
+      //
+      // Read from `current`, the locked row, not from the `scheduled` snapshot
+      // taken before the transaction: a concurrent edit to occurrencesRemaining
+      // or endDate would otherwise be reverted by this advancement.
       const newNextDueDateStr = calcNextDueDate(
-        ensureYMD(scheduled.nextDueDate),
-        scheduled.frequency,
+        nextDueDateStr,
+        current.frequency,
       );
 
       await m
@@ -1696,20 +1768,17 @@ export class ScheduledTransactionsService {
       };
 
       if (
-        scheduled.occurrencesRemaining !== null &&
-        scheduled.occurrencesRemaining > 0
+        current.occurrencesRemaining !== null &&
+        current.occurrencesRemaining > 0
       ) {
-        const newRemaining = scheduled.occurrencesRemaining - 1;
+        const newRemaining = current.occurrencesRemaining - 1;
         updateFields.occurrencesRemaining = newRemaining;
         if (newRemaining === 0) {
           updateFields.isActive = false;
         }
       }
 
-      if (
-        scheduled.endDate &&
-        newNextDueDateStr > ensureYMD(scheduled.endDate)
-      ) {
+      if (current.endDate && newNextDueDateStr > ensureYMD(current.endDate)) {
         updateFields.isActive = false;
       }
 

--- a/backend/src/securities/security-price.service.spec.ts
+++ b/backend/src/securities/security-price.service.spec.ts
@@ -30,6 +30,57 @@ describe("SecurityPriceService", () => {
   let securitiesRepository: Record<string, jest.Mock>;
   let userPreferenceRepository: Record<string, jest.Mock>;
   let dataSourceMock: Record<string, jest.Mock>;
+  /** The SQL of the last single-price upsert the service issued. */
+  function priceUpsertSql(): string {
+    const call = scopedManagerQuery.mock.calls
+      .filter((c) => String(c[0]).includes("INSERT INTO security_prices"))
+      .pop();
+    return String(call?.[0] ?? "");
+  }
+
+  /** Make the next single-price upsert fail, the way a DB error would. */
+  function failPriceWrite(error: Error): void {
+    priceWriteError = error;
+  }
+
+  /**
+   * Pretend a price row is already stored for a security and date, so the
+   * upsert's `ON CONFLICT DO UPDATE` merges onto it. Replaces the old
+   * `findOne.mockResolvedValue(existing)`, which stubbed a read the write path
+   * no longer performs.
+   */
+  function seedStoredPrice(row: Record<string, unknown>): void {
+    upsertedPrices.push({
+      id: (row.id as number) ?? upsertedPrices.length + 1,
+      securityId: row.securityId as string,
+      priceDate: row.priceDate as string,
+      openPrice: (row.openPrice as number) ?? null,
+      highPrice: (row.highPrice as number) ?? null,
+      lowPrice: (row.lowPrice as number) ?? null,
+      closePrice: row.closePrice as number,
+      volume: (row.volume as number) ?? null,
+      source: (row.source as string) ?? "yahoo_finance",
+      quotedAt: (row.quotedAt as Date) ?? null,
+    });
+  }
+
+  /** The scoped transaction manager's `query`, for asserting on statements. */
+  let scopedManagerQuery: jest.Mock;
+  /** Set to make the next single-price upsert reject. */
+  let priceWriteError: Error | null;
+  /** Rows the single-price upsert wrote, in the shape the statement stores them. */
+  let upsertedPrices: Array<{
+    id: number;
+    securityId: string;
+    priceDate: string;
+    openPrice: number | null;
+    highPrice: number | null;
+    lowPrice: number | null;
+    closePrice: number;
+    volume: number | null;
+    source: string;
+    quotedAt: Date | null;
+  }>;
   let netWorthService: Record<string, jest.Mock>;
   let msnFinanceService: Record<string, jest.Mock>;
   let originalFetch: typeof global.fetch;
@@ -146,7 +197,14 @@ describe("SecurityPriceService", () => {
     originalFetch = global.fetch;
 
     securityPriceRepository = {
-      findOne: jest.fn(),
+      // Default: answer a by-id read (the price upsert's read-back) from the
+      // rows the upsert recorded. Tests that care about a specific stored row
+      // still override this with `mockResolvedValue`.
+      findOne: jest.fn(async ({ where }: { where?: { id?: number } } = {}) =>
+        where?.id === undefined
+          ? null
+          : (upsertedPrices.find((row) => row.id === where.id) ?? null),
+      ),
       find: jest.fn(),
       create: jest.fn().mockImplementation((data) => ({ ...data, id: 1 })),
       save: jest.fn().mockImplementation((data) => data),
@@ -204,8 +262,59 @@ describe("SecurityPriceService", () => {
       [Security, securitiesRepository],
       [UserPreference, userPreferenceRepository],
     ]);
-    manager.query.mockImplementation((sql: string, params?: unknown[]) =>
-      dataSourceMock.query(sql, params),
+    // The single-price write is now one `INSERT ... ON CONFLICT DO UPDATE
+    // RETURNING id`, so the spec records what it wrote and answers the by-id
+    // read-back with the resulting row -- which is what the assertions are about.
+    upsertedPrices = [];
+    priceWriteError = null;
+    scopedManagerQuery = manager.query;
+    manager.query.mockImplementation(
+      async (sql: string, params?: unknown[]) => {
+        if (
+          typeof sql === "string" &&
+          sql.includes("INSERT INTO security_prices") &&
+          sql.includes("RETURNING id")
+        ) {
+          if (priceWriteError) throw priceWriteError;
+          const [
+            securityId,
+            priceDate,
+            openPrice,
+            highPrice,
+            lowPrice,
+            closePrice,
+            volume,
+            source,
+            quotedAt,
+          ] = params as unknown[];
+          const previous = upsertedPrices.find(
+            (row) =>
+              row.securityId === securityId && row.priceDate === priceDate,
+          );
+          // `COALESCE(EXCLUDED.x, security_prices.x)` in the statement: a value
+          // the quote did not supply keeps whatever is stored.
+          const row = {
+            id: (previous?.id ?? upsertedPrices.length + 1) as number,
+            securityId: securityId as string,
+            priceDate: priceDate as string,
+            openPrice: (openPrice ?? previous?.openPrice ?? null) as
+              | number
+              | null,
+            highPrice: (highPrice ?? previous?.highPrice ?? null) as
+              | number
+              | null,
+            lowPrice: (lowPrice ?? previous?.lowPrice ?? null) as number | null,
+            closePrice: closePrice as number,
+            volume: (volume ?? previous?.volume ?? null) as number | null,
+            source: (source ?? "manual") as string,
+            quotedAt: (quotedAt ?? previous?.quotedAt ?? null) as Date | null,
+          };
+          if (previous) Object.assign(previous, row);
+          else upsertedPrices.push(row);
+          return [{ id: row.id }];
+        }
+        return dataSourceMock.query(sql, params);
+      },
     );
 
     const yahooFinanceService = new YahooFinanceService();
@@ -522,7 +631,6 @@ describe("SecurityPriceService", () => {
       global.fetch = jest
         .fn()
         .mockResolvedValue(createMockFetchResponse(yahooData)) as jest.Mock;
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       const result = await service.refreshAllPrices();
 
@@ -545,10 +653,10 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(createMockFetchResponse(yahooData)) as jest.Mock;
 
       // savePriceData: findOne returns null (new price), then create and save
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       const result = await service.refreshAllPrices();
 
+      expect(result.results[0].error).toBeUndefined();
       expect(result.totalSecurities).toBe(1);
       expect(result.updated).toBe(1);
       expect(result.failed).toBe(0);
@@ -568,8 +676,6 @@ describe("SecurityPriceService", () => {
       global.fetch = jest
         .fn()
         .mockResolvedValue(createMockFetchResponse(yahooData)) as jest.Mock;
-
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       await service.refreshAllPrices();
 
@@ -599,8 +705,6 @@ describe("SecurityPriceService", () => {
         ); // MSFT.CN fails
       global.fetch = fetchMock;
 
-      securityPriceRepository.findOne.mockResolvedValue(null);
-
       const result = await service.refreshAllPrices();
 
       // Should have tried plain symbol + 3 alternates
@@ -619,8 +723,6 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(
           createMockFetchResponse({ chart: { result: [] } }),
         ) as jest.Mock;
-
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       const result = await service.refreshAllPrices();
 
@@ -666,18 +768,18 @@ describe("SecurityPriceService", () => {
 
       // savePriceData: findOne returns existing entry
       const existingPrice = { ...mockPriceEntry };
-      securityPriceRepository.findOne.mockResolvedValue(existingPrice);
+      // A row already stored for this security and date: the upsert's
+      // `ON CONFLICT DO UPDATE` merges onto it rather than inserting.
+      seedStoredPrice(existingPrice);
 
       await service.refreshAllPrices();
 
-      // Should update existing, not create new
-      expect(securityPriceRepository.create).not.toHaveBeenCalled();
-      expect(securityPriceRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          closePrice: 193.5,
-          source: "yahoo_finance",
-        }),
-      );
+      // Merged onto the stored row, not inserted alongside it.
+      expect(upsertedPrices).toHaveLength(1);
+      expect(upsertedPrices[0]).toMatchObject({
+        closePrice: 193.5,
+        source: "yahoo_finance",
+      });
     });
 
     it("handles save error for individual security", async () => {
@@ -688,10 +790,7 @@ describe("SecurityPriceService", () => {
         .fn()
         .mockResolvedValue(createMockFetchResponse(yahooData)) as jest.Mock;
 
-      securityPriceRepository.findOne.mockResolvedValue(null);
-      securityPriceRepository.save.mockRejectedValue(
-        new Error("DB write failed"),
-      );
+      failPriceWrite(new Error("DB write failed"));
 
       const result = await service.refreshAllPrices();
 
@@ -722,8 +821,6 @@ describe("SecurityPriceService", () => {
       global.fetch = jest
         .fn()
         .mockResolvedValue(createMockFetchResponse(yahooData)) as jest.Mock;
-
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       const result = await service.refreshAllPrices();
 
@@ -774,8 +871,6 @@ describe("SecurityPriceService", () => {
         .fn()
         .mockResolvedValue(createMockFetchResponse(yahooData)) as jest.Mock;
 
-      securityPriceRepository.findOne.mockResolvedValue(null);
-
       const result = await service.refreshPricesForSecurities(["sec-1"]);
 
       expect(result.totalSecurities).toBe(1);
@@ -799,8 +894,6 @@ describe("SecurityPriceService", () => {
           createMockFetchResponse({ chart: { result: [] } }),
         );
       global.fetch = fetchMock;
-
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       const result = await service.refreshPricesForSecurities([
         "sec-1",
@@ -827,8 +920,6 @@ describe("SecurityPriceService", () => {
         ); // MSFT.TO succeeds
       global.fetch = fetchMock;
 
-      securityPriceRepository.findOne.mockResolvedValue(null);
-
       const result = await service.refreshPricesForSecurities(["sec-3"]);
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -843,10 +934,7 @@ describe("SecurityPriceService", () => {
         .fn()
         .mockResolvedValue(createMockFetchResponse(yahooData)) as jest.Mock;
 
-      securityPriceRepository.findOne.mockResolvedValue(null);
-      securityPriceRepository.save.mockRejectedValue(
-        new Error("Constraint violation"),
-      );
+      failPriceWrite(new Error("Constraint violation"));
 
       const result = await service.refreshPricesForSecurities(["sec-1"]);
 
@@ -1795,7 +1883,6 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(
           createMockFetchResponse(makeYahooChartResponse()),
         ) as jest.Mock;
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       await service.refreshAllPrices();
 
@@ -1814,7 +1901,6 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(
           createMockFetchResponse(makeYahooChartResponse()),
         ) as jest.Mock;
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       await service.refreshAllPrices();
 
@@ -1833,7 +1919,6 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(
           createMockFetchResponse(makeYahooChartResponse()),
         ) as jest.Mock;
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       await service.refreshAllPrices();
 
@@ -1852,7 +1937,6 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(
           createMockFetchResponse(makeYahooChartResponse()),
         ) as jest.Mock;
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       await service.refreshAllPrices();
 
@@ -1871,7 +1955,6 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(
           createMockFetchResponse(makeYahooChartResponse()),
         ) as jest.Mock;
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       await service.refreshAllPrices();
 
@@ -1890,7 +1973,6 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(
           createMockFetchResponse(makeYahooChartResponse()),
         ) as jest.Mock;
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       await service.refreshAllPrices();
 
@@ -1909,7 +1991,6 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(
           createMockFetchResponse(makeYahooChartResponse()),
         ) as jest.Mock;
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       await service.refreshAllPrices();
 
@@ -1928,7 +2009,6 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(
           createMockFetchResponse(makeYahooChartResponse()),
         ) as jest.Mock;
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       await service.refreshAllPrices();
 
@@ -1947,7 +2027,6 @@ describe("SecurityPriceService", () => {
         .mockResolvedValue(
           createMockFetchResponse(makeYahooChartResponse()),
         ) as jest.Mock;
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       await service.refreshAllPrices();
 
@@ -1970,8 +2049,6 @@ describe("SecurityPriceService", () => {
         .fn()
         .mockResolvedValue(createMockFetchResponse(yahooData)) as jest.Mock;
 
-      securityPriceRepository.findOne.mockResolvedValue(null);
-
       await service.refreshAllPrices();
 
       // The trading date should be derived from the timestamp (zeroed in UTC)
@@ -1981,11 +2058,9 @@ describe("SecurityPriceService", () => {
         expected.getUTCMonth() + 1,
       ).padStart(2, "0")}-${String(expected.getUTCDate()).padStart(2, "0")}`;
 
-      expect(securityPriceRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          priceDate: expectedDateStr,
-        }),
-      );
+      expect(upsertedPrices[0]).toMatchObject({
+        priceDate: expectedDateStr,
+      });
     });
 
     it("falls back to current date when regularMarketTime is missing", async () => {
@@ -2000,16 +2075,12 @@ describe("SecurityPriceService", () => {
         .fn()
         .mockResolvedValue(createMockFetchResponse(yahooData)) as jest.Mock;
 
-      securityPriceRepository.findOne.mockResolvedValue(null);
-
       await service.refreshAllPrices();
 
       // Should use today (or adjusted for weekend) as a YYYY-MM-DD string
-      expect(securityPriceRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          priceDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
-        }),
-      );
+      expect(upsertedPrices[0]).toMatchObject({
+        priceDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      });
     });
   });
 
@@ -2027,21 +2098,17 @@ describe("SecurityPriceService", () => {
         .fn()
         .mockResolvedValue(createMockFetchResponse(yahooData)) as jest.Mock;
 
-      securityPriceRepository.findOne.mockResolvedValue(null);
-
       await service.refreshAllPrices();
 
-      expect(securityPriceRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          securityId: "sec-1",
-          closePrice: 200.0,
-          highPrice: 205.0,
-          lowPrice: 198.0,
-          volume: 60000000,
-          source: "yahoo_finance",
-        }),
-      );
-      expect(securityPriceRepository.save).toHaveBeenCalled();
+      expect(upsertedPrices).toHaveLength(1);
+      expect(upsertedPrices[0]).toMatchObject({
+        securityId: "sec-1",
+        closePrice: 200.0,
+        highPrice: 205.0,
+        lowPrice: 198.0,
+        volume: 60000000,
+        source: "yahoo_finance",
+      });
     });
 
     it("updates existing price entry when one exists for the date", async () => {
@@ -2065,22 +2132,21 @@ describe("SecurityPriceService", () => {
         closePrice: 189.0,
         volume: 40000000,
       };
-      securityPriceRepository.findOne.mockResolvedValue(existingPrice);
+      // A row already stored for this security and date: the upsert's
+      // `ON CONFLICT DO UPDATE` merges onto it rather than inserting.
+      seedStoredPrice(existingPrice);
 
       await service.refreshAllPrices();
 
-      // Should NOT call create
-      expect(securityPriceRepository.create).not.toHaveBeenCalled();
-      // Should update existing and save
-      expect(securityPriceRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          closePrice: 200.0,
-          highPrice: 205.0,
-          lowPrice: 198.0,
-          volume: 60000000,
-          source: "yahoo_finance",
-        }),
-      );
+      // Merged onto the row that was there, not inserted alongside it.
+      expect(upsertedPrices).toHaveLength(1);
+      expect(upsertedPrices[0]).toMatchObject({
+        closePrice: 200.0,
+        highPrice: 205.0,
+        lowPrice: 198.0,
+        volume: 60000000,
+        source: "yahoo_finance",
+      });
     });
 
     it("preserves existing openPrice when quote has no open", async () => {
@@ -2099,12 +2165,19 @@ describe("SecurityPriceService", () => {
         ...mockPriceEntry,
         openPrice: 188.0,
       };
-      securityPriceRepository.findOne.mockResolvedValue(existingPrice);
+      // A row already stored for this security and date: the upsert's
+      // `ON CONFLICT DO UPDATE` merges onto it rather than inserting.
+      seedStoredPrice(existingPrice);
 
       await service.refreshAllPrices();
 
-      // openPrice should remain 188.0 because quote.regularMarketOpen is undefined
-      expect(securityPriceRepository.save).toHaveBeenCalledWith(
+      // openPrice stays 188.0 because the quote carries no open and the
+      // statement says `COALESCE(EXCLUDED.open_price, security_prices.open_price)`
+      // -- read from the stored row rather than from a copy fetched earlier.
+      expect(priceUpsertSql()).toContain(
+        "COALESCE(EXCLUDED.open_price,  security_prices.open_price)",
+      );
+      expect(upsertedPrices[0]).toMatchObject(
         expect.objectContaining({
           openPrice: 188.0,
         }),
@@ -2168,8 +2241,6 @@ describe("SecurityPriceService", () => {
           ),
         ); // MSFT.TO succeeds
       global.fetch = fetchMock;
-
-      securityPriceRepository.findOne.mockResolvedValue(null);
 
       const result = await service.refreshAllPrices();
 
@@ -2313,40 +2384,110 @@ describe("SecurityPriceService", () => {
     });
   });
 
+  describe("single-price writes are one guarded statement", () => {
+    it("does not read the row before deciding to insert or update", async () => {
+      // The regression: this used to `findOne` and then either save a mutated
+      // copy or insert a fresh row. The 5 PM ET price cron fires on every
+      // replica, so two processes routinely fetch the same quote for the same
+      // security and day, both find no row, and both insert -- the loser hit
+      // `UNIQUE(security_id, price_date)` and that security had no price at all
+      // for the day. There is now nothing to check and nothing to get wrong.
+      securitiesRepository.find.mockResolvedValue([mockSecurity]);
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          createMockFetchResponse(makeYahooChartResponse()),
+        ) as jest.Mock;
+
+      await service.refreshAllPrices();
+
+      const sql = priceUpsertSql();
+      expect(sql).toContain("ON CONFLICT (security_id, price_date) DO UPDATE");
+      // The read-back is by the id the statement returned, so it cannot pick up
+      // a different row.
+      expect(sql).toContain("RETURNING id");
+      const reads = securityPriceRepository.findOne.mock.calls.map(
+        (call) => (call[0] as { where?: Record<string, unknown> })?.where ?? {},
+      );
+      expect(
+        reads.some(
+          (where) =>
+            "securityId" in where && "priceDate" in where && !("id" in where),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps a stored field the quote does not carry, reading it from the row", async () => {
+      // `?? existing.x` on a copy fetched earlier would write back whatever that
+      // copy held, overwriting a value another writer had since stored. The
+      // COALESCE reads the row as it is at write time.
+      securitiesRepository.find.mockResolvedValue([mockSecurity]);
+      seedStoredPrice({ ...mockPriceEntry, openPrice: 111.0 });
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          createMockFetchResponse(
+            makeYahooChartResponse({ regularMarketPrice: 200 }),
+          ),
+        ) as jest.Mock;
+
+      await service.refreshAllPrices();
+
+      expect(upsertedPrices).toHaveLength(1);
+      // The fixture carries a close and a volume but no open, so only the open
+      // falls back -- and it falls back to what is stored.
+      expect(upsertedPrices[0]).toMatchObject({
+        closePrice: 200,
+        openPrice: 111.0,
+      });
+      for (const column of [
+        "open_price",
+        "high_price",
+        "low_price",
+        "volume",
+      ]) {
+        expect(priceUpsertSql()).toContain(`COALESCE(EXCLUDED.${column},`);
+      }
+    });
+  });
+
   describe("createManualPrice", () => {
     it("should create a new manual price entry", async () => {
-      securityPriceRepository.findOne.mockResolvedValue(null);
-
       await service.createManualPrice("sec-1", {
         priceDate: "2025-06-01",
         closePrice: 150.5,
       });
 
-      expect(securityPriceRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          securityId: "sec-1",
-          closePrice: 150.5,
-          source: "manual",
-        }),
+      expect(upsertedPrices).toHaveLength(1);
+      expect(upsertedPrices[0]).toMatchObject({
+        securityId: "sec-1",
+        priceDate: "2025-06-01",
+        closePrice: 150.5,
+        source: "manual",
+      });
+      expect(priceUpsertSql()).toContain(
+        "ON CONFLICT (security_id, price_date) DO UPDATE",
       );
-      expect(securityPriceRepository.save).toHaveBeenCalled();
     });
 
     it("should overwrite existing price entry", async () => {
       const existing = { ...mockPriceEntry, source: "yahoo_finance" };
-      securityPriceRepository.findOne.mockResolvedValue(existing);
+      // A row already stored for this security and date: the upsert's
+      // `ON CONFLICT DO UPDATE` merges onto it rather than inserting.
+      seedStoredPrice(existing);
 
       await service.createManualPrice("sec-1", {
         priceDate: "2025-06-01",
         closePrice: 200.0,
       });
 
-      expect(securityPriceRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          closePrice: 200.0,
-          source: "manual",
-        }),
-      );
+      // One statement: the manual entry merges onto the provider's row for the
+      // same day instead of racing it to a unique violation.
+      expect(upsertedPrices).toHaveLength(1);
+      expect(upsertedPrices[0]).toMatchObject({
+        closePrice: 200.0,
+        source: "manual",
+      });
     });
   });
 

--- a/backend/src/securities/security-price.service.ts
+++ b/backend/src/securities/security-price.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { tr } from "../i18n/translate";
 import { In, DataSource } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
+import { returnedRows } from "../common/db/query-result";
 import { Cron } from "@nestjs/schedule";
 import { SecurityPrice } from "./entities/security-price.entity";
 import { Security } from "./entities/security.entity";
@@ -717,39 +718,57 @@ export class SecurityPriceService {
       ? new Date(quote.regularMarketTime * 1000)
       : null;
 
-    const existing = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(SecurityPrice).findOne({
-        where: { securityId, priceDate },
-      }),
-    );
-
-    if (existing) {
-      existing.openPrice = quote.regularMarketOpen ?? existing.openPrice;
-      existing.highPrice = quote.regularMarketDayHigh ?? existing.highPrice;
-      existing.lowPrice = quote.regularMarketDayLow ?? existing.lowPrice;
-      existing.closePrice = quote.regularMarketPrice!;
-      existing.volume = quote.regularMarketVolume ?? existing.volume;
-      existing.source = source;
-      existing.quotedAt = quotedAt ?? existing.quotedAt;
-      return withScopedDb(this.dataSource, (m) =>
-        m.getRepository(SecurityPrice).save(existing),
+    // One statement, arbitrated by `UNIQUE(security_id, price_date)`. This used
+    // to read the row, then in one branch save a mutated copy and in the other
+    // insert a new one -- a check-then-act on a path the 5 PM ET cron runs on
+    // every replica at once, so two processes routinely fetch the same quote for
+    // the same security and day, both find no row, and both insert. The loser
+    // got a unique violation and that security had no price for the day.
+    //
+    // `COALESCE(EXCLUDED.x, security_prices.x)` keeps the previous value where
+    // the quote does not supply one, which is what the `?? existing.x` in the old
+    // update branch meant -- except it now reads the stored value rather than a
+    // copy fetched before another writer touched it.
+    return withScopedDb(this.dataSource, async (m) => {
+      const rows: unknown = await m.query(
+        `INSERT INTO security_prices
+           (security_id, price_date, open_price, high_price, low_price,
+            close_price, volume, source, quoted_at)
+         VALUES ($1, $2::DATE, $3, $4, $5, $6, $7, $8, $9)
+         ON CONFLICT (security_id, price_date) DO UPDATE SET
+           close_price = EXCLUDED.close_price,
+           open_price  = COALESCE(EXCLUDED.open_price,  security_prices.open_price),
+           high_price  = COALESCE(EXCLUDED.high_price,  security_prices.high_price),
+           low_price   = COALESCE(EXCLUDED.low_price,   security_prices.low_price),
+           volume      = COALESCE(EXCLUDED.volume,      security_prices.volume),
+           source      = EXCLUDED.source,
+           quoted_at   = COALESCE(EXCLUDED.quoted_at,   security_prices.quoted_at)
+         RETURNING id`,
+        [
+          securityId,
+          priceDate,
+          quote.regularMarketOpen ?? null,
+          quote.regularMarketDayHigh ?? null,
+          quote.regularMarketDayLow ?? null,
+          quote.regularMarketPrice!,
+          quote.regularMarketVolume ?? null,
+          source,
+          quotedAt,
+        ],
       );
-    }
 
-    return withScopedDb(this.dataSource, (m) => {
-      const repo = m.getRepository(SecurityPrice);
-      const priceEntry = repo.create({
-        securityId,
-        priceDate,
-        openPrice: quote.regularMarketOpen,
-        highPrice: quote.regularMarketDayHigh,
-        lowPrice: quote.regularMarketDayLow,
-        closePrice: quote.regularMarketPrice!,
-        volume: quote.regularMarketVolume,
-        source,
-        quotedAt,
-      });
-      return repo.save(priceEntry);
+      const id = returnedRows<{ id: number }>(rows)[0]?.id;
+      const saved = id
+        ? await m.getRepository(SecurityPrice).findOne({ where: { id } })
+        : null;
+      if (!saved) {
+        // `DO UPDATE` always returns its row, so this cannot happen without a
+        // real fault -- better to say so than to hand back a synthesized entity.
+        throw new Error(
+          `Failed to persist price for security ${securityId} on ${priceDate}`,
+        );
+      }
+      return saved;
     });
   }
 
@@ -1560,37 +1579,45 @@ export class SecurityPriceService {
     securityId: string,
     dto: CreateSecurityPriceDto,
   ): Promise<SecurityPrice> {
-    const existing = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(SecurityPrice).findOne({
-        where: { securityId, priceDate: dto.priceDate },
-      }),
-    );
-
-    if (existing) {
-      existing.closePrice = dto.closePrice;
-      existing.openPrice = dto.openPrice as number;
-      existing.highPrice = dto.highPrice as number;
-      existing.lowPrice = dto.lowPrice as number;
-      existing.volume = dto.volume as number;
-      existing.source = "manual";
-      return withScopedDb(this.dataSource, (m) =>
-        m.getRepository(SecurityPrice).save(existing),
+    // Same shape as the quote path, and the same reason: read-then-insert on a
+    // uniquely-keyed row turns a second submission -- a double-clicked Save, or a
+    // manual entry landing on the same day the price cron just wrote -- into a
+    // unique violation instead of an update.
+    return withScopedDb(this.dataSource, async (m) => {
+      const rows: unknown = await m.query(
+        `INSERT INTO security_prices
+           (security_id, price_date, open_price, high_price, low_price,
+            close_price, volume, source)
+         VALUES ($1, $2::DATE, $3, $4, $5, $6, $7, 'manual')
+         ON CONFLICT (security_id, price_date) DO UPDATE SET
+           close_price = EXCLUDED.close_price,
+           open_price  = COALESCE(EXCLUDED.open_price,  security_prices.open_price),
+           high_price  = COALESCE(EXCLUDED.high_price,  security_prices.high_price),
+           low_price   = COALESCE(EXCLUDED.low_price,   security_prices.low_price),
+           volume      = COALESCE(EXCLUDED.volume,      security_prices.volume),
+           source      = 'manual'
+         RETURNING id`,
+        [
+          securityId,
+          dto.priceDate,
+          dto.openPrice ?? null,
+          dto.highPrice ?? null,
+          dto.lowPrice ?? null,
+          dto.closePrice,
+          dto.volume ?? null,
+        ],
       );
-    }
 
-    return withScopedDb(this.dataSource, (m) => {
-      const repo = m.getRepository(SecurityPrice);
-      const priceEntry = repo.create({
-        securityId,
-        priceDate: dto.priceDate,
-        closePrice: dto.closePrice,
-        openPrice: dto.openPrice as number,
-        highPrice: dto.highPrice as number,
-        lowPrice: dto.lowPrice as number,
-        volume: dto.volume as number,
-        source: "manual",
-      });
-      return repo.save(priceEntry);
+      const id = returnedRows<{ id: number }>(rows)[0]?.id;
+      const saved = id
+        ? await m.getRepository(SecurityPrice).findOne({ where: { id } })
+        : null;
+      if (!saved) {
+        throw new Error(
+          `Failed to persist manual price for security ${securityId} on ${dto.priceDate}`,
+        );
+      }
+      return saved;
     });
   }
 

--- a/backend/src/test-helpers/job-claim-testing.ts
+++ b/backend/src/test-helpers/job-claim-testing.ts
@@ -1,0 +1,97 @@
+import { JobClaimService } from "../common/jobs/job-claim.service";
+import { UserMaintenanceService } from "../common/jobs/user-maintenance.service";
+
+/**
+ * A `JobClaimService` double that always wins the claim.
+ *
+ * Typed as `jest.Mocked<JobClaimService>` rather than
+ * `Record<string, jest.Mock>` on purpose: this is one of our own services, so
+ * `tsc` should reject a return shape the real method cannot produce. An untyped
+ * double here would let a spec assert against fiction -- see the mock rule in
+ * `backend/CLAUDE.md`.
+ *
+ * Winning by default keeps the existing behaviour of every cron spec written
+ * before the claim existed. A spec that wants the *loser* path -- the one that
+ * proves a second replica sends nothing -- sets `claimOnce` to resolve false or
+ * `claimLease` to resolve `null`, which is the assertion worth writing.
+ *
+ * `claimLease` resolves a **token**, not `true`, because that is what the real
+ * method returns since DR-RRV4-01: the caller carries it into `release` and
+ * `markDelivered` so a stalled attempt cannot write against a lease another replica
+ * retook. {@link TEST_LEASE_TOKEN} is that token, so a spec can assert the value
+ * travelled rather than merely that a string did.
+ *
+ * `wasDelivered` defaults to false for the same reason: a lease says a replica may
+ * send, and only the delivery record says one did, so the two have to be settable
+ * independently or the recovery path cannot be tested at all.
+ */
+export type JobClaimMock = jest.Mocked<
+  Pick<
+    JobClaimService,
+    | "claimOnce"
+    | "claimLease"
+    | "releaseLease"
+    | "releasePermanentClaim"
+    | "markDelivered"
+    | "wasDelivered"
+  >
+>;
+
+/** The lease token this double hands out, so specs can assert it was carried. */
+export const TEST_LEASE_TOKEN = "8f3a5c1e-0000-4000-8000-000000000001";
+
+export function createJobClaimMock(): JobClaimMock {
+  return {
+    claimOnce: jest.fn().mockResolvedValue(true),
+    claimLease: jest.fn().mockResolvedValue(TEST_LEASE_TOKEN),
+    releaseLease: jest.fn().mockResolvedValue(undefined),
+    releasePermanentClaim: jest.fn().mockResolvedValue(undefined),
+    markDelivered: jest.fn().mockResolvedValue(undefined),
+    // "Not yet delivered" by default, so a spec written before the delivery
+    // record still exercises the send. A spec about the *recovery* -- the lease
+    // won but the work already done -- sets this true, which is the assertion
+    // worth writing (audit RV4-006).
+    wasDelivered: jest.fn().mockResolvedValue(false),
+  };
+}
+
+/** Provider entry for `Test.createTestingModule({ providers: [...] })`. */
+export function jobClaimProvider(mock: JobClaimMock = createJobClaimMock()): {
+  provide: typeof JobClaimService;
+  useValue: JobClaimMock;
+} {
+  return { provide: JobClaimService, useValue: mock };
+}
+
+/**
+ * A `UserMaintenanceService` double for the surfaces that consult it.
+ *
+ * Defaults to "not under maintenance" and to running the body, so a spec written
+ * before the lease existed behaves as it did. The interesting assertions are the
+ * refusals -- set `isUnderMaintenance` to resolve true, or make
+ * `withMaintenanceLease` reject, and check that the destructive operation wrote
+ * nothing.
+ */
+export type UserMaintenanceMock = jest.Mocked<
+  Pick<UserMaintenanceService, "isUnderMaintenance" | "withMaintenanceLease">
+>;
+
+export function createUserMaintenanceMock(): UserMaintenanceMock {
+  return {
+    isUnderMaintenance: jest.fn().mockResolvedValue(false),
+    withMaintenanceLease: jest.fn(
+      async (_userId: string, _operation: string, fn: () => Promise<unknown>) =>
+        fn(),
+    ) as UserMaintenanceMock["withMaintenanceLease"],
+  };
+}
+
+/** Provider entry for `Test.createTestingModule({ providers: [...] })`. */
+export function userMaintenanceProvider(
+  mock: UserMaintenanceMock = createUserMaintenanceMock(),
+): {
+  provide: typeof UserMaintenanceService;
+  useValue: UserMaintenanceMock;
+} {
+  return { provide: UserMaintenanceService, useValue: mock };
+}

--- a/backend/src/updates/tours.service.spec.ts
+++ b/backend/src/updates/tours.service.spec.ts
@@ -18,23 +18,37 @@ const CURRENT_VERSION = "1.13.0";
 
 describe("ToursService", () => {
   let prefsMock: UserPreferenceRepoMock;
-  let repo: Record<string, jest.Mock>;
   let query: jest.Mock;
   let manager: EntityManager;
   let service: ToursService;
 
   beforeEach(() => {
-    // The row-modelling double: the prune path writes through the column-scoped
-    // writer (insert-if-absent + UPDATE of only the named columns), so a mock
-    // that recorded `save` calls could not tell a whole-row save from a scoped
-    // patch -- and the whole point of the change is that it is the latter.
     prefsMock = createUserPreferenceRepoMock(null);
-    repo = prefsMock.repo;
-    // Default: the atomic-merge UPDATE affects a row.
-    query = jest.fn().mockResolvedValue([{ user_id: "user-1" }]);
+
+    // The merge is raw SQL, so the double applies it the way Postgres would --
+    // against whatever row the insert-if-absent left behind. A `query` mock that
+    // just returns a value could not show that the merge landed on a row this
+    // call had to create first.
+    query = jest.fn(async (sql: string, params: unknown[]) => {
+      if (/tour_progress\s*=\s*'\{\}'::jsonb/.test(sql)) {
+        const row = prefsMock.row();
+        if (row) row.tourProgress = {};
+        return [[], row ? 1 : 0];
+      }
+      if (/tour_progress\s*=\s*COALESCE/.test(sql)) {
+        const row = prefsMock.row();
+        if (!row) return [[], 0];
+        row.tourProgress = {
+          ...(row.tourProgress ?? {}),
+          ...(JSON.parse(params[0] as string) as TourProgressMap),
+        };
+        return [[], 1];
+      }
+      return [[], 0];
+    });
 
     manager = {
-      getRepository: jest.fn(() => repo),
+      getRepository: jest.fn(() => prefsMock.repo),
       query,
     } as unknown as EntityManager;
 
@@ -49,22 +63,20 @@ describe("ToursService", () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  function prefs(tourProgress: TourProgressMap = {}): UserPreference {
-    return { userId: "user-1", tourProgress } as UserPreference;
+  function seed(tourProgress: TourProgressMap = {}): void {
+    prefsMock.seed({ userId: "user-1", tourProgress } as UserPreference);
   }
 
   describe("getProgress", () => {
     it("returns the stored map", async () => {
       const map = { "intro/basics": { status: "completed", updatedAt: "x" } };
-      repo.findOne.mockResolvedValue(prefs(map as TourProgressMap));
+      seed(map as TourProgressMap);
 
-      const result = await service.getProgress("user-1");
-
-      expect(result).toEqual(map);
+      expect(await service.getProgress("user-1")).toEqual(map);
     });
 
     it("returns an empty map when no row exists", async () => {
-      repo.findOne.mockResolvedValue(null);
+      prefsMock.seed(null);
 
       expect(await service.getProgress("user-1")).toEqual({});
     });
@@ -72,7 +84,7 @@ describe("ToursService", () => {
 
   describe("saveProgress", () => {
     it("atomically merges a single entry without a version for evergreen tours", async () => {
-      repo.findOne.mockResolvedValue(prefs());
+      seed();
 
       const result = await service.saveProgress(
         "user-1",
@@ -81,19 +93,21 @@ describe("ToursService", () => {
       );
 
       expect(result).toEqual({ saved: true });
-      expect(query).toHaveBeenCalledTimes(1);
-      const [sql, params] = query.mock.calls[0];
-      expect(sql).toContain("tour_progress || $1::jsonb");
-      const patch = JSON.parse(params[0]);
+      const merge = query.mock.calls.find(([sql]) =>
+        String(sql).includes("tour_progress = COALESCE"),
+      )!;
+      expect(merge[0]).toContain("|| $1::jsonb");
+      const patch = JSON.parse(merge[1][0]);
       expect(patch["intro/basics"]).toMatchObject({ status: "completed" });
       expect(patch["intro/basics"].version).toBeUndefined();
-      expect(params[1]).toBe("user-1");
-      // Existing row -> no fallback save.
-      expect(repo.save).not.toHaveBeenCalled();
+      expect(merge[1][1]).toBe("user-1");
+      expect(prefsMock.row()!.tourProgress["intro/basics"]).toMatchObject({
+        status: "completed",
+      });
     });
 
     it("stamps the running version on release-* tours", async () => {
-      repo.findOne.mockResolvedValue(prefs());
+      seed();
 
       await service.saveProgress(
         "user-1",
@@ -101,27 +115,68 @@ describe("ToursService", () => {
         "dismissed",
       );
 
-      const patch = JSON.parse(query.mock.calls[0][1][0]);
-      expect(patch["release-1.13.0/accounts"]).toMatchObject({
-        status: "dismissed",
-        version: CURRENT_VERSION,
-      });
+      expect(
+        prefsMock.row()!.tourProgress["release-1.13.0/accounts"],
+      ).toMatchObject({ status: "dismissed", version: CURRENT_VERSION });
     });
 
-    it("materializes a preferences row when the UPDATE affects no rows", async () => {
-      query.mockResolvedValue([]);
+    it("keeps entries another tab already recorded", async () => {
+      // The merge is `||` in SQL rather than a read-modify-write precisely so two
+      // tabs finishing different tours at the same time do not overwrite each
+      // other.
+      seed({ "already/done": { status: "completed", updatedAt: "x" } });
 
       await service.saveProgress("user-1", "intro/basics", "completed");
 
-      expect(repo.save).toHaveBeenCalledTimes(1);
-      const saved = repo.save.mock.calls[0][0] as UserPreference;
-      expect(saved.userId).toBe("user-1");
-      expect(saved.tourProgress["intro/basics"]).toMatchObject({
+      expect(Object.keys(prefsMock.row()!.tourProgress).sort()).toEqual([
+        "already/done",
+        "intro/basics",
+      ]);
+    });
+
+    it("materializes a preferences row and still records the tour", async () => {
+      // The regression, and the reason it survived: the service used to read an
+      // `UPDATE ... RETURNING` result with `updated.length === 0` to decide
+      // whether to create a missing row. TypeORM answers an UPDATE with the tuple
+      // `[rows, rowCount]`, so that length is 2 whatever happened and the branch
+      // could not run -- the row stayed missing, the progress went nowhere, and
+      // the endpoint answered `{ saved: true }`. The old spec passed only because
+      // its mock returned a bare `[]`, a shape the driver never produces for an
+      // UPDATE.
+      prefsMock.seed(null);
+
+      const result = await service.saveProgress(
+        "user-1",
+        "intro/basics",
+        "completed",
+      );
+
+      expect(result).toEqual({ saved: true });
+      expect(prefsMock.insertAttempts()).toHaveLength(1);
+      expect(prefsMock.row()!.tourProgress["intro/basics"]).toMatchObject({
         status: "completed",
       });
     });
 
-    it("prunes the oldest entries when the map exceeds the cap, writing only tour_progress", async () => {
+    it("does not depend on the driver's result shape at all", async () => {
+      // Whatever the UPDATE reports, the row exists by then, so there is no
+      // "did it match" question left to answer wrongly.
+      prefsMock.seed(null);
+      for (const shape of [[[], 0], [[], 1], [], undefined]) {
+        const merge = query.getMockImplementation()!;
+        query.mockImplementation(async (sql: string, params: unknown[]) => {
+          await merge(sql, params);
+          return shape;
+        });
+
+        await expect(
+          service.saveProgress("user-1", "intro/basics", "completed"),
+        ).resolves.toEqual({ saved: true });
+        expect(prefsMock.row()!.tourProgress["intro/basics"]).toBeDefined();
+      }
+    });
+
+    it("prunes the oldest entries when the map exceeds the cap", async () => {
       const bloated: TourProgressMap = {};
       for (let i = 0; i < 205; i++) {
         bloated[`tour-${i}`] = {
@@ -129,30 +184,42 @@ describe("ToursService", () => {
           updatedAt: new Date(2020, 0, 1, 0, i).toISOString(),
         };
       }
-      repo.findOne.mockResolvedValue(prefs(bloated));
+      seed(bloated);
 
       await service.saveProgress("user-1", "tour-999", "completed");
 
-      // The prune writes through the column-scoped writer, never a whole-entity
-      // save that would revert a concurrent change to another preference
-      // (finding 3). Exactly one column is touched: tour_progress.
-      expect(repo.save).not.toHaveBeenCalled();
-      expect(prefsMock.patches()).toHaveLength(1);
-      const patched = prefsMock.patches()[0].tourProgress as TourProgressMap;
-      expect(Object.keys(patched)).toHaveLength(200);
+      const written = prefsMock.patches();
+      const pruned = written[written.length - 1]
+        .tourProgress as TourProgressMap;
+      expect(Object.keys(pruned)).toHaveLength(200);
       // Oldest (tour-0) pruned, newest kept.
-      expect(patched["tour-0"]).toBeUndefined();
-      expect(patched["tour-204"]).toBeDefined();
+      expect(pruned["tour-0"]).toBeUndefined();
+      expect(pruned["tour-204"]).toBeDefined();
+    });
+
+    it("prunes by writing only tour_progress", async () => {
+      // The prune is the one read-modify-write left here, so it must not carry
+      // any other column back with it.
+      const bloated: TourProgressMap = {};
+      for (let i = 0; i < 205; i++) {
+        bloated[`tour-${i}`] = { status: "completed", updatedAt: `${i}` };
+      }
+      seed(bloated);
+
+      await service.saveProgress("user-1", "tour-999", "completed");
+
+      const written = prefsMock.patches();
+      expect(Object.keys(written[written.length - 1])).toEqual([
+        "tourProgress",
+      ]);
     });
 
     it("does not prune when under the cap", async () => {
-      repo.findOne.mockResolvedValue(
-        prefs({ a: { status: "completed", updatedAt: "x" } }),
-      );
+      seed({ a: { status: "completed", updatedAt: "x" } });
 
       await service.saveProgress("user-1", "intro/basics", "completed");
 
-      expect(repo.save).not.toHaveBeenCalled();
+      expect(prefsMock.patches()).toHaveLength(0);
     });
   });
 

--- a/backend/src/updates/tours.service.ts
+++ b/backend/src/updates/tours.service.ts
@@ -5,9 +5,10 @@ import {
   TourProgressMap,
   UserPreference,
 } from "../users/entities/user-preference.entity";
-import { buildDefaultPreferences } from "../users/user-preference.factory";
-import { patchUserPreferences } from "../users/user-preference-writer";
-import { currentRequestLocale } from "../i18n/request-locale";
+import {
+  ensureUserPreferencesRow,
+  patchUserPreferences,
+} from "../users/user-preference-writer";
 import { withScopedDb } from "../common/db/scoped-db";
 import { ReleaseNotesService } from "./release-notes.service";
 
@@ -65,28 +66,29 @@ export class ToursService {
     await withScopedDb(this.dataSource, async (manager) => {
       const repo = manager.getRepository(UserPreference);
 
-      // Atomic single-entry merge; RETURNING lets us detect the missing-row case
-      // without a separate read.
-      const updated: unknown[] = await manager.query(
+      // Materialize the row first, then merge. The previous shape was an
+      // `UPDATE ... RETURNING user_id` with a `updated.length === 0` fallback
+      // meant to create a missing row -- and that branch could never run:
+      // TypeORM answers an UPDATE with the tuple `[rows, rowCount]`, whose
+      // length is 2 whatever happened. So a user without a preferences row lost
+      // every tour they completed while the endpoint reported success.
+      //
+      // Insert-if-absent has no such question to get wrong, and no window: the
+      // primary key arbitrates between two first-time writers and the merge
+      // below then always matches a row.
+      await ensureUserPreferencesRow(manager, userId);
+
+      await manager.query(
         `UPDATE user_preferences
-            SET tour_progress = tour_progress || $1::jsonb
-          WHERE user_id = $2
-        RETURNING user_id`,
+            SET tour_progress = COALESCE(tour_progress, '{}'::jsonb) || $1::jsonb
+          WHERE user_id = $2`,
         [JSON.stringify(patch), userId],
       );
 
-      if (updated.length === 0) {
-        const created = buildDefaultPreferences(userId, currentRequestLocale());
-        created.tourProgress = patch;
-        await repo.save(created);
-        return;
-      }
-
       // Best-effort cap: prune the oldest entries when the map grows unbounded.
-      // Rare enough (200+ tours completed) that reading the map to prune it is
-      // fine -- but write back only the tour_progress column via the shared
-      // writer, never `save(prefs)` on the whole entity, so a preference another
-      // request changed between this read and the write is not reverted.
+      // Rare enough (200+ tours completed) that a read-modify-write here is
+      // fine -- but it writes only `tour_progress`, so a concurrent change to
+      // any other preference is not dragged back to what this read saw.
       const prefs = await repo.findOne({ where: { userId } });
       const map = prefs?.tourProgress ?? {};
       const keys = Object.keys(map);

--- a/backend/src/updates/updates.service.spec.ts
+++ b/backend/src/updates/updates.service.spec.ts
@@ -43,8 +43,8 @@ describe("version helpers", () => {
 
 describe("UpdatesService", () => {
   let service: UpdatesService;
-  let prefsMock: UserPreferenceRepoMock;
   let preferencesRepo: Record<string, jest.Mock>;
+  let preferencesRow: UserPreferenceRepoMock;
   let configGet: jest.Mock;
   let originalFetch: typeof fetch;
   let fetchMock: jest.Mock;
@@ -74,10 +74,11 @@ describe("UpdatesService", () => {
     }) as unknown as Response;
 
   beforeEach(async () => {
-    // The row-modelling double so `dismiss` can exercise the column-scoped
-    // writer (insert-if-absent + UPDATE of only the named column).
-    prefsMock = createUserPreferenceRepoMock(null);
-    preferencesRepo = prefsMock.repo;
+    // Behaves like the row: the dismiss path now materializes it with
+    // `ON CONFLICT DO NOTHING` and patches one column, so a `save`-recording
+    // mock could not tell that from overwriting the whole row.
+    preferencesRow = createUserPreferenceRepoMock(null);
+    preferencesRepo = preferencesRow.repo;
     configGet = jest.fn().mockReturnValue(undefined);
 
     const { dataSource } = createScopedDbMocks([
@@ -231,46 +232,44 @@ describe("UpdatesService", () => {
   });
 
   describe("dismiss", () => {
-    it("writes only the dismissed-version column when a row exists", async () => {
+    it("saves latestVersion to user preferences when they exist", async () => {
       fetchMock.mockResolvedValueOnce(mockOkResponse(buildRelease()));
       await service.refreshLatestRelease();
-      prefsMock.seed({ userId: "user-1", dismissedUpdateVersion: null });
+
+      preferencesRow.seed({
+        userId: "user-1",
+        theme: "nord",
+        dismissedUpdateVersion: null,
+      });
 
       const result = await service.dismiss("user-1");
-
       expect(result).toEqual({ dismissed: true, version: "99.0.0" });
-      // Column-scoped: only dismissed_update_version is written, never a whole
-      // entity that would revert a concurrent change to another preference
-      // (finding 3).
-      expect(preferencesRepo.save).not.toHaveBeenCalled();
-      expect(prefsMock.patches()).toEqual([
-        { dismissedUpdateVersion: "99.0.0" },
+      expect(preferencesRow.row()!.dismissedUpdateVersion).toBe("99.0.0");
+      // Only that column: dismissing an update banner must not drag any other
+      // preference back to whatever this request happened to read.
+      expect(Object.keys(preferencesRow.patches()[0])).toEqual([
+        "dismissedUpdateVersion",
       ]);
-      expect(prefsMock.row()?.dismissedUpdateVersion).toBe("99.0.0");
+      expect(preferencesRow.row()!.theme).toBe("nord");
     });
 
-    it("materializes the row through the writer when none exists", async () => {
+    it("creates preferences row if none exists", async () => {
       fetchMock.mockResolvedValueOnce(mockOkResponse(buildRelease()));
       await service.refreshLatestRelease();
-      prefsMock.seed(null);
+      preferencesRow.seed(null);
 
       const result = await service.dismiss("user-1");
-
       expect(result).toEqual({ dismissed: true, version: "99.0.0" });
-      // The writer's ON CONFLICT DO NOTHING insert creates the row from the
-      // shared defaults, then the scoped UPDATE sets the dismissed version.
-      expect(prefsMock.insertAttempts().length).toBeGreaterThan(0);
-      expect(prefsMock.row()?.userId).toBe("user-1");
-      expect(prefsMock.row()?.dismissedUpdateVersion).toBe("99.0.0");
+      expect(preferencesRow.insertAttempts()).toHaveLength(1);
+      expect(preferencesRow.row()!.userId).toBe("user-1");
+      expect(preferencesRow.row()!.dismissedUpdateVersion).toBe("99.0.0");
     });
 
     it("is a no-op when no latest release has been fetched", async () => {
       const result = await service.dismiss("user-1");
       expect(result).toEqual({ dismissed: false, version: null });
-      expect(preferencesRepo.save).not.toHaveBeenCalled();
-      // The early return never reaches the writer at all.
-      expect(prefsMock.patches()).toHaveLength(0);
-      expect(prefsMock.insertAttempts()).toHaveLength(0);
+      expect(preferencesRow.patches()).toHaveLength(0);
+      expect(preferencesRow.insertAttempts()).toHaveLength(0);
     });
   });
 

--- a/backend/src/updates/whats-new.service.spec.ts
+++ b/backend/src/updates/whats-new.service.spec.ts
@@ -1,4 +1,4 @@
-import { DataSource, EntityManager } from "typeorm";
+import { DataSource, EntityManager, Repository } from "typeorm";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { DemoModeService } from "../common/demo-mode.service";
 import { ReleaseNotesService } from "./release-notes.service";
@@ -27,7 +27,7 @@ const SAMPLE_NOTES: ReleaseNotes = {
 
 describe("WhatsNewService", () => {
   let prefsMock: UserPreferenceRepoMock;
-  let repo: Record<string, jest.Mock>;
+  let repo: jest.Mocked<Pick<Repository<UserPreference>, "findOne" | "save">>;
   let releaseNotes: jest.Mocked<
     Pick<ReleaseNotesService, "getForCurrentVersion" | "currentVersion">
   >;
@@ -35,13 +35,13 @@ describe("WhatsNewService", () => {
   let service: WhatsNewService;
 
   beforeEach(() => {
-    // Row-modelling double: markSeen/remindNextLogin write through the
-    // column-scoped writer (insert-if-absent + UPDATE of one column), so the
-    // double has to model the row and record which columns a write touched --
-    // a `save`-recording mock could not tell a scoped patch from a whole-row
-    // save, which is the exact regression finding 3 removes.
+    // Behaves like the row: the writers now insert-if-absent and patch one
+    // column, so a mock that only records `save` could not tell that apart from
+    // the whole-entity overwrite it replaced.
     prefsMock = createUserPreferenceRepoMock(null);
-    repo = prefsMock.repo;
+    repo = prefsMock.repo as unknown as jest.Mocked<
+      Pick<Repository<UserPreference>, "findOne" | "save">
+    >;
 
     const manager = {
       getRepository: jest.fn(() => repo),
@@ -154,59 +154,57 @@ describe("WhatsNewService", () => {
   });
 
   describe("markSeen", () => {
-    it("writes only last_seen_version onto an existing row", async () => {
-      prefsMock.seed({ lastSeenVersion: "1.11.0" });
+    it("stores the current version on an existing preferences row", async () => {
+      prefsMock.seed({
+        ...prefs({ lastSeenVersion: "1.11.0" }),
+        theme: "nord",
+      });
 
       const result = await service.markSeen("user-1");
 
-      // Column-scoped patch, never a whole-entity save: only last_seen_version
-      // is touched, so a concurrent change to another preference survives
-      // (maintainer review PR #1097, finding 3).
-      expect(prefsMock.patches()).toEqual([
-        { lastSeenVersion: CURRENT_VERSION },
-      ]);
-      expect(prefsMock.row()?.lastSeenVersion).toBe(CURRENT_VERSION);
+      expect(prefsMock.row()!.lastSeenVersion).toBe(CURRENT_VERSION);
       expect(result).toEqual({ seen: true, version: CURRENT_VERSION });
+      // Only that column: acknowledging a digest must not carry any other
+      // preference back to whatever this request happened to read.
+      expect(Object.keys(prefsMock.patches()[0])).toEqual(["lastSeenVersion"]);
+      expect(prefsMock.row()!.theme).toBe("nord");
     });
 
-    it("materializes a preferences row when none exists, then stores the version", async () => {
+    it("materializes a preferences row when none exists", async () => {
       prefsMock.seed(null);
 
       const result = await service.markSeen("user-1");
 
-      // Insert-if-absent first so the UPDATE has a row to hit, then the scoped
-      // patch -- no read-modify-write, no whole-row save.
+      // `ON CONFLICT DO NOTHING`, not read-then-insert: the first page load fires
+      // several requests at once, and two of them both finding no row used to
+      // mean one failed on a unique violation.
       expect(prefsMock.insertAttempts()).toHaveLength(1);
-      expect(prefsMock.insertAttempts()[0].userId).toBe("user-1");
-      expect(prefsMock.patches()).toEqual([
-        { lastSeenVersion: CURRENT_VERSION },
-      ]);
-      expect(prefsMock.row()?.lastSeenVersion).toBe(CURRENT_VERSION);
+      expect(prefsMock.row()!.userId).toBe("user-1");
+      expect(prefsMock.row()!.lastSeenVersion).toBe(CURRENT_VERSION);
       expect(result.seen).toBe(true);
     });
   });
 
   describe("remindNextLogin", () => {
-    it("clears last_seen_version on an existing row so the digest shows again", async () => {
-      prefsMock.seed({ lastSeenVersion: CURRENT_VERSION });
+    it("clears an existing acknowledgement so the digest shows again", async () => {
+      prefsMock.seed(prefs({ lastSeenVersion: CURRENT_VERSION }));
 
       const result = await service.remindNextLogin("user-1");
 
-      expect(prefsMock.patches()).toEqual([{ lastSeenVersion: null }]);
-      expect(prefsMock.row()?.lastSeenVersion).toBeNull();
+      expect(prefsMock.row()!.lastSeenVersion).toBeNull();
       expect(result).toEqual({ reminded: true });
     });
 
-    it("writes unconditionally even when it is already clear", async () => {
-      // The old code gated the write on a snapshot saying there was something to
-      // clear, and could skip it entirely. Setting an already-null column to
-      // null is a harmless idempotent write; gating it on a stale read is the
-      // lost-write shape finding 3 removes, so the patch is applied every time.
-      prefsMock.seed({ lastSeenVersion: null });
+    it("clears unconditionally rather than reading first", async () => {
+      // Writing NULL over NULL is a no-op the database settles far more cheaply
+      // than a read-compare-write can -- and the read-compare-write was the thing
+      // that could revert a concurrent change to another column.
+      prefsMock.seed(prefs({ lastSeenVersion: null }));
 
       const result = await service.remindNextLogin("user-1");
 
-      expect(prefsMock.patches()).toEqual([{ lastSeenVersion: null }]);
+      expect(prefsMock.row()!.lastSeenVersion).toBeNull();
+      expect(Object.keys(prefsMock.patches()[0])).toEqual(["lastSeenVersion"]);
       expect(result.reminded).toBe(true);
     });
 
@@ -215,24 +213,22 @@ describe("WhatsNewService", () => {
 
       const result = await service.remindNextLogin("user-1");
 
+      expect(prefsMock.insertAttempts()).toHaveLength(1);
+      const saved = prefsMock.row()!;
+      expect(saved.userId).toBe("user-1");
       // Defaults stamp the running version; the reminder has to clear it, or the
       // digest the user just asked for would be suppressed as a first login.
-      expect(prefsMock.insertAttempts()).toHaveLength(1);
-      expect(prefsMock.patches()).toEqual([{ lastSeenVersion: null }]);
-      expect(prefsMock.row()?.lastSeenVersion).toBeNull();
+      expect(saved.lastSeenVersion).toBeNull();
       expect(result.reminded).toBe(true);
     });
 
     it("re-enables auto-show after an acknowledgement was cleared", async () => {
       // Acknowledged -> would not auto-show...
-      repo.findOne.mockResolvedValue(
-        prefs({ lastSeenVersion: CURRENT_VERSION }),
-      );
+      prefsMock.seed(prefs({ lastSeenVersion: CURRENT_VERSION }));
       expect((await service.getWhatsNew("user-1")).autoShow).toBe(false);
 
       // ...clearing it brings the popup back on the next status check.
-      const cleared = prefs({ lastSeenVersion: null });
-      repo.findOne.mockResolvedValue(cleared);
+      prefsMock.seed(prefs({ lastSeenVersion: null }));
       expect((await service.getWhatsNew("user-1")).autoShow).toBe(true);
     });
   });

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -4,6 +4,7 @@ import { UsersController } from "./users.controller";
 import { PasswordBreachService } from "../auth/password-breach.service";
 import { OidcReauthService } from "../auth/oidc/oidc-reauth.service";
 import { DemoModeModule } from "../common/demo-mode.module";
+import { JobClaimModule } from "../common/jobs/job-claim.module";
 
 /**
  * `PasswordBreachService` is re-provided here (rather than imported from
@@ -20,6 +21,13 @@ import { DemoModeModule } from "../common/demo-mode.module";
     // around UsersModule without AppModule's global registration, and would
     // otherwise fail to resolve DemoModeService.
     DemoModeModule,
+    // Same reason, and it is the same trap: `@Global()` is registered by
+    // AppModule, so a module whose service injects a global provider still has to
+    // declare the import to be usable on its own. `deleteData` takes the
+    // maintenance lease (audit DR-04-02), and without this line every integration
+    // suite that builds UsersModule fails to resolve UserMaintenanceService --
+    // while the running app is fine, which is what makes it easy to miss.
+    JobClaimModule,
   ],
   // `OidcReauthService` is re-provided here for the same reason as
   // `PasswordBreachService`: UsersModule cannot import AuthModule. It holds no

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -21,8 +21,16 @@ import { CurrenciesService } from "../currencies/currencies.service";
 import { BackupEncryptionService } from "../backup/backup-encryption.service";
 import { DemoModeService } from "../common/demo-mode.service";
 import { OidcReauthService } from "../auth/oidc/oidc-reauth.service";
+import {
+  createUserMaintenanceMock,
+  userMaintenanceProvider,
+  type UserMaintenanceMock,
+} from "../test-helpers/job-claim-testing";
 import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
-import { createUserPreferenceRepoMock } from "../test-helpers/user-preference-testing";
+import {
+  createUserPreferenceRepoMock,
+  type UserPreferenceRepoMock,
+} from "../test-helpers/user-preference-testing";
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
@@ -32,12 +40,13 @@ describe("UsersService", () => {
   let service: UsersService;
   let usersRepository: Record<string, jest.Mock>;
   let preferencesRepository: Record<string, jest.Mock>;
-  let prefsMock: ReturnType<typeof createUserPreferenceRepoMock>;
+  let preferencesRow: UserPreferenceRepoMock;
   let refreshTokensRepository: Record<string, jest.Mock>;
   let patRepository: Record<string, jest.Mock>;
   let trustedDevicesRepository: Record<string, jest.Mock>;
   let passwordBreachService: { isBreached: jest.Mock };
   let demoModeService: { isDemo: boolean };
+  let maintenance: UserMaintenanceMock;
   let exchangeRateService: { refreshAllRates: jest.Mock };
   let currenciesService: { ensureSystemCurrency: jest.Mock };
   let backupEncryptionService: { rememberLoginPassword: jest.Mock };
@@ -86,13 +95,11 @@ describe("UsersService", () => {
       count: jest.fn(),
     };
 
-    // Row-modelling double: updatePreferences writes through the column-scoped
-    // writer (insert-if-absent + UPDATE of only the DTO's columns), so the
-    // double models the row and records which columns each write touched. A
-    // save-recording mock could not tell a scoped patch from a whole-row save --
-    // the exact regression finding 3 removes (maintainer review PR #1097).
-    prefsMock = createUserPreferenceRepoMock(null);
-    preferencesRepository = prefsMock.repo;
+    // A double that behaves like the row rather than recording `save` calls: the
+    // writers now insert-if-absent then patch named columns, and a call-recording
+    // mock cannot tell a targeted patch from a whole-entity overwrite.
+    preferencesRow = createUserPreferenceRepoMock(null);
+    preferencesRepository = preferencesRow.repo;
 
     refreshTokensRepository = {
       update: jest.fn(),
@@ -140,6 +147,7 @@ describe("UsersService", () => {
     };
 
     demoModeService = { isDemo: false };
+    maintenance = createUserMaintenanceMock();
 
     mockQueryRunner = {
       connect: jest.fn(),
@@ -178,6 +186,7 @@ describe("UsersService", () => {
         // re-authentication assertion below vacuous -- which is how the
         // sentinel survived (P2-005).
         OidcReauthService,
+        userMaintenanceProvider(maintenance),
       ],
     }).compile();
 
@@ -409,12 +418,14 @@ describe("UsersService", () => {
     });
 
     it("creates default preferences when none exist", async () => {
-      preferencesRepository.findOne.mockResolvedValue(null);
-      preferencesRepository.save.mockImplementation((data) => data);
+      preferencesRow.seed(null);
 
       const result = await service.getPreferences("user-1");
 
-      expect(preferencesRepository.save).toHaveBeenCalled();
+      // Materialized with `INSERT ... ON CONFLICT DO NOTHING`, not a read-then-
+      // save: the first page load fires several requests at once and two of them
+      // both finding no row used to mean one got a unique violation.
+      expect(preferencesRow.insertAttempts()).toHaveLength(1);
       expect(result.userId).toBe("user-1");
       expect(result.defaultCurrency).toBe("USD");
       expect(result.dateFormat).toBe("browser");
@@ -423,30 +434,89 @@ describe("UsersService", () => {
     });
   });
 
-  describe("updatePreferences", () => {
-    it("updates only provided fields", async () => {
-      prefsMock.seed({ ...mockPreferences });
+  describe("updatePreferences -- writes only what was asked for", () => {
+    it("sends exactly the supplied columns to the database", async () => {
+      // The regression: this used to mutate a loaded entity and `repo.save` it,
+      // which writes back every column that differs from what the entity holds.
+      // `tour_progress`, `last_seen_version` and `dismissed_update_version` are
+      // written by other endpoints on the same row, so a Settings save could
+      // quietly undo a tour the user had just dismissed in another tab.
+      preferencesRow.seed(mockPreferences);
+
+      await service.updatePreferences("user-1", {
+        theme: "dark",
+        weekStartsOn: 1,
+      });
+
+      expect(preferencesRow.patches()).toHaveLength(1);
+      expect(Object.keys(preferencesRow.patches()[0]).sort()).toEqual([
+        "theme",
+        "weekStartsOn",
+      ]);
+      expect(preferencesRepository.save).not.toHaveBeenCalled();
+    });
+
+    it("leaves a column another request changed alone", async () => {
+      preferencesRow.seed({
+        ...mockPreferences,
+        tourProgress: { a: 1 } as never,
+      });
 
       await service.updatePreferences("user-1", { theme: "dark" });
 
-      const savedData = prefsMock.row()!;
+      expect(preferencesRow.row()!.tourProgress).toEqual({ a: 1 });
+      expect(preferencesRow.row()!.theme).toBe("dark");
+    });
+
+    it("writes nothing when the request carries no recognised field", async () => {
+      // An empty patch must not become `UPDATE ... SET` with no assignments, and
+      // must not fall back to writing the whole row either.
+      preferencesRow.seed(mockPreferences);
+
+      await service.updatePreferences("user-1", {});
+
+      expect(preferencesRow.patches()).toHaveLength(0);
+      expect(preferencesRepository.save).not.toHaveBeenCalled();
+    });
+
+    it("omits the language in demo mode without dropping the rest", async () => {
+      demoModeService.isDemo = true;
+      preferencesRow.seed({ ...mockPreferences, language: "en" });
+
+      await service.updatePreferences("user-1", {
+        language: "pl",
+        theme: "dark",
+      });
+
+      expect(Object.keys(preferencesRow.patches()[0])).toEqual(["theme"]);
+      expect(preferencesRow.row()!.language).toBe("en");
+    });
+  });
+
+  describe("updatePreferences", () => {
+    it("updates only provided fields", async () => {
+      preferencesRow.seed(mockPreferences);
+
+      await service.updatePreferences("user-1", { theme: "dark" });
+
+      const savedData = preferencesRow.row()!;
       expect(savedData.theme).toBe("dark");
       expect(savedData.defaultCurrency).toBe("USD"); // unchanged
     });
 
     it("persists the language when not in demo mode", async () => {
       demoModeService.isDemo = false;
-      prefsMock.seed({ ...mockPreferences });
+      preferencesRow.seed(mockPreferences);
 
       await service.updatePreferences("user-1", { language: "pl" });
 
-      const savedData = prefsMock.row()!;
+      const savedData = preferencesRow.row()!;
       expect(savedData.language).toBe("pl");
     });
 
     it("does not persist the language in demo mode (shared account)", async () => {
       demoModeService.isDemo = true;
-      prefsMock.seed({
+      preferencesRow.seed({
         ...mockPreferences,
         language: "en",
       });
@@ -456,29 +526,26 @@ describe("UsersService", () => {
         theme: "dark",
       });
 
-      const savedData = prefsMock.row()!;
+      const savedData = preferencesRow.row()!;
       // Language stays as the shared account had it; other fields still apply.
       expect(savedData.language).toBe("en");
       expect(savedData.theme).toBe("dark");
     });
 
     it("creates defaults first if preferences do not exist", async () => {
-      prefsMock.seed(null);
+      preferencesRow.seed(null);
 
-      const result = await service.updatePreferences("user-1", {
+      await service.updatePreferences("user-1", {
         defaultCurrency: "EUR",
       });
 
-      // Insert-if-absent materializes the row from defaults (ON CONFLICT DO
-      // NOTHING, so replaying it is a no-op), then the scoped patch applies --
-      // never a whole-row save that would clobber a concurrent writer.
-      expect(prefsMock.insertAttempts().length).toBeGreaterThanOrEqual(1);
-      expect(prefsMock.patches()).toEqual([{ defaultCurrency: "EUR" }]);
-      expect(result.defaultCurrency).toBe("EUR");
+      // The row is materialized from the shared defaults and then patched.
+      expect(preferencesRow.insertAttempts()).toHaveLength(1);
+      expect(preferencesRow.row()!.defaultCurrency).toBe("EUR");
     });
 
     it("ensures the chosen default currency exists when it changes", async () => {
-      prefsMock.seed({ ...mockPreferences });
+      preferencesRow.seed(mockPreferences);
 
       await service.updatePreferences("user-1", { defaultCurrency: "EUR" });
 
@@ -488,7 +555,7 @@ describe("UsersService", () => {
     });
 
     it("does not ensure a currency when the default is unchanged", async () => {
-      prefsMock.seed({ ...mockPreferences });
+      preferencesRow.seed(mockPreferences);
 
       await service.updatePreferences("user-1", { defaultCurrency: "USD" });
 
@@ -496,7 +563,7 @@ describe("UsersService", () => {
     });
 
     it("updates multiple fields at once", async () => {
-      prefsMock.seed({ ...mockPreferences });
+      preferencesRow.seed(mockPreferences);
 
       await service.updatePreferences("user-1", {
         defaultCurrency: "CAD",
@@ -505,7 +572,7 @@ describe("UsersService", () => {
         gettingStartedDismissed: true,
       });
 
-      const savedData = prefsMock.row()!;
+      const savedData = preferencesRow.row()!;
       expect(savedData.defaultCurrency).toBe("CAD");
       expect(savedData.theme).toBe("dark");
       expect(savedData.notificationEmail).toBe(false);
@@ -513,22 +580,22 @@ describe("UsersService", () => {
     });
 
     it("updates the showWhatsNew preference", async () => {
-      prefsMock.seed({ ...mockPreferences });
+      preferencesRow.seed(mockPreferences);
 
       await service.updatePreferences("user-1", { showWhatsNew: false });
 
-      const savedData = prefsMock.row()!;
+      const savedData = preferencesRow.row()!;
       expect(savedData.showWhatsNew).toBe(false);
     });
 
     it("updates favouriteReportIds", async () => {
-      prefsMock.seed({ ...mockPreferences });
+      preferencesRow.seed(mockPreferences);
 
       await service.updatePreferences("user-1", {
         favouriteReportIds: ["spending-by-category", "net-worth"],
       });
 
-      const savedData = prefsMock.row()!;
+      const savedData = preferencesRow.row()!;
       expect(savedData.favouriteReportIds).toEqual([
         "spending-by-category",
         "net-worth",
@@ -536,13 +603,13 @@ describe("UsersService", () => {
     });
 
     it("updates dashboardWidgets", async () => {
-      prefsMock.seed({ ...mockPreferences });
+      preferencesRow.seed(mockPreferences);
 
       await service.updatePreferences("user-1", {
         dashboardWidgets: ["upcoming-bills", "favourite-accounts"],
       });
 
-      const savedData = prefsMock.row()!;
+      const savedData = preferencesRow.row()!;
       expect(savedData.dashboardWidgets).toEqual([
         "upcoming-bills",
         "favourite-accounts",
@@ -550,7 +617,7 @@ describe("UsersService", () => {
     });
 
     it("updates dashboardWidgetConfig", async () => {
-      prefsMock.seed({ ...mockPreferences });
+      preferencesRow.seed(mockPreferences);
 
       await service.updatePreferences("user-1", {
         dashboardWidgetConfig: {
@@ -558,25 +625,25 @@ describe("UsersService", () => {
         },
       });
 
-      const savedData = prefsMock.row()!;
+      const savedData = preferencesRow.row()!;
       expect(savedData.dashboardWidgetConfig).toEqual({
         "spending-by-payee": { range: "6m" },
       });
     });
 
     it("updates preferredExchanges", async () => {
-      prefsMock.seed({ ...mockPreferences });
+      preferencesRow.seed(mockPreferences);
 
       await service.updatePreferences("user-1", {
         preferredExchanges: ["LSE", "ASX", "TSX"],
       });
 
-      const savedData = prefsMock.row()!;
+      const savedData = preferencesRow.row()!;
       expect(savedData.preferredExchanges).toEqual(["LSE", "ASX", "TSX"]);
     });
 
     it("clears preferredExchanges with empty array", async () => {
-      prefsMock.seed({
+      preferencesRow.seed({
         ...mockPreferences,
         preferredExchanges: ["LSE"],
       });
@@ -585,7 +652,7 @@ describe("UsersService", () => {
         preferredExchanges: [],
       });
 
-      const savedData = prefsMock.row()!;
+      const savedData = preferencesRow.row()!;
       expect(savedData.preferredExchanges).toEqual([]);
     });
 
@@ -606,30 +673,29 @@ describe("UsersService", () => {
     ])(
       "updates the %s field when provided",
       async (field: string, value: any) => {
-        prefsMock.seed({ ...mockPreferences });
+        preferencesRow.seed(mockPreferences);
 
         await service.updatePreferences("user-1", { [field]: value } as any);
 
-        const savedData = prefsMock.row()!;
+        const savedData = preferencesRow.row()!;
         expect(savedData[field]).toEqual(value);
       },
     );
 
     it("leaves colorTheme untouched when not provided", async () => {
-      prefsMock.seed({
+      preferencesRow.seed({
         ...mockPreferences,
         colorTheme: "nord",
       });
 
       await service.updatePreferences("user-1", { theme: "dark" });
 
-      const savedData = prefsMock.row()!;
+      const savedData = preferencesRow.row()!;
       expect(savedData.colorTheme).toBe("nord");
     });
 
     it("seeds language='en' when creating default preferences", async () => {
-      preferencesRepository.findOne.mockResolvedValue(null);
-      preferencesRepository.save.mockImplementation((data) => data);
+      preferencesRow.seed(null);
 
       const result = await service.getPreferences("user-1");
 
@@ -637,8 +703,7 @@ describe("UsersService", () => {
     });
 
     it("seeds language from the request locale when creating default preferences", async () => {
-      preferencesRepository.findOne.mockResolvedValue(null);
-      preferencesRepository.save.mockImplementation((data) => data);
+      preferencesRow.seed(null);
       const spy = jest
         .spyOn(I18nContext, "current")
         .mockReturnValue({ lang: "pl" } as never);
@@ -1077,6 +1142,67 @@ describe("UsersService", () => {
   });
 
   describe("deleteData", () => {
+    it("holds the maintenance lease for a user-initiated wipe", async () => {
+      const hashedPassword = await bcrypt.hash("CorrectPass123!", 10);
+      usersRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        passwordHash: hashedPassword,
+      });
+
+      await service.deleteData("user-1", { password: "CorrectPass123!" });
+
+      expect(maintenance.withMaintenanceLease).toHaveBeenCalledWith(
+        "user-1",
+        expect.any(String),
+        expect.any(Function),
+      );
+    });
+
+    it("deletes nothing when another operation is already replacing the data", async () => {
+      const hashedPassword = await bcrypt.hash("CorrectPass123!", 10);
+      usersRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        passwordHash: hashedPassword,
+      });
+      maintenance.withMaintenanceLease.mockRejectedValue(
+        new ConflictException("busy"),
+      );
+
+      await expect(
+        service.deleteData("user-1", { password: "CorrectPass123!" }),
+      ).rejects.toThrow(ConflictException);
+
+      const deletes = mockQueryRunner.query.mock.calls.filter(
+        (call: string[]) => String(call[0]).includes("DELETE FROM"),
+      );
+      expect(deletes).toHaveLength(0);
+    });
+
+    it("skips the lease for the .mny importer's own wipe", async () => {
+      // The importer already holds the user's single import slot, and that slot
+      // is what excludes a second wipe. Taking the lease here would have
+      // `withMaintenanceLease` refuse on the importer's own in-flight job.
+      const hashedPassword = await bcrypt.hash("CorrectPass123!", 10);
+      usersRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        passwordHash: hashedPassword,
+      });
+
+      await service.deleteData(
+        "user-1",
+        { password: "CorrectPass123!" },
+        "import-wipe",
+        "mny-import",
+      );
+
+      expect(maintenance.withMaintenanceLease).not.toHaveBeenCalled();
+      expect(
+        mockQueryRunner.query.mock.calls.some((call: string[]) =>
+          String(call[0]).includes("DELETE FROM"),
+        ),
+      ).toBe(true);
+    });
+
     it("requires password for local auth users", async () => {
       usersRepository.findOne.mockResolvedValue({ ...mockUser });
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -17,16 +17,13 @@ import {
 import { withScopedDb } from "../common/db/scoped-db";
 import * as bcrypt from "bcryptjs";
 import { tr } from "../i18n/translate";
-import { currentRequestLocale } from "../i18n/request-locale";
 import { User } from "./entities/user.entity";
 import { UserPreference } from "./entities/user-preference.entity";
-import { buildDefaultPreferences } from "./user-preference.factory";
+import { lockAdminsForUpdate, wouldRemoveLastAdmin } from "./last-admin.util";
 import {
   ensureUserPreferencesRow,
-  patchUserPreferences,
   type UserPreferencePatch,
 } from "./user-preference-writer";
-import { lockAdminsForUpdate, wouldRemoveLastAdmin } from "./last-admin.util";
 import { TrustedDevice } from "./entities/trusted-device.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
@@ -45,6 +42,7 @@ import {
   type OidcReauthPurpose,
 } from "../auth/oidc/oidc-reauth.service";
 import { toUserProfile } from "./user-profile";
+import { UserMaintenanceService } from "../common/jobs/user-maintenance.service";
 
 @Injectable()
 export class UsersService {
@@ -56,6 +54,7 @@ export class UsersService {
     private moduleRef: ModuleRef,
     private demoModeService: DemoModeService,
     private oidcReauth: OidcReauthService,
+    private maintenance: UserMaintenanceService,
   ) {}
 
   /**
@@ -151,37 +150,39 @@ export class UsersService {
   }
 
   async getPreferences(userId: string): Promise<UserPreference> {
-    let preferences = await this.scoped(UserPreference, (repo) =>
-      repo.findOne({
-        where: { userId },
-      }),
-    );
-
-    // Create default preferences if they don't exist. Seed `language` from the
-    // request locale (browser-detected on first visit, forwarded by the proxy)
-    // so a row first materialized here still captures the user's UI language
-    // rather than defaulting everyone to English.
-    if (!preferences) {
-      const created = buildDefaultPreferences(userId, currentRequestLocale());
-      preferences = created;
-      await this.scoped(UserPreference, (repo) => repo.save(created));
-    }
-
-    return preferences;
+    // Materialize the row if it does not exist, then read it back. `language` is
+    // seeded from the request locale (browser-detected on first visit, forwarded
+    // by the proxy) so a row first materialized here captures the user's UI
+    // language rather than defaulting everyone to English.
+    //
+    // Insert-if-absent rather than read-then-insert: the first page load fires
+    // several requests at once, and two of them both finding no row used to mean
+    // one got a unique violation on a plain read. Both statements are in one
+    // transaction so the value returned is the value that is there.
+    return withScopedDb(this.dataSource, async (manager) => {
+      await ensureUserPreferencesRow(manager, userId);
+      const preferences = await manager
+        .getRepository(UserPreference)
+        .findOne({ where: { userId } });
+      // The insert above guarantees the row; the non-null assertion records that
+      // rather than inventing a fallback that could mask a real absence.
+      return preferences!;
+    });
   }
 
   async updatePreferences(
     userId: string,
     dto: UpdatePreferencesDto,
   ): Promise<UserPreference> {
-    // Write exactly the columns the DTO carries, and nothing else. The Settings
-    // form is one of many writers of this single-row table (a dismissed tour, a
-    // "What's New" acknowledgement, enabling 2FA), so reading the whole row and
-    // `save`-ing it back would revert a column another request changed in
-    // between -- switch the theme in one tab while a tour is dismissed in
-    // another and the theme reverts, silently. `patchUserPreferences` sets only
-    // the named columns; see user-preference-writer.ts.
+    // Build a patch of exactly the fields the request supplied, and write only
+    // those. The previous shape mutated a loaded entity and `repo.save`d it,
+    // which writes back every column that differs from what the entity holds --
+    // including columns another request changed in between. `tour_progress`,
+    // `last_seen_version` and `dismissed_update_version` are all written by
+    // other endpoints on the same row, so saving a Settings form could quietly
+    // undo a tour the user had just dismissed in another tab.
     const patch: UserPreferencePatch = {};
+
     if (dto.defaultCurrency !== undefined) {
       patch.defaultCurrency = dto.defaultCurrency;
     }
@@ -231,7 +232,11 @@ export class UsersService {
       patch.dashboardWidgets = dto.dashboardWidgets;
     }
     if (dto.dashboardWidgetConfig !== undefined) {
-      patch.dashboardWidgetConfig = dto.dashboardWidgetConfig;
+      // A free-form JSONB map: `QueryDeepPartialEntity` treats a bare
+      // `Record<string, unknown>` as a possible nested-entity patch, so say
+      // plainly that this value is the column's whole contents.
+      patch.dashboardWidgetConfig =
+        dto.dashboardWidgetConfig as UserPreference["dashboardWidgetConfig"];
     }
     if (dto.showCreatedAt !== undefined) {
       patch.showCreatedAt = dto.showCreatedAt;
@@ -256,22 +261,30 @@ export class UsersService {
       patch.language = dto.language;
     }
 
+    // One transaction: materialize the row if absent, capture the currency the
+    // refresh decision below compares against, apply the patch, read the result
+    // back. The old code did each of those in its own autocommit transaction,
+    // so the value it reported was not necessarily the value it wrote.
     const { saved, previousDefaultCurrency } = await withScopedDb(
       this.dataSource,
       async (manager) => {
-        const repo = manager.getRepository(UserPreference);
-        // Materialize the row first (same baseline as getPreferences) so the
-        // currency-change comparison below reads the value this request actually
-        // replaced, rather than undefined for a user whose row did not exist
-        // yet. patchUserPreferences then writes only `patch`'s columns.
         await ensureUserPreferencesRow(manager, userId);
+        const repo = manager.getRepository(UserPreference);
         const before = await repo.findOne({ where: { userId } });
-        await patchUserPreferences(manager, userId, patch);
+        // Copy the value out now, not after the write: reading it from `before`
+        // later would depend on that object not having been touched by the
+        // update in between.
+        const previousDefaultCurrency = before?.defaultCurrency;
+        if (Object.keys(patch).length > 0) {
+          await repo
+            .createQueryBuilder()
+            .update()
+            .set(patch)
+            .where("user_id = :userId", { userId })
+            .execute();
+        }
         const after = await repo.findOne({ where: { userId } });
-        return {
-          saved: after!,
-          previousDefaultCurrency: before?.defaultCurrency,
-        };
+        return { saved: after!, previousDefaultCurrency };
       },
     );
 
@@ -538,11 +551,34 @@ export class UsersService {
    * .mny import's wipe-first mode passes its own, so an artifact obtained for one
    * cannot silently drive the other -- they present different confirmations to
    * the user and one of them is followed by an import.
+   *
+   * @param initiator who asked. `"user-request"` is the self-service flow and
+   *   must not overlap another operation replacing this account's data, so it
+   *   takes the maintenance lease. `"mny-import"` is the importer's "start
+   *   fresh" wipe, which already holds the user's single import slot -- taking
+   *   the lease there would have it refuse itself, and consulting it would
+   *   refuse on the importer's own in-flight job (audit DR-04-02).
    */
   async deleteData(
     userId: string,
     dto: DeleteDataDto,
     reauthPurpose: OidcReauthPurpose = "delete-data",
+    initiator: "user-request" | "mny-import" = "user-request",
+  ): Promise<{ deleted: Record<string, number> }> {
+    if (initiator === "user-request") {
+      return this.maintenance.withMaintenanceLease(
+        userId,
+        "delete my data",
+        () => this.deleteDataWithinLease(userId, dto, reauthPurpose),
+      );
+    }
+    return this.deleteDataWithinLease(userId, dto, reauthPurpose);
+  }
+
+  private async deleteDataWithinLease(
+    userId: string,
+    dto: DeleteDataDto,
+    reauthPurpose: OidcReauthPurpose,
   ): Promise<{ deleted: Record<string, number> }> {
     const user = await this.scoped(User, (repo) =>
       repo.findOne({ where: { id: userId } }),

--- a/backend/test/helpers/rls-setup.ts
+++ b/backend/test/helpers/rls-setup.ts
@@ -72,6 +72,46 @@ function stripSqlComments(sql: string): string {
   return sql.replace(/\/\*[\s\S]*?\*\//g, "").replace(/--[^\n]*/g, "");
 }
 
+/**
+ * Migrations that install a **behavioural trigger** -- a rule enforced by the
+ * database rather than by the entities.
+ *
+ * `synchronize` builds the schema from entity metadata and creates no triggers at
+ * all, so every such rule is simply absent from a test database unless the harness
+ * puts it there. That is not a cosmetic gap: migration 141's trigger is the only
+ * thing that fences a *previous-version* import worker during a rolling deployment
+ * (audit RRV4-001), and a suite that silently lacks it would report the fence as
+ * working while nothing enforced it.
+ *
+ * Selected by content marker (`RETURNS TRIGGER`) for the same reason the RLS files
+ * are: a new migration that adds a trigger is picked up with no per-file
+ * registration to forget. Overlap with the RLS set is harmless -- every migration
+ * body is required to be re-runnable.
+ */
+export function findTriggerMigrations(): string[] {
+  if (!fs.existsSync(MIGRATIONS_DIR)) {
+    throw new Error(`Migrations directory not found at ${MIGRATIONS_DIR}`);
+  }
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort()
+    .filter((f) =>
+      /RETURNS\s+TRIGGER/i.test(
+        stripSqlComments(fs.readFileSync(path.join(MIGRATIONS_DIR, f), "utf8")),
+      ),
+    );
+
+  if (files.length === 0) {
+    throw new Error(
+      `No trigger migrations found in ${MIGRATIONS_DIR}. The harness applies them by ` +
+        "content marker (RETURNS TRIGGER); finding none means either the migrations " +
+        "are missing or the marker changed.",
+    );
+  }
+  return files.map((f) => path.join(MIGRATIONS_DIR, f));
+}
+
 export function findRlsMigrations(includeEnable = false): string[] {
   if (!fs.existsSync(MIGRATIONS_DIR)) {
     throw new Error(`Migrations directory not found at ${MIGRATIONS_DIR}`);
@@ -202,8 +242,9 @@ function updatedAtTriggers(): { trigger: string; table: string }[] {
 
 /**
  * Brings a `synchronize`-built test database up to the shape the real one has:
- * the runtime role and its grants, the RLS helper functions and policies, and
- * the `updated_at` triggers.
+ * the runtime role and its grants, the RLS helper functions and policies, the
+ * behavioural triggers that enforce rules the entities cannot express, and the
+ * `updated_at` triggers.
  *
  * Call after the schema exists (i.e. after `DataSource.initialize()` with
  * `synchronize: true`). Idempotent, and re-applied per suite because
@@ -284,7 +325,21 @@ export async function applyRlsPolicies(
     );
   }
 
-  // 4. The updated_at triggers, which synchronize never creates.
+  // 4. Behavioural triggers, which synchronize never creates either. Applied after
+  //    the policies because one of them (136's tombstone recorder) is SECURITY
+  //    DEFINER and its own migration is already in the set above; re-applying is a
+  //    no-op by the idempotency rule every migration follows.
+  for (const file of findTriggerMigrations()) {
+    try {
+      await dataSource.query(fs.readFileSync(file, "utf8"));
+    } catch (err) {
+      throw new Error(
+        `Failed applying trigger migration ${path.basename(file)}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  // 5. The updated_at triggers, which synchronize never creates.
   for (const { trigger, table } of updatedAtTriggers()) {
     // Skip a table the entities do not produce -- the harness synchronizes from
     // entity metadata, so schema.sql can legitimately be ahead of it.

--- a/backend/test/integration/backup-restore.integration.spec.ts
+++ b/backend/test/integration/backup-restore.integration.spec.ts
@@ -18,6 +18,8 @@ import { OidcReauthService } from "@/auth/oidc/oidc-reauth.service";
 import { AiEncryptionService } from "@/ai/ai-encryption.service";
 import { DatabaseStorageProvider } from "@/attachments/storage/database-storage.provider";
 import { ATTACHMENT_STORAGE_PROVIDER } from "@/attachments/storage/attachment-storage.interface";
+import { JobClaimService } from "@/common/jobs/job-claim.service";
+import { UserMaintenanceService } from "@/common/jobs/user-maintenance.service";
 import { createTestUserDirect } from "../helpers/integration-setup";
 import { applyRlsPolicies } from "../helpers/rls-setup";
 import { withUserContext } from "@/common/db/with-context";
@@ -96,6 +98,11 @@ describe("Backup export/restore round-trip (integration)", () => {
         // future change remove that check with this suite still green. Local-auth
         // users prove identity with their password, so these tests never mint one.
         OidcReauthService,
+        // Real, not doubles: the restore takes a maintenance lease against the
+        // real `job_claims` table, so a broken lease shows up here rather than
+        // only in production.
+        JobClaimService,
+        UserMaintenanceService,
         // Only consulted for backups encrypted with a stored password; the
         // round-trip tests supply the password explicitly instead.
         { provide: AiEncryptionService, useValue: { decrypt: () => "" } },

--- a/backend/test/integration/job-claim-lease-rollout.integration.spec.ts
+++ b/backend/test/integration/job-claim-lease-rollout.integration.spec.ts
@@ -1,0 +1,158 @@
+import { DataSource } from "typeorm";
+
+import { JobClaimService, JobClaimType } from "@/common/jobs/job-claim.service";
+import { withUserContext } from "@/common/db/with-context";
+
+import {
+  INTEGRATION_TYPEORM_OPTIONS,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { applyRlsPolicies } from "../helpers/rls-setup";
+
+/**
+ * Lease ownership across a rolling deployment (audit V4R3-004).
+ *
+ * Migration 139 gave a lease a `lease_token` and the new `release`/`markDelivered`
+ * filter on it, which protects new code from new code. The previous binary names
+ * the work and not the holder:
+ *
+ *     DELETE FROM job_claims WHERE claim_type=$1 AND user_id=$2 AND claim_key=$3
+ *     UPDATE job_claims SET delivered_at=now(), expires_at=NULL WHERE <same key>
+ *
+ * so during a rollout a stalled old pod can delete or mark a lease a new pod has
+ * retaken. Migration 139's triggers make a live tokenized lease mutable only by the
+ * session that declares its token in `app.job_claim_lease_token`. This exercises the
+ * literal previous-release statements against the migrated schema -- which a mocked
+ * repository cannot do, because the property is the interaction between an
+ * untokenized statement and the trigger.
+ */
+describe("job-claim lease ownership during a rolling deployment", () => {
+  let dataSource: DataSource;
+  let service: JobClaimService;
+  let userId: string;
+
+  const KEY = "2026-08-05#rollout";
+
+  const claim = (): Promise<{ claim_type: string; claim_key: string }[]> =>
+    dataSource.query(
+      `SELECT claim_type, claim_key, lease_token, delivered_at, expires_at
+         FROM job_claims WHERE user_id = $1`,
+      [userId],
+    );
+
+  /** The previous binary's release: delete by work key, no token, no GUC. */
+  const oldRelease = (): Promise<unknown> =>
+    dataSource.query(
+      `DELETE FROM job_claims
+        WHERE claim_type = $1 AND user_id = $2 AND claim_key = $3`,
+      [JobClaimType.BillReminder, userId, KEY],
+    );
+
+  /** The previous binary's markDelivered: update by work key, no token, no GUC. */
+  const oldMarkDelivered = (): Promise<unknown> =>
+    dataSource.query(
+      `UPDATE job_claims
+          SET delivered_at = CURRENT_TIMESTAMP, expires_at = NULL
+        WHERE claim_type = $1 AND user_id = $2 AND claim_key = $3`,
+      [JobClaimType.BillReminder, userId, KEY],
+    );
+
+  const takeLease = (): Promise<string | null> =>
+    withUserContext(userId, () =>
+      service.claimLease(
+        JobClaimType.BillReminder,
+        userId,
+        KEY,
+        10 * 60 * 1000,
+      ),
+    );
+
+  beforeAll(async () => {
+    dataSource = new DataSource(INTEGRATION_TYPEORM_OPTIONS as never);
+    await dataSource.initialize();
+    await applyRlsPolicies(dataSource);
+    service = new JobClaimService(dataSource);
+  });
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, ["job_claims", "users"]);
+    userId = (
+      await createTestUserDirect(dataSource, { email: "lease@example.com" })
+    ).id;
+  });
+
+  it("refuses a previous-release release of a live tokenized lease", async () => {
+    const token = await takeLease();
+    expect(token).not.toBeNull();
+
+    // The stalled old pod resumes and releases by work key. The trigger refuses,
+    // so the lease the new holder is relying on survives.
+    await expect(oldRelease()).rejects.toThrow(/another attempt/i);
+    expect(await claim()).toHaveLength(1);
+  });
+
+  it("refuses a previous-release delivery mark of a live tokenized lease", async () => {
+    await takeLease();
+
+    await expect(oldMarkDelivered()).rejects.toThrow(/another attempt/i);
+    const [row] = await claim();
+    expect(
+      (row as unknown as { delivered_at: Date | null }).delivered_at,
+    ).toBeNull();
+  });
+
+  it("lets the current holder release and mark its own lease", async () => {
+    const token = await takeLease();
+
+    await withUserContext(userId, () =>
+      service.markDelivered(JobClaimType.BillReminder, userId, KEY, token!),
+    );
+    const [row] = await claim();
+    expect(
+      (row as unknown as { delivered_at: Date | null }).delivered_at,
+    ).not.toBeNull();
+  });
+
+  it("still lets an expired lease be retaken and an old release drop a stale row", async () => {
+    const token = await takeLease();
+    // Age the lease past expiry, as the wall clock would. This is itself a write to
+    // a live tokenized lease, so it declares the token first -- exactly as the
+    // holder's own writes do; a raw update of a live lease is what the guard blocks.
+    await dataSource.transaction(async (m) => {
+      await m.query(
+        `SELECT set_config('app.job_claim_lease_token', $1, true)`,
+        [token],
+      );
+      await m.query(
+        `UPDATE job_claims SET expires_at = CURRENT_TIMESTAMP - INTERVAL '1 minute'
+          WHERE user_id = $1`,
+        [userId],
+      );
+    });
+
+    // The trigger only guards a *live* lease, so an expired one is free to be
+    // retaken (by either binary) and cleaned up -- otherwise a dead holder would
+    // lock the work forever.
+    await expect(oldRelease()).resolves.toBeDefined();
+    expect(await claim()).toHaveLength(0);
+  });
+
+  it("leaves a permanent claimOnce row releasable without a token", async () => {
+    // claimOnce rows carry no lease_token, so the trigger ignores them and the
+    // ordinary release path still works.
+    await withUserContext(userId, () =>
+      service.claimOnce(JobClaimType.DemoIntraday, userId, KEY),
+    );
+    await withUserContext(userId, () =>
+      service.releasePermanentClaim(JobClaimType.DemoIntraday, userId, KEY),
+    );
+    expect(await claim()).toHaveLength(0);
+  });
+});

--- a/backend/test/integration/migration-139-preflight.integration.spec.ts
+++ b/backend/test/integration/migration-139-preflight.integration.spec.ts
@@ -1,0 +1,424 @@
+import { DataSource } from "typeorm";
+import * as fs from "fs";
+import * as path from "path";
+
+import {
+  INTEGRATION_TYPEORM_OPTIONS,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { applyRlsPolicies } from "../helpers/rls-setup";
+
+/**
+ * Migration 139's repair phases, against a database already in the state the
+ * migration's own guards forbid.
+ *
+ * Two of the six guards are constraints over data that already exists, and both
+ * constrain a state the pre-133 code could reach: more than one active import per
+ * user (the racy `hasActiveJob()` count, P4-001) and duplicate budget alerts (the
+ * application-level `deduplicateAlerts()`, P4-015). `CREATE UNIQUE INDEX` over a
+ * table already in that state **fails**, and a failed migration is not a failed
+ * check: `db-migrate` runs at container start, so the backend never boots and the
+ * deploy reports only "backend exited (1)" (audit FV4-006).
+ *
+ * A unit test cannot see any of this -- the failure is PostgreSQL refusing an
+ * index -- so the fixture is a real database put into the legacy state, with the
+ * migration read **from disk** so the assertions cannot drift from what ships.
+ *
+ * The spec also re-applies the file a second time, because that is what a
+ * half-applied migration does on the next boot: a repair that is not
+ * re-runnable trades a startup crash for a different startup crash.
+ */
+describe("migration 139 preflight over legacy data", () => {
+  let dataSource: DataSource;
+  let userA: string;
+  let userB: string;
+
+  const MIGRATION = path.join(
+    __dirname,
+    "../../../database/migrations/139_concurrency_integrity_guards.sql",
+  );
+
+  /** The keys the stale-job reaper uses; the migration reuses them deliberately. */
+  const STALLED = "mnyJobStalled";
+  const STALLED_AFTER_COMMIT = "mnyJobStalledAfterCommit";
+
+  const applyMigration = () =>
+    dataSource.query(fs.readFileSync(MIGRATION, "utf8"));
+
+  /**
+   * Put the database back the way it looked before 133: no status CHECK, no
+   * active-job uniqueness, no alert fingerprint. `applyRlsPolicies` applies 133
+   * (it references the identity helpers, so the harness picks it up by content),
+   * which is why these have to be dropped rather than merely not created.
+   */
+  const removeGuards = async () => {
+    await dataSource.query(
+      `ALTER TABLE import_jobs DROP CONSTRAINT IF EXISTS import_jobs_status_check`,
+    );
+    await dataSource.query(
+      `DROP INDEX IF EXISTS idx_import_jobs_one_active_per_user`,
+    );
+    await dataSource.query(
+      `DROP INDEX IF EXISTS idx_budget_alerts_fingerprint`,
+    );
+  };
+
+  const indexExists = async (name: string): Promise<boolean> => {
+    const rows = await dataSource.query(
+      `SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = $1`,
+      [name],
+    );
+    return rows.length > 0;
+  };
+
+  const constraintExists = async (name: string): Promise<boolean> => {
+    const rows = await dataSource.query(
+      `SELECT 1 FROM pg_constraint WHERE conname = $1`,
+      [name],
+    );
+    return rows.length > 0;
+  };
+
+  interface JobRow {
+    id: string;
+    status: string;
+    error_key: string | null;
+    retryable: boolean;
+    data_committed: boolean;
+    progress: unknown;
+  }
+
+  const job = async (id: string): Promise<JobRow> => {
+    const rows: JobRow[] = await dataSource.query(
+      `SELECT id, status, error_key, retryable, data_committed, progress
+         FROM import_jobs WHERE id = $1`,
+      [id],
+    );
+    return rows[0];
+  };
+
+  /**
+   * Insert an import job directly, bypassing the service. The point of this spec
+   * is a row the current code cannot create, so it cannot come from the service.
+   */
+  const seedJob = async (
+    id: string,
+    userId: string,
+    fields: {
+      status: string;
+      dataCommitted?: boolean;
+      heartbeatAt?: string | null;
+      createdAt?: string;
+    },
+  ): Promise<void> => {
+    await dataSource.query(
+      `INSERT INTO import_jobs
+         (id, user_id, source_format, status, options, data_committed,
+          heartbeat_at, created_at, retryable)
+       VALUES ($1, $2, 'mny', $3, '{}'::jsonb, $4, $5, $6, false)`,
+      [
+        id,
+        userId,
+        fields.status,
+        fields.dataCommitted ?? false,
+        fields.heartbeatAt ?? null,
+        fields.createdAt ?? "2026-01-01 00:00:00",
+      ],
+    );
+  };
+
+  beforeAll(async () => {
+    if (!fs.existsSync(MIGRATION)) {
+      throw new Error(`Migration 139 not found at ${MIGRATION}`);
+    }
+    dataSource = new DataSource(INTEGRATION_TYPEORM_OPTIONS as never);
+    await dataSource.initialize();
+    // Brings the synchronize-built schema up to the real one's shape, which
+    // includes applying 133 itself.
+    await applyRlsPolicies(dataSource);
+  });
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, ["import_jobs", "budget_alerts", "users"]);
+    userA = (
+      await createTestUserDirect(dataSource, { email: "pre133-a@example.com" })
+    ).id;
+    userB = (
+      await createTestUserDirect(dataSource, { email: "pre133-b@example.com" })
+    ).id;
+    await removeGuards();
+  });
+
+  describe("import_jobs", () => {
+    it("keeps the committed job and fails the rest, without offering it as a retry", async () => {
+      const committed = "aaaaaaaa-0000-4000-8000-000000000001";
+      const running = "aaaaaaaa-0000-4000-8000-000000000002";
+      const pending = "aaaaaaaa-0000-4000-8000-000000000003";
+      // Newest first, so "keep the newest" alone would keep the wrong one --
+      // the ordering has to prefer data_committed.
+      await seedJob(committed, userA, {
+        status: "running",
+        dataCommitted: true,
+        heartbeatAt: "2026-01-01 00:00:00",
+        createdAt: "2026-01-01 00:00:00",
+      });
+      await seedJob(running, userA, {
+        status: "running",
+        heartbeatAt: "2026-01-03 00:00:00",
+        createdAt: "2026-01-03 00:00:00",
+      });
+      await seedJob(pending, userA, {
+        status: "pending",
+        createdAt: "2026-01-04 00:00:00",
+      });
+
+      await applyMigration();
+
+      expect(await indexExists("idx_import_jobs_one_active_per_user")).toBe(
+        true,
+      );
+      expect((await job(committed)).status).toBe("running");
+
+      // The two losers: failed, and each one's retryability derived from its own
+      // data_committed rather than from having lost.
+      for (const id of [running, pending]) {
+        const row = await job(id);
+        expect(row.status).toBe("failed");
+        expect(row.error_key).toBe(STALLED);
+        expect(row.retryable).toBe(true);
+        expect(row.progress).toBeNull();
+      }
+    });
+
+    it("never offers a superseded job whose data is already in the ledger", async () => {
+      const keep = "bbbbbbbb-0000-4000-8000-000000000001";
+      const loserWithData = "bbbbbbbb-0000-4000-8000-000000000002";
+      // Both committed, so the tie-break drops one of them -- and the one
+      // dropped must not be retryable, or the retry re-imports the file.
+      await seedJob(keep, userA, {
+        status: "running",
+        dataCommitted: true,
+        heartbeatAt: "2026-02-02 00:00:00",
+        createdAt: "2026-02-02 00:00:00",
+      });
+      await seedJob(loserWithData, userA, {
+        status: "pending",
+        dataCommitted: true,
+        createdAt: "2026-02-01 00:00:00",
+      });
+
+      await applyMigration();
+
+      expect((await job(keep)).status).toBe("running");
+      const loser = await job(loserWithData);
+      expect(loser.status).toBe("failed");
+      expect(loser.error_key).toBe(STALLED_AFTER_COMMIT);
+      expect(loser.retryable).toBe(false);
+    });
+
+    it("leaves one user's active job alone while repairing another's", async () => {
+      const aOnly = "cccccccc-0000-4000-8000-000000000001";
+      const bOne = "cccccccc-0000-4000-8000-000000000002";
+      const bTwo = "cccccccc-0000-4000-8000-000000000003";
+      await seedJob(aOnly, userA, { status: "running" });
+      await seedJob(bOne, userB, {
+        status: "running",
+        heartbeatAt: "2026-03-02 00:00:00",
+      });
+      await seedJob(bTwo, userB, { status: "pending" });
+
+      await applyMigration();
+
+      expect((await job(aOnly)).status).toBe("running");
+      expect((await job(bOne)).status).toBe("running");
+      expect((await job(bTwo)).status).toBe("failed");
+    });
+
+    it("normalizes a status the new CHECK would refuse", async () => {
+      const odd = "dddddddd-0000-4000-8000-000000000001";
+      await seedJob(odd, userA, { status: "aborted" });
+
+      await applyMigration();
+
+      expect(await constraintExists("import_jobs_status_check")).toBe(true);
+      const row = await job(odd);
+      expect(row.status).toBe("failed");
+      expect(row.error_key).toBe(STALLED);
+      expect(row.retryable).toBe(true);
+    });
+
+    it("completed and failed jobs are not active, so several may coexist", async () => {
+      await seedJob("eeeeeeee-0000-4000-8000-000000000001", userA, {
+        status: "completed",
+      });
+      await seedJob("eeeeeeee-0000-4000-8000-000000000002", userA, {
+        status: "completed",
+      });
+      await seedJob("eeeeeeee-0000-4000-8000-000000000003", userA, {
+        status: "failed",
+      });
+
+      await applyMigration();
+
+      const [{ count }] = await dataSource.query(
+        `SELECT COUNT(*)::int AS count FROM import_jobs WHERE user_id = $1`,
+        [userA],
+      );
+      expect(count).toBe(3);
+    });
+  });
+
+  describe("budget_alerts", () => {
+    const seedAlert = async (
+      id: string,
+      userId: string,
+      fields: {
+        alertType: string;
+        severity: string;
+        categoryId?: string | null;
+        isRead?: boolean;
+        isEmailSent?: boolean;
+        dismissed?: boolean;
+        createdAt?: string;
+      },
+    ): Promise<void> => {
+      await dataSource.query(
+        `INSERT INTO budget_alerts
+           (id, user_id, budget_id, budget_category_id, alert_type, severity,
+            title, message, is_read, is_email_sent, period_start, created_at,
+            dismissed_at)
+         VALUES ($1, $2, NULL, $3, $4, $5, 'title', 'message', $6, $7,
+                 DATE '2026-01-01', $8, $9)`,
+        [
+          id,
+          userId,
+          fields.categoryId ?? null,
+          fields.alertType,
+          fields.severity,
+          fields.isRead ?? false,
+          fields.isEmailSent ?? false,
+          fields.createdAt ?? "2026-01-05 00:00:00",
+          fields.dismissed ? "2026-01-06 00:00:00" : null,
+        ],
+      );
+    };
+
+    const alertIds = async (userId: string): Promise<string[]> => {
+      const rows: { id: string }[] = await dataSource.query(
+        `SELECT id FROM budget_alerts WHERE user_id = $1 ORDER BY id`,
+        [userId],
+      );
+      return rows.map((r) => r.id);
+    };
+
+    it("collapses a duplicate set and keeps the row the user acted on", async () => {
+      const pristine = "f0000000-0000-4000-8000-000000000001";
+      const dismissed = "f0000000-0000-4000-8000-000000000002";
+      const read = "f0000000-0000-4000-8000-000000000003";
+      // The dismissed one is the newest, so "keep the oldest" alone would throw
+      // away the acknowledgement.
+      await seedAlert(pristine, userA, {
+        alertType: "overspend",
+        severity: "warning",
+        createdAt: "2026-01-02 00:00:00",
+      });
+      await seedAlert(read, userA, {
+        alertType: "overspend",
+        severity: "warning",
+        isRead: true,
+        createdAt: "2026-01-03 00:00:00",
+      });
+      await seedAlert(dismissed, userA, {
+        alertType: "overspend",
+        severity: "warning",
+        isRead: true,
+        dismissed: true,
+        createdAt: "2026-01-04 00:00:00",
+      });
+
+      await applyMigration();
+
+      expect(await indexExists("idx_budget_alerts_fingerprint")).toBe(true);
+      expect(await alertIds(userA)).toEqual([dismissed]);
+    });
+
+    it("keeps a budget-wide duplicate set too, where the category is NULL", async () => {
+      // The COALESCE in the index is what makes NULL-category alerts part of the
+      // key at all; without it these three would be the only unguarded ones, and
+      // the repair would leave them behind.
+      const first = "f1000000-0000-4000-8000-000000000001";
+      await seedAlert(first, userA, {
+        alertType: "income_shortfall",
+        severity: "info",
+        categoryId: null,
+        createdAt: "2026-01-01 00:00:00",
+      });
+      await seedAlert("f1000000-0000-4000-8000-000000000002", userA, {
+        alertType: "income_shortfall",
+        severity: "info",
+        categoryId: null,
+        createdAt: "2026-01-02 00:00:00",
+      });
+
+      await applyMigration();
+
+      expect(await alertIds(userA)).toEqual([first]);
+    });
+
+    it("a higher severity is a different alert, so an escalation survives", async () => {
+      const warning = "f2000000-0000-4000-8000-000000000001";
+      const critical = "f2000000-0000-4000-8000-000000000002";
+      await seedAlert(warning, userA, {
+        alertType: "overspend",
+        severity: "warning",
+      });
+      await seedAlert(critical, userA, {
+        alertType: "overspend",
+        severity: "critical",
+      });
+
+      await applyMigration();
+
+      expect((await alertIds(userA)).sort()).toEqual(
+        [warning, critical].sort(),
+      );
+    });
+  });
+
+  /**
+   * The reason both repairs are written as select-then-act over a window
+   * function rather than as one-shot cleanups: a migration whose tracker INSERT
+   * did not commit runs again on the next boot, and a repair that only works on
+   * a dirty database would turn one startup crash into another.
+   */
+  it("is re-runnable: a second apply changes nothing", async () => {
+    await seedJob("f3000000-0000-4000-8000-000000000001", userA, {
+      status: "running",
+      heartbeatAt: "2026-04-02 00:00:00",
+    });
+    await seedJob("f3000000-0000-4000-8000-000000000002", userA, {
+      status: "pending",
+    });
+
+    await applyMigration();
+    const afterFirst = await dataSource.query(
+      `SELECT id, status, error_key, retryable FROM import_jobs ORDER BY id`,
+    );
+
+    await applyMigration();
+    const afterSecond = await dataSource.query(
+      `SELECT id, status, error_key, retryable FROM import_jobs ORDER BY id`,
+    );
+
+    expect(afterSecond).toEqual(afterFirst);
+    expect(await indexExists("idx_import_jobs_one_active_per_user")).toBe(true);
+    expect(await indexExists("idx_budget_alerts_fingerprint")).toBe(true);
+  });
+});

--- a/backend/test/integration/rls-enforcement.integration.spec.ts
+++ b/backend/test/integration/rls-enforcement.integration.spec.ts
@@ -70,6 +70,7 @@ describe("RLS enforcement (T2, catalog-driven)", () => {
     scheduled_transaction_split_tags:
       "scheduled_transaction_splits -> scheduled_transactions",
     scheduled_transaction_overrides: "scheduled_transactions",
+    scheduled_transaction_postings: "scheduled_transactions",
     security_prices: "securities",
     security_tags: "securities",
     holdings: "accounts",

--- a/backend/test/integration/support-backup.integration.spec.ts
+++ b/backend/test/integration/support-backup.integration.spec.ts
@@ -22,6 +22,8 @@ import { OidcReauthService } from "@/auth/oidc/oidc-reauth.service";
 import { AiEncryptionService } from "@/ai/ai-encryption.service";
 import { DatabaseStorageProvider } from "@/attachments/storage/database-storage.provider";
 import { ATTACHMENT_STORAGE_PROVIDER } from "@/attachments/storage/attachment-storage.interface";
+import { JobClaimService } from "@/common/jobs/job-claim.service";
+import { UserMaintenanceService } from "@/common/jobs/user-maintenance.service";
 import {
   createTestUserDirect,
   INTEGRATION_TYPEORM_OPTIONS,
@@ -58,6 +60,11 @@ describe("Support backup (integration)", () => {
         BackupRestoreService,
         BackupAttachmentTransferService,
         BackupRestoreDatabaseService,
+        // Real, not doubles: the restore takes a maintenance lease against the
+        // real `job_claims` table, so a broken lease shows up here rather than
+        // only in production.
+        JobClaimService,
+        UserMaintenanceService,
         SupportBackupService,
         // Real, for the reason the sibling suite gives: a mocked step-up would
         // keep this suite green through the removal of the check it gates.

--- a/database/migrations/139_concurrency_integrity_guards.sql
+++ b/database/migrations/139_concurrency_integrity_guards.sql
@@ -1,0 +1,348 @@
+-- 139: Database-enforced guards for the concurrency defects the Phase 4 audit
+-- confirmed. Each one replaces an application-level check-then-act that two
+-- replicas, two tabs or a retry could both pass.
+--
+-- Six independent guards, all idempotent:
+--
+--   1. job_claims          -- the one durable claim mechanism for per-user work
+--                             that must happen at most once however many
+--                             replicas fire the cron (P4-013, P4-014, P4-018).
+--   2. import_jobs         -- a status CHECK and a partial unique index, so
+--                             "one active import per user" is enforced by the
+--                             database instead of by a count() before an insert
+--                             (P4-001), plus a data_committed checkpoint that
+--                             tells a retry whether the first run already wrote
+--                             the ledger (P4-002).
+--   3. scheduled_transaction_postings -- an occurrence key, so one due date
+--                             posts one transaction (P4-004).
+--   4. budget_alerts       -- a unique fingerprint matching the app's own
+--                             de-duplication rule, so two alert processors
+--                             cannot both insert the same alert and both email
+--                             it (P4-015).
+--   5. transaction_attachments -- an index supporting the parent-locked cap
+--                             count (P4-017).
+--   6. attachment_blob_tombstones -- a deletion record for bytes PostgreSQL
+--                             cannot roll back, written by a trigger so the
+--                             ON DELETE CASCADE path is covered too (P4-010).
+--
+-- Behaviour-neutral at RLS_MODE=off. All three new tables ship their policy AND
+-- their own ENABLE, per the post-123 convention the T1 harness enforces.
+--
+-- Two of the guards are constraints over data that already exists, and both are
+-- constraints against a state the old code could reach: more than one active
+-- import per user, and duplicate budget alerts. A `CREATE UNIQUE INDEX` over a
+-- table already in that state fails -- and a failed migration is not a failed
+-- check, because `db-migrate` runs at container start, so the backend never
+-- boots and the deploy reports only "backend exited (1)". Each of those two
+-- guards is therefore preceded by a documented repair phase that says exactly
+-- which row survives and what happens to the rest. Both repairs are
+-- re-runnable: after the first pass their queries select nothing.
+-- `backend/test/integration/migration-139-preflight.integration.spec.ts` seeds
+-- the legacy states and asserts the migration completes and repairs them.
+
+-- ---------------------------------------------------------------------------
+-- 1. job_claims
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS job_claims (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    claim_type VARCHAR(64) NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    claim_key VARCHAR(200) NOT NULL,
+    claimed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- NULL means a permanent claim (a delivery); a timestamp means a lease that
+    -- a later worker may retake once it has passed.
+    expires_at TIMESTAMP
+);
+
+-- The whole point of the table: the claim is one atomic statement, so there is
+-- no window between a replica deciding to send and recording that it did.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_job_claims_key
+    ON job_claims(claim_type, user_id, claim_key);
+
+CREATE INDEX IF NOT EXISTS idx_job_claims_claimed_at ON job_claims(claimed_at);
+
+ALTER TABLE job_claims ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS job_claims_isolation ON job_claims;
+CREATE POLICY job_claims_isolation ON job_claims
+  USING (user_id = (SELECT app_current_user_id()) OR (SELECT app_bypass_rls()))
+  WITH CHECK (user_id = (SELECT app_current_user_id()) OR (SELECT app_bypass_rls()));
+
+-- ---------------------------------------------------------------------------
+-- 2. import_jobs: status CHECK, active-job uniqueness, commit checkpoint
+-- ---------------------------------------------------------------------------
+
+-- Set inside the import transaction itself, so it commits with the rows it
+-- describes. That is what makes the difference between "the run failed before
+-- writing anything, retry is free" and "the ledger is already written and only
+-- the completion metadata is missing" -- states the old retryable flag folded
+-- into one and offered as an ordinary retry.
+--
+-- Added before the repair below, which reads it to decide whether a superseded
+-- job may be offered as a retry.
+ALTER TABLE import_jobs ADD COLUMN IF NOT EXISTS data_committed BOOLEAN NOT NULL DEFAULT false;
+
+-- PREFLIGHT (1 of 2): statuses the new CHECK would refuse.
+--
+-- A constraint added to a populated table validates every existing row, so a
+-- status outside the four the application writes -- a hand-edited row, a value
+-- from a version of the code that predates this vocabulary -- aborts the
+-- migration. And an aborted migration is not a failed check: `db-migrate` runs
+-- at container start, so the backend never comes up and the deploy reports only
+-- "backend exited (1)". Normalize first, then constrain.
+--
+-- 'failed' is the honest landing place: the row describes a run nobody is
+-- driving, and it is not retryable if its data is already in the ledger.
+UPDATE import_jobs
+   SET status = 'failed',
+       error_key = CASE WHEN data_committed THEN 'mnyJobStalledAfterCommit'
+                        ELSE 'mnyJobStalled' END,
+       error_detail = 'Import job carried a status this version does not recognize',
+       retryable = (data_committed = false),
+       progress = NULL,
+       completed_at = COALESCE(completed_at, CURRENT_TIMESTAMP)
+ WHERE status IS NULL
+    OR status NOT IN ('pending', 'running', 'completed', 'failed');
+
+-- The CHECK is load-bearing for the partial index below, not cosmetic: the
+-- index's predicate names two statuses, so a typo'd status written by
+-- application code would sit outside the predicate and let a second active job
+-- exist while still looking active to hasActiveJob().
+ALTER TABLE import_jobs DROP CONSTRAINT IF EXISTS import_jobs_status_check;
+ALTER TABLE import_jobs ADD CONSTRAINT import_jobs_status_check
+    CHECK (status IN ('pending', 'running', 'completed', 'failed'));
+
+-- PREFLIGHT (2 of 2): the duplicates the new unique index would refuse.
+--
+-- "More than one active import for one user" is precisely the state this index
+-- exists to prevent, so any database that ran the racy `hasActiveJob()` check
+-- can already be in it -- and `CREATE UNIQUE INDEX` on a table that is already
+-- in it fails. The guard cannot be introduced without saying what happens to
+-- the rows that predate it.
+--
+-- Keep exactly one job per user and fail the rest. The one kept is the one most
+-- likely to be real work, in this order:
+--
+--   1. `data_committed` -- a job that has written to the ledger is the one whose
+--      completion path still matters; never discard it in favour of a pristine
+--      duplicate.
+--   2. 'running' over 'pending' -- a worker picked it up.
+--   3. the most recent heartbeat -- among running jobs, the live one.
+--   4. the newest -- an arbitrary but stable tie-break.
+--
+-- The losers are failed with the same keys the stale-job reaper uses, so the UI
+-- copy and the Retry gating are already right: `mnyJobStalledAfterCommit` and
+-- `retryable = false` for a job whose data is in, `mnyJobStalled` and a genuine
+-- retry for one whose is not. Those two literals are owned by
+-- `backend/src/import/mny/mny-import-job.service.ts`
+-- (`JOB_STALLED_ERROR_KEY` / `JOB_COMMITTED_STALLED_ERROR_KEY`); a rename there
+-- has to change them here.
+--
+-- Re-runnable: after the first pass no user has two active jobs, so the CTE
+-- returns nothing.
+WITH superseded AS (
+    SELECT id
+      FROM (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY user_id
+                 ORDER BY data_committed DESC,
+                          (status = 'running') DESC,
+                          heartbeat_at DESC NULLS LAST,
+                          created_at DESC NULLS LAST,
+                          id DESC
+               ) AS rn
+          FROM import_jobs
+         WHERE status IN ('pending', 'running')
+      ) ranked
+     WHERE rn > 1
+)
+UPDATE import_jobs j
+   SET status = 'failed',
+       error_key = CASE WHEN j.data_committed THEN 'mnyJobStalledAfterCommit'
+                        ELSE 'mnyJobStalled' END,
+       error_detail = 'Superseded: this account had more than one import running before the database enforced one at a time',
+       retryable = (j.data_committed = false),
+       progress = NULL,
+       completed_at = CURRENT_TIMESTAMP
+  FROM superseded s
+ WHERE s.id = j.id;
+
+-- One active import per user, enforced where it cannot be raced. The intended
+-- key at this baseline is the user: hasActiveJob() asks only whether that user
+-- has any pending/running job, the 409 says "an import is already running", and
+-- the product deliberately blocks a second file as well as the same one.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_import_jobs_one_active_per_user
+    ON import_jobs(user_id)
+    WHERE status IN ('pending', 'running');
+
+-- ---------------------------------------------------------------------------
+-- 3. scheduled_transaction_postings
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS scheduled_transaction_postings (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    scheduled_transaction_id UUID NOT NULL
+        REFERENCES scheduled_transactions(id) ON DELETE CASCADE,
+    -- The occurrence's identity: the schedule's next_due_date at posting time.
+    -- Not posted_date, which an override or an inline transactionDate moves.
+    original_due_date DATE NOT NULL,
+    posted_date DATE NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stp_occurrence
+    ON scheduled_transaction_postings(scheduled_transaction_id, original_due_date);
+
+ALTER TABLE scheduled_transaction_postings ENABLE ROW LEVEL SECURITY;
+
+-- Indirect ownership: the postings table has no user_id of its own, so it
+-- inherits the schedule's, exactly like scheduled_transaction_overrides.
+DROP POLICY IF EXISTS scheduled_transaction_postings_isolation ON scheduled_transaction_postings;
+CREATE POLICY scheduled_transaction_postings_isolation ON scheduled_transaction_postings
+  USING ((SELECT app_bypass_rls()) OR EXISTS (
+    SELECT 1 FROM scheduled_transactions st
+    WHERE st.id = scheduled_transaction_postings.scheduled_transaction_id
+      AND st.user_id = (SELECT app_current_user_id())))
+  WITH CHECK ((SELECT app_bypass_rls()) OR EXISTS (
+    SELECT 1 FROM scheduled_transactions st
+    WHERE st.id = scheduled_transaction_postings.scheduled_transaction_id
+      AND st.user_id = (SELECT app_current_user_id())));
+
+-- ---------------------------------------------------------------------------
+-- 4. budget_alerts: the app's de-duplication rule as a database key
+-- ---------------------------------------------------------------------------
+
+-- PREFLIGHT: the duplicates the fingerprint would refuse.
+--
+-- `deduplicateAlerts()` ran in application code with no key under it, which is
+-- the whole finding (P4-015) -- so on any database that has had two alert
+-- processors overlap, the duplicate rows are already there and the unique index
+-- cannot be created over them.
+--
+-- Alerts are notifications, so collapsing a duplicate set to one row loses
+-- nothing except the duplicate. What must survive is anything the user did with
+-- it: keep the row that was dismissed, then the one that was read, then the one
+-- whose email went out, then the oldest -- the one they actually saw.
+-- Deleting the others cannot orphan anything: no table references
+-- `budget_alerts`.
+--
+-- Re-runnable: after the first pass no fingerprint has two rows.
+DELETE FROM budget_alerts
+ WHERE id IN (
+   SELECT id
+     FROM (
+       SELECT id,
+              ROW_NUMBER() OVER (
+                PARTITION BY budget_id,
+                             period_start,
+                             alert_type,
+                             COALESCE(budget_category_id, '00000000-0000-0000-0000-000000000000'::uuid),
+                             severity
+                ORDER BY (dismissed_at IS NOT NULL) DESC,
+                         COALESCE(is_read, false) DESC,
+                         COALESCE(is_email_sent, false) DESC,
+                         created_at ASC NULLS LAST,
+                         id ASC
+              ) AS rn
+         FROM budget_alerts
+     ) ranked
+    WHERE rn > 1
+ );
+
+-- deduplicateAlerts() drops a candidate matching an existing (alert_type,
+-- budget_category_id) unless its severity is strictly higher -- so severity
+-- belongs in the key, and an escalation is still allowed to insert. COALESCE
+-- because a budget-wide alert has a NULL category, and NULL never equals NULL
+-- in a unique index: without it the budget-wide alerts -- flex group, income
+-- shortfall, positive milestone -- would be exactly the ones left unguarded.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_budget_alerts_fingerprint
+    ON budget_alerts(
+        budget_id,
+        period_start,
+        alert_type,
+        COALESCE(budget_category_id, '00000000-0000-0000-0000-000000000000'::uuid),
+        severity
+    );
+
+-- ---------------------------------------------------------------------------
+-- 5. transaction_attachments
+-- ---------------------------------------------------------------------------
+
+-- The per-transaction cap is now counted under a lock on the parent transaction
+-- row; this index keeps that count from being a sequential scan.
+CREATE INDEX IF NOT EXISTS idx_transaction_attachments_transaction
+    ON transaction_attachments(transaction_id);
+
+-- ---------------------------------------------------------------------------
+-- 6. attachment_blob_tombstones -- external bytes get a deletion record
+-- ---------------------------------------------------------------------------
+--
+-- Local-filesystem and S3 attachment bytes cannot be rolled back with
+-- PostgreSQL, and deleting them *before* the metadata delete commits meant a
+-- rollback left metadata pointing at bytes that were already gone. Worse,
+-- deleting a transaction removes its attachment metadata by ON DELETE CASCADE
+-- with no application code running at all, so those objects were never deleted
+-- and accumulated unbounded (audit P4-010).
+--
+-- A tombstone written by a trigger covers every deletion path -- API delete,
+-- parent-transaction cascade, restore wipe, account deletion -- because it is
+-- the database that knows a row went away. The sweeper then deletes the object
+-- and drops the tombstone, so a crash between the two costs a retry rather than
+-- an orphan nobody can find.
+--
+-- user_id is ON DELETE SET NULL, not CASCADE: deleting a user is exactly when
+-- their bytes most need removing, so the tombstone must outlive them.
+CREATE TABLE IF NOT EXISTS attachment_blob_tombstones (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    storage_provider VARCHAR(20) NOT NULL,
+    storage_key VARCHAR(255) NOT NULL,
+    deleted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT
+);
+
+-- Unique, so a tombstone is idempotent: two records for one object describe the
+-- same pending deletion, and the trigger can therefore be a plain
+-- ON CONFLICT DO NOTHING insert with no bookkeeping of its own.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_abt_object
+    ON attachment_blob_tombstones(storage_provider, storage_key);
+CREATE INDEX IF NOT EXISTS idx_abt_deleted_at ON attachment_blob_tombstones(deleted_at);
+
+ALTER TABLE attachment_blob_tombstones ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS attachment_blob_tombstones_isolation ON attachment_blob_tombstones;
+CREATE POLICY attachment_blob_tombstones_isolation ON attachment_blob_tombstones
+  USING (user_id = (SELECT app_current_user_id()) OR (SELECT app_bypass_rls()))
+  WITH CHECK (user_id = (SELECT app_current_user_id()) OR (SELECT app_bypass_rls()));
+
+-- SECURITY DEFINER so the tombstone is written as the table owner.
+--
+-- Under RLS the trigger would otherwise insert as the invoking role and be
+-- refused whenever the deleted row's owner is not the session's identity -- a
+-- cross-owner transfer counterpart, an admin path -- and a refused trigger
+-- fails the DELETE itself. Losing the audit record must never be able to block
+-- the delete, and neither must the delete be able to skip the record.
+-- search_path is pinned: a SECURITY DEFINER function that resolves its tables
+-- through the caller's search_path is a privilege-escalation hole.
+CREATE OR REPLACE FUNCTION record_attachment_blob_tombstone() RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+    INSERT INTO attachment_blob_tombstones (user_id, storage_provider, storage_key)
+    VALUES (OLD.user_id, OLD.storage_provider, OLD.storage_key)
+    ON CONFLICT (storage_provider, storage_key) DO NOTHING;
+    RETURN OLD;
+END;
+$$;
+
+-- Only for providers whose bytes live outside PostgreSQL. The database provider
+-- keeps them in `attachment_blobs`, whose own foreign key cascades -- a
+-- tombstone there would describe work already done.
+DROP TRIGGER IF EXISTS trg_attachment_blob_tombstone ON transaction_attachments;
+CREATE TRIGGER trg_attachment_blob_tombstone
+    AFTER DELETE ON transaction_attachments
+    FOR EACH ROW
+    WHEN (OLD.storage_provider <> 'database')
+    EXECUTE FUNCTION record_attachment_blob_tombstone();

--- a/database/migrations/140_job_claim_delivery_record.sql
+++ b/database/migrations/140_job_claim_delivery_record.sql
@@ -1,0 +1,61 @@
+-- 139: a job claim can now record that its delivery actually happened.
+--
+-- Migration 139 gave the multi-replica reminders a durable claim, which stopped
+-- two replicas emailing the same user twice. It did not make a claimed-but-unsent
+-- reminder recoverable, because `claimOnce` is taken *before* the send and is the
+-- only record that the send was owed (audit RV4-006).
+--
+-- A replica that commits the claim and is then killed -- an OOM, a rolling
+-- restart, a pod eviction -- leaves a permanent row that every other replica and
+-- every later run reads as "already handled". The bill-payment or mortgage-renewal
+-- email is simply never sent, and nothing can notice, because the row cannot tell
+-- "I sent this" from "I intended to".
+--
+-- Those are two different facts and they need two different columns:
+--
+--   expires_at   -- the lease. Present while a replica is doing the work, gone or
+--                   past when it is not. Bounded, so a killed replica costs a
+--                   retry window rather than the delivery.
+--   delivered_at -- the delivery. Written *after* the side effect succeeded, and
+--                   re-read under the lease to decide whether the work is still
+--                   owed. A delivered row is never retaken.
+--
+-- The resulting contract is **at-least-once**: a process killed between SMTP
+-- acceptance and `delivered_at` re-sends on the next run. For a reminder that is
+-- the right trade -- a duplicate nudge is a minor annoyance, a missed mortgage
+-- renewal is not -- and it is a deliberate choice rather than a gap, so it is
+-- written down in `docs/cron-jobs.md` next to the jobs that make it.
+--
+-- Backfill: every existing row is a `claimOnce` row, whose whole meaning was
+-- "this window is spent". Treating those as delivered is the only reading that
+-- preserves today's behaviour -- leaving them NULL would re-send every reminder
+-- claimed before the upgrade. `claimed_at` is the honest timestamp for when that
+-- decision was made.
+--
+-- What that backfill *also* preserves, and the decision taken about it
+-- (DR-RRV4-02): a reminder lost in the old claim-before-send crash window is
+-- indistinguishable from one delivered, because the old row recorded only the
+-- intent. Marking these delivered therefore keeps any such loss lost. The state is
+-- genuinely ambiguous and no predicate over these columns can resolve it without
+-- provider evidence, so the choice is between one possible duplicate per affected
+-- claim and one possible missed notice.
+--
+-- **Accepted deliberately, in this direction, once.** The alternative -- scoping the
+-- backfill by claim type or date so recent windows re-send -- trades a silent miss
+-- for a duplicate on every claim it covers, including the overwhelming majority that
+-- were delivered correctly. These are daily reminders: a duplicate is noise a user
+-- will forgive and a miss is a single day's notice, so neither outcome is severe,
+-- and the tie is broken in favour of not emailing a population of users about bills
+-- they were already told about. Every claim written *after* this migration keeps a
+-- real delivery record, so the ambiguity is bounded to rows that predate it and does
+-- not recur.
+
+ALTER TABLE job_claims
+    ADD COLUMN IF NOT EXISTS delivered_at TIMESTAMP;
+
+-- A permanent claim (`expires_at IS NULL`) is what the old `claimOnce` wrote, and
+-- it meant the window was consumed. Preserve that reading rather than re-sending.
+UPDATE job_claims
+   SET delivered_at = claimed_at
+ WHERE delivered_at IS NULL
+   AND expires_at IS NULL;

--- a/database/migrations/141_job_claim_lease_token.sql
+++ b/database/migrations/141_job_claim_lease_token.sql
@@ -1,0 +1,37 @@
+-- 140: a lease needs an owner, so a worker cannot act on a lease it has lost.
+--
+-- `claimLease` returned a boolean and `release`/`markDelivered` addressed the row
+-- by `(claim_type, user_id, claim_key)` alone (audit DR-RRV4-01). That identifies
+-- the *work*, not the attempt, so a worker delayed past its own expiry -- a long
+-- garbage-collection pause, a stalled SMTP connect -- can come back and write
+-- against a lease another replica has since retaken:
+--
+--   * its `release` deletes the live lease, and the replica actually sending now
+--     has no exclusion at all;
+--   * its `markDelivered` records a delivery for a send the *new* holder has not
+--     finished, so a genuine failure there is never retried.
+--
+-- Today's job set makes that interleaving rare (daily schedules, a ten-minute
+-- lease), which is why the audit filed it as a design risk rather than a defect.
+-- It stops being rare the moment `JobClaimService` is reused for anything more
+-- frequent or slower, and the failure is silent when it happens, so the token goes
+-- in now rather than being a condition on the next caller.
+--
+-- `lease_token` is minted per successful `claimLease` and required by
+-- `markDelivered`; `release` requires it whenever the caller holds one, and still
+-- accepts a bare delete for `claimOnce` callers, whose claim is the fact itself and
+-- has no attempt to identify.
+--
+-- This column on its own protects new code from new code (its `WHERE lease_token =`
+-- matches nothing once the lease is retaken). It does NOT stop a previous-release
+-- pod, whose `release`/`markDelivered` name the work and carry no token -- that gap
+-- is closed by the migration-141 triggers, which reject an untokenized mutation of a
+-- live tokenized lease. The two ship together; this column is inert against the old
+-- binary without them (audit V4R3-004, DOC-V4R3-01).
+--
+-- Backfill: NULL for every existing row. A permanent `claimOnce` row has no lease
+-- to own, and an in-flight lease at deploy time keeps whatever token it had (none
+-- for a pre-140 lease); when it expires it is retaken normally.
+
+ALTER TABLE job_claims
+    ADD COLUMN IF NOT EXISTS lease_token UUID;

--- a/database/migrations/142_job_claim_lease_ownership_enforcement.sql
+++ b/database/migrations/142_job_claim_lease_ownership_enforcement.sql
@@ -1,0 +1,80 @@
+-- 141: enforce lease ownership in the database, so a previous-release pod cannot
+-- release or mark a lease that a new pod has retaken during a rolling deployment.
+--
+-- Migration 140 added `job_claims.lease_token`; the new `release()` and
+-- `markDelivered()` filter on it, so a stalled new-code attempt whose lease was
+-- retaken matches zero rows and writes nothing. That protects new code from new
+-- code. It does not protect a new-code lease from the *previous* binary, whose
+-- statements name the work and not the holder (audit V4R3-004):
+--
+--     DELETE FROM job_claims WHERE claim_type=$1 AND user_id=$2 AND claim_key=$3
+--     UPDATE job_claims SET delivered_at=now(), expires_at=NULL WHERE <same key>
+--
+-- During a rollout: old pod A claims work and stalls past its lease; new pod B
+-- retakes it and writes token B; A resumes and its old `release()` deletes B's live
+-- row by work key, leaving the replica actually sending with no exclusion, or its
+-- old `markDelivered()` stamps a delivery for a send B has not finished. The nullable
+-- column cannot stop those statements, exactly as it could not for the MNY checkpoint
+-- (migration 140 -> 141) or the attachment quarantine (143 -> 144). The rule lives
+-- where both binaries meet: a session that mutates a *live tokenized* lease must own
+-- it.
+--
+-- Ownership is proven by a transaction-local GUC, `app.job_claim_lease_token`, that
+-- the new tokenized `release()` / `markDelivered()` set to their lease token before
+-- the write. A BEFORE DELETE / BEFORE UPDATE trigger, firing only on a live lease
+-- that carries a token, rejects the statement unless the session's GUC matches the
+-- row's token. The previous binary never sets the GUC, so it can never mutate a
+-- tokenized live lease held by new code.
+--
+-- What the WHEN clause deliberately excludes, so nothing legitimate is blocked:
+--
+--   * `claimLease` retaking an expired lease -- the row is expired, WHEN is false.
+--   * a permanent `claimOnce` row -- `lease_token` is NULL, WHEN is false.
+--   * the retention sweep -- it deletes rows older than 30 days, which are expired
+--     or permanent, so `expires_at > now()` is false.
+--   * a delivered row -- `markDelivered` sets `expires_at = NULL`, so WHEN is false.
+--
+-- The only writes reaching a live tokenized lease are the tokenized release/mark
+-- themselves, which set the GUC, and the previous binary's untokenized ones, which
+-- do not. Idempotent: CREATE OR REPLACE FUNCTION, triggers dropped first.
+
+CREATE OR REPLACE FUNCTION guard_job_claim_lease_ownership()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF COALESCE(current_setting('app.job_claim_lease_token', true), '')
+       IS DISTINCT FROM OLD.lease_token::text THEN
+        RAISE EXCEPTION
+          'job_claims lease % (%/%/%) is held by another attempt; this session does not own it',
+          OLD.lease_token, OLD.claim_type, OLD.user_id, OLD.claim_key
+          USING ERRCODE = 'raise_exception';
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_job_claims_guard_delete ON job_claims;
+CREATE TRIGGER trg_job_claims_guard_delete
+    BEFORE DELETE ON job_claims
+    FOR EACH ROW
+    WHEN (
+      OLD.lease_token IS NOT NULL
+      AND OLD.expires_at IS NOT NULL
+      AND OLD.expires_at > CURRENT_TIMESTAMP
+    )
+    EXECUTE FUNCTION guard_job_claim_lease_ownership();
+
+DROP TRIGGER IF EXISTS trg_job_claims_guard_update ON job_claims;
+CREATE TRIGGER trg_job_claims_guard_update
+    BEFORE UPDATE ON job_claims
+    FOR EACH ROW
+    WHEN (
+      OLD.lease_token IS NOT NULL
+      AND OLD.expires_at IS NOT NULL
+      AND OLD.expires_at > CURRENT_TIMESTAMP
+    )
+    EXECUTE FUNCTION guard_job_claim_lease_ownership();

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -341,6 +341,62 @@ CREATE TABLE attachment_blobs (
     data BYTEA NOT NULL
 );
 
+-- Attachment objects whose metadata is gone and whose bytes still need deleting
+-- (migration 139).
+--
+-- Only the database provider keeps bytes where PostgreSQL can roll them back. A
+-- local filesystem write and an S3 put cannot join the transaction, so deleting
+-- the object before the metadata delete committed left metadata pointing at bytes
+-- that no longer existed. And deleting a transaction removes its attachment
+-- metadata by ON DELETE CASCADE with no application code running at all, so
+-- those objects were never deleted.
+--
+-- A trigger writes the tombstone, which is why it covers every path the
+-- application does not control. AttachmentOrphanSweeper deletes the object and
+-- drops the row, so a crash between the two costs a retry.
+--
+-- user_id is ON DELETE SET NULL, not CASCADE: deleting a user is exactly when
+-- their bytes most need removing, so the record must outlive them.
+CREATE TABLE attachment_blob_tombstones (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    storage_provider VARCHAR(20) NOT NULL,
+    storage_key VARCHAR(255) NOT NULL,
+    deleted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT
+);
+
+-- Unique, so a tombstone is idempotent: two records for one object describe the
+-- same pending deletion, and the trigger can therefore be a plain
+-- ON CONFLICT DO NOTHING insert with no bookkeeping of its own.
+CREATE UNIQUE INDEX idx_abt_object
+    ON attachment_blob_tombstones(storage_provider, storage_key);
+CREATE INDEX idx_abt_deleted_at ON attachment_blob_tombstones(deleted_at);
+
+-- SECURITY DEFINER so the tombstone is written as the table owner: under RLS the
+-- trigger would otherwise insert as the invoking role and be refused whenever the
+-- deleted row's owner is not the session's identity, and a refused trigger fails
+-- the DELETE itself. search_path is pinned -- a SECURITY DEFINER function that
+-- resolves its tables through the caller's search_path is an escalation hole.
+CREATE OR REPLACE FUNCTION record_attachment_blob_tombstone() RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+    INSERT INTO attachment_blob_tombstones (user_id, storage_provider, storage_key)
+    VALUES (OLD.user_id, OLD.storage_provider, OLD.storage_key)
+    ON CONFLICT (storage_provider, storage_key) DO NOTHING;
+    RETURN OLD;
+END;
+$$;
+
+-- Only for providers whose bytes live outside PostgreSQL. The database provider
+-- keeps them in attachment_blobs, whose own foreign key cascades.
+CREATE TRIGGER trg_attachment_blob_tombstone
+    AFTER DELETE ON transaction_attachments
+    FOR EACH ROW
+    WHEN (OLD.storage_provider <> 'database')
+    EXECUTE FUNCTION record_attachment_blob_tombstone();
+
 -- Tags
 CREATE TABLE tags (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -566,6 +622,23 @@ CREATE TABLE scheduled_transaction_overrides (
 CREATE INDEX idx_sched_txn_overrides_sched_txn_id ON scheduled_transaction_overrides(scheduled_transaction_id);
 CREATE INDEX idx_sched_txn_overrides_date ON scheduled_transaction_overrides(override_date);
 CREATE INDEX idx_sched_txn_overrides_orig ON scheduled_transaction_overrides(scheduled_transaction_id, original_date);
+
+-- Posted occurrences (migration 139). The occurrence -- not the schedule -- is
+-- the thing that must happen once, and this unique key is its name. Manual and
+-- automatic posting both insert it inside the same transaction as the money they
+-- create, so the key arbitrates between two replicas, a manual post racing the
+-- cron, and a retry after a crash. original_due_date is the schedule's own
+-- next_due_date at posting time, not posted_date, which an override moves.
+CREATE TABLE scheduled_transaction_postings (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    scheduled_transaction_id UUID NOT NULL REFERENCES scheduled_transactions(id) ON DELETE CASCADE,
+    original_due_date DATE NOT NULL,
+    posted_date DATE NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX idx_stp_occurrence
+    ON scheduled_transaction_postings(scheduled_transaction_id, original_due_date);
 
 -- Security documents: factsheet, KIID, prospectus, annual report, tax slip,
 -- research. Real columns rather than a JSONB blob so the type, name, date and
@@ -1296,6 +1369,24 @@ CREATE INDEX idx_budget_alerts_user ON budget_alerts(user_id);
 CREATE INDEX idx_budget_alerts_user_unread ON budget_alerts(user_id, is_read) WHERE is_read = false;
 CREATE INDEX idx_budget_alerts_budget_period ON budget_alerts(budget_id, period_start);
 
+-- The app's own de-duplication rule as a database key (migration 139).
+-- deduplicateAlerts() drops a candidate matching an existing (alert_type,
+-- budget_category_id) unless its severity is strictly higher, so severity
+-- belongs in the key and an escalation still inserts. COALESCE because a
+-- budget-wide alert has a NULL category and NULL never equals NULL in a unique
+-- index: without it the budget-wide alerts would be the only unguarded ones.
+--
+-- Duplicates predating the key are collapsed by the migration's preflight before
+-- it is created, keeping whichever row the user acted on.
+CREATE UNIQUE INDEX idx_budget_alerts_fingerprint
+    ON budget_alerts(
+        budget_id,
+        period_start,
+        alert_type,
+        COALESCE(budget_category_id, '00000000-0000-0000-0000-000000000000'::uuid),
+        severity
+    );
+
 -- Triggers for budget tables updated_at
 CREATE TRIGGER update_budgets_updated_at BEFORE UPDATE ON budgets FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_budget_categories_updated_at BEFORE UPDATE ON budget_categories FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
@@ -1351,22 +1442,122 @@ CREATE TABLE import_jobs (
     error_key VARCHAR(100),
     error_detail TEXT,
     retryable BOOLEAN NOT NULL DEFAULT false,
+    -- Set inside the import transaction, so it commits with the rows it
+    -- describes (migration 139). Distinguishes "failed before writing anything,
+    -- retry is free" from "the ledger is already written and only the completion
+    -- metadata is missing" -- two states the retryable flag used to fold into
+    -- one and offer as an ordinary retry, which re-imported the file.
+    data_committed BOOLEAN NOT NULL DEFAULT false,
     heartbeat_at TIMESTAMP,
     started_at TIMESTAMP,
     completed_at TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    -- Load-bearing for the partial unique index below, not cosmetic: its
+    -- predicate names two statuses, so a status the application never intended
+    -- would sit outside the predicate and let a second active job exist.
+    CONSTRAINT import_jobs_status_check
+        CHECK (status IN ('pending', 'running', 'completed', 'failed'))
 );
 
 CREATE INDEX idx_import_jobs_user ON import_jobs(user_id);
 CREATE INDEX idx_import_jobs_staged_file ON import_jobs(staged_file_id);
 CREATE INDEX idx_import_jobs_running_heartbeat ON import_jobs(heartbeat_at) WHERE status = 'running';
--- One in-flight import per user, enforced here rather than by a read-then-insert
--- in the service: two concurrent starts would otherwise both see no active job
--- and import the same staged file twice.
-CREATE UNIQUE INDEX idx_import_jobs_one_active_per_user ON import_jobs(user_id) WHERE status IN ('pending', 'running');
+-- One active import per user, enforced where it cannot be raced (migration 139).
+-- The key is the user because that is what the product blocks on: hasActiveJob()
+-- asks only whether this user has any pending/running job, and the 409 says "an
+-- import is already running".
+--
+-- A fresh database is trivially in this state; an upgraded one need not be, since
+-- more than one active job is exactly what the pre-136 code could produce. The
+-- migration therefore repairs before it constrains -- see its preflight, and
+-- backend/test/integration/migration-139-preflight.integration.spec.ts.
+CREATE UNIQUE INDEX idx_import_jobs_one_active_per_user
+    ON import_jobs(user_id)
+    WHERE status IN ('pending', 'running');
 
 CREATE TRIGGER update_import_jobs_updated_at BEFORE UPDATE ON import_jobs FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Durable claims on per-user work that must happen at most once (migration 139).
+--
+-- ScheduleModule lives in the API process, so every backend replica fires every
+-- cron (docs/cron-jobs.md). A guard held in process memory is therefore not a
+-- guard -- each replica has its own -- and "query for a row like the one I am
+-- about to write" is a check-then-act both replicas pass. The unique key makes
+-- the claim itself the atomic operation.
+--
+-- expires_at NULL means a permanent claim (one delivery per user per window);
+-- a timestamp means a lease a later worker may retake once it has passed, so a
+-- replica killed mid-run does not lock the user out.
+CREATE TABLE job_claims (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    claim_type VARCHAR(64) NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    claim_key VARCHAR(200) NOT NULL,
+    claimed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- The lease: present while a replica is doing the work, gone or past when it
+    -- is not. NULL on a legacy permanent claim.
+    expires_at TIMESTAMP,
+    -- When the side effect this claim coordinates actually happened
+    -- (migration 139). Written *after* the send, and re-read under the lease to
+    -- decide whether the work is still owed: a claim taken before the send says
+    -- only that somebody intended to send, and an intention does not survive the
+    -- process holding it (audit RV4-006). A delivered row is never retaken.
+    delivered_at TIMESTAMP,
+    -- Which attempt owns the current lease (migration 140). The key above
+    -- identifies the *work*; this identifies the holder, so a worker delayed past
+    -- its own expiry cannot release a lease another replica has retaken or record a
+    -- delivery for a send that replica has not finished (audit DR-RRV4-01). NULL for
+    -- a permanent `claimOnce` row, which has no attempt to identify.
+    lease_token UUID
+);
+
+CREATE UNIQUE INDEX idx_job_claims_key ON job_claims(claim_type, user_id, claim_key);
+CREATE INDEX idx_job_claims_claimed_at ON job_claims(claimed_at);
+
+-- Lease-ownership enforcement (migration 141). A session mutating a *live tokenized*
+-- lease must own it, proven by the transaction-local `app.job_claim_lease_token`
+-- GUC the new release/markDelivered set. The previous binary never sets it, so it
+-- cannot delete or mark a lease this deployment has retaken. The WHEN clauses
+-- exclude expired rows (retakes, retention sweep), permanent claimOnce rows
+-- (NULL token) and delivered rows (NULL expiry), so only the tokenized writes and
+-- the old binary's untokenized ones ever reach the guard.
+CREATE OR REPLACE FUNCTION guard_job_claim_lease_ownership() RETURNS TRIGGER
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF COALESCE(current_setting('app.job_claim_lease_token', true), '')
+       IS DISTINCT FROM OLD.lease_token::text THEN
+        RAISE EXCEPTION
+          'job_claims lease % (%/%/%) is held by another attempt; this session does not own it',
+          OLD.lease_token, OLD.claim_type, OLD.user_id, OLD.claim_key
+          USING ERRCODE = 'raise_exception';
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_job_claims_guard_delete
+    BEFORE DELETE ON job_claims
+    FOR EACH ROW
+    WHEN (
+      OLD.lease_token IS NOT NULL
+      AND OLD.expires_at IS NOT NULL
+      AND OLD.expires_at > CURRENT_TIMESTAMP
+    )
+    EXECUTE FUNCTION guard_job_claim_lease_ownership();
+
+CREATE TRIGGER trg_job_claims_guard_update
+    BEFORE UPDATE ON job_claims
+    FOR EACH ROW
+    WHEN (
+      OLD.lease_token IS NOT NULL
+      AND OLD.expires_at IS NOT NULL
+      AND OLD.expires_at > CURRENT_TIMESTAMP
+    )
+    EXECUTE FUNCTION guard_job_claim_lease_ownership();
 
 -- Trigger for tags updated_at
 CREATE TRIGGER update_tags_updated_at BEFORE UPDATE ON tags FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
@@ -1391,7 +1582,6 @@ CREATE TABLE action_history (
 CREATE INDEX idx_action_history_user_created ON action_history(user_id, created_at DESC);
 CREATE INDEX idx_action_history_user_undone ON action_history(user_id, is_undone, created_at DESC);
 
-
 -- OAuth 2.1 Authorization Server payloads (node-oidc-provider adapter)
 CREATE TABLE oauth_payloads (
     id VARCHAR(255) NOT NULL,
@@ -1410,7 +1600,6 @@ CREATE INDEX idx_oauth_payloads_grant ON oauth_payloads(grant_id) WHERE grant_id
 CREATE INDEX idx_oauth_payloads_uid ON oauth_payloads(uid) WHERE uid IS NOT NULL;
 CREATE INDEX idx_oauth_payloads_user_code ON oauth_payloads(user_code) WHERE user_code IS NOT NULL;
 CREATE INDEX idx_oauth_payloads_expires ON oauth_payloads(expires_at) WHERE expires_at IS NOT NULL;
-
 
 -- Monte Carlo retirement-projection scenarios (saved simulation inputs)
 CREATE TABLE monte_carlo_scenarios (
@@ -1627,8 +1816,6 @@ CREATE TABLE gem_strategy_signals (
 CREATE UNIQUE INDEX idx_gem_strategy_signals_period ON gem_strategy_signals(strategy_id, evaluated_on, algorithm_version);
 CREATE INDEX idx_gem_strategy_signals_user ON gem_strategy_signals(user_id);
 
-
-
 -- ===========================================================================
 -- Row-Level Security policies
 --
@@ -1655,6 +1842,7 @@ DECLARE
     t text;
     direct_tables text[] := ARRAY[
         'action_history',
+        'attachment_blob_tombstones',
         'ai_insights',
         'ai_provider_configs',
         'ai_usage_logs',
@@ -1672,6 +1860,7 @@ DECLARE
         'institutions',
         'investment_reports',
         'investment_transactions',
+        'job_claims',
         'loan_rate_changes',
         'loan_scenarios',
         'monte_carlo_scenarios',
@@ -1970,6 +2159,18 @@ CREATE POLICY scheduled_transaction_overrides_isolation ON scheduled_transaction
     WHERE st.id = scheduled_transaction_overrides.scheduled_transaction_id
       AND st.user_id = (SELECT app_current_user_id())));
 
+-- scheduled_transaction_postings -> scheduled_transactions.user_id (migration 139)
+DROP POLICY IF EXISTS scheduled_transaction_postings_isolation ON scheduled_transaction_postings;
+CREATE POLICY scheduled_transaction_postings_isolation ON scheduled_transaction_postings
+  USING ((SELECT app_bypass_rls()) OR EXISTS (
+    SELECT 1 FROM scheduled_transactions st
+    WHERE st.id = scheduled_transaction_postings.scheduled_transaction_id
+      AND st.user_id = (SELECT app_current_user_id())))
+  WITH CHECK ((SELECT app_bypass_rls()) OR EXISTS (
+    SELECT 1 FROM scheduled_transactions st
+    WHERE st.id = scheduled_transaction_postings.scheduled_transaction_id
+      AND st.user_id = (SELECT app_current_user_id())));
+
 -- ---------------------------------------------------------------------------
 -- Securities family
 --
@@ -2218,7 +2419,9 @@ CREATE POLICY emergency_access_contacts_isolation ON emergency_access_contacts
 --           15 indirect (113), 5 special (114),
 --           2 direct for the .mny import's staging + job tables (117),
 --           1 direct for security_documents (118),
---           4 direct for the GEM strategy tables (124, 125).
+--           4 direct for the GEM strategy tables (124, 125),
+--           2 direct for job_claims and attachment_blob_tombstones, and
+--           1 indirect for scheduled_transaction_postings (133).
 
 -- ---------------------------------------------------------------------------
 -- Enable row-level security (migration 123).

--- a/docs/cron-jobs.md
+++ b/docs/cron-jobs.md
@@ -30,6 +30,7 @@ One row per `@Cron` handler. The Cron column is the decorator's expression verba
 | `mny-import-job.service` | `0 0-23/1 * * *` | Hourly | Backstop sweep for import jobs whose worker stopped heartbeating; the reap that a waiting user depends on runs on their own next request, not here |
 | `auto-backup.service` | `0 * * * *` | Hourly | Enrol every non-admin user on the default backup policy, then write each user's due automatic backup, promote weekly/monthly copies, enforce retention |
 | `action-history.service` | `0 3 * * *` | Daily 3 AM | Delete undo-log entries past their retention window |
+| `job-claim.service` | `0 04 * * *` | Daily 4 AM | Delete job-claim/lease rows past the retention window (idempotent across replicas) |
 | `holdings.service` | `30 * * * *` | Hourly at :30 | Apply matured fixed-term investment holdings |
 | `emergency-access-monitor.service` | `0 09 * * *` | Daily 9 AM | Advance emergency-access requests past their waiting period and notify |
 | `updates.service` | `0 0-23/12 * * *` | Every 12 hours | Refresh the cached latest-release metadata for the What's New digest |


### PR DESCRIPTION
> **Draft / stacked Phase 4 PR — not ready for final review yet.**
>
> The current branch head is `e41d66264acc2f6fb09b8ad6b83eb11b78bdaf08`, exactly one commit above
> `a5231a1095cacd89b37e7d3e8375362f38ad7e5c`, a historical `04-03` commit.
> The live `pr/04-03-auth-session-safety` branch has since moved to
> `dac59f589d9bf98aafe0047963c5c9835b3d1fbe`, and upstream `main` has moved to
> `249390cedbc10d2c0c4c167e2611d999cff90b12`.
>
> Phase 3 PR #1078 and Phase 4 PR #1096 are now merged. This branch therefore needs to be
> restacked/rebased onto the current Phase 4 chain and latest `main` before final review. In
> particular, the backup changes need to be reconciled with the newer streaming-export work that
> landed upstream in #1109.
>
> Until that restack is done, review the unique commit
> `e41d66264acc2f6fb09b8ad6b83eb11b78bdaf08`, not the combined branch-vs-`main` diff.

**Phase 4 merge order: 4**, after the auth/session safety PR. Targets `main` after restacking.

## Summary

Every backend replica runs the same NestJS `@Cron()` handlers. Process-local booleans, `Set`s,
`Map`s and read-then-write checks therefore do not coordinate scheduled work across replicas.
This PR introduces database-backed ownership and arbitration for the scheduled and background
work that can otherwise double-send, double-post, race a destructive maintenance operation, or
write stale derived state.

The main mechanisms are:

- a shared `JobClaimService` with permanent claims, expiring leases and per-attempt lease tokens;
- a durable delivery record that distinguishes **"I own this attempt"** from **"the side effect
  actually happened"**;
- database enforcement preventing a stale or previous-release worker from mutating a lease it no
  longer owns;
- durable occurrence/fingerprint keys for work whose uniqueness belongs in the domain table;
- guarded upserts and row locks for cron writers that update shared database state;
- a per-user maintenance protocol for whole-account replacement operations;
- source-scanning regression guards for concurrency mistakes that previously reappeared in several
  unrelated services.

This is intentionally not a single "put a mutex around every cron" change. Each job uses the
smallest durable mechanism that matches its failure semantics: a permanent key, an expiring lease,
a unique domain row, an idempotent predicate, a row lock, or an atomic upsert.

## Why

`ScheduleModule.forRoot()` runs in the API process, so a deployment with two backend replicas
normally executes a scheduled handler twice. Before this series, several paths implicitly assumed
there was only one process:

- bill and mortgage reminders could send the same email from every replica;
- AI insight generation could call the provider twice for the same user and account usage twice;
- two demo resets could interleave a wipe and re-seed and leave a partial demo dataset;
- a scheduled transaction could be posted manually while the cron posted the same occurrence;
- two budget processors could both pass application-level de-duplication and both send an alert;
- market-data refreshes could both observe a missing row and race the same insert;
- long-running whole-account replacement could overlap background work derived from the dataset.

The invariant for this PR is:

> If scheduled/background work is not safe to execute independently on every replica, ownership or
> idempotency must be represented in durable shared state, and the side effect must be derived from
> the state that won that arbitration.

## What this changes

### 1. Durable job claims with owned leases

`backend/src/common/jobs/job-claim.service.ts` is the shared coordination primitive.

It supports three distinct contracts rather than treating every claim as "done":

- `claimOnce(type, userId, key)` — permanent uniqueness for work where the claim itself is the
  durable fact and a second execution must never happen;
- `claimLease(type, userId, key, ttl)` — temporary exclusion for work that may need to be retaken
  after a worker dies;
- `markDelivered(...)` / `wasDelivered(...)` — a delivery record for work with an external side
  effect, written only after that side effect succeeds.

A lease returns a random UUID token identifying **the attempt**, not merely the work. `releaseLease`
and `markDelivered` require that token. This closes the stale-holder race where worker A stalls past
its expiry, worker B legitimately retakes the lease, and A later resumes and deletes or completes B's
lease by addressing only `(claim_type, user_id, claim_key)`.

Migration 141 adds database enforcement for the same property. The current holder declares its token
through a transaction-local `app.job_claim_lease_token` GUC; attempts that try to mutate a live
tokenized lease without owning it are rejected by PostgreSQL. That matters during a rolling deploy,
where a previous-release pod cannot be trusted to know about the new token predicate.

`backend/test/integration/job-claim-lease-rollout.integration.spec.ts` exercises the literal old
untokenized `DELETE` / delivery-update shapes against the migrated database rather than mocking the
property.

### 2. Reminder delivery is recoverable and multi-replica safe

Bill and mortgage reminder jobs now take a per-user lease before sending.

The delivery protocol is deliberately **at-least-once**:

1. take a bounded lease;
2. check whether that exact reminder fingerprint was already delivered;
3. send the email;
4. only after SMTP succeeds, record `delivered_at` using the winning lease token;
5. release the lease on a pre-send refusal or failure.

This fixes two opposite failure modes:

- healthy replicas no longer both send the same reminder;
- a worker killed after claiming but before SMTP no longer leaves a permanent "already handled"
  record that suppresses the reminder forever.

A crash after SMTP acceptance but before `delivered_at` can still cause a retry. That duplicate is an
intentional at-least-once tradeoff: a duplicate reminder is preferable to silently losing the only
renewal/bill warning.

Primary paths:

- `backend/src/notifications/bill-reminder.service.ts`
- `backend/src/accounts/mortgage-reminder.service.ts`
- their focused unit specs.

### 3. AI insights keep the local shortcut but move exclusion to PostgreSQL

`AiInsightsService` still has its in-process `generatingUsers` set because it is a cheap same-process
shortcut, but that set is no longer the concurrency mechanism.

A durable per-user `ai_insight_generation` lease now surrounds aggregate computation, provider calls
and persistence. A killed replica eventually loses the lease by expiry; a normal completion releases
it early by token. This prevents duplicate provider spend and duplicate usage accounting across pods
without replacing the existing recent-insight cooldown.

### 4. Demo reset and intraday generation use different contracts intentionally

The destructive daily demo reset takes an expiring lease. Two wipe-and-reseed passes are not harmless:
one replica can delete rows while the other is still seeding them.

The deterministic intraday generator uses a permanent window claim instead. Every replica computes
the same date/hour window; generating a window twice is worse than losing part of one failed window,
so the claim itself is the durable "this window was consumed" fact.

This distinction is intentional and documented in `DemoResetService`; it is not a single generic retry
policy applied to both jobs.

### 5. Scheduled transaction occurrences become one transactional unit

Posting a scheduled transaction now has a durable occurrence identity:

`(scheduled_transaction_id, original_due_date)`

The posting path locks the schedule, inserts into `scheduled_transaction_postings`, and then performs
the financial mutation, override consumption and schedule advancement in **the same transaction**.

That closes the materially different routes to the same duplicate posting:

- two replicas firing the hourly cron;
- a user manually posting while the cron is running;
- a crash after the financial transaction committed but before `next_due_date` advanced.

The unique occurrence key survives process death and turns the losing poster into a conflict instead
of a second financial transaction.

### 6. Budget period and budget-alert races are moved into database arbitration

Budget-period creation uses the existing `(budget_id, period_start)` uniqueness as the serialization
point through `INSERT ... ON CONFLICT DO NOTHING RETURNING`. The loser reads and returns the period the
winner created rather than surfacing a unique-constraint 500.

Closing a period now locks the open period before deriving its actuals and freezes the period plus its
next-period creation in one transaction. This prevents two monthly cron executions from independently
closing the same snapshot.

Budget alerts keep their application-level candidate filtering as an optimization, but the deciding
operation is now the database fingerprint introduced by migration 138. Only the request whose
`INSERT ... ON CONFLICT DO NOTHING RETURNING` actually created the alert is allowed to treat it as new
and send an immediate critical-alert email.

### 7. Exchange-rate and security-price writers use atomic database writes

The market-data cron paths are normal multi-replica writers, so "find a row, then insert it" is not a
safe creation protocol.

The exchange-rate path now upserts the `(from_currency, to_currency, rate_date)` key in one statement,
and persists the forward and inverse directions inside one transaction. This removes the duplicate
insert race that could abort the pair transaction and leave the reverse direction stale.

The security-price refresh path is similarly moved away from stale entity-save/check-then-act shapes
toward guarded database updates/upserts, with focused specs covering the write contract.

### 8. Backup scheduling gets its own domain claim

Automatic backup already has a durable schedule row, so it does not need a second job-claim row for
the due window.

The claim is the schedule advance itself:

`UPDATE auto_backup_settings ... WHERE next_backup_at <= now RETURNING id`

Only the replica that advanced the schedule runs the backup. The outcome is then written with a
narrow update of only `lastBackupAt`, `lastBackupStatus` and `lastBackupError`, so a stale cron snapshot
cannot overwrite a concurrent administrator edit to folder/frequency/retention settings.

This branch also preserves the Phase 3 backup completeness contract:

- incomplete attachment exports remain visible as incomplete;
- partial automatic backups are not promoted or used to drive retention;
- export reads use one `REPEATABLE READ` snapshot;
- the long-lived export snapshot is bounded with `idle_in_transaction_session_timeout`;
- restore keeps staged attachment bytes and displaced-key cleanup ordering.

**Important:** upstream `main` now contains the later streaming-export work from #1109. This branch
must be rebased and the backup section re-reviewed against that implementation before merge; this
description does not claim that the pre-restack backup diff is the final one.

### 9. Whole-account replacement has a shared maintenance concept

Backup restore and self-service "delete my data" use `UserMaintenanceService` so destructive operations
can refuse overlap instead of independently replacing the same user's dataset.

An active `.mny` import is also treated as maintenance state, because a wipe-first import can leave the
account intentionally empty between the committed wipe and the later import write.

The restore itself runs under the maintenance lease and keeps its database replacement transactional.
This closes several direct overlap cases, but the current acquisition protocol still has an important
cross-table race documented under **Known blockers before ready-for-review** below.

### 10. Source-scanning guards make recurring mistakes red

`backend/src/common/db/derived-state-writers.guard.spec.ts` adds repository-level checks for mechanical
patterns that had reappeared in multiple services:

- unsanctioned direct `accounts.current_balance` writers;
- balance-adjusting services that do not use the shared locked-read protocol;
- bare entity removal beside a balance reversal;
- process-local `Set` / `Map` state used as a cron exclusion mechanism;
- open-coded `.length` checks on tuple-shaped raw `UPDATE` / `DELETE` results;
- `ActionHistoryService.record` calls placed inside an active database transaction even though the
  recorder deliberately swallows its own failures.

Reviewed exceptions are explicit allowlist entries with reasons. A new occurrence fails the suite
instead of depending on a reviewer remembering the same historical race.

## Database migrations

This PR introduces four migrations, reconciled to the current numbering on this branch:

### `138_concurrency_integrity_guards.sql`

Adds six database-enforced guards:

1. `job_claims` durable uniqueness;
2. `import_jobs` status constraint, `data_committed` checkpoint and one-active-import-per-user index;
3. `scheduled_transaction_postings` occurrence uniqueness;
4. budget-alert fingerprint uniqueness;
5. the supporting transaction-attachment index used by the concurrency-safe cap check;
6. `attachment_blob_tombstones` plus the deletion trigger for external attachment objects.

The migration includes preflight repair for legacy states that would otherwise make the new
constraints fail at deploy time: invalid import statuses, multiple active imports for one user and
duplicate budget-alert fingerprints.

`backend/test/integration/migration-138-preflight.integration.spec.ts` seeds those legacy states and
exercises the migration rather than assuming production data is already clean.

### `139_job_claim_delivery_record.sql`

Adds the delivery record needed to distinguish a claimed reminder from a successfully delivered one.
Existing permanent claims are backfilled as delivered so an upgrade does not suddenly re-send all
previously consumed windows.

### `140_job_claim_lease_token.sql`

Adds the per-attempt UUID token used by owned leases.

### `141_job_claim_lease_ownership_enforcement.sql`

Enforces lease ownership in PostgreSQL, including mixed-version rolling deployments where a previous
binary still issues the old untokenized statements.

`database/schema.sql` is updated to carry the resulting schema, indexes, RLS policies and trigger
state.

## Known blockers before ready-for-review

The branch has moved substantially since the first draft of this PR description, but the following
material issues are still reproducible on head `e41d66264acc2f6fb09b8ad6b83eb11b78bdaf08`.
They should be fixed before converting this PR out of Draft.

### HIGH — maintenance and `.mny` import do not acquire one atomic exclusion

**Paths**

- `backend/src/common/jobs/user-maintenance.service.ts`
- `backend/src/import/mny/mny-import-job.service.ts`
- `backend/src/import/mny/mny-import.service.ts`

`withMaintenanceLease()` first checks `import_jobs` and only afterwards takes a `job_claims`
maintenance lease. `MnyImportJobService.create()` independently inserts the active `import_jobs` row.
Those are two different tables with no shared lock or atomic predicate spanning them.

A realistic interleaving is:

1. restore/delete-data checks and sees no active import;
2. an import creates its `pending` row;
3. restore/delete-data takes the independent maintenance lease;
4. both sides now believe they own the user's dataset transition.

For an import that proceeds to write, a destructive replacement can commit while the import worker is
still active, and the worker can then write into the replaced dataset.

**Required correction:** make acquisition of the import slot and maintenance exclusion share one
database serialization mechanism. A check in one transaction followed by a claim in another is not a
guarantee.

**Regression test:** two real connections attempting maintenance acquisition and import-slot creation
in both orders; exactly one protocol may win and the loser must perform no destructive/data writes.

### HIGH — backup/maintenance exclusion is still a TOCTOU pre-check

**Path:** `backend/src/backup/auto-backup.service.ts`

Both manual and automatic backup ask `isUnderMaintenance(userId)` and then start the backup later.
`UserMaintenanceService` correctly documents `isUnderMaintenance()` as a **hint, not a guarantee**.
Maintenance can begin after that read and before the export snapshot is established.

This is especially dangerous once the `.mny wipeExistingData` path is repaired: the import may commit
its wipe and then rebuild the account over time, while the backup that passed the earlier pre-check can
start inside that window. A valid gzip/envelope containing the transitional dataset is not a safe
backup merely because the pre-check was false a moment earlier.

**Required correction:** make backup admission and maintenance acquisition mutually exclusive with a
shared lock/lease protocol that remains valid until the export snapshot is established (or otherwise
make the database snapshot itself prove it did not overlap the destructive transition).

**Regression test:** two real connections/futures that pause between the maintenance check and backup
snapshot while the other begins maintenance; assert no artifact is produced from the replacement
window and no retention/promotion runs.

### HIGH — emergency-access delivery is still uncoordinated across replicas

**Path:** `backend/src/emergency-access/emergency-access-monitor.service.ts`

The branch defines `EmergencyAccessReminder` and `EmergencyAccessGrantNotify` claim types, but the
emergency-access monitor does not use `JobClaimService` or an equivalent guarded domain update.

For reminders, every replica can read the same old `lastReminderSentAt`, send the same email and only
then save the marker.

For grants the impact is worse:

1. replica A and B both observe `grantedAt === null`;
2. each generates a different raw claim token;
3. each saves its token hash and sends its own email;
4. the later save can replace the hash that validates the earlier email's link.

The user can receive duplicate grant notifications and at least one delivered claim URL can be invalid
by the time it is clicked.

**Required correction:** claim the owner/contact delivery before generating/sending, and ensure token
state plus the delivery marker follow one reviewed retry contract. The existing owned-lease mechanism
is suitable only if the domain writes are also guarded against a superseded attempt.

**Regression test:** run two monitor instances against the same real database state; assert one grant
attempt owns each contact and every delivered URL still matches the stored token hash.

### MEDIUM — `.mny` "wipe existing data" currently refuses itself

**Paths**

- `backend/src/import/mny/mny-import.service.ts`
- `backend/src/users/users.service.ts`

`MnyImportService.start()` creates the pending import job first, then calls:

`usersService.deleteData(userId, ..., "import-wipe")`

But `UsersService.deleteData()` has a fourth `initiator` parameter whose default is
`"user-request"`. That default takes the maintenance lease, whose active-import check sees the pending
job the same request just created and returns `409`.

The caller therefore discards the pending job and `wipeExistingData` cannot start successfully.

**Required correction:** pass the import-specific initiator deliberately, but do so as part of the
HIGH-severity shared exclusion fix above; simply bypassing the maintenance lease without replacing the
cross-protocol guarantee would trade the obvious 409 for a race.

**Regression test:** start a wipe-first import through the real service boundary; assert the wipe and
worker start, while an actually concurrent restore/delete-data request is refused without writi