### PR TITLE
docs: add investment account consolidation design and task list

### DIFF
--- a/docs/future-plans/investment-account-consolidation-tasks.md
+++ b/docs/future-plans/investment-account-consolidation-tasks.md
@@ -1,0 +1,392 @@
+# Investment Account Consolidation: Agent Task List
+
+> Companion to [`investment-account-consolidation.md`](./investment-account-consolidation.md)
+> (the design). Same conventions as `joint-accounts-tasks.md` and
+> `cross-owner-transfers-tasks.md`: one task per session/PR, dependency order, mark a task done
+> by checking its box and noting the branch/PR.
+
+## How to use this list (read first, every session)
+
+- One task per session/PR. Touching files outside the task's scope is a scope violation -- stop
+  and leave a note here instead.
+- The design doc's invariants govern every task. Invariant 7 is the tripwire: if your change
+  alters how a non-investment account lists, labels, closes or filters, the task is wrong.
+- **Definition of done, every task:** `npm run build && npm run lint` clean in each touched app;
+  `TZ=UTC npm run test:unit` (backend) / `npm run test` (frontend) green with coverage
+  thresholds held; new user-facing strings land in the **English catalogs only**
+  (`frontend/src/i18n/messages/en/`, `backend/src/i18n/locales/en/`) followed by
+  `npm run i18n:pseudo`; the full-locale pass is task Q1 and nothing before it. Parity-test
+  failures for non-English locales are expected on this branch until Q1.
+- **Line numbers and code excerpts in these docs are snapshots.** Re-locate by symbol name
+  (`buildAccountActions`, `close()`, `holdingsByAccount`), not by line.
+- No migrations exist in this plan. If a task appears to need one, the task is wrong -- stop.
+
+## Deployment safety
+
+Same meaning as in `row-level-security-tasks.md`:
+
+| Class | Meaning |
+|---|---|
+| none | Docs or tests only; no runtime change. |
+| inert | Ships dark: new code/fields nothing consumes yet. Deployable any time. |
+| neutral | Behavior changes are the intended feature and the app is consistent after the task alone. Deployable any time. |
+
+Nothing in this plan is DO NOT DEPLOY; the graph is ordered so `main` is shippable after every
+merged task.
+
+## Task graph
+
+| ID | Task | Depends on | Deploy impact | Status |
+|----|------|-----------|---------------|--------|
+| S1 | Design doc + this task list | -- | none | [x] (this document) |
+| A1 | `logical-accounts.ts` fold + `useLogicalAccounts.ts` + `useAccountOptionLabel` | S1 | inert | [ ] |
+| A2 | Backend `unpricedHoldingsCount` on `AccountHoldings` | S1 | inert | [ ] |
+| B1 | Symmetric close/reopen + holdings close guard | S1 | neutral | [ ] |
+| B2 | Pair rename propagation in `update()` | S1 | neutral | [ ] |
+| L1 | Account list: one row per pair (render only) | A1, A2 | neutral | [ ] |
+| L2 | Account list actions: reconcile/close/reopen/delete pair-aware | L1, B1 | neutral | [ ] |
+| D1 | Extract `InvestmentViewToggle.tsx`; swap `/investments` onto it | S1 | neutral | [ ] |
+| D2 | `InvestmentRegisterPanel.tsx` + mount in `InvestmentDetailView.tsx` | D1, A1 | neutral | [ ] |
+| D3 | Detail canonical URL + shell title + switcher fold | A1 | neutral | [ ] |
+| E1 | AccountForm investment-pair mode | A1, B2 | neutral | [ ] |
+| P1 | Picker + register labels through `useAccountOptionLabel` + guard scan | A1 | neutral | [ ] |
+| R1 | `ReportAccountMultiSelect` mode unification | A1 | neutral | [ ] |
+| R2 | `AccountBalancesReport` logical rows | A1, A2 | neutral | [ ] |
+| R3 | `FavouriteAccounts` card dedupe + dashboard count | A1, A2 | neutral | [ ] |
+| V1 | Playwright e2e journey | L2, D2, D3, E1, P1 | none | [ ] |
+| Q1 | Full-locale i18n pass (final acceptance commit) | all above | none | [ ] |
+| S2 | Docs as-built pass + contract note | all above | none | [ ] |
+
+**Why A1/A2 precede every UI task:** every surface consumes the fold and the unpriced-holdings
+signal; landing them first (dark) means each UI task is a consumer-only diff. **Why B1 precedes
+L2:** the list's single Close action calls the API once with the primary id and needs the server
+cascade to exist -- a frontend-only cascade would race and violate "a rejected command must not
+already have written". **Why B2 precedes E1:** the form's single name field submits one rename
+and relies on the server converging both halves. **Why D1 precedes D2:** the toggle is extracted
+from `/investments` first so the panel and the page provably share one component rather than a
+copy.
+
+## Task details
+
+### A1 -- Logical-account fold
+
+- [ ] Status:
+
+**Files:** `frontend/src/lib/logical-accounts.ts` (new), `frontend/src/lib/logical-accounts.test.ts`
+(new), `frontend/src/hooks/useLogicalAccounts.ts` (new), `frontend/src/lib/account-utils.ts`
+(delegate `countLogicalAccounts`), `frontend/src/hooks/useMainAccountName.ts` (add
+`useAccountOptionLabel`).
+
+**Do:**
+1. Implement `buildLogicalAccounts` / `LogicalAccount` exactly per the design's shape: fold rule
+   (cash half absorbed only when its partner is in the input), canonical id = brokerage half,
+   `cashRegisterId` per the truth table, `combinedValue` = market value + cash `currentBalance`
+   + cash `futureTransactionsSum`, null when `unpricedCounts` reports > 0 for the holdings
+   account or market value is missing for an account with holdings. No FX -- the halves share a
+   currency by construction.
+2. `useLogicalAccounts` memoizes over accounts + portfolio summary and injects
+   `useMainAccountName()` as the strip function. `useAccountOptionLabel` returns the standard
+   picker label builder (stripped name + currency + closed marker).
+3. `countLogicalAccounts` delegates to the fold. Nothing else consumes it yet.
+
+**Accept:** unit tests: pair folds to one entry (primary = brokerage, `cashRegisterId` = cash
+id, both member ids present); standalone -> `cash` null, `cashRegisterId` = self; orphan
+brokerage -> `cashRegisterId` = self; orphan cash -> its own entry with stripped name;
+**regression: `combinedValue` is null, not the cash subtotal, when any holding is unpriced**;
+existing `countLogicalAccounts` tests unchanged and green.
+
+### A2 -- Backend unpriced-holdings count
+
+- [ ] Status:
+
+**Files:** `backend/src/securities/portfolio-calculation.service.ts` (both `holdingsByAccount`
+build loops -- pair path and standalone path), `backend/src/securities/portfolio-calculation.service.spec.ts`,
+`frontend/src/types/investment.ts` (`AccountHoldings.unpricedHoldingsCount: number`).
+
+**Do:** count holdings whose `marketValue` is null per account and emit
+`unpricedHoldingsCount` on each `AccountHoldings` entry. Do **not** change `totalMarketValue`
+semantics -- existing consumers (sorting, summary) stay valid; this is an additive field only.
+
+**Accept:** spec: an account with one null-priced holding reports `unpricedHoldingsCount: 1`
+and an unchanged `totalMarketValue` -- a test that fails against the pre-change payload; an
+all-priced account reports 0. Inert: nothing reads the field yet.
+
+### B1 -- Symmetric close/reopen + holdings close guard
+
+- [ ] Status:
+
+**Files:** `backend/src/accounts/accounts.service.ts` (`close()`, `reopen()`),
+`backend/src/accounts/accounts.service.spec.ts`, `backend/src/i18n/locales/en/errors.json`
+(new key, English only).
+
+**Do:**
+1. Mirror the existing cash -> brokerage close cascade for brokerage -> cash, in both `close()`
+   and `reopen()`, inside the same transaction under the same `pessimistic_write` lock.
+2. Add the holdings guard: refuse close when the account's own holdings -- or, when closing
+   from the cash side, the linked brokerage's -- include any nonzero quantity. Message via
+   `tr(...)` with the new key. The check runs inside the mutation's transaction (financial
+   contract section 7).
+
+**Accept:** specs: closing the brokerage closes the cash half (**regression -- fails on the
+current asymmetric code**); closing either half of a pair whose brokerage holds positions is
+refused with no write (**regression -- fails on the `currentBalance`-only guard**); reopen
+mirrors close; standalone and orphan accounts unaffected. Neutral: the cascade widens behavior
+the UI already implies, and the guard only refuses closes that were silently wrong.
+
+### B2 -- Pair rename propagation
+
+- [ ] Status:
+
+**Files:** `backend/src/accounts/accounts.service.ts` (`update()`; reuse the suffix helpers in
+`backend/src/accounts/account-name.util.ts`), `backend/src/accounts/accounts.service.spec.ts`.
+
+**Do:** when `update()` changes `name` on either half of a linked pair: derive the base name by
+stripping the server's known suffixes (request locale + English), re-suffix **both** halves for
+the request locale, save both inside the one transaction -- joining the existing
+`currencyCode`/`institutionId` propagation. Non-pair accounts unchanged; no `UpdateAccountDto`
+change.
+
+**Accept:** specs: renaming the brokerage renames the cash half to the matching base + localized
+suffix, and vice versa (**regression -- fails when only the addressed row is renamed**); a name
+stored under a different locale's suffix still re-bases correctly; the existing
+currency/institution propagation specs stay green.
+
+### L1 -- Account list: one row per pair (render only)
+
+- [ ] Status:
+
+**Files:** `frontend/src/components/accounts/AccountList.tsx`,
+`frontend/src/components/accounts/AccountRow.tsx`, their tests
+(`frontend/src/components/accounts/AccountList.test.tsx`,
+`frontend/src/components/accounts/AccountRow.test.tsx`), `frontend/src/app/accounts/page.tsx`
+(pass unpriced counts alongside `brokerageMarketValues`),
+`frontend/src/i18n/messages/en/accounts.json` (caption + unknown-value tooltip strings).
+
+**Do:** replace the pair-adjacent ordering block inside the INVESTMENT group with
+`useLogicalAccounts`; add the optional `logical` prop to `AccountRow`; combined value with the
+"Investments X / Cash Y" caption; em-dash + tooltip when `combinedValue` is null; drop the
+chain-link/`pairedWith` presentation for folded rows; search matches member names; balance sort
+keys on `combinedValue ?? 0`. Row click and all actions stay as they are (L2's job).
+
+**Accept:** component tests: a pair renders exactly one row labeled with the stripped name; the
+orphan-cash account renders its own row; **regression: null combined renders the em-dash, not
+the cash balance**; group header count and page summary values are unchanged against the same
+fixture (they already fold / already iterate raw accounts).
+
+### L2 -- Pair-aware actions
+
+- [ ] Status:
+
+**Files:** `frontend/src/components/accounts/AccountRow.tsx` (`buildAccountActions`),
+`frontend/src/components/accounts/AccountList.tsx` (action handlers + delete/close dialogs),
+their tests, `frontend/src/i18n/messages/en/accounts.json` (pair-delete confirm copy).
+
+**Do:** Reconcile un-hidden for logical investment rows with a `cashRegisterId`, routing to
+`/reconcile?accountId={cashRegisterId}`; Close/Reopen call the API once with the primary id (B1
+cascades), Close disabled unless `combinedValue === 0` exactly (null disables, with the
+unknown-value title); Delete shows one confirm naming both ledgers, then deletes brokerage
+first, cash second, and calls `invalidateBalanceCaches()`.
+
+**Accept:** tests: reconcile pushes the **cash** id (**regression -- fails if it targets the
+brokerage**); close is disabled at nonzero and at unknown combined value; delete issues two
+calls brokerage-first; an orphan brokerage row hides reconcile.
+
+### D1 -- InvestmentViewToggle extraction
+
+- [ ] Status:
+
+**Files:** `frontend/src/components/investments/InvestmentViewToggle.tsx` (new, + test),
+`frontend/src/app/investments/page.tsx` (replace both inline copies).
+
+**Do:** extract the segmented brokerage/cash toggle verbatim (props: `value`, `onChange`;
+labels from the `investments` namespace); the page's behavior -- including localStorage
+persistence -- is unchanged.
+
+**Accept:** existing page tests green; the toggle's own test covers both states; the page
+renders the same classes as before the extraction.
+
+### D2 -- InvestmentRegisterPanel in the detail view
+
+- [ ] Status:
+
+**Files:** `frontend/src/components/investments/InvestmentRegisterPanel.tsx` (new, + test),
+`frontend/src/components/accounts/investment-detail/InvestmentDetailView.tsx` (+ its test),
+`frontend/src/i18n/messages/en/accountDetail-investment.json` (tab/empty-state strings as
+needed).
+
+**Do:** the panel takes the resolved ids (`brokerageIds`, `cashIds`) and owns: the D1 toggle
+(persisted under its own localStorage key), the brokerage tab (`InvestmentTransactionList.tsx`
+with create/edit/delete via `InvestmentTransactionForm.tsx`), the cash tab
+(`frontend/src/components/transactions/TransactionList.tsx` scoped to the cash ids, with
+new-cash via the transaction form), and pagination. `InvestmentDetailView.tsx` mounts it in
+place of the recent-transactions list -- pair passes both ids, standalone/orphan-brokerage pass
+self as the cash id. Every write path calls `invalidateBalanceCaches()`.
+
+**Accept:** tests (act-wrapped render helper per `frontend/CLAUDE.md`): the cash tab requests
+exactly the cash id (**regression -- fails if brokerage rows leak into the cash register**);
+standalone scopes both tabs to itself; a create in either tab invalidates the balance caches
+(extend the `balance-cache.guard.test.ts` scan if it enumerates files).
+
+### D3 -- Canonical URL + shell fold
+
+- [ ] Status:
+
+**Files:** `frontend/src/app/accounts/[id]/page.tsx`,
+`frontend/src/components/accounts/shared/AccountDetailShell.tsx`,
+`frontend/src/components/accounts/shared/AccountSwitcher.tsx`, their tests.
+
+**Do:** when the loaded account is a linked cash half, `router.replace` to
+`/accounts/{linkedAccountId}`. The shell strips the title suffix for investment accounts; the
+switcher receives the logical list (one entry per pair, primary ids, stripped names).
+
+**Accept:** tests: a cash-id deep link replaces to the brokerage URL (**regression -- fails on
+rendering under the cash URL**); the switcher lists one entry per pair; non-investment accounts
+are untouched.
+
+### E1 -- AccountForm pair mode
+
+- [ ] Status:
+
+**Files:** `frontend/src/components/accounts/AccountForm.tsx` (+
+`frontend/src/components/accounts/AccountForm.test.tsx`),
+`frontend/src/i18n/messages/en/accounts.json` (section heading + labels).
+
+**Do:** on edit of an account resolving to a pair (via `accountsApi.getInvestmentPair`): one
+base-name field pre-filled with the stripped base (submits to the brokerage id; B2 propagates);
+shared fields once; a collapsed "Cash account" section with the cash half's opening balance
+(`CurrencyInput`), account number and description, saved by a second `update()` to the cash id
+only when dirty. Busy flag is a counter (nested-saves rule). Standalone/orphans keep today's
+form; the create-time `createInvestmentPair` checkbox is untouched.
+
+**Accept:** tests: saving pair mode issues `update(brokerageId, { name })` and, when the cash
+section is dirty, `update(cashId, { openingBalance, ... })`; an untouched cash section issues no
+second call; **regression: the cash half's opening balance is reachable from the single row's
+Edit action at all** (the community branch's gap).
+
+### P1 -- Picker + register labels
+
+- [ ] Status:
+
+**Files:** `frontend/src/components/transactions/TransferTransactionFields.tsx`,
+`frontend/src/components/transactions/NormalTransactionFields.tsx`,
+`frontend/src/components/transactions/SplitTransactionFields.tsx`,
+`frontend/src/components/transactions/SplitEditor.tsx`,
+`frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx`,
+`frontend/src/hooks/useTransactionFilters.ts`,
+`frontend/src/components/transactions/TransactionRow.tsx` (transfer other-side labels),
+`frontend/src/test/ui-conventions.test.ts` (guard scan), tests beside each touched surface.
+
+**Do:** every listed surface labels account options through `useAccountOptionLabel` (option
+**values unchanged** -- the cash id keeps flowing). Add the guard scan: a file under the
+transaction/scheduled-transaction component trees that passes a label built from raw
+`account.name` into `buildAccountDropdownOptions` fails with a message naming the hook.
+
+**Accept:** per-picker tests: a linked cash half renders the stripped label with the cash id as
+value (**regression -- fails on the " - Cash" label**); the guard scan fails when a picker
+bypasses the hook (verify by breaking one temporarily); `useTransactionFilters` still excludes
+the brokerage half.
+
+### R1 -- Report picker unification
+
+- [ ] Status:
+
+**Files:** `frontend/src/components/reports/ReportAccountMultiSelect.tsx` (+ its test), callers:
+`frontend/src/components/reports/SectorWeightingsReport.tsx`,
+`frontend/src/components/reports/GeographicAllocationReport.tsx`,
+`frontend/src/components/reports/SecurityTypeAllocationReport.tsx`,
+`frontend/src/components/reports/CurrencyExposureReport.tsx`,
+`frontend/src/components/reports/DividendIncomeReport.tsx`,
+`frontend/src/components/dashboard/PortfolioValueWidget.tsx`, and the transaction-based report
+callers of the default filter.
+
+**Do:** replace the free-form `filter`/`excludeCashAccounts` conventions with
+`mode: 'transactions' | 'portfolio'`: both modes build the identical logical option list from
+`buildLogicalAccounts`; transactions mode emits `cashRegisterId`, portfolio mode emits the
+primary id; orphans appear only in their applicable mode. Migrate every caller and delete the
+old plumbing.
+
+**Accept:** tests: the same account set renders identical option labels in both modes; for the
+same pair, transactions mode emits the cash id and portfolio mode the brokerage id
+(**regression -- fails on the old two-convention filters**); orphan brokerage appears only in
+portfolio mode, orphan cash only in transactions mode.
+
+### R2 -- AccountBalancesReport logical rows
+
+- [ ] Status:
+
+**Files:** `frontend/src/components/reports/AccountBalancesReport.tsx` (+ its test),
+`frontend/src/i18n/messages/en/reports.json` (caption strings if the accounts namespace is not
+imported there).
+
+**Do:** fold to one row per logical account; combined value with the "Investments X / Cash Y"
+caption; em-dash on null; totals derived from the folded rows.
+
+**Accept:** tests: a pair renders one row; totals for fully priced fixtures are unchanged
+against the pre-fold output; **regression: null combined renders the em-dash, not the cash
+subtotal**.
+
+### R3 -- Dashboard
+
+- [ ] Status:
+
+**Files:** `frontend/src/components/dashboard/FavouriteAccounts.tsx` (+ its test),
+`frontend/src/app/dashboard/page.tsx` (investment count).
+
+**Do:** one card per logical account when either half is favourited (dedupe when both);
+combined value + caption + em-dash rule; the dashboard investment count uses
+`countLogicalAccounts` over active investment accounts.
+
+**Accept:** tests: both halves favourited -> one card (**regression -- fails on two cards**);
+one pair + one standalone counts as 2 investment accounts (**regression -- fails on 3**).
+
+### V1 -- Playwright e2e journey
+
+- [ ] Status:
+
+**Files:** `e2e/tests/investment-account-consolidation.spec.ts` (new; model on
+`e2e/tests/joint-accounts.spec.ts`).
+
+**Do:** seed a pair, a standalone and an orphan; walk: the list shows one row with the combined
+value -> row click lands on filtered `/investments` -> Details shows the merged view with a
+working cash tab -> Edit changes the base name and the cash opening balance -> the transfer
+picker offers the stripped name and the money lands in the cash ledger -> Close from the single
+row closes both halves -> Reopen restores both.
+
+**Accept:** suite green in CI's e2e lane (one worker; the `zz-` ordering rule applies locally).
+
+### Q1 -- Full-locale i18n pass (final acceptance commit)
+
+- [ ] Status:
+
+**Files:** every locale of each namespace touched by earlier tasks
+(`frontend/src/i18n/messages/{locale}/accounts.json`, `accountDetail-investment.json`,
+`investments.json`, `reports.json`, `dashboard.json` as applicable) and
+`backend/src/i18n/locales/{locale}/errors.json` for B1's key; regenerate pseudo-locales.
+
+**Do:** one localization pass filling every supported locale for all strings added on this
+branch; `npm run i18n:pseudo` + `npm run i18n:check` in both apps. Grep for each key before
+adding -- a duplicate key in a catalog is invisible and ships the wrong copy (see the duplicate-
+keys rule in the root `CLAUDE.md`).
+
+**Accept:** `messages.parity.test.ts` (frontend) and `locales.parity.spec.ts` (backend) green;
+pseudo-locales up to date.
+
+### S2 -- Docs as-built pass
+
+- [ ] Status:
+
+**Files:** `docs/future-plans/investment-account-consolidation.md` (truth tables to as-built),
+this file (statuses), `docs/financial-calculation-contract.md` (record `unpricedHoldingsCount`
+as the null-propagation carrier for per-account market values).
+
+**Do:** update both docs to as-built, record any scope-cut deltas, and restate the two named
+follow-ups: contract-complete group totals/summary cards, and migrating `/investments` onto
+`InvestmentRegisterPanel.tsx`.
+
+**Accept:** `backend/src/common/doc-paths.spec.ts` green; no stale identifier claims.
+
+---
+
+Every task here is an agent task; there are no operator-only steps in this plan (no migrations,
+no deploy toggles). If a session discovers work that does not fit its task, add a row to the
+graph rather than widening the session.

--- a/docs/future-plans/investment-account-consolidation.md
+++ b/docs/future-plans/investment-account-consolidation.md
@@ -1,0 +1,341 @@
+# Plan: Investment Account Consolidation (one visible account per brokerage/cash pair)
+
+## Goal
+
+An investment account pair -- an `INVESTMENT_BROKERAGE` account and its linked `INVESTMENT_CASH`
+account -- presents as **one logical account everywhere the user reads**: one account-list row,
+one combined value (holdings market value + cash balance), one name with the localized
+" - Brokerage"/" - Cash" suffix stripped, one detail page with a brokerage/cash register toggle,
+one entry in every picker, one row in every report. Underneath, the two-row data model stays
+exactly as it is: two ledgers, linked by `linked_account_id`, with money on the cash half and
+holdings on the brokerage half. This is the request in GitHub discussion #903, where a community
+draft branch (`bcorob:investmentconsolidation`) validated the direction but stalled on the
+missing UI path for editing the cash half and covered only the account list and detail view.
+
+An investment account may or may not have a cash component. Three shapes exist today and all
+three keep working on every surface: the **linked pair**, the **standalone** investment account
+(`account_sub_type` NULL -- one row carrying both holdings and cash), and the **orphan** (one
+half of a deleted pair, `linked_account_id` NULL).
+
+The plan reuses the collapse logic that already exists in pieces -- `countLogicalAccounts`,
+`isInvestmentCashHalf`, `getMainAccountName` in `frontend/src/lib/account-utils.ts`, the
+`/investments` page's brokerage/cash register toggle, `InstitutionAccountsManager.tsx`'s
+drop-the-cash-half pattern, `accountsApi.getInvestmentPair` -- and gives them one shared home
+instead of a per-surface restatement.
+
+## Data model (unchanged)
+
+No migration. No change to pair creation, importers, or `linked_account_id` semantics.
+
+- Both halves are `accounts` rows with `account_type = 'INVESTMENT'`. `account_sub_type`
+  (`'INVESTMENT_BROKERAGE'` / `'INVESTMENT_CASH'` / NULL) discriminates roles;
+  `linked_account_id` is a self-FK (`ON DELETE SET NULL`), bidirectional by convention. Nothing
+  in the database enforces the pairing -- the orphan states are reachable and stay supported.
+- Money lives on the cash half (an ordinary ledger). The brokerage half's `current_balance` is
+  deliberately 0 (`resetBrokerageBalances` in `backend/src/accounts/accounts.service.ts`); its
+  value is the market value of its `holdings`. Trades generate ordinary transactions on the
+  settlement account resolved by `findCashAccount` in
+  `backend/src/securities/investment-transactions.service.ts`: explicit `fundingAccountId` ->
+  linked cash -> the account itself.
+- Names are stored **with** the localized suffix (`account-name.util.ts` owns generation and
+  `stripBrokerageSuffix`); the UI strips for display. That stays true -- see Naming below.
+
+## The logical-account fold
+
+One frontend abstraction, consumed by every surface. **No backend "logical accounts" payload**:
+every input the fold needs is already on the client (`accountsApi.getAll()` and
+`investmentsApi.getPortfolioSummary()`, both cached in `apiCache.ts`), and the backend already
+states the pairing rule in its own canonical places (`getLlmAccounts`,
+`logicalAccountsQuery` in `backend/src/institutions/institutions.service.ts`, the net-worth
+summation). A second server-side statement of the rule would drift, not help.
+
+New `frontend/src/lib/logical-accounts.ts` (+ `logical-accounts.test.ts`), pure functions:
+
+```ts
+export interface LogicalAccount {
+  id: string;               // canonical id: the brokerage half of a pair, else the account itself
+  primary: Account;         // the row that represents the entity
+  cash: Account | null;     // the linked cash half (pairs only; null otherwise)
+  memberIds: string[];      // 1 or 2 ids belonging to this entity
+  displayName: string;      // suffix-stripped via caller-supplied strip fn
+  isInvestment: boolean;
+  // id whose ledger holds the money: pair -> cash half; standalone / orphan brokerage -> self
+  cashRegisterId: string | null;
+  // market value + cash balance (+ cash futureTransactionsSum);
+  // null when unpricedHoldingsCount > 0 or market value is unknown for an account with holdings
+  combinedValue: number | null;
+}
+
+export function buildLogicalAccounts(
+  accounts: Account[],
+  stripName: (name: string) => string,
+  portfolio?: { marketValues: Map<string, number>; unpricedCounts: Map<string, number> },
+): LogicalAccount[];
+```
+
+Fold rule: an account matching `isInvestmentCashHalf` **whose partner is present in the input**
+is absorbed into the partner's entry; everything else is its own entry. `countLogicalAccounts`
+becomes a delegation to `buildLogicalAccounts(...).length` -- behavior-identical, held by its
+existing tests. A `useLogicalAccounts.ts` hook wires `useMainAccountName()` in as the strip
+function and memoizes; a `useAccountOptionLabel` hook (added to
+`frontend/src/hooks/useMainAccountName.ts`) becomes the single place picker option labels are
+built (`${strippedName} (${currencyCode})` + closed marker), so every picker labels accounts
+through one function.
+
+The fold does **no FX of its own**: the two halves of a pair share `currencyCode` by
+construction (`update()` already propagates it), so `combinedValue` is a same-currency sum of
+numbers the API already reports.
+
+## Invariants (govern every task)
+
+1. **No data-model change.** No migration; pair creation (`createInvestmentAccountPair`,
+   `CreateAccountDto.createInvestmentPair`) and every importer are untouched.
+2. **One entity on read surfaces; two ledgers on write surfaces.** A write always targets a real
+   account id -- the cash half for money movement, the brokerage for holdings -- never a
+   synthetic logical id. No API request shape changes.
+3. **Canonical ids are resolved through `LogicalAccount`, never re-derived ad hoc.** Portfolio
+   surfaces carry `id` (the brokerage half); transaction surfaces carry `cashRegisterId`. A
+   surface that needs the mapping imports the fold; a second inline `linkedAccountId` hop is the
+   defect the fold exists to prevent.
+4. **A combined total with an unknown component is unknown** (`docs/financial-calculation-contract.md`
+   section 1): `combinedValue` is null when any holding is unpriced, and renders as an em-dash
+   with an explanatory tooltip -- never as the cash-only subtotal. An account with **no**
+   holdings has a settled market value of zero and combines normally: "nothing to price" is
+   known, "could not price" is not.
+5. **Every shape works when the other half is absent.** Standalone: cash register = self. Orphan
+   brokerage: treated as standalone (cash register = self -- matching the `findCashAccount`
+   settlement fallback, so its own ledger genuinely holds the trade-generated cash rows). Orphan
+   cash: fails `isInvestmentCashHalf` (the link is null) and renders as an ordinary account with
+   its suffix stripped.
+6. **Names stay stored with suffixes; the UI strips.** The server remains the sole owner of
+   suffix generation -- at creation as today, and in the one new place: rename propagation
+   (below). No stored-name migration.
+7. **Non-investment behavior is untouched.** Every new branch is entered only for
+   `account_type = 'INVESTMENT'` rows (or a `LogicalAccount` wrapping one). If a change alters
+   how a chequing account lists, labels, closes or filters, the task is wrong.
+
+## Per-surface truth table
+
+| Surface | Linked pair | Standalone (sub-type NULL) | Orphan brokerage | Orphan cash |
+|---|---|---|---|---|
+| Account list | 1 row; combined value; caption "Investments X / Cash Y" | 1 row; market value + own balance | 1 row; market value + own balance; no cash caption | 1 row; own balance; suffix stripped |
+| Row click | `/investments?accountId={brokerageId}` (unchanged) | same | same | `/transactions?accountId=` (unchanged) |
+| Detail `/accounts/{id}` | merged view; a cash-id deep link `router.replace`s to the brokerage id | merged view | merged view | investment detail fallback (as today) |
+| Register toggle in detail | brokerage tab = investment transactions; cash tab = cash half's ledger | cash tab = own ledger | cash tab = own ledger | n/a |
+| Reconcile | targets the cash half | targets self | hidden (own ledger is trade-generated rows only) | targets self |
+| Money pickers (transfer/split/scheduled) | one option, stripped label, **value = cash id** | one option, value = self | excluded (as today) | one option, value = self |
+| Report pickers | one option; transactions mode emits cash id, portfolio mode emits brokerage id | one option; both modes emit self | portfolio mode only | transactions mode only |
+| Close / reopen | acts on the pair from either half (server cascades) | self | self (holdings guard applies) | self |
+| Delete | one confirm naming both ledgers; frontend deletes brokerage, then cash | self | self | self |
+| Favourites card | one card when either half is favourited | one card | one card | one card |
+
+## Combined-value truth table
+
+| Holdings | Unpriced holdings | Cash balance | `combinedValue` | Renders as |
+|---|---|---|---|---|
+| all priced, MV = 12,000.00 | 0 | 3,500.00 | 15,500.00 | 15,500.00 with caption "Investments 12,000.00 / Cash 3,500.00" |
+| none | 0 | 3,500.00 | 3,500.00 | 3,500.00 (settled zero MV, not unknown) |
+| some priced (subtotal 9,000.00) | 2 | 3,500.00 | null | em-dash + tooltip "Includes 2 holdings without a price" |
+| all priced | 0 | cash half missing (orphan brokerage) | MV + own balance | as pair, no cash caption |
+
+The subtotal (9,000.00) is never shown in the total's place. Today the backend collapses an
+unpriced holding to zero inside `holdingsByAccount` (`h.marketValue ?? 0` in
+`portfolio-calculation.service.ts`), so the client cannot distinguish the second and third rows;
+the one backend addition this plan makes is `unpricedHoldingsCount` on each `AccountHoldings`
+entry so it can.
+
+## Surface specs
+
+### Account list
+
+`frontend/src/components/accounts/AccountList.tsx` currently orders a pair adjacently inside the
+INVESTMENT group (brokerage first) and renders two rows. Replace that block with the fold: cash
+halves whose partner is in the filtered set disappear; orphans stay. Details:
+
+- `frontend/src/components/accounts/AccountRow.tsx` takes an optional `logical: LogicalAccount`
+  prop (non-investment rows are untouched): stripped display name; type pill "Investment"
+  (orphan cash keeps its "Inv. Cash" pill); balance cell shows `combinedValue` with a small
+  caption "Investments X / Cash Y" replacing today's "Market value" caption; the chain-link
+  icon and `pairedWith` sub-line are dropped for folded rows.
+- `combinedValue === null` renders an em-dash plus a tooltip naming the unpriced-holdings count
+  (invariant 4).
+- Search matches against every member's raw name plus the display name, so searching "cash" or a
+  suffix still finds the row. Balance sort uses `combinedValue ?? 0` as the key (sort key only;
+  the display stays contract-clean).
+- Group header counts already use `countLogicalAccounts`; the page summary math in
+  `frontend/src/app/accounts/page.tsx` already iterates raw accounts correctly -- both are
+  asserted unchanged.
+- Action sheet (`buildAccountActions`): View transactions -> `/investments?accountId={id}`;
+  Details -> `/accounts/{id}`; Edit -> pair mode (below); **Reconcile un-hidden** for logical
+  investment rows, routing to `/reconcile?accountId={cashRegisterId}` (today it is hidden for
+  brokerage rows -- the cash half's ledger is exactly what reconciliation is for); Close/Reopen
+  call the API with the primary id (the server cascades -- below), Close disabled unless
+  `combinedValue === 0` exactly (null disables with the unknown-value title); Delete runs the
+  two-call pair delete behind one confirm dialog that names both ledgers.
+
+### Detail view and canonical URL
+
+- **One URL per entity.** In `frontend/src/app/accounts/[id]/page.tsx`, when the loaded account
+  is a linked cash half, `router.replace` to `/accounts/{linkedAccountId}`. Old bookmarks and
+  deep links to the cash id keep working; the switcher and history stay coherent. (The community
+  draft rendered the merged view under either URL -- two URLs for one entity.)
+- `AccountDetailShell.tsx` strips the title suffix for investment accounts, and
+  `AccountSwitcher.tsx` receives the logical list so it stops offering both halves.
+- **Register toggle.** The segmented `brokerage | cash` toggle currently appears twice inline in
+  `frontend/src/app/investments/page.tsx`; extract it verbatim into a shared
+  `InvestmentViewToggle.tsx` under `frontend/src/components/investments/` and swap the page onto
+  it (visually identical, localStorage persistence unchanged). Then build
+  `InvestmentRegisterPanel.tsx` beside it: a self-contained panel owning the toggle, the
+  brokerage tab (`InvestmentTransactionList.tsx` with create/edit/delete via
+  `InvestmentTransactionForm.tsx`) and the cash tab (the generic
+  `frontend/src/components/transactions/TransactionList.tsx` scoped to `cashRegisterId`, with
+  new-cash via the transaction form), paginated via `frontend/src/components/ui/Pagination.tsx`.
+  `InvestmentDetailView.tsx` replaces its recent-transactions list with the panel; it already
+  resolves the pair via `accountsApi.getInvestmentPair` and scopes its summary cards to both
+  ids.
+- The `/investments` page is **not** rebuilt on the panel in v1 -- its register is welded to
+  `useInvestmentData.ts` (filters, density, undo/redo); only the toggle is shared. Migrating the
+  page onto the panel is a named follow-up.
+- Every write from the panel calls `invalidateBalanceCaches()` (the rule in
+  `frontend/CLAUDE.md`; `balance-cache.guard.test.ts` scans for it).
+
+### Editing the pair (the gap that stalled the community branch)
+
+`frontend/src/components/accounts/AccountForm.tsx` gains a **pair mode**, entered when the
+edited account resolves to a pair via `getInvestmentPair`:
+
+- One "Account name" field, pre-filled with the stripped base name. It submits to the brokerage
+  id; the server propagates (below).
+- Shared fields (institution, currency -- already server-propagated) appear once.
+- A collapsed "Cash account" section holds the cash half's own fields: opening balance
+  (`CurrencyInput`), account number, description. Saving issues a second `update()` to the cash
+  id only when the section is dirty. The busy flag is a counter, not a boolean (nested-saves
+  rule in `frontend/CLAUDE.md`).
+- Standalone and orphan accounts get today's single-account form unchanged; the
+  `createInvestmentPair` checkbox on create is untouched.
+
+Backend: in `update()` (`accounts.service.ts`), `name` joins `currencyCode` + `institutionId` as
+pair-propagated fields. When the target is half of a linked pair and `name` changes, the server
+derives the base by stripping its own known suffixes (the request locale's and English, same set
+`getMainAccountName` strips), then re-suffixes **both** halves inside the same transaction. The
+server stays the sole owner of suffix generation, and a name stored under a stale locale's
+suffix self-heals on rename. No `UpdateAccountDto` change.
+
+### Money pickers
+
+**The option value stays the cash id.** Money genuinely lands in the cash ledger; changing the
+submitted id would be a backend change for zero benefit. Only the **label** changes: every
+picker that lists accounts for transfers, splits, or scheduled transactions labels options
+through `useAccountOptionLabel`, so a linked cash half reads as "TFSA (CAD)" instead of
+"TFSA - Cash (CAD)". Surfaces: `TransferTransactionFields.tsx`, `NormalTransactionFields.tsx`,
+`SplitTransactionFields.tsx`, `SplitEditor.tsx`, `ScheduledTransactionForm.tsx`, the account
+filter in `useTransactionFilters.ts` (its brokerage exclusion stays), and the transfer
+other-side labels in `TransactionRow.tsx`. Stripping is safe to apply to every account name:
+`getMainAccountName` strips only an exact trailing localized suffix, a behavior already accepted
+across `/investments` and the reports.
+
+A source-scan guard in `frontend/src/test/ui-conventions.test.ts` fails any file under the
+transaction/scheduled-transaction component trees that builds an account option label from raw
+`account.name` instead of the hook -- the same pattern as the existing raw-input scans.
+
+### Reports and dashboard
+
+- `frontend/src/components/reports/ReportAccountMultiSelect.tsx` replaces its free-form `filter`
+  prop with `mode: 'transactions' | 'portfolio'`. Both modes render the **identical** logical
+  option list (one entry per logical account, stripped labels); they differ only in the id they
+  emit -- transactions mode emits `cashRegisterId`, portfolio mode emits the primary id. Orphans
+  appear only in the mode that has a half for them. All callers migrate
+  (`SectorWeightingsReport.tsx`, `GeographicAllocationReport.tsx`,
+  `SecurityTypeAllocationReport.tsx`, `CurrencyExposureReport.tsx`,
+  `DividendIncomeReport.tsx`, `PortfolioValueWidget.tsx`, and the transaction-based reports);
+  the two opposite exclusion conventions (`exclude BROKERAGE` vs `excludeCashAccounts`) die.
+- `AccountBalancesReport.tsx`: one row per logical account -- combined value with the same
+  "Investments X / Cash Y" caption, em-dash on null. No expandable sub-rows in v1; the caption
+  carries the split. Totals for fully priced data are identical to today's.
+- `FavouriteAccounts.tsx`: one card per logical account when **either** half is favourited
+  (dedupe when both are), combined value + caption + em-dash rule.
+- `frontend/src/app/dashboard/page.tsx`: the investment-account count folds the pair (both
+  halves are type INVESTMENT, so `countLogicalAccounts` over the active investment accounts is
+  the fix).
+
+### Close, reopen, delete
+
+- **Close/reopen become symmetric server-side** (`close()` / `reopen()` in
+  `accounts.service.ts`): closing or reopening the **brokerage** half cascades to the linked
+  cash exactly as cash -> brokerage does today, in the same transaction under the same lock. The
+  UI then issues one call with the primary id.
+- **The close guard learns about holdings.** Today `close()` refuses only a nonzero
+  `currentBalance` -- which for a brokerage is always 0, so the server happily closes a
+  brokerage full of positions (only the frontend blocks it). Per the financial contract's
+  "a rejected command must not already have written", `close()` additionally refuses any account
+  whose own (or, when closing from the cash side, linked brokerage's) holdings include a nonzero
+  quantity, with a locale-keyed error.
+- **Delete stays unlink-don't-delete server-side.** A server-side cascade delete of the
+  partner's entire ledger is a destructive semantics change to an existing endpoint. The
+  frontend delete flow for a pair issues two deletes -- brokerage first, then cash -- behind one
+  confirm dialog naming both ledgers. If the second call fails, the survivor is an orphan
+  **cash** account: an ordinary, fully functional account, the least-bad failure shape, and one
+  every surface already supports (invariant 5).
+
+### Naming
+
+Stored names keep their suffixes; every display surface strips through the shared helpers. The
+generic `/transactions` register header and the transfer other-side labels join the stripped
+world via `useAccountOptionLabel`. The only server-side naming change is the rename propagation
+above. Import-wizard pickers keep raw names (cut).
+
+## Deviations from the community draft
+
+| Community draft | This plan | Why |
+|---|---|---|
+| combined = market value + cash, unconditionally | null + em-dash when any holding is unpriced | `docs/financial-calculation-contract.md`: a subtotal is not a total |
+| no edit path for the cash half | AccountForm pair mode + server rename propagation | the gap that stalled the branch |
+| `isInvestmentCashHalf` filtering re-implemented per surface | one `buildLogicalAccounts` fold consumed everywhere | ten-plus surfaces would each restate the rule and drift |
+| merged view rendered under either half's URL | cash deep links `router.replace` to the brokerage id | one canonical URL per entity; switcher and history stay coherent |
+| account list + detail view only | pickers, reports, dashboard, switcher, close/delete symmetry | the request is "a single account everywhere" |
+| close symmetry not addressed | server-side symmetric close/reopen + holdings guard | a frontend-only cascade races, and the server-side guard hole (closing a brokerage full of positions) predates this feature |
+
+## Adversarial test matrix (from `docs/testing-contract.md`)
+
+- **Missing data:** one unpriced holding -> list row, balances report row and favourites card all
+  show the em-dash, never the cash subtotal; zero holdings -> combined equals cash (settled
+  zero, not unknown).
+- **Aggregation:** group totals, page summary cards and report totals for fully priced data are
+  byte-identical before and after the fold; a pair, a standalone and one orphan of each kind
+  count as 1 + 1 + 1 + 1 logical accounts.
+- **Ownership/identity:** the reconcile action carries the cash id, never the brokerage id; the
+  pair delete issues brokerage-first; a rename from either half converges both names.
+- **Concurrency:** close from the brokerage half cascades in one transaction -- a concurrent
+  transaction insert on the cash half either lands before the close or is refused, never
+  half-closed.
+- **Dates:** `futureTransactionsSum` stays inside `combinedValue` exactly as it is inside
+  today's per-row balances (no new date math).
+- **Orphans:** every surface spec above is asserted for both orphan shapes, not only the pair.
+
+## Explicit v1 scope cuts
+
+No data-model merge and no migrations. Pair creation and all importers untouched. No
+stored-name migration. The `/investments` page is not rebuilt on `InvestmentRegisterPanel` (only
+the toggle is shared) -- named follow-up. Accounts-page group totals and summary cards keep
+their known-components sums (a pre-existing contract gap, now documented -- fixing it means
+threading nullable totals through the summary cards and is a named follow-up). No expandable
+sub-rows in the balances report. Net-worth snapshot internals (two rows per pair in
+`monthly_account_balances`) unchanged -- the month totals are already correct. AI Assistant and
+MCP account listings (`getLlmAccounts`) unchanged -- they already state the per-account value
+rule. Import-wizard account pickers keep raw names.
+
+## Critical files
+
+- `frontend/src/lib/account-utils.ts` -- the fold's building blocks; `logical-accounts.ts` lands beside it
+- `frontend/src/hooks/useMainAccountName.ts` -- suffix stripping; gains `useAccountOptionLabel`
+- `frontend/src/components/accounts/AccountList.tsx` + `frontend/src/components/accounts/AccountRow.tsx` -- the single-row fold, actions, dialogs
+- `frontend/src/components/accounts/investment-detail/InvestmentDetailView.tsx` -- merged detail, hosts the register panel
+- `frontend/src/components/accounts/AccountForm.tsx` -- pair mode
+- `frontend/src/components/reports/ReportAccountMultiSelect.tsx` -- picker-mode unification
+- `backend/src/accounts/accounts.service.ts` -- close/reopen symmetry, holdings guard, rename propagation
+- `backend/src/securities/portfolio-calculation.service.ts` -- `unpricedHoldingsCount`, the contract-critical backend addition
+
+## Companion task list
+
+See [`investment-account-consolidation-tasks.md`](./investment-account-consolidation-tasks.md)
+for the per-task breakdown, dependency order, deploy-impact classes and acceptance criteria.


### PR DESCRIPTION
## Linked discussion / issue

Closes #903
Approved in: GitHub discussion #903

## Summary

This PR adds comprehensive design and task-list documentation for the investment account consolidation feature, which allows a linked brokerage/cash account pair to present as a single logical account throughout the UI while maintaining the two-ledger data model underneath.

The two new documents establish:

1. **`investment-account-consolidation.md`** — The design specification covering:
   - The logical-account fold abstraction (`buildLogicalAccounts`) that will be consumed by every UI surface
   - Data model (unchanged; no migrations)
   - Seven invariants governing all implementation tasks
   - Per-surface truth tables for linked pairs, standalone accounts, and orphans
   - Combined-value semantics (null when any holding is unpriced, per the financial contract)
   - Detailed specs for account list, detail view, pickers, reports, close/reopen/delete, and naming
   - Deviations from the community draft that stalled on this feature

2. **`investment-account-consolidation-tasks.md`** — The agent task list with:
   - 19 tasks (S1–S2) in dependency order, one per session/PR
   - Deployment safety classification (none/inert/neutral; nothing is DO NOT DEPLOY)
   - Task graph showing dependencies and status tracking
   - Detailed acceptance criteria for each task, including regression tests
   - Scope cuts (no data-model merge, no migrations, `/investments` page not rebuilt in v1)
   - Definition of done (build/lint/test/i18n requirements per task)

Both documents follow the conventions established in `joint-accounts-tasks.md` and `cross-owner-transfers-tasks.md`: one task per PR, dependency order, mark done by checking the box and noting the branch/PR.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (documentation only; no runtime changes).
- [x] No code changes; documentation only.
- [x] No user-facing strings (documentation is not localized).
- [x] No shared/core areas refactored.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below.

## AI assistance disclosure

Claude (Anthropic) assisted in structuring and refining the task list and design document for clarity and completeness. All content has been reviewed and is owned by the author.

https://claude.ai/code/session_01EmFpeHHhB4nK6K9gUY1aFi