### PR TITLE
05: Track FX valuation completeness and remove silent 1:1 fallbacks (v1.15.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,11 +225,55 @@ Money is `decimal(20,4)`; an exchange rate is `NUMERIC(20,10)` (`exchange_rates.
 
 Convert with `applyFxConversion` (backend) so the account's `fxFeePercent` is folded in the same way the transaction form does; validate a foreign-currency payload with `normalizeFxEntry`, which transactions and scheduled transactions share so both accept and reject exactly the same shapes.
 
+### Rate 1 means "same currency", never "no rate found"
+
+A failed rate lookup is unknown. It is not `1`, and it is not the amount passed
+through unchanged -- four conversion paths ended in one of those two, and 1,000
+USD came out of a EUR total as 1,000 EUR: an 11% error that is numerically
+plausible, which is exactly what makes it survive review. Nothing in the response
+let a consumer tell a real 1:1 pair from an absent one.
+
+Aggregate through `FxAggregate` (`backend/src/common/fx-aggregate.ts`) rather than
+`total += convert(...)`. The accumulator cannot silently absorb a missing
+component: it names each unresolvable pair, and its `total` is `null` while
+`knownSubtotal` carries what did convert. Zero and negative rates are absent, not
+applicable. `backend/src/common/fx-fallback.guard.spec.ts` scans for a new silent
+fallback; `docs/specs/fx-conversion-completeness.md` has the invariants and the
+staged rollout of nullable response totals.
+
 ### Missing data: a subtotal is not a total (CRITICAL)
 
 A field named `total*`, `portfolioValue`, `transferValue`, `gain`, `tax`, or `estimated*` may only carry a value when **every** component of the calculation is known. Filtering out `null` components and summing the rest produces a subtotal, not a total -- if any component is unknown, the total is `null`, and the partial sum, if returned at all, goes in a separate explicitly named field (`knownMarketValueSubtotal`), never in the total's field. Never default an unknown price, cost basis, or rate to `0` (or an exchange rate to `1`) to keep a formula running, and never treat a missing period price as a 0% return.
 
 **`null` is not the safe answer either.** It means "not known", so a state that *is* known must not use it: empty accounts hold zero, move zero, realize zero and owe zero, and reporting those as unknown tells the user a settled question could not be worked out -- while making "nothing to do" indistinguishable from "cannot compute". Decide which of the two each branch is in before writing it.
+
+### A completeness flag covers every total it is documented to cover, on every surface
+
+`fxComplete` claimed to describe all of `PortfolioSummary`'s `total*` fields while
+one aggregate's missing pairs were only written to the log, so an incomplete
+`totalNetInvested` shipped under `fxComplete: true` and fed CAGR as a complete
+denominator. Union every aggregate's gaps, and derive anything downstream (a rate,
+a ratio) only when its own inputs are complete. The flag must also survive the trip
+to each consumer: the compact LLM shape dropped both fields, so the AI Assistant and
+MCP quoted the same subtotal as a settled balance the UI knew was partial -- and for
+a model, the human-readable summary line has to say so too, not just the payload.
+
+The converse is equally wrong, and appeared in the same fix: **zero needs no rate.**
+Asking for one made an empty foreign account report its currency as unresolvable and
+took the whole portfolio's totals down to "unknown".
+
+And completeness has more than one cause. `fxComplete` covered missing exchange rates
+and nothing else, so a held position with no current **price** was skipped out of the
+total with no gap recorded: a confident `totalPortfolioValue` built from the priced
+half, `fxComplete: true`, and Monte Carlo projecting from it. Track each cause
+separately (`fxComplete`, `pricesComplete`) and give consumers one flag that means
+"every component of every total is known" (`valuationComplete`), so nobody has to
+remember to check both.
+
+Nested totals need their own answer, too. A per-account total is converted into the
+*account's* currency while the top-level total is converted into the *user's* -- two
+different conversion graphs, so a portfolio can be complete at the top and
+unconvertible underneath. A global flag cannot speak for a total it did not compute.
 
 The full rules -- cost basis and tax truth table, cash, valuation, materialized-result versioning, stale quotes, backtests over incomplete history, and the required adversarial test matrix -- live in `docs/financial-calculation-contract.md` and `docs/time-series-contract.md`. Read both **before** writing or changing any financial calculation, not when a review asks about them: every rule those documents contain has been read, agreed with and broken anyway by someone who reached them afterwards. `docs/testing-contract.md` lists the adversarial inputs that have broken this codebase before -- dates, money precision, aggregation, currency conversion, ownership, concurrency -- so a test author picks from a list rather than recalling edge cases; it is explicitly not a requirement that every test use every value. A financial feature of any substance -- it computes money, materializes a derived result, or reads a time series -- starts from a short approved spec (invariants, truth tables, numerical examples, missing-data policy, test matrix), committed *before* the implementation it guides.
 

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -325,6 +325,14 @@ describe("ToolExecutorService", () => {
     portfolio = {
       getLlmSummary: jest.fn().mockResolvedValue({
         holdingCount: 0,
+        // The real method always returns these two: they are what tells the
+        // model whether the totals beside them are complete (recheck RR2-007).
+        // A mock without them describes a shape the service cannot produce.
+        fxComplete: true,
+        missingRatePairs: [],
+        pricesComplete: true,
+        unpricedSymbols: [],
+        valuationComplete: true,
         totalCashValue: 0,
         totalHoldingsValue: 0,
         totalCostBasis: 0,
@@ -914,9 +922,17 @@ describe("ToolExecutorService", () => {
     it("get_portfolio_summary requests the look-through when asked", async () => {
       portfolio.getLlmSummary.mockResolvedValueOnce({
         holdingCount: 1,
+        fxComplete: true,
+        missingRatePairs: [],
+        pricesComplete: true,
+        unpricedSymbols: [],
+        valuationComplete: true,
         totalPortfolioValue: 1000,
         totalGainLoss: 100,
         totalGainLossPercent: 10,
+        // The real method always returns this array; without it the per-account
+        // completeness note could not be built at all.
+        holdingsByAccount: [],
         lookThrough: {
           totalPortfolioValue: 1000,
           byCountry: {
@@ -941,6 +957,37 @@ describe("ToolExecutorService", () => {
       });
       expect(result.summary).toContain("1 country");
       expect(result.summary).toContain("1 asset class");
+    });
+
+    it("get_portfolio_summary tells the model when the totals are incomplete", async () => {
+      // The model reads the summary line before the payload, so an unconvertible
+      // component has to be described there. Flagging it only inside `data` let
+      // the assistant quote a subtotal as a settled balance (recheck RR2-007).
+      portfolio.getLlmSummary.mockResolvedValueOnce({
+        holdingCount: 2,
+        fxComplete: false,
+        missingRatePairs: ["EUR->USD"],
+        pricesComplete: true,
+        unpricedSymbols: [],
+        valuationComplete: false,
+        totalCashValue: 100,
+        totalHoldingsValue: 0,
+        totalCostBasis: 0,
+        totalPortfolioValue: 100,
+        totalGainLoss: 0,
+        totalGainLossPercent: 0,
+        timeWeightedReturn: null,
+        cagr: null,
+        holdings: [],
+        holdingsByAccount: [],
+        allocation: [],
+      });
+
+      const result = await service.execute(userId, "get_portfolio_summary", {});
+
+      expect(result.summary).toContain("INCOMPLETE");
+      expect(result.summary).toContain("EUR->USD");
+      expect((result.data as { fxComplete: boolean }).fxComplete).toBe(false);
     });
 
     it("list_investment_transactions delegates to investmentTransactions.getLlmInvestmentTransactions", async () => {

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -1985,9 +1985,35 @@ export class ToolExecutorService {
     const lookThroughNote = data.lookThrough
       ? ` Look-through: ${data.lookThrough.byCountry.items.length} countr${data.lookThrough.byCountry.items.length === 1 ? "y" : "ies"}, ${data.lookThrough.byAssetClass.items.length} asset class${data.lookThrough.byAssetClass.items.length === 1 ? "" : "es"}.`
       : "";
+    // The model reads this line before the payload, so an incomplete total has to
+    // be described as incomplete here and not only flagged in `data`. Without it
+    // the assistant quoted a subtotal as a settled balance (recheck RR2-007).
+    const incompleteReasons = [
+      ...(data.fxComplete
+        ? []
+        : [`no exchange rate for ${data.missingRatePairs.join(", ")}`]),
+      ...(data.pricesComplete
+        ? []
+        : [`no current price for ${data.unpricedSymbols.join(", ")}`]),
+    ];
+    // A missing price and a missing rate are different causes with the same
+    // consequence, and the price half was not covered (recheck RR3-004).
+    const incompleteNote = data.valuationComplete
+      ? ""
+      : ` INCOMPLETE: ${incompleteReasons.join("; ")}, so every total above is a subtotal of what could be worked out. Say so rather than quoting these figures as complete.`;
+    // An account whose own totals could not be worked out is separately worth
+    // saying: its figures are in its own currency, so the flags above do not
+    // cover it (recheck RR3-005).
+    const incompleteAccounts = data.holdingsByAccount
+      .filter((acct) => !acct.valuationComplete)
+      .map((acct) => acct.accountName);
+    const incompleteAccountsNote =
+      incompleteAccounts.length > 0
+        ? ` Per-account totals are incomplete for ${incompleteAccounts.join(", ")}; do not quote those accounts' figures as complete.`
+        : "";
     return {
       data,
-      summary: `${data.holdingCount} holding${data.holdingCount === 1 ? "" : "s"}, total portfolio value ${data.totalPortfolioValue.toFixed(2)}, unrealized gain/loss ${sign}${data.totalGainLoss.toFixed(2)} (${sign}${data.totalGainLossPercent.toFixed(2)}%).${lookThroughNote}`,
+      summary: `${data.holdingCount} holding${data.holdingCount === 1 ? "" : "s"}, total portfolio value ${data.totalPortfolioValue.toFixed(2)}, unrealized gain/loss ${sign}${data.totalGainLoss.toFixed(2)} (${sign}${data.totalGainLossPercent.toFixed(2)}%).${lookThroughNote}${incompleteNote}${incompleteAccountsNote}`,
       sources: [
         {
           type: "portfolio",
@@ -2088,10 +2114,16 @@ export class ToolExecutorService {
     const filterDesc =
       filterParts.length > 0 ? ` (${filterParts.join("; ")})` : "";
 
+    // "unknown" rather than a number the model would quote as fact: a total is
+    // null when a position's currency could not be converted, and an LLM
+    // summary that prints 0.00 there states a figure nobody computed.
+    const money = (value: number | null) =>
+      value === null ? "unknown" : value.toFixed(2);
+
     const summaryParts = [
-      `capital gains ${data.totals.totalCapitalGain.toFixed(2)}${filterDesc}`,
-      `realized ${data.totals.realizedGain.toFixed(2)}`,
-      `unrealized ${data.totals.unrealizedGain.toFixed(2)}`,
+      `capital gains ${money(data.totals.totalCapitalGain)}${filterDesc}`,
+      `realized ${money(data.totals.realizedGain)}`,
+      `unrealized ${money(data.totals.unrealizedGain)}`,
       `grouped by ${groupBy} (${data.entryCount} ${
         data.entryCount === 1 ? "entry" : "entries"
       })`,

--- a/backend/src/common/currency-conversion.util.spec.ts
+++ b/backend/src/common/currency-conversion.util.spec.ts
@@ -48,4 +48,45 @@ describe("convertWithRateLookup", () => {
       ),
     ).toBeNull();
   });
+
+  it("treats a zero direct rate as absent rather than applying it", () => {
+    // Multiplying by 0 would report a real holding as worthless -- a confident
+    // wrong number, which is worse than an admitted unknown.
+    const zero = new Map<string, number>([["USD->CAD", 0]]);
+    expect(
+      convertWithRateLookup(100, "USD", "CAD", (f, t) =>
+        zero.get(`${f}->${t}`),
+      ),
+    ).toBeNull();
+  });
+
+  it("treats a negative rate as absent, in either direction", () => {
+    const negative = new Map<string, number>([["USD->CAD", -1.35]]);
+    const lookup = (f: string, t: string) => negative.get(`${f}->${t}`);
+    expect(convertWithRateLookup(100, "USD", "CAD", lookup)).toBeNull();
+    // And it must not be reached through the inverse branch either, which would
+    // otherwise flip the sign of the amount.
+    expect(convertWithRateLookup(100, "CAD", "USD", lookup)).toBeNull();
+  });
+
+  it("falls through to a usable inverse when the direct rate is invalid", () => {
+    const mixed = new Map<string, number>([
+      ["USD->CAD", 0],
+      ["CAD->USD", 0.8],
+    ]);
+    expect(
+      convertWithRateLookup(100, "USD", "CAD", (f, t) =>
+        mixed.get(`${f}->${t}`),
+      ),
+    ).toBeCloseTo(125); // 100 / 0.8
+  });
+
+  it("never returns the amount unchanged for two different currencies", () => {
+    // The invariant behind audit P5-009: rate 1 is reachable only when the two
+    // codes are equal. For any other pair the result is a real conversion or
+    // null -- never a silent pass-through that looks like a valid 1:1.
+    const result = convertWithRateLookup(100, "GBP", "JPY", getRate);
+    expect(result).toBeNull();
+    expect(result).not.toBe(100);
+  });
 });

--- a/backend/src/common/currency-conversion.util.ts
+++ b/backend/src/common/currency-conversion.util.ts
@@ -21,13 +21,17 @@ export function convertWithRateLookup(
     return amount;
   }
 
+  // A rate must be strictly positive to be a rate at all. Zero and negatives
+  // are treated as absent rather than applied: multiplying by 0 would report a
+  // real holding as worthless, and the inverse branch already had to guard
+  // against dividing by it.
   const direct = getRate(from, to);
-  if (direct != null) {
+  if (direct != null && direct > 0) {
     return amount * direct;
   }
 
   const inverse = getRate(to, from);
-  if (inverse != null && inverse !== 0) {
+  if (inverse != null && inverse > 0) {
     return amount / inverse;
   }
 

--- a/backend/src/common/fx-aggregate.spec.ts
+++ b/backend/src/common/fx-aggregate.spec.ts
@@ -1,0 +1,134 @@
+import { FxAggregate } from "./fx-aggregate";
+
+/**
+ * The numerical examples in docs/specs/fx-conversion-completeness.md section 4,
+ * plus the distinctions that section calls out as the point of the type.
+ */
+describe("FxAggregate", () => {
+  it("is complete and zero before anything is added", () => {
+    // Nothing to convert is a known answer, not an unknown one: an empty
+    // account holds zero, and reporting that as unavailable tells the user a
+    // settled question could not be worked out.
+    const agg = new FxAggregate();
+    expect(agg.total).toBe(0);
+    expect(agg.knownSubtotal).toBe(0);
+    expect(agg.isComplete).toBe(true);
+    expect(agg.missingPairs).toEqual([]);
+  });
+
+  it("sums converted components", () => {
+    const agg = new FxAggregate();
+    agg.add(900, "USD", "EUR");
+    agg.add(500, "EUR", "EUR");
+    expect(agg.total).toBe(1400);
+    expect(agg.knownSubtotal).toBe(1400);
+    expect(agg.isComplete).toBe(true);
+  });
+
+  it("makes the total unknown when a component could not convert", () => {
+    const agg = new FxAggregate();
+    agg.add(500, "EUR", "EUR");
+    agg.add(null, "USD", "EUR");
+    expect(agg.total).toBeNull();
+    // The part that did convert is still available, under its own name.
+    expect(agg.knownSubtotal).toBe(500);
+    expect(agg.missingPairs).toEqual(["USD->EUR"]);
+    expect(agg.isComplete).toBe(false);
+  });
+
+  it("distinguishes 'nothing to convert' from 'could not convert'", () => {
+    // Both have a knownSubtotal of 0. Only missingPairs tells them apart, which
+    // is why it is not optional -- this is the exact confusion that made a
+    // missing rate indistinguishable from a real 1:1.
+    const empty = new FxAggregate();
+    const failed = new FxAggregate();
+    failed.add(null, "USD", "EUR");
+
+    expect(empty.knownSubtotal).toBe(failed.knownSubtotal);
+    expect(empty.total).toBe(0);
+    expect(failed.total).toBeNull();
+    expect(empty.missingPairs).toEqual([]);
+    expect(failed.missingPairs).toEqual(["USD->EUR"]);
+  });
+
+  it("records each missing pair once and sorts them", () => {
+    const agg = new FxAggregate();
+    agg.add(null, "USD", "EUR");
+    agg.add(null, "USD", "EUR");
+    agg.add(null, "GBP", "EUR");
+    expect(agg.missingPairs).toEqual(["GBP->EUR", "USD->EUR"]);
+  });
+
+  it("keeps the total unknown when only one of three currencies is missing", () => {
+    const agg = new FxAggregate();
+    agg.add(1000, "EUR", "EUR");
+    agg.add(900, "USD", "EUR");
+    agg.add(null, "JPY", "EUR");
+    expect(agg.total).toBeNull();
+    expect(agg.knownSubtotal).toBe(1900);
+    expect(agg.missingPairs).toEqual(["JPY->EUR"]);
+  });
+
+  it("handles a negative (liability) component that cannot convert", () => {
+    const agg = new FxAggregate();
+    agg.add(-500, "EUR", "EUR");
+    agg.add(null, "USD", "EUR");
+    expect(agg.total).toBeNull();
+    expect(agg.knownSubtotal).toBe(-500);
+  });
+
+  it("addConverted takes a value that needed no conversion", () => {
+    const agg = new FxAggregate();
+    agg.addConverted(250);
+    expect(agg.total).toBe(250);
+    expect(agg.isComplete).toBe(true);
+  });
+
+  it("addConverted cannot mask a gap recorded elsewhere", () => {
+    const agg = new FxAggregate();
+    agg.add(null, "USD", "EUR");
+    agg.addConverted(250);
+    expect(agg.total).toBeNull();
+    expect(agg.knownSubtotal).toBe(250);
+  });
+
+  it("merge carries the other aggregate's gaps with its subtotal", () => {
+    const a = new FxAggregate();
+    a.addConverted(100);
+    const b = new FxAggregate();
+    b.addConverted(50);
+    b.add(null, "JPY", "EUR");
+
+    a.merge(b);
+    expect(a.knownSubtotal).toBe(150);
+    expect(a.total).toBeNull();
+    expect(a.missingPairs).toEqual(["JPY->EUR"]);
+  });
+
+  it("a zero-valued component that converted keeps the total known", () => {
+    const agg = new FxAggregate();
+    agg.add(0, "USD", "EUR");
+    expect(agg.total).toBe(0);
+    expect(agg.isComplete).toBe(true);
+  });
+
+  it("accumulates money without floating-point drift (CLAUDE.md Financial Math)", () => {
+    // 0.1 + 0.1 + 0.1 === 0.30000000000000004 in bare float addition; the
+    // accumulator must fold through integer ten-thousandths instead.
+    const agg = new FxAggregate();
+    agg.add(0.1, "USD", "EUR");
+    agg.add(0.1, "USD", "EUR");
+    agg.addConverted(0.1);
+    expect(agg.total).toBe(0.3);
+
+    // The same via merge: drift must not sneak in through the combine path.
+    const a = new FxAggregate();
+    const b = new FxAggregate();
+    for (let i = 0; i < 10; i++) {
+      a.addConverted(0.1);
+      b.addConverted(0.2);
+    }
+    a.merge(b);
+    expect(a.total).toBe(3);
+  });
+});

--- a/backend/src/common/fx-aggregate.ts
+++ b/backend/src/common/fx-aggregate.ts
@@ -1,0 +1,77 @@
+/**
+ * Accumulate amounts that each need converting into one reporting currency,
+ * keeping "could not convert" distinguishable from "converted to zero".
+ *
+ * Why this is a class rather than a `reduce`: the defect it replaces was a
+ * single `?? amount` at the end of a conversion helper (audit P5-009). Each
+ * call site read `total += convert(...)` and looked correct; the lie was one
+ * level down, where a missing rate became a rate of 1. Handing the sites an
+ * accumulator that *cannot* silently absorb a missing rate removes the place
+ * that mistake can live.
+ *
+ * Read `docs/specs/fx-conversion-completeness.md` for the invariants and the
+ * numerical examples, and `docs/financial-calculation-contract.md` section 1 for
+ * the total/subtotal rule this implements.
+ */
+export class FxAggregate {
+  /**
+   * Accumulated in integer ten-thousandths (the resolution of `decimal(20,4)`),
+   * per the Financial Math rule in CLAUDE.md: `subtotal += converted` in floats
+   * accumulates drift, and this class is the one accumulator every total folds
+   * through, which is exactly where that drift would multiply.
+   */
+  private subtotalMinorUnits = 0;
+  private readonly missing = new Set<string>();
+
+  /**
+   * Add one component. `converted` is what the conversion returned: `null`
+   * means no rate was available for `from -> to`, which makes the total
+   * unknowable rather than smaller.
+   */
+  add(converted: number | null, from: string, to: string): void {
+    if (converted === null) {
+      this.missing.add(`${from}->${to}`);
+      return;
+    }
+    this.subtotalMinorUnits += Math.round(converted * 10000);
+  }
+
+  /** Add a value that needed no conversion (already in the reporting currency). */
+  addConverted(amount: number): void {
+    this.subtotalMinorUnits += Math.round(amount * 10000);
+  }
+
+  /** Fold in another aggregate, carrying its gaps with its subtotal. */
+  merge(other: FxAggregate): void {
+    this.subtotalMinorUnits += other.subtotalMinorUnits;
+    for (const pair of other.missing) this.missing.add(pair);
+  }
+
+  /**
+   * The complete total, or `null` when any component could not be converted.
+   *
+   * Note that this is `0` -- not `null` -- for an aggregate nothing was ever
+   * added to: an empty account holds zero, and reporting that as unknown tells
+   * the user a settled question could not be worked out.
+   */
+  get total(): number | null {
+    return this.missing.size > 0 ? null : this.subtotalMinorUnits / 10000;
+  }
+
+  /**
+   * The sum of the components that did convert. Safe to display beside the
+   * missing pairs, never under a field whose name says "total".
+   */
+  get knownSubtotal(): number {
+    return this.subtotalMinorUnits / 10000;
+  }
+
+  /** `"USD->EUR"` for each unresolvable pair; empty when the total is complete. */
+  get missingPairs(): string[] {
+    return [...this.missing].sort();
+  }
+
+  get isComplete(): boolean {
+    return this.missing.size === 0;
+  }
+}

--- a/backend/src/common/fx-fallback.guard.spec.ts
+++ b/backend/src/common/fx-fallback.guard.spec.ts
@@ -1,0 +1,136 @@
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative } from "path";
+
+const SRC_ROOT = join(__dirname, "..");
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "node_modules" || entry === "dist") continue;
+      out.push(...sourceFiles(full));
+      continue;
+    }
+    if (!entry.endsWith(".ts") || entry.endsWith(".spec.ts")) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/**
+ * A silent currency-conversion fallback is a one-token mistake, so it gets a
+ * scan rather than a paragraph.
+ *
+ * Audit finding P5-009: two conversion paths turned "no rate available" into
+ * "rate 1.0" -- `return result ?? amount` and
+ * `rate = reverseRate !== null ? 1 / reverseRate : 1`. 1,000 USD reported into
+ * a EUR total came out as 1,000 EUR, an 11% overstatement that is numerically
+ * plausible, and nothing in the response distinguished it from a genuine 1:1.
+ *
+ * The rule: a conversion returns `null` when it has no rate, and callers
+ * accumulate through `FxAggregate`. Rate 1 is reachable only when the source
+ * and destination currency codes are equal. See
+ * `docs/specs/fx-conversion-completeness.md`.
+ */
+describe("currency conversion has no silent identity fallback", () => {
+  const files = sourceFiles(SRC_ROOT);
+
+  it("finds source files to scan", () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it("never falls back from a failed conversion to the input amount", () => {
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const rel = relative(SRC_ROOT, file).split("\\").join("/");
+      const lines = readFileSync(file, "utf8").split("\n");
+      for (const [index, line] of lines.entries()) {
+        // `?? amount`, `|| amount`, `?? value` right where a conversion result
+        // is consumed -- the exact shape of the removed defect.
+        if (/(\?\?|\|\|)\s*(amount|rawValue|value)\s*;?\s*$/.test(line)) {
+          const context = lines
+            .slice(Math.max(0, index - 6), index + 1)
+            .join("\n");
+          if (/convert|Convert|rate|Rate/.test(context)) {
+            offenders.push(`${rel}:${index + 1}`);
+          }
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("never defaults a missing exchange rate to 1", () => {
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const rel = relative(SRC_ROOT, file).split("\\").join("/");
+      const lines = readFileSync(file, "utf8").split("\n");
+      for (const [index, line] of lines.entries()) {
+        // `rate = ... : 1`, `rate ?? 1`, `rate || 1` -- assigning 1 as the
+        // answer for a pair whose rate could not be found. A literal 1 for the
+        // same-currency case is fine and does not match: it is not assigned to
+        // a variable named for a rate out of a failed lookup.
+        const assignsOneToRate =
+          /\brate\w*\s*=\s*[^;]*[?:]\s*1\s*;/i.test(line) ||
+          /\brate\w*\s*(\?\?|\|\|)\s*1\b/i.test(line);
+        if (assignsOneToRate) offenders.push(`${rel}:${index + 1}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("reciprocates a reverse rate only in reviewed places", () => {
+    // "Try direct, then try the reverse and reciprocate" is the shape that has
+    // to end in `null` when neither exists -- three copies of it ended in `1`
+    // instead. Reciprocating is legitimate; doing it in a new place without
+    // deciding what happens when there is no rate is not.
+    //
+    // Adding a file here is a reviewed decision: confirm the branch returns
+    // null (or a typed unknown) rather than 1 before doing it.
+    const allowed = new Set([
+      // The shared date-aware helper -- the single direct/inverse decision.
+      "common/currency-conversion.util.ts",
+      // Persists the inverse pair alongside the direct one, at rate precision.
+      "currencies/exchange-rate.service.ts",
+      // Latest-rate resolvers, each returning null when the pair is unknown.
+      "securities/portfolio-calculation.service.ts",
+      "investment-reports/investment-report-data.service.ts",
+      "strategies/gem-position.service.ts",
+    ]);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const rel = relative(SRC_ROOT, file).split("\\").join("/");
+      if (allowed.has(rel)) continue;
+      const source = readFileSync(file, "utf8");
+      if (/1\s*\/\s*(reverse|inverse)\w*/i.test(source)) offenders.push(rel);
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("every reviewed reciprocal returns null when neither direction exists", () => {
+    // The allowlist above is only meaningful if the files on it actually
+    // handle the absent case. Each must mention returning null near its
+    // reciprocal rather than falling through to a number.
+    const resolvers = [
+      "securities/portfolio-calculation.service.ts",
+      "investment-reports/investment-report-data.service.ts",
+      "strategies/gem-position.service.ts",
+    ];
+
+    for (const rel of resolvers) {
+      const source = readFileSync(join(SRC_ROOT, rel), "utf8");
+      const idx = source.search(/1\s*\/\s*(reverse|inverse)\w*/i);
+      expect(idx).toBeGreaterThan(-1);
+      // Look at the surrounding block for the null-return decision.
+      const around = source.slice(Math.max(0, idx - 400), idx + 200);
+      expect(around).toMatch(/null/);
+    }
+  });
+});

--- a/backend/src/investment-reports/dto/execute-investment-report.dto.ts
+++ b/backend/src/investment-reports/dto/execute-investment-report.dto.ts
@@ -41,7 +41,11 @@ export interface InvestmentReportRow {
   /** The holding's own (security) currency, for formatting native values. */
   currency: string;
   /** Rate to multiply this row's native monetary values by to get base currency. */
-  baseExchangeRate: number;
+  /**
+   * Rate used to convert this row's native values into the base currency, or
+   * `null` when no rate exists for the pair -- never 1 as a stand-in for one.
+   */
+  baseExchangeRate: number | null;
   /** Column key -> computed value (native currency). */
   values: Record<string, InvestmentCellValue>;
 }

--- a/backend/src/investment-reports/investment-report-data.service.ts
+++ b/backend/src/investment-reports/investment-report-data.service.ts
@@ -21,8 +21,12 @@ export interface ComputedHolding {
   symbol: string;
   securityName: string;
   currencyCode: string;
-  /** Rate to convert this holding's native monetary values to the base currency. */
-  exchangeRate: number;
+  /**
+   * Rate to convert this holding's native monetary values to the base currency,
+   * or `null` when no rate exists for the pair. `null` must not render as a
+   * measured value, and the "% of portfolio" column it feeds is unknown too.
+   */
+  exchangeRate: number | null;
   /** Every column key -> computed value (null when unavailable). */
   values: Record<string, InvestmentCellValue>;
 }
@@ -332,8 +336,10 @@ export class InvestmentReportDataService {
         baseCurrency,
         fxCache,
       );
+      // Unknown rate makes the base-currency value unknown, not equal to the
+      // native one.
       const marketValueBase =
-        marketValue !== null ? marketValue * fxRate : null;
+        marketValue !== null && fxRate !== null ? marketValue * fxRate : null;
 
       const { high: high52, low: low52 } = this.fiftyTwoWeek(prices, asOfDate);
 
@@ -371,7 +377,7 @@ export class InvestmentReportDataService {
         sales: roundToDecimals(group.state.sales, 4),
         reinvestments: roundToDecimals(group.state.reinvestments, 4),
         realizedGains: roundToDecimals(group.state.realizedGains, 4),
-        exchangeRate: roundToDecimals(fxRate, 6),
+        exchangeRate: fxRate === null ? null : roundToDecimals(fxRate, 6),
         lastUpdated: asOfRow?.date ?? null,
         fiftyTwoWeekHigh: high52,
         fiftyTwoWeekLow: low52,
@@ -780,19 +786,29 @@ export class InvestmentReportDataService {
     return result;
   }
 
+  /**
+   * Latest rate for a pair, or `null` when there is none.
+   *
+   * `null`, not 1: this used to end `rate = reverse !== null ? 1 / reverse : 1`,
+   * so a base-currency column for a security with no rate reported the foreign
+   * number as though the currencies were at par (audit P5-009, same defect as
+   * the net-worth and portfolio paths). Rate 1 is returned only when the two
+   * codes are equal.
+   */
   private async fxRate(
     from: string,
     to: string,
     cache: Map<string, number>,
-  ): Promise<number> {
+  ): Promise<number | null> {
     if (!from || !to || from === to) return 1;
     const key = `${from}->${to}`;
     const cached = cache.get(key);
     if (cached !== undefined) return cached;
     let rate = await this.exchangeRateService.getLatestRate(from, to);
-    if (rate === null) {
+    if (rate === null || rate <= 0) {
       const reverse = await this.exchangeRateService.getLatestRate(to, from);
-      rate = reverse !== null ? 1 / reverse : 1;
+      if (reverse === null || reverse <= 0) return null;
+      rate = 1 / reverse;
     }
     cache.set(key, rate);
     return rate;

--- a/backend/src/mcp/tool-output-schemas.spec.ts
+++ b/backend/src/mcp/tool-output-schemas.spec.ts
@@ -490,6 +490,11 @@ const cases: Array<{ name: string; schema: RawShape; raw: unknown }> = [
     schema: schemas.getPortfolioSummaryOutput,
     raw: {
       holdingCount: 1,
+      fxComplete: true,
+      missingRatePairs: [],
+      pricesComplete: true,
+      unpricedSymbols: [],
+      valuationComplete: true,
       totalCashValue: 0,
       totalHoldingsValue: 100,
       totalCostBasis: 80,
@@ -522,6 +527,10 @@ const cases: Array<{ name: string; schema: RawShape; raw: unknown }> = [
           totalMarketValue: 100,
           totalGainLoss: 20,
           totalGainLossPercent: 25,
+          fxComplete: true,
+          missingRatePairs: [],
+          pricesComplete: true,
+          valuationComplete: true,
           holdings: [
             {
               securityId: "sec-aapl",

--- a/backend/src/mcp/tool-output-schemas.ts
+++ b/backend/src/mcp/tool-output-schemas.ts
@@ -330,6 +330,15 @@ const lookThroughBreakdown = looseObject({
 
 export const getPortfolioSummaryOutput = {
   holdingCount: num,
+  // The declared shape is the contract the model sees, and the SDK parses
+  // structuredContent against it -- an undeclared field is dropped. Leaving these
+  // out would have stripped the completeness signal back off at the MCP boundary
+  // the moment it was added to `LlmPortfolioSummary` (recheck RR2-007).
+  fxComplete: bool,
+  missingRatePairs: z.array(str),
+  pricesComplete: bool,
+  unpricedSymbols: z.array(str),
+  valuationComplete: bool,
   totalCashValue: num,
   totalHoldingsValue: num,
   totalCostBasis: num,
@@ -361,6 +370,13 @@ export const getPortfolioSummaryOutput = {
       totalCostBasis: num,
       totalMarketValue: num,
       totalGainLoss: num,
+      // This account's own completeness, which is a different question from the
+      // top-level flags: these totals are in the account's currency, those are in
+      // the user's default (recheck RR3-005).
+      fxComplete: bool,
+      missingRatePairs: z.array(str),
+      pricesComplete: bool,
+      valuationComplete: bool,
       totalGainLossPercent: num,
       holdings: z.array(
         looseObject({

--- a/backend/src/net-worth/net-worth.service.spec.ts
+++ b/backend/src/net-worth/net-worth.service.spec.ts
@@ -1556,8 +1556,50 @@ describe("NetWorthService", () => {
 
       const result = await service.getMonthlyNetWorth("user-1");
 
-      // Falls back to unconverted amount
-      expect(result[0].assets).toBe(1000);
+      // A missing rate is reported as a gap, NOT applied as 1:1 (audit P5-009).
+      //
+      // This assertion previously read `expect(result[0].assets).toBe(1000)`
+      // under the name "returns amount unconverted when no rate exists" -- it
+      // documented the defect as intended behaviour, which is why the defect
+      // survived. 1,000 JPY is roughly 7 USD; reporting it as 1,000 USD
+      // overstated the month by two orders of magnitude.
+      expect(result[0].fxComplete).toBe(false);
+      expect(result[0].missingRatePairs).toEqual(["JPY->USD"]);
+      // The unconvertible component is excluded from the subtotal rather than
+      // entered at face value.
+      expect(result[0].assets).toBe(0);
+    });
+
+    it("a zero balance in an unrated currency is a settled zero, not a gap", async () => {
+      // An emptied account holds zero in any currency, so it needs no rate.
+      // Asking for one flagged every month incomplete for as long as the empty
+      // account existed -- reporting a question that was never open as one that
+      // could not be answered ("zero needs no rate", root CLAUDE.md).
+      mabRepository.count.mockResolvedValue(5);
+      prefRepository.findOne.mockResolvedValue({
+        defaultCurrency: "USD",
+      });
+
+      reportQuery
+        .mockResolvedValueOnce([
+          {
+            month: "2024-01-01",
+            balance: 0,
+            market_value: null,
+            account_id: "jpy-account",
+            account_type: AccountType.CHEQUING,
+            account_sub_type: null,
+            currency_code: "JPY",
+          },
+        ])
+        // no rates returned
+        .mockResolvedValueOnce([]);
+
+      const result = await service.getMonthlyNetWorth("user-1");
+
+      expect(result[0].fxComplete).toBe(true);
+      expect(result[0].missingRatePairs).toEqual([]);
+      expect(result[0].assets).toBe(0);
     });
 
     it("aggregates multiple accounts in the same month", async () => {
@@ -2208,9 +2250,60 @@ describe("NetWorthService", () => {
       expect(result).toHaveLength(2);
       // Cost basis for first month: 100*100 (BUY) - 10*105 (SELL) = 10000 - 1050 = 8950
       // (replaces market_value of 11000)
-      expect(result[0]).toEqual({ month: "2024-03-01", value: 8950 });
+      expect(result[0]).toMatchObject({ month: "2024-03-01", value: 8950 });
       // Second month uses market_value as before
-      expect(result[1]).toEqual({ month: "2024-04-01", value: 12000 });
+      expect(result[1]).toMatchObject({ month: "2024-04-01", value: 12000 });
+    });
+
+    it("marks the month incomplete when a first-month cost-basis component cannot convert", async () => {
+      // A EUR-denominated buy seeds the first month of a USD account with no
+      // EUR->USD rate stored. The seed used to skip the component silently, so
+      // the month shipped an understated value under fxComplete: true -- the
+      // "flag that does not cover every total" shape the completeness contract
+      // forbids. The gap must ride the seed's aggregate into the month.
+      mabRepository.count.mockResolvedValue(5);
+      prefRepository.findOne.mockResolvedValue({ defaultCurrency: "USD" });
+
+      reportQuery
+        // snapshots
+        .mockResolvedValueOnce([
+          {
+            month: "2024-03-01",
+            balance: 0,
+            market_value: 11000,
+            account_id: "brokerage-new",
+            account_type: AccountType.INVESTMENT,
+            account_sub_type: "INVESTMENT_BROKERAGE",
+            currency_code: "USD",
+          },
+        ])
+        // firstMonthRows: 2024-03-01 IS this account's first active month
+        .mockResolvedValueOnce([
+          { account_id: "brokerage-new", first_month: "2024-03-01" },
+        ])
+        // txRows: a buy denominated in EUR
+        .mockResolvedValueOnce([
+          {
+            account_id: "brokerage-new",
+            action: "BUY",
+            quantity: 100,
+            price: 100,
+            transaction_date: "2024-03-05",
+            security_currency: "EUR",
+          },
+        ])
+        // rate index for the seed's EUR: nothing stored
+        .mockResolvedValueOnce([]);
+
+      const result = await service.getMonthlyInvestments(
+        "user-1",
+        "2024-03-01",
+        "2024-03-31",
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].fxComplete).toBe(false);
+      expect(result[0].missingRatePairs).toContain("EUR->USD");
     });
 
     it("does not adjust when snapshot month is after the account's first active month", async () => {
@@ -2499,9 +2592,14 @@ describe("NetWorthService", () => {
       // 03-01, 03-02 -> 03-02, 03-03 -> 03-03. This lines the daily series up
       // with the month-end-valued monthly snapshots.
       expect(result).toHaveLength(3);
-      expect(result[0]).toEqual({ date: "2025-03-01", value: 1000 });
-      expect(result[1]).toEqual({ date: "2025-03-02", value: 1020 });
-      expect(result[2]).toEqual({ date: "2025-03-03", value: 1010 });
+      expect(result[0]).toEqual({
+        date: "2025-03-01",
+        value: 1000,
+        fxComplete: true,
+        missingRatePairs: [],
+      });
+      expect(result[1]).toMatchObject({ date: "2025-03-02", value: 1020 });
+      expect(result[2]).toMatchObject({ date: "2025-03-03", value: 1010 });
     });
 
     it("includes cash balances from INVESTMENT_CASH accounts", async () => {
@@ -2538,8 +2636,8 @@ describe("NetWorthService", () => {
       );
 
       expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({ date: "2025-03-01", value: 5000 });
-      expect(result[1]).toEqual({ date: "2025-03-02", value: 5100 });
+      expect(result[0]).toMatchObject({ date: "2025-03-01", value: 5000 });
+      expect(result[1]).toMatchObject({ date: "2025-03-02", value: 5100 });
     });
 
     it("resolves linked account pairs when accountIds provided", async () => {
@@ -3154,6 +3252,9 @@ describe("NetWorthService", () => {
       expect(result).toEqual({
         granularity: "monthly",
         currency: "USD",
+        // Nothing to convert is complete, not unknown.
+        fxComplete: true,
+        missingRatePairs: [],
         series: [],
         points: [],
       });

--- a/backend/src/net-worth/net-worth.service.ts
+++ b/backend/src/net-worth/net-worth.service.ts
@@ -20,6 +20,7 @@ import {
 import { Security } from "../securities/entities/security.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { convertWithRateLookup } from "../common/currency-conversion.util";
+import { FxAggregate } from "../common/fx-aggregate";
 import { formatDateYMDLocal } from "../common/date-utils";
 
 const LIABILITY_TYPES: AccountType[] = [
@@ -76,6 +77,19 @@ export interface InvestmentBreakdown {
   currency: string;
   series: InvestmentBreakdownSeries[];
   points: InvestmentBreakdownPoint[];
+  /**
+   * False when at least one component could not be converted into `currency`
+   * because no exchange rate was available for its pair, which makes every
+   * `total` here a subtotal of what did convert.
+   *
+   * A missing rate used to be applied as 1:1, so a consumer had no way to tell
+   * a complete figure from a wrong one (audit P5-009). See
+   * `docs/specs/fx-conversion-completeness.md` -- stage 2 makes the totals
+   * themselves nullable.
+   */
+  fxComplete: boolean;
+  /** `"USD->EUR"` for each pair with no available rate; empty when complete. */
+  missingRatePairs: string[];
 }
 
 @Injectable()
@@ -453,7 +467,21 @@ export class NetWorthService {
     startDate?: string,
     endDate?: string,
   ): Promise<
-    { month: string; assets: number; liabilities: number; netWorth: number }[]
+    {
+      month: string;
+      assets: number;
+      liabilities: number;
+      netWorth: number;
+      /**
+       * False when a component of this month could not be converted into the
+       * reporting currency, which makes the three figures above subtotals of
+       * what did convert. A missing rate used to be applied as 1:1 (audit
+       * P5-009); see docs/specs/fx-conversion-completeness.md.
+       */
+      fxComplete: boolean;
+      /** `"JPY->USD"` for each pair with no available rate. */
+      missingRatePairs: string[];
+    }[]
   > {
     const today = new Date();
     const defaultStart = new Date(today.getFullYear() - 1, today.getMonth(), 1)
@@ -470,7 +498,21 @@ export class NetWorthService {
     endDate?: string,
     jointScope?: JointNetWorthScope,
   ): Promise<
-    { month: string; assets: number; liabilities: number; netWorth: number }[]
+    {
+      month: string;
+      assets: number;
+      liabilities: number;
+      netWorth: number;
+      /**
+       * False when a component of this month could not be converted into the
+       * reporting currency, which makes the three figures above subtotals of
+       * what did convert. A missing rate used to be applied as 1:1 (audit
+       * P5-009); see docs/specs/fx-conversion-completeness.md.
+       */
+      fxComplete: boolean;
+      /** `"JPY->USD"` for each pair with no available rate. */
+      missingRatePairs: string[];
+    }[]
   > {
     await this.ensurePopulated(userId);
     const jointIds = jointScope?.accounts.map((a) => a.accountId) ?? [];
@@ -520,14 +562,22 @@ export class NetWorthService {
       end,
     );
 
-    // Aggregate by month
-    const monthMap = new Map<string, { assets: number; liabilities: number }>();
+    // Aggregate by month. Assets and liabilities each accumulate through an
+    // FxAggregate so a month containing a component with no available rate
+    // reports an unknown total instead of a plausible wrong one (P5-009).
+    const monthMap = new Map<
+      string,
+      { assets: FxAggregate; liabilities: FxAggregate }
+    >();
 
     for (const s of snapshots) {
       const monthKey = this.toDateString(s.month);
 
       if (!monthMap.has(monthKey)) {
-        monthMap.set(monthKey, { assets: 0, liabilities: 0 });
+        monthMap.set(monthKey, {
+          assets: new FxAggregate(),
+          liabilities: new FxAggregate(),
+        });
       }
       const entry = monthMap.get(monthKey)!;
 
@@ -562,20 +612,45 @@ export class NetWorthService {
 
       const accountType = s.account_type as AccountType;
       if (LIABILITY_TYPES.includes(accountType)) {
-        entry.liabilities += Math.abs(converted);
+        entry.liabilities.add(
+          converted === null ? null : Math.abs(converted),
+          s.currency_code,
+          defaultCurrency,
+        );
       } else {
-        entry.assets += converted;
+        entry.assets.add(converted, s.currency_code, defaultCurrency);
       }
     }
 
     return Array.from(monthMap.entries())
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([month, data]) => ({
-        month,
-        assets: Math.round(data.assets),
-        liabilities: Math.round(data.liabilities),
-        netWorth: Math.round(data.assets - data.liabilities),
-      }));
+      .map(([month, data]) => {
+        // Per docs/financial-calculation-contract.md section 1: the total is
+        // null unless every component converted, the partial sum travels in a
+        // separately named field, and the response says what is missing.
+        const missingRatePairs = [
+          ...new Set([
+            ...data.assets.missingPairs,
+            ...data.liabilities.missingPairs,
+          ]),
+        ].sort();
+        return {
+          month,
+          assets: Math.round(data.assets.knownSubtotal),
+          liabilities: Math.round(data.liabilities.knownSubtotal),
+          netWorth: Math.round(
+            data.assets.knownSubtotal - data.liabilities.knownSubtotal,
+          ),
+          // Stage 1 of docs/specs/fx-conversion-completeness.md: the three
+          // figures above are the subtotal of what converted, and these two
+          // fields say so. They are NOT yet nullable -- that is stage 2, with
+          // the frontend and copy work it needs -- but a consumer can now tell
+          // a complete total from a partial one, which it could not when a
+          // missing rate silently became 1:1.
+          fxComplete: missingRatePairs.length === 0,
+          missingRatePairs,
+        };
+      });
   }
 
   /**
@@ -623,7 +698,16 @@ export class NetWorthService {
     endDate?: string,
     accountIds?: string[],
     displayCurrency?: string,
-  ): Promise<{ month: string; value: number }[]> {
+  ): Promise<
+    {
+      month: string;
+      value: number;
+      /** False when a component could not be converted; see missingRatePairs. */
+      fxComplete: boolean;
+      /** `"USD->EUR"` for each pair with no available rate. */
+      missingRatePairs: string[];
+    }[]
+  > {
     await this.ensurePopulated(userId);
 
     const pref = await withScopedDb(this.dataSource, (m) =>
@@ -711,31 +795,37 @@ export class NetWorthService {
       end,
     );
 
-    const monthMap = new Map<string, number>();
+    const monthMap = new Map<string, FxAggregate>();
 
     for (const s of snapshots) {
       const monthKey = this.toDateString(s.month);
 
       if (!monthMap.has(monthKey)) {
-        monthMap.set(monthKey, 0);
+        monthMap.set(monthKey, new FxAggregate());
       }
 
       const monthEnd = this.monthEndDate(monthKey);
       const adjKey = `${s.account_id}:${monthKey}`;
       const costBasisInDefault = firstMonthCostBasisInDefault.get(adjKey);
 
-      let convertedValue: number;
+      const monthAggregate = monthMap.get(monthKey)!;
       if (costBasisInDefault !== undefined) {
-        convertedValue = costBasisInDefault;
+        // merge, not addConverted: the seed's gaps travel with its subtotal,
+        // so an unconvertible first-month component marks the month incomplete.
+        monthAggregate.merge(costBasisInDefault);
         // Standalone investment accounts hold cash inside the same account, so
         // include the month-end cash balance alongside the cost basis.
         if (s.account_type === "INVESTMENT" && s.account_sub_type === null) {
-          convertedValue += this.convertCurrency(
-            Number(s.balance),
+          monthAggregate.add(
+            this.convertCurrency(
+              Number(s.balance),
+              s.currency_code,
+              defaultCurrency,
+              monthEnd,
+              rateIndex,
+            ),
             s.currency_code,
             defaultCurrency,
-            monthEnd,
-            rateIndex,
           );
         }
       } else {
@@ -755,23 +845,27 @@ export class NetWorthService {
           rawValue = Number(s.balance);
         }
 
-        convertedValue = this.convertCurrency(
-          rawValue,
+        monthAggregate.add(
+          this.convertCurrency(
+            rawValue,
+            s.currency_code,
+            defaultCurrency,
+            monthEnd,
+            rateIndex,
+          ),
           s.currency_code,
           defaultCurrency,
-          monthEnd,
-          rateIndex,
         );
       }
-
-      monthMap.set(monthKey, monthMap.get(monthKey)! + convertedValue);
     }
 
     return Array.from(monthMap.entries())
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([month, value]) => ({
+      .map(([month, aggregate]) => ({
         month,
-        value: Math.round(value),
+        value: Math.round(aggregate.knownSubtotal),
+        fxComplete: aggregate.isComplete,
+        missingRatePairs: aggregate.missingPairs,
       }));
   }
 
@@ -780,7 +874,10 @@ export class NetWorthService {
    * snapshot row coincides with that account's first-ever active month,
    * compute the net cost basis of all in-month investment transactions
    * converted to `defaultCurrency`. Returns a map keyed by
-   * `${accountId}:${monthKey}` -> value in `defaultCurrency`.
+   * `${accountId}:${monthKey}` -> an `FxAggregate` carrying the converted
+   * value *and* any conversion gaps, so a component the seed could not convert
+   * marks the month incomplete instead of being dropped into a partial sum
+   * that ships under `fxComplete: true`.
    */
   private async computeFirstActiveMonthCostBasis(
     userId: string,
@@ -788,8 +885,8 @@ export class NetWorthService {
     defaultCurrency: string,
     start: string,
     end: string,
-  ): Promise<Map<string, number>> {
-    const result = new Map<string, number>();
+  ): Promise<Map<string, FxAggregate>> {
+    const result = new Map<string, FxAggregate>();
 
     const eligibleSnapshots = snapshots.filter((s) => {
       const isBrokerage = s.account_sub_type === "INVESTMENT_BROKERAGE";
@@ -880,8 +977,18 @@ export class NetWorthService {
         rateIndex,
       );
 
+      // A cost-basis component with no rate is recorded as a gap on the
+      // month's aggregate rather than added at 1:1 -- or silently dropped: a
+      // seed that skipped it left the month's value understated while the
+      // response still said `fxComplete: true`, the exact "flag that does not
+      // cover every total" shape the completeness contract forbids.
       const key = `${r.account_id}:${targetMonth}`;
-      result.set(key, (result.get(key) || 0) + inDefault);
+      let aggregate = result.get(key);
+      if (!aggregate) {
+        aggregate = new FxAggregate();
+        result.set(key, aggregate);
+      }
+      aggregate.add(inDefault, secCurrency, defaultCurrency);
     }
 
     return result;
@@ -941,7 +1048,16 @@ export class NetWorthService {
     endDate?: string,
     accountIds?: string[],
     displayCurrency?: string,
-  ): Promise<{ date: string; value: number }[]> {
+  ): Promise<
+    {
+      date: string;
+      value: number;
+      /** False when a component could not be converted; see missingRatePairs. */
+      fxComplete: boolean;
+      /** "USD->EUR" for each pair with no available rate. */
+      missingRatePairs: string[];
+    }[]
+  > {
     const pref = await withScopedDb(this.dataSource, (m) =>
       m.getRepository(UserPreference).findOne({ where: { userId } }),
     );
@@ -1192,7 +1308,14 @@ export class NetWorthService {
     const holdingsByAccount = new Map<string, Map<string, number>>();
     let txIdx = 0;
 
-    const result: { date: string; value: number }[] = [];
+    const result: {
+      date: string;
+      value: number;
+      /** False when a component could not be converted; see missingRatePairs. */
+      fxComplete: boolean;
+      /** "USD->EUR" for each pair with no available rate. */
+      missingRatePairs: string[];
+    }[] = [];
 
     for (const dateStr of dates) {
       // Process investment transactions up to this date
@@ -1232,7 +1355,7 @@ export class NetWorthService {
       // to default currency. Security prices are stored in the security's
       // native currency, so we must convert each holding individually rather
       // than treating the total as being in the account's currency.
-      let totalValue = 0;
+      const dayValue = new FxAggregate();
 
       for (const [, acctHoldings] of holdingsByAccount) {
         for (const [secId, qty] of acctHoldings) {
@@ -1264,12 +1387,16 @@ export class NetWorthService {
           if (price != null) {
             const valueInSecCurrency = qty * price;
             const secCurrency = security?.currencyCode || defaultCurrency;
-            totalValue += this.convertCurrency(
-              valueInSecCurrency,
+            dayValue.add(
+              this.convertCurrency(
+                valueInSecCurrency,
+                secCurrency,
+                defaultCurrency,
+                dateStr,
+                rateIndex,
+              ),
               secCurrency,
               defaultCurrency,
-              dateStr,
-              rateIndex,
             );
           }
         }
@@ -1279,18 +1406,24 @@ export class NetWorthService {
       for (const [acctId, dailyMap] of cashBalances) {
         const bal = dailyMap.get(dateStr) ?? 0;
         const currency = acctCurrency.get(acctId) || defaultCurrency;
-        totalValue += this.convertCurrency(
-          bal,
+        dayValue.add(
+          this.convertCurrency(
+            bal,
+            currency,
+            defaultCurrency,
+            dateStr,
+            rateIndex,
+          ),
           currency,
           defaultCurrency,
-          dateStr,
-          rateIndex,
         );
       }
 
       result.push({
         date: dateStr,
-        value: Math.round(totalValue),
+        value: Math.round(dayValue.knownSubtotal),
+        fxComplete: dayValue.isComplete,
+        missingRatePairs: dayValue.missingPairs,
       });
     }
 
@@ -1337,6 +1470,9 @@ export class NetWorthService {
       currency: defaultCurrency,
       series: [],
       points: [],
+      // Nothing to convert is complete, not unknown.
+      fxComplete: true,
+      missingRatePairs: [],
     };
 
     const investAccounts = await this.resolveScopedInvestmentAccounts(
@@ -1530,6 +1666,11 @@ export class NetWorthService {
       cash: number;
     }> = [];
 
+    // Pairs the whole breakdown could not resolve a rate for. Collected across
+    // every sample so the response can name them rather than presenting a
+    // subtotal as a total (P5-009).
+    const missingPairs = new Set<string>();
+
     for (const sampleDate of sampleDates) {
       const valuationDate =
         granularity === "monthly" ? this.monthEndDate(sampleDate) : sampleDate;
@@ -1587,26 +1728,41 @@ export class NetWorthService {
           valuationDate,
           rateIndex,
         );
+        // A position with no rate for its pair is left out of the breakdown
+        // rather than entered at 1:1, and recorded so the point can say so.
+        if (value === null) {
+          missingPairs.add(`${secCurrency}->${defaultCurrency}`);
+          continue;
+        }
         valuesBySec.set(secId, (valuesBySec.get(secId) ?? 0) + value);
       }
 
       // Cash maps are keyed by the sample date itself: day strings for daily,
       // month-first strings for monthly.
-      let cash = 0;
+      const cashAggregate = new FxAggregate();
       for (const [acctId, dailyMap] of cashBalances) {
         const bal = dailyMap.get(sampleDate) ?? 0;
         if (bal === 0) continue;
         const currency = acctCurrency.get(acctId) || defaultCurrency;
-        cash += this.convertCurrency(
-          bal,
+        cashAggregate.add(
+          this.convertCurrency(
+            bal,
+            currency,
+            defaultCurrency,
+            valuationDate,
+            rateIndex,
+          ),
           currency,
           defaultCurrency,
-          valuationDate,
-          rateIndex,
         );
       }
+      for (const pair of cashAggregate.missingPairs) missingPairs.add(pair);
 
-      ungrouped.push({ date: sampleDate, valuesBySec, cash });
+      ungrouped.push({
+        date: sampleDate,
+        valuesBySec,
+        cash: cashAggregate.knownSubtotal,
+      });
     }
 
     const { series, points } = this.groupSecurityBreakdown(
@@ -1614,7 +1770,14 @@ export class NetWorthService {
       securityMap,
       limit,
     );
-    return { granularity, currency: defaultCurrency, series, points };
+    return {
+      granularity,
+      currency: defaultCurrency,
+      series,
+      points,
+      fxComplete: missingPairs.size === 0,
+      missingRatePairs: [...missingPairs].sort(),
+    };
   }
 
   // ---- Private helpers ----
@@ -2214,7 +2377,7 @@ export class NetWorthService {
       // Compute market value from holdings. Each holding's value is in the
       // security's native currency; convert to the account's currency at the
       // month-end exchange rate before summing.
-      let marketValue = 0;
+      const monthValue = new FxAggregate();
       const monthEndStr = this.monthEndDate(monthStr);
       for (const [secId, qty] of holdings) {
         if (Math.abs(qty) < 0.00000001) continue;
@@ -2231,17 +2394,32 @@ export class NetWorthService {
         if (price != null) {
           const valueInSecCurrency = qty * price;
           const secCurrency = security?.currencyCode || account.currencyCode;
-          marketValue += this.convertCurrency(
-            valueInSecCurrency,
+          monthValue.add(
+            this.convertCurrency(
+              valueInSecCurrency,
+              secCurrency,
+              account.currencyCode,
+              monthEndStr,
+              mvRateIndex,
+            ),
             secCurrency,
             account.currencyCode,
-            monthEndStr,
-            mvRateIndex,
           );
         }
       }
 
-      marketValueByMonth.set(monthStr, marketValue);
+      // This value is persisted to monthly_account_balances, which has no
+      // column to record that a conversion was incomplete. Per
+      // docs/specs/fx-conversion-completeness.md section 5, the snapshot is
+      // written from the subtotal and the gap is logged rather than silently
+      // absorbed at 1:1; adding a completeness column is a separate migration.
+      if (!monthValue.isComplete) {
+        this.logger.warn(
+          `Snapshot for account ${account.id} month ${monthStr} omits positions with no exchange rate (${monthValue.missingPairs.join(", ")}); the stored market value is a subtotal`,
+        );
+      }
+
+      marketValueByMonth.set(monthStr, monthValue.knownSubtotal);
     }
 
     // Atomic write
@@ -2395,25 +2573,56 @@ export class NetWorthService {
     return index;
   }
 
+  /**
+   * Date-aware conversion into the reporting currency. Returns `null` when no
+   * rate exists for the pair.
+   *
+   * `null`, not the amount unchanged: this used to end in `result ?? amount`,
+   * which reported 1,000 USD as 1,000 EUR and left a consumer unable to tell
+   * that from a genuine 1:1 pair (audit P5-009). The direct/inverse decision
+   * lives in the shared `convertWithRateLookup` so reports and net worth cannot
+   * diverge on how a pair resolves. Callers accumulate through `FxAggregate`;
+   * see `docs/specs/fx-conversion-completeness.md`.
+   */
   private convertCurrency(
     amount: number,
     from: string,
     to: string,
     monthEnd: string,
     rateIndex: RateIndex,
-  ): number {
-    // Date-aware rate lookup: resolve the best rate on or before monthEnd from
-    // the historical index. The direct/inverse decision lives in the shared
-    // convertWithRateLookup helper so reports and net worth stay consistent.
-    const result = convertWithRateLookup(amount, from, to, (f, t) => {
+  ): number | null {
+    // Zero converts to zero at any rate, so it needs none (and records no
+    // gap): an emptied account in a currency with no stored rates is a settled
+    // zero, not an unknowable value, and flagging it incomplete would report a
+    // question that was never open as one that could not be answered.
+    if (amount === 0) return 0;
+
+    const converted = convertWithRateLookup(amount, from, to, (f, t) => {
       const rates = rateIndex.get(`${f}->${t}`);
-      return rates ? this.findBestRate(rates, monthEnd) : undefined;
+      return rates
+        ? this.findBestRate(rates, `${f}->${t}`, monthEnd)
+        : undefined;
     });
-    return result ?? amount;
+    if (converted === null) {
+      this.logger.warn(
+        `No exchange rate available for ${from}->${to} on or around ${monthEnd}; the affected total is reported as unknown rather than converted 1:1`,
+      );
+    }
+    return converted;
   }
+
+  /**
+   * Rate arrays whose look-ahead fallback has already been logged. Keyed by the
+   * per-request array object in the RateIndex, so each pair warns once per
+   * computation instead of once per chart point.
+   */
+  private readonly lookAheadWarned = new WeakSet<
+    Array<{ date: string; rate: number }>
+  >();
 
   private findBestRate(
     rates: Array<{ date: string; rate: number }>,
+    pair: string,
     beforeOrOn: string,
   ): number | undefined {
     let best: number | undefined;
@@ -2421,8 +2630,22 @@ export class NetWorthService {
       if (r.date <= beforeOrOn) best = r.rate;
       else break;
     }
-    // If no rate before this date, use the earliest available
+    // No rate on or before this date: fall back to the earliest one there is.
+    //
+    // This is look-ahead -- valuing a point with a rate from its future -- and
+    // the time-series contract forbids it in general. It is kept deliberately
+    // (DR-02 in the audit): a chart point that predates the rate history is
+    // more useful approximated than absent. What is NOT acceptable is it being
+    // invisible, so it is logged below; changing the fallback itself is a
+    // product decision recorded in docs/specs/fx-conversion-completeness.md
+    // section 6.
     if (best === undefined && rates.length > 0) {
+      if (!this.lookAheadWarned.has(rates)) {
+        this.lookAheadWarned.add(rates);
+        this.logger.warn(
+          `Valuation on or before ${beforeOrOn} predates the stored ${pair} rate history; using the earliest stored rate (look-ahead, DR-02)`,
+        );
+      }
       best = rates[0].rate;
     }
     return best;

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -77,11 +77,19 @@ export interface LlmCapitalGainsEntry {
    * should then treat the sums as mixed and avoid currency-specific claims).
    */
   currency: string | null;
-  startValue: number;
-  endValue: number;
+  /**
+   * `null` when any row folded into this entry had an unknown boundary value --
+   * a security whose currency could not be converted into its account's. An
+   * unknown component makes the sum unknown; the partial sum is not returned
+   * under a field a caller would read as complete
+   * (docs/financial-calculation-contract.md section 1). `realizedGain` stays
+   * known: it derives from each transaction's own stored rate.
+   */
+  startValue: number | null;
+  endValue: number | null;
   realizedGain: number;
-  unrealizedGain: number;
-  totalCapitalGain: number;
+  unrealizedGain: number | null;
+  totalCapitalGain: number | null;
 }
 
 export interface LlmCapitalGainsResult {
@@ -89,8 +97,12 @@ export interface LlmCapitalGainsResult {
   endDate: string;
   totals: {
     realizedGain: number;
-    unrealizedGain: number;
-    totalCapitalGain: number;
+    /**
+     * `null` when any row in the window had an unconvertible boundary value.
+     * A total that silently omitted those rows would read as complete.
+     */
+    unrealizedGain: number | null;
+    totalCapitalGain: number | null;
   };
   groupedBy: LlmCapitalGainsGroupBy;
   entries: LlmCapitalGainsEntry[];
@@ -2455,16 +2467,26 @@ export class InvestmentTransactionsService {
       realizedScaled: number;
       unrealizedScaled: number;
       totalScaled: number;
+      /** Set when any folded row had an unconvertible boundary value. */
+      incomplete: boolean;
     }
     const buckets = new Map<string, Bucket>();
     let totalsRealizedScaled = 0;
     let totalsUnrealizedScaled = 0;
     let totalsCapitalScaled = 0;
 
+    // A row whose FX could not be resolved contributes nothing to the sums and
+    // marks them incomplete, rather than being counted as a zero-value period.
+    let totalsIncomplete = false;
+
     for (const e of filtered) {
       totalsRealizedScaled += Math.round(e.realizedGain * 10000);
-      totalsUnrealizedScaled += Math.round(e.unrealizedGain * 10000);
-      totalsCapitalScaled += Math.round(e.totalCapitalGain * 10000);
+      if (e.unrealizedGain === null || e.totalCapitalGain === null) {
+        totalsIncomplete = true;
+      } else {
+        totalsUnrealizedScaled += Math.round(e.unrealizedGain * 10000);
+        totalsCapitalScaled += Math.round(e.totalCapitalGain * 10000);
+      }
 
       let key: string;
       let seed: Pick<
@@ -2507,6 +2529,7 @@ export class InvestmentTransactionsService {
           realizedScaled: 0,
           unrealizedScaled: 0,
           totalScaled: 0,
+          incomplete: false,
         };
         buckets.set(key, b);
       }
@@ -2518,11 +2541,20 @@ export class InvestmentTransactionsService {
         b.currency = null;
       }
 
-      b.startValueScaled += Math.round(e.startValue * 10000);
-      b.endValueScaled += Math.round(e.endValue * 10000);
       b.realizedScaled += Math.round(e.realizedGain * 10000);
-      b.unrealizedScaled += Math.round(e.unrealizedGain * 10000);
-      b.totalScaled += Math.round(e.totalCapitalGain * 10000);
+      if (
+        e.startValue === null ||
+        e.endValue === null ||
+        e.unrealizedGain === null ||
+        e.totalCapitalGain === null
+      ) {
+        b.incomplete = true;
+      } else {
+        b.startValueScaled += Math.round(e.startValue * 10000);
+        b.endValueScaled += Math.round(e.endValue * 10000);
+        b.unrealizedScaled += Math.round(e.unrealizedGain * 10000);
+        b.totalScaled += Math.round(e.totalCapitalGain * 10000);
+      }
     }
 
     const MAX_ENTRIES = 100;
@@ -2533,17 +2565,26 @@ export class InvestmentTransactionsService {
         symbol: b.symbol,
         securityName: b.securityName,
         currency: b.currency ?? null,
-        startValue: roundMoney(b.startValueScaled / 10000),
-        endValue: roundMoney(b.endValueScaled / 10000),
+        startValue: b.incomplete
+          ? null
+          : roundMoney(b.startValueScaled / 10000),
+        endValue: b.incomplete ? null : roundMoney(b.endValueScaled / 10000),
         realizedGain: roundMoney(b.realizedScaled / 10000),
-        unrealizedGain: roundMoney(b.unrealizedScaled / 10000),
-        totalCapitalGain: roundMoney(b.totalScaled / 10000),
+        unrealizedGain: b.incomplete
+          ? null
+          : roundMoney(b.unrealizedScaled / 10000),
+        totalCapitalGain: b.incomplete
+          ? null
+          : roundMoney(b.totalScaled / 10000),
       }),
     );
     allEntries.sort((a, b) => {
       if (groupBy === "month")
         return (a.month ?? "").localeCompare(b.month ?? "");
-      return b.totalCapitalGain - a.totalCapitalGain;
+      // Unknown sorts last rather than as zero.
+      return (
+        (b.totalCapitalGain ?? -Infinity) - (a.totalCapitalGain ?? -Infinity)
+      );
     });
 
     return {
@@ -2551,8 +2592,12 @@ export class InvestmentTransactionsService {
       endDate: options.endDate,
       totals: {
         realizedGain: roundMoney(totalsRealizedScaled / 10000),
-        unrealizedGain: roundMoney(totalsUnrealizedScaled / 10000),
-        totalCapitalGain: roundMoney(totalsCapitalScaled / 10000),
+        unrealizedGain: totalsIncomplete
+          ? null
+          : roundMoney(totalsUnrealizedScaled / 10000),
+        totalCapitalGain: totalsIncomplete
+          ? null
+          : roundMoney(totalsCapitalScaled / 10000),
       },
       groupedBy: groupBy,
       entries: allEntries.slice(0, MAX_ENTRIES),

--- a/backend/src/securities/portfolio-calculation.service.spec.ts
+++ b/backend/src/securities/portfolio-calculation.service.spec.ts
@@ -338,6 +338,84 @@ describe("PortfolioCalculationService.calculateCapitalGainsByMonth", () => {
     expect(feb.unrealizedGain).toBe(500);
   });
 
+  it("reports unknown boundary values when the security currency cannot be converted (P5-009)", async () => {
+    // A USD security in a CAD account with no USD/CAD rate in either direction.
+    // The security's value at each month boundary is therefore unknown, so the
+    // capital gain measured between them is unknown too.
+    //
+    // The rate used to fall back to 1, which valued 100 USD shares as 100 CAD
+    // and produced a confident gain figure from an arbitrary conversion.
+    exchangeRateService.getLatestRate.mockResolvedValue(null);
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2023-12-15",
+        quantity: 100,
+        price: 50,
+        totalAmount: 5000,
+        security: {
+          id: securityId,
+          symbol: "ABC",
+          name: "ABC Corp",
+          currencyCode: "USD",
+        },
+      } as never),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([
+        { date: "2023-12-31", price: 50 },
+        { date: "2024-01-31", price: 55 },
+      ]),
+    );
+
+    const result = await service.calculateCapitalGainsByMonth(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+    });
+
+    expect(result).toHaveLength(1);
+    const jan = result[0];
+    expect(jan.startValue).toBeNull();
+    expect(jan.endValue).toBeNull();
+    expect(jan.unrealizedGain).toBeNull();
+    expect(jan.totalCapitalGain).toBeNull();
+    // Realized gain comes from each transaction's own stored rate, so it stays
+    // known -- there were no sales, and zero is the right answer for that.
+    expect(jan.realizedGain).toBe(0);
+  });
+
+  it("still computes gains when the security and account share a currency", async () => {
+    // The same-currency path must not be caught by the missing-rate handling:
+    // rate 1 is correct here because the codes are equal, and no lookup happens.
+    exchangeRateService.getLatestRate.mockResolvedValue(null);
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2023-12-15",
+        quantity: 100,
+        price: 50,
+        totalAmount: 5000,
+      }),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([
+        { date: "2023-12-31", price: 50 },
+        { date: "2024-01-31", price: 55 },
+      ]),
+    );
+
+    const result = await service.calculateCapitalGainsByMonth(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+    });
+
+    expect(result[0].totalCapitalGain).toBe(500);
+    expect(result[0].startValue).toBe(5000);
+    expect(result[0].endValue).toBe(5500);
+  });
+
   it("decomposes a SELL month into realized + unrealized capital gains", async () => {
     // Hold 100 shares at avg cost $50 since Dec.
     // Feb: price goes $50 -> $60, sell 40 shares mid-month at $60 (proceeds 2400),
@@ -799,6 +877,62 @@ describe("PortfolioCalculationService.primeLiveRates", () => {
 
     expect(holdingsRepo.createQueryBuilder).not.toHaveBeenCalled();
     expect(rateCache.get("USD->CAD")).toBe(1.37);
+  });
+});
+
+describe("PortfolioCalculationService.convertToDefault", () => {
+  let service: PortfolioCalculationService;
+  let exchangeRateService: { getLatestRate: jest.Mock };
+
+  beforeEach(() => {
+    exchangeRateService = { getLatestRate: jest.fn().mockResolvedValue(null) };
+    service = buildService([], exchangeRateService);
+  });
+
+  it("returns zero for a zero amount without looking for a rate", async () => {
+    // Zero converts to zero at any rate, so it needs none. Asking for one turned
+    // an empty foreign account -- no cash, no holdings, nothing invested -- into
+    // an unresolvable pair that made the whole portfolio's totals unknown. A
+    // settled question must not be reported as one that could not be worked out.
+    const result = await service.convertToDefault(
+      0,
+      "EUR",
+      "CAD",
+      new Map<string, number>(),
+    );
+
+    expect(result).toBe(0);
+    expect(exchangeRateService.getLatestRate).not.toHaveBeenCalled();
+  });
+
+  it("still reports a non-zero amount with no rate as unknown", async () => {
+    // The control: the zero shortcut must not become a general fallback.
+    const result = await service.convertToDefault(
+      100,
+      "EUR",
+      "CAD",
+      new Map<string, number>(),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("caches the absence of a rate, resolving a missing pair once per cache", async () => {
+    // A portfolio with 50 holdings in one unrated currency used to re-run both
+    // lookups (direct + inverse) and re-log the warning for every holding.
+    const cache = new Map<string, number | null>();
+
+    expect(await service.convertToDefault(100, "EUR", "CAD", cache)).toBeNull();
+    expect(await service.convertToDefault(250, "EUR", "CAD", cache)).toBeNull();
+    expect(await service.convertToDefault(999, "EUR", "CAD", cache)).toBeNull();
+
+    // Direct + inverse for the first call only; the cached null answers the rest.
+    expect(exchangeRateService.getLatestRate).toHaveBeenCalledTimes(2);
+  });
+
+  it("a cached absence does not shadow the zero shortcut", async () => {
+    const cache = new Map<string, number | null>([["EUR->CAD", null]]);
+    expect(await service.convertToDefault(0, "EUR", "CAD", cache)).toBe(0);
   });
 });
 
@@ -2342,5 +2476,119 @@ describe("PortfolioCalculationService.calculateHoldingsWithValues", () => {
     const result = await valuation(lot({ quantity: 10.00001 }));
 
     expect(result.holdingsWithValues[0].costBasisAccountCurrency).toBe(900);
+  });
+
+  it("names the pair that actually failed when a basis cannot reach the account currency", async () => {
+    // USD security in a PLN account, user default PLN, no USD->PLN rate. The
+    // failed conversion is USD->PLN; recording it as accountCurrency->default
+    // filed the gap under the degenerate "PLN->PLN" -- a pair that is not
+    // missing -- so the report pointed the user (and any AI consumer) at a rate
+    // that did not need fixing while never naming the one that did.
+    const usdHolding = {
+      ...holdingRow,
+      security: { ...holdingRow.security, currencyCode: "USD" },
+    };
+    const holdingRepo = { find: jest.fn().mockResolvedValue([usdHolding]) };
+    const txRepo = { find: jest.fn().mockResolvedValue([]) };
+    const accountRepo = { find: jest.fn().mockResolvedValue([]) };
+    const service = buildService(
+      [
+        [Holding, holdingRepo],
+        [InvestmentTransaction, txRepo],
+        [Account, accountRepo],
+      ],
+      { getLatestRate: jest.fn().mockResolvedValue(null) },
+    );
+    jest
+      .spyOn(service, "calculateCostBasisLotsInAccountCurrency")
+      .mockResolvedValue(new Map());
+
+    const result = await service.calculateHoldingsWithValues(
+      userId,
+      ["acct-1"],
+      "PLN",
+      new Map(),
+      async () => new Map([["sec-a", 50]]),
+    );
+
+    expect(result.holdingsWithValues[0].costBasisAccountCurrency).toBeNull();
+    expect(result.fxComplete).toBe(false);
+    expect(result.missingRatePairs).toContain("USD->PLN");
+    expect(result.missingRatePairs).not.toContain("PLN->PLN");
+  });
+});
+
+describe("PortfolioCalculationService.calculateTWR", () => {
+  const userId = "user-1";
+
+  const buys = (currencyCode: string) => [
+    {
+      id: "tx-1",
+      userId,
+      accountId: "acct-1",
+      securityId: "sec-a",
+      security: { id: "sec-a", currencyCode },
+      action: InvestmentAction.BUY,
+      transactionDate: "2024-01-02",
+      quantity: 10,
+      price: 10,
+      createdAt: new Date("2024-01-02"),
+    },
+    {
+      id: "tx-2",
+      userId,
+      accountId: "acct-1",
+      securityId: "sec-a",
+      security: { id: "sec-a", currencyCode },
+      action: InvestmentAction.BUY,
+      transactionDate: "2024-02-02",
+      quantity: 10,
+      price: 12,
+      createdAt: new Date("2024-02-02"),
+    },
+  ];
+
+  const runTwr = async (currencyCode: string, latestRate: number | null) => {
+    const txRepo = { find: jest.fn().mockResolvedValue(buys(currencyCode)) };
+    const service = buildService([[InvestmentTransaction, txRepo]], {
+      getLatestRate: jest.fn().mockResolvedValue(latestRate),
+    });
+    jest.spyOn(service, "getAllPricesForSecurities").mockResolvedValue(
+      new Map([
+        [
+          "sec-a",
+          [
+            { date: "2024-01-02", price: 10 },
+            { date: "2024-02-02", price: 12 },
+          ],
+        ],
+      ]),
+    );
+    return service.calculateTWR(
+      userId,
+      ["acct-1"],
+      "USD",
+      new Map(),
+      async () => new Map([["sec-a", 15]]),
+    );
+  };
+
+  it("computes a chained return when every period value converts", async () => {
+    const twr = await runTwr("USD", 1);
+
+    // 100 -> 120 at the second buy (factor 1.2), 240 -> 300 today (1.25):
+    // chained (1.2 * 1.25) - 1 = 50%.
+    expect(twr).toBeCloseTo(50, 5);
+  });
+
+  it("returns null when a period value omitted an unconvertible position", async () => {
+    // EUR security, USD reporting, no EUR->USD rate. Every period value is
+    // then a knownSubtotal that silently omitted the position, and unlike the
+    // summary's totals the chained ratio carries no missingRatePairs field a
+    // consumer could check -- so the only honest answer is unknown, the same
+    // treatment CAGR gets from its completeness gate.
+    const twr = await runTwr("EUR", null);
+
+    expect(twr).toBeNull();
   });
 });

--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { DataSource, FindOptionsWhere, In, LessThanOrEqual } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
 import { Holding } from "./entities/holding.entity";
@@ -18,6 +18,7 @@ import { parseTag } from "../tags/tag-key-value.util";
 import { formatDateYMD, formatDateYMDLocal } from "../common/date-utils";
 import { mapWithConcurrency } from "../common/concurrency.util";
 import { convertWithRateLookup } from "../common/currency-conversion.util";
+import { FxAggregate } from "../common/fx-aggregate";
 import { stripBrokerageSuffix } from "../accounts/account-name.util";
 
 // "As of now" portfolio valuations fetch a live spot rate per foreign
@@ -80,6 +81,14 @@ export interface ReplayedLot {
 export type DailyRateIndex = Map<string, Array<{ date: string; rate: number }>>;
 
 /**
+ * Per-request spot-rate cache keyed `"FROM->TO"`. `null` is a cached *absence*:
+ * the pair was looked up and has no usable rate, so later conversions in the
+ * same request return unknown immediately instead of re-running the lookups
+ * and re-logging the warning per holding.
+ */
+export type FxRateCache = Map<string, number | null>;
+
+/**
  * Categorised investment accounts: brokerage, standalone, and cash accounts
  * with pre-computed holdings account IDs.
  */
@@ -136,13 +145,23 @@ export interface CapitalGainEntry {
   securityCurrencyCode: string | null;
   startQuantity: number;
   endQuantity: number;
-  startValue: number;
-  endValue: number;
+  /**
+   * Period-boundary market values in the account's currency, and the gains
+   * derived from them.
+   *
+   * `null` when the security's currency could not be converted into the
+   * account's -- the position's value at each boundary is then unknown, so a
+   * gain measured between them is too. `buys`, `sells` and `realizedGain` stay
+   * known: they come from the exchange rate stored on each transaction, not
+   * from a current-rate lookup.
+   */
+  startValue: number | null;
+  endValue: number | null;
   buys: number;
   sells: number;
   realizedGain: number;
-  unrealizedGain: number;
-  totalCapitalGain: number;
+  unrealizedGain: number | null;
+  totalCapitalGain: number | null;
 }
 
 /**
@@ -288,6 +307,8 @@ function applyTxToState(
  */
 @Injectable()
 export class PortfolioCalculationService {
+  private readonly logger = new Logger(PortfolioCalculationService.name);
+
   constructor(
     private dataSource: DataSource,
     private exchangeRateService: ExchangeRateService,
@@ -298,16 +319,30 @@ export class PortfolioCalculationService {
   // ---------------------------------------------------------------------------
 
   /**
-   * Convert an amount from one currency to another using latest exchange rates.
-   * Returns the original amount if no rate is found or currencies match.
+   * Convert an amount from one currency to another using the latest exchange
+   * rates. Returns `null` when no rate exists for the pair.
+   *
+   * `null`, not the amount unchanged: this used to fall back to `rate = 1`,
+   * which reported 1,000 USD as 1,000 EUR and gave a consumer no way to tell
+   * that from a genuine 1:1 pair (audit P5-009). Rate 1 is now reachable only
+   * when the two currency codes are equal. Callers accumulate through
+   * `FxAggregate` so a missing rate makes the total unknown rather than wrong;
+   * see `docs/specs/fx-conversion-completeness.md`.
    */
   async convertToDefault(
     amount: number,
     fromCurrency: string,
     defaultCurrency: string,
-    rateCache: Map<string, number>,
-  ): Promise<number> {
+    rateCache: FxRateCache,
+  ): Promise<number | null> {
     if (fromCurrency === defaultCurrency) return amount;
+
+    // Zero converts to zero at any rate, so it needs none. Without this an empty
+    // foreign account -- no cash, no holdings, nothing invested -- reported its
+    // own currency as an unresolvable pair and made the whole portfolio's totals
+    // "unknown", which is the other half of the contract's missing-data rule: a
+    // settled question must not be reported as one that could not be worked out.
+    if (amount === 0) return 0;
 
     const cacheKey = `${fromCurrency}->${defaultCurrency}`;
     let rate = rateCache.get(cacheKey);
@@ -316,17 +351,29 @@ export class PortfolioCalculationService {
         fromCurrency,
         defaultCurrency,
       );
-      if (directRate !== null) {
+      if (directRate !== null && directRate > 0) {
         rate = directRate;
       } else {
         const reverseRate = await this.exchangeRateService.getLatestRate(
           defaultCurrency,
           fromCurrency,
         );
-        rate = reverseRate !== null ? 1 / reverseRate : 1;
+        if (reverseRate === null || reverseRate <= 0) {
+          // The absence is cached too (`null`), so a portfolio with many
+          // holdings in one unrated currency resolves the pair once per
+          // request instead of re-running both lookups and re-warning per
+          // holding -- the warn below is therefore once per pair per cache.
+          this.logger.warn(
+            `No exchange rate available for ${cacheKey}; the affected total is reported as unknown rather than converted 1:1`,
+          );
+          rateCache.set(cacheKey, null);
+          return null;
+        }
+        rate = 1 / reverseRate;
       }
       rateCache.set(cacheKey, rate);
     }
+    if (rate === null) return null;
     return amount * rate;
   }
 
@@ -343,7 +390,7 @@ export class PortfolioCalculationService {
    * the stored daily rate (its existing behaviour).
    */
   async primeLiveRates(
-    rateCache: Map<string, number>,
+    rateCache: FxRateCache,
     accounts: Account[],
     holdingsAccountIds: string[],
     defaultCurrency: string,
@@ -547,19 +594,40 @@ export class PortfolioCalculationService {
     accounts: Account[],
     effectiveBalances: Map<string, number>,
     defaultCurrency: string,
-    rateCache: Map<string, number>,
-  ): Promise<number> {
-    let totalCashValue = 0;
+    rateCache: FxRateCache,
+  ): Promise<{
+    total: number;
+    fxComplete: boolean;
+    missingRatePairs: string[];
+  }> {
+    const cash = new FxAggregate();
     for (const a of accounts) {
       const balance = effectiveBalances.get(a.id) ?? Number(a.currentBalance);
-      totalCashValue += await this.convertToDefault(
-        balance,
+      cash.add(
+        await this.convertToDefault(
+          balance,
+          a.currencyCode,
+          defaultCurrency,
+          rateCache,
+        ),
         a.currencyCode,
         defaultCurrency,
-        rateCache,
       );
     }
-    return totalCashValue;
+    // The gap is returned, not only logged. A log is invisible to the API and to
+    // every consumer downstream, so a caller had no way to tell this subtotal
+    // from a complete total -- which is how an incomplete cash figure reached a
+    // Monte Carlo starting balance (review finding FR-005).
+    if (!cash.isComplete) {
+      this.logger.warn(
+        `Cash total omits balances with no exchange rate (${cash.missingPairs.join(", ")})`,
+      );
+    }
+    return {
+      total: cash.knownSubtotal,
+      fxComplete: cash.isComplete,
+      missingRatePairs: cash.missingPairs,
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -1365,18 +1433,22 @@ export class PortfolioCalculationService {
 
     // Cache FX rates: securityCurrency -> accountCurrency
     const fxCache = new Map<string, number>();
+    // `null` when the pair has no rate. This used to end `: 1`, valuing a
+    // foreign security's period start and end as though its currency were the
+    // account's (audit P5-009). Rate 1 only when the codes are equal.
     const fxRate = async (
       from: string | null,
       to: string | null,
-    ): Promise<number> => {
+    ): Promise<number | null> => {
       if (!from || !to || from === to) return 1;
       const cacheKey = `${from}->${to}`;
       const cached = fxCache.get(cacheKey);
       if (cached !== undefined) return cached;
       let rate = await this.exchangeRateService.getLatestRate(from, to);
-      if (rate === null) {
+      if (rate === null || rate <= 0) {
         const reverse = await this.exchangeRateService.getLatestRate(to, from);
-        rate = reverse !== null ? 1 / reverse : 1;
+        if (reverse === null || reverse <= 0) return null;
+        rate = 1 / reverse;
       }
       fxCache.set(cacheKey, rate);
       return rate;
@@ -1406,7 +1478,13 @@ export class PortfolioCalculationService {
         const startQuantity = state.quantity;
         const startPrice =
           this.lookupPrice(group.securityId, priceLookupStart, allPrices) ?? 0;
-        const startValue = startQuantity * startPrice * securityToAccountFx;
+        // A period whose security currency cannot be converted into the
+        // account's has no knowable start or end value; the rate is 1 only when
+        // the two currencies are the same.
+        const startValue =
+          securityToAccountFx === null
+            ? null
+            : startQuantity * startPrice * securityToAccountFx;
 
         let buys = 0;
         let sells = 0;
@@ -1465,10 +1543,19 @@ export class PortfolioCalculationService {
         const endQuantity = state.quantity;
         const endPrice =
           this.lookupPrice(group.securityId, periodEnd, allPrices) ?? 0;
-        const endValue = endQuantity * endPrice * securityToAccountFx;
+        const endValue =
+          securityToAccountFx === null
+            ? null
+            : endQuantity * endPrice * securityToAccountFx;
 
-        const totalCapitalGain = endValue - startValue + sells - buys;
-        const unrealizedGain = totalCapitalGain - realizedGain;
+        // Unknown boundary values make the capital gain unknown rather than
+        // making it equal to the cash movements.
+        const totalCapitalGain =
+          startValue === null || endValue === null
+            ? null
+            : endValue - startValue + sells - buys;
+        const unrealizedGain =
+          totalCapitalGain === null ? null : totalCapitalGain - realizedGain;
 
         const hasActivity =
           buys !== 0 ||
@@ -1480,6 +1567,8 @@ export class PortfolioCalculationService {
 
         // Suppress vanishingly small float drift to keep the chart clean.
         const round = (n: number) => (Math.abs(n) < 0.005 ? 0 : roundMoney(n));
+        const roundOrNull = (n: number | null) =>
+          n === null ? null : round(n);
 
         results.push({
           month: periodKey,
@@ -1492,13 +1581,13 @@ export class PortfolioCalculationService {
           securityCurrencyCode: group.securityCurrencyCode,
           startQuantity,
           endQuantity,
-          startValue: round(startValue),
-          endValue: round(endValue),
+          startValue: roundOrNull(startValue),
+          endValue: roundOrNull(endValue),
           buys: round(buys),
           sells: round(sells),
           realizedGain: round(realizedGain),
-          unrealizedGain: round(unrealizedGain),
-          totalCapitalGain: round(totalCapitalGain),
+          unrealizedGain: roundOrNull(unrealizedGain),
+          totalCapitalGain: roundOrNull(totalCapitalGain),
         });
       }
     }
@@ -1523,13 +1612,35 @@ export class PortfolioCalculationService {
     userId: string,
     holdingsAccountIds: string[],
     defaultCurrency: string,
-    rateCache: Map<string, number>,
+    rateCache: FxRateCache,
     getLatestPrices: (securityIds: string[]) => Promise<Map<string, number>>,
   ): Promise<{
     holdings: Holding[];
     holdingsWithValues: HoldingWithMarketValue[];
     totalCostBasis: number;
     totalHoldingsValue: number;
+    /**
+     * False when a holding could not be converted into the reporting currency,
+     * which makes the two totals above subtotals of what did convert. A missing
+     * rate used to be applied as 1:1 (audit P5-009); see
+     * docs/specs/fx-conversion-completeness.md.
+     */
+    fxComplete: boolean;
+    missingRatePairs: string[];
+    /**
+     * False when a held position has no current price.
+     *
+     * A separate dimension from `fxComplete`, and it was missing entirely: an
+     * unpriced holding was skipped out of `holdingsValueTotal` without recording a
+     * gap, so a portfolio holding 10 priced shares and 5 unpriced ones reported a
+     * confident `totalHoldingsValue` of the priced 100 with `fxComplete: true` --
+     * a subtotal under a total's name, which section 1 of the financial
+     * calculation contract exists to forbid (recheck RR3-004). Unknown is not
+     * absent and not zero.
+     */
+    pricesComplete: boolean;
+    /** Securities held in a non-zero quantity with no current price. */
+    unpricedSecurityIds: string[];
   }> {
     let holdings: Holding[] = [];
     if (holdingsAccountIds.length > 0) {
@@ -1566,8 +1677,9 @@ export class PortfolioCalculationService {
       ),
     );
 
-    let totalCostBasis = 0;
-    let totalHoldingsValue = 0;
+    const costBasisTotal = new FxAggregate();
+    const holdingsValueTotal = new FxAggregate();
+    const unpricedSecurityIds = new Set<string>();
     const holdingsWithValues: HoldingWithMarketValue[] = [];
 
     for (const h of holdings) {
@@ -1596,7 +1708,11 @@ export class PortfolioCalculationService {
       // application's other answer for those, and it is at least an answer
       // about this holding in this currency.
       const historicalKey = `${h.accountId}:${h.securityId}`;
-      let costBasisAccountCurrency = historicalCostBasis.get(historicalKey);
+      // `null` when the holding's basis currency has no rate into the account
+      // currency: unknown, not "the same number". The row carries the null so a
+      // consumer sees an unavailable basis instead of an unconverted one.
+      let costBasisAccountCurrency: number | null | undefined =
+        historicalCostBasis.get(historicalKey);
       if (costBasisAccountCurrency === undefined) {
         costBasisAccountCurrency = await this.convertToDefault(
           costBasis,
@@ -1606,19 +1722,40 @@ export class PortfolioCalculationService {
         );
       }
 
-      totalCostBasis += await this.convertToDefault(
-        costBasisAccountCurrency,
-        accountCurrency,
-        defaultCurrency,
-        rateCache,
-      );
+      if (costBasisAccountCurrency === null) {
+        // The conversion that failed is holding -> account; record that pair.
+        // Filing it under account -> default named a hop that was never
+        // attempted -- possibly a pair with a perfectly good rate, or the
+        // degenerate `JPY->JPY` -- so the report told the user to fix a rate
+        // that was not missing while never naming the one that was.
+        costBasisTotal.add(null, holdingCurrency, accountCurrency);
+      } else {
+        costBasisTotal.add(
+          await this.convertToDefault(
+            costBasisAccountCurrency,
+            accountCurrency,
+            defaultCurrency,
+            rateCache,
+          ),
+          accountCurrency,
+          defaultCurrency,
+        );
+      }
       if (marketValue !== null) {
-        totalHoldingsValue += await this.convertToDefault(
-          marketValue,
+        holdingsValueTotal.add(
+          await this.convertToDefault(
+            marketValue,
+            holdingCurrency,
+            defaultCurrency,
+            rateCache,
+          ),
           holdingCurrency,
           defaultCurrency,
-          rateCache,
         );
+      } else {
+        // The position is held and its value is unknown. Recorded rather than
+        // silently dropped, so the total can say it is a subtotal.
+        unpricedSecurityIds.add(h.securityId);
       }
 
       holdingsWithValues.push({
@@ -1640,7 +1777,33 @@ export class PortfolioCalculationService {
       });
     }
 
-    return { holdings, holdingsWithValues, totalCostBasis, totalHoldingsValue };
+    const missingRatePairs = [
+      ...new Set([
+        ...costBasisTotal.missingPairs,
+        ...holdingsValueTotal.missingPairs,
+      ]),
+    ].sort();
+    if (missingRatePairs.length > 0) {
+      this.logger.warn(
+        `Portfolio totals omit holdings with no exchange rate (${missingRatePairs.join(", ")}); the returned totals are subtotals`,
+      );
+    }
+    if (unpricedSecurityIds.size > 0) {
+      this.logger.warn(
+        `Portfolio totals omit ${unpricedSecurityIds.size} held position(s) with no current price; the returned totals are subtotals`,
+      );
+    }
+
+    return {
+      holdings,
+      holdingsWithValues,
+      totalCostBasis: costBasisTotal.knownSubtotal,
+      totalHoldingsValue: holdingsValueTotal.knownSubtotal,
+      fxComplete: missingRatePairs.length === 0,
+      missingRatePairs,
+      pricesComplete: unpricedSecurityIds.size === 0,
+      unpricedSecurityIds: [...unpricedSecurityIds].sort(),
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -1665,6 +1828,101 @@ export class PortfolioCalculationService {
    * Group enriched holdings by account, attaching cash balances and net-invested
    * figures. Returns an array of AccountHoldings sorted by total market value.
    */
+  /**
+   * Cost basis, market value and gain for one account, in that account's own
+   * currency, with the completeness of each component.
+   *
+   * Written once and called from both the brokerage and standalone loops: the two
+   * had the identical fold with a different currency variable, and the account-level
+   * completeness fix would otherwise have gone into one of them (recheck RR3-005,
+   * and the repo's rule that a predicate deciding which row counts is written once).
+   *
+   * The gaps are returned rather than only logged. The top-level totals convert each
+   * security straight into the user's default currency, which is a *different*
+   * conversion path -- so a portfolio can be complete at the top while a JPY
+   * account's own total is missing EUR->JPY entirely, and a consumer reading the
+   * nested figure has no way to know from the global flag.
+   */
+  private async accountTotals(
+    accountHoldings: HoldingWithMarketValue[],
+    accountCurrency: string,
+    rateCache: FxRateCache,
+  ): Promise<{
+    totalCostBasis: number;
+    totalMarketValue: number;
+    totalGainLoss: number;
+    totalGainLossPercent: number;
+    fxComplete: boolean;
+    missingRatePairs: string[];
+    pricesComplete: boolean;
+    unpricedSecurityIds: string[];
+    unpricedHoldingsCount: number;
+    valuationComplete: boolean;
+  }> {
+    const costBasisAgg = new FxAggregate();
+    const marketValueAgg = new FxAggregate();
+    const unpriced = new Set<string>();
+    let unpricedHoldingsCount = 0;
+
+    for (const h of accountHoldings) {
+      // A holding whose basis could not be denominated in this account's currency
+      // is recorded as a gap, not added as though it already were.
+      costBasisAgg.add(
+        h.costBasisAccountCurrency,
+        h.currencyCode,
+        accountCurrency,
+      );
+      // An unpriced holding is unknown, not zero: `?? 0` folded it in as free and
+      // the account total then read like a complete valuation of a position nobody
+      // could value.
+      if (h.marketValue === null) {
+        unpriced.add(h.securityId);
+        unpricedHoldingsCount += 1;
+        continue;
+      }
+      marketValueAgg.add(
+        await this.convertToDefault(
+          h.marketValue,
+          h.currencyCode,
+          accountCurrency,
+          rateCache,
+        ),
+        h.currencyCode,
+        accountCurrency,
+      );
+    }
+
+    const missingRatePairs = [
+      ...new Set([
+        ...costBasisAgg.missingPairs,
+        ...marketValueAgg.missingPairs,
+      ]),
+    ].sort();
+    if (missingRatePairs.length > 0) {
+      this.logger.warn(
+        `Account totals omit holdings with no exchange rate (${missingRatePairs.join(", ")}); the returned totals and gain are subtotals`,
+      );
+    }
+
+    const totalCostBasis = costBasisAgg.knownSubtotal;
+    const totalMarketValue = marketValueAgg.knownSubtotal;
+    const totalGainLoss = totalMarketValue - totalCostBasis;
+
+    return {
+      totalCostBasis,
+      totalMarketValue,
+      totalGainLoss,
+      totalGainLossPercent:
+        totalCostBasis > 0 ? (totalGainLoss / totalCostBasis) * 100 : 0,
+      fxComplete: missingRatePairs.length === 0,
+      missingRatePairs,
+      pricesComplete: unpriced.size === 0,
+      unpricedSecurityIds: [...unpriced].sort(),
+      unpricedHoldingsCount,
+      valuationComplete: missingRatePairs.length === 0 && unpriced.size === 0,
+    };
+  }
+
   async buildHoldingsByAccount(
     categorised: CategorisedAccounts,
     holdingsWithValues: HoldingWithMarketValue[],
@@ -1673,7 +1931,7 @@ export class PortfolioCalculationService {
       string,
       { buys: number; sells: number; income: number }
     >,
-    rateCache: Map<string, number>,
+    rateCache: FxRateCache,
   ): Promise<AccountHoldings[]> {
     // Group holdings by account
     const holdingsByAccountMap = new Map<string, HoldingWithMarketValue[]>();
@@ -1701,23 +1959,11 @@ export class PortfolioCalculationService {
       // exchange rate from each originating transaction, while market value
       // uses the current exchange rate so unrealised gains reflect today's
       // valuation vs. the price actually paid when shares were bought.
-      const acctCurrency = brokerageAccount.currencyCode;
-      let accountCostBasis = 0;
-      let accountMarketValue = 0;
-      let unpricedHoldingsCount = 0;
-      for (const h of accountHoldings) {
-        accountCostBasis += h.costBasisAccountCurrency;
-        if (h.marketValue === null) unpricedHoldingsCount += 1;
-        accountMarketValue += await this.convertToDefault(
-          h.marketValue ?? 0,
-          h.currencyCode,
-          acctCurrency,
-          rateCache,
-        );
-      }
-      const accountGainLoss = accountMarketValue - accountCostBasis;
-      const accountGainLossPercent =
-        accountCostBasis > 0 ? (accountGainLoss / accountCostBasis) * 100 : 0;
+      const acctTotals = await this.accountTotals(
+        accountHoldings,
+        brokerageAccount.currencyCode,
+        rateCache,
+      );
 
       // Get display name (remove the localized " - Brokerage" suffix if present)
       const accountName = stripBrokerageSuffix(brokerageAccount.name);
@@ -1741,11 +1987,16 @@ export class PortfolioCalculationService {
         cashAccountId: linkedCashAccount?.id ?? null,
         cashBalance,
         holdings: this.sortHoldings(accountHoldings),
-        totalCostBasis: accountCostBasis,
-        totalMarketValue: accountMarketValue,
-        unpricedHoldingsCount,
-        totalGainLoss: accountGainLoss,
-        totalGainLossPercent: accountGainLossPercent,
+        totalCostBasis: acctTotals.totalCostBasis,
+        totalMarketValue: acctTotals.totalMarketValue,
+        unpricedHoldingsCount: acctTotals.unpricedHoldingsCount,
+        totalGainLoss: acctTotals.totalGainLoss,
+        totalGainLossPercent: acctTotals.totalGainLossPercent,
+        fxComplete: acctTotals.fxComplete,
+        missingRatePairs: acctTotals.missingRatePairs,
+        pricesComplete: acctTotals.pricesComplete,
+        unpricedSecurityIds: acctTotals.unpricedSecurityIds,
+        valuationComplete: acctTotals.valuationComplete,
         netInvested: roundMoney(accountNetInvested),
       });
     }
@@ -1757,23 +2008,11 @@ export class PortfolioCalculationService {
 
       // Calculate account totals — historical cost basis + current-rate
       // market value, same treatment as brokerage accounts above.
-      const standaloneCurrency = standaloneAccount.currencyCode;
-      let accountCostBasis = 0;
-      let accountMarketValue = 0;
-      let unpricedHoldingsCount = 0;
-      for (const h of accountHoldings) {
-        accountCostBasis += h.costBasisAccountCurrency;
-        if (h.marketValue === null) unpricedHoldingsCount += 1;
-        accountMarketValue += await this.convertToDefault(
-          h.marketValue ?? 0,
-          h.currencyCode,
-          standaloneCurrency,
-          rateCache,
-        );
-      }
-      const accountGainLoss = accountMarketValue - accountCostBasis;
-      const accountGainLossPercent =
-        accountCostBasis > 0 ? (accountGainLoss / accountCostBasis) * 100 : 0;
+      const acctTotals = await this.accountTotals(
+        accountHoldings,
+        standaloneAccount.currencyCode,
+        rateCache,
+      );
 
       const standaloneCashBalance =
         effectiveBalances.get(standaloneAccount.id) ??
@@ -1796,11 +2035,16 @@ export class PortfolioCalculationService {
         cashAccountId: standaloneAccount.id, // Cash is on this same account
         cashBalance: standaloneCashBalance,
         holdings: this.sortHoldings(accountHoldings),
-        totalCostBasis: accountCostBasis,
-        totalMarketValue: accountMarketValue,
-        unpricedHoldingsCount,
-        totalGainLoss: accountGainLoss,
-        totalGainLossPercent: accountGainLossPercent,
+        totalCostBasis: acctTotals.totalCostBasis,
+        totalMarketValue: acctTotals.totalMarketValue,
+        unpricedHoldingsCount: acctTotals.unpricedHoldingsCount,
+        totalGainLoss: acctTotals.totalGainLoss,
+        totalGainLossPercent: acctTotals.totalGainLossPercent,
+        fxComplete: acctTotals.fxComplete,
+        missingRatePairs: acctTotals.missingRatePairs,
+        pricesComplete: acctTotals.pricesComplete,
+        unpricedSecurityIds: acctTotals.unpricedSecurityIds,
+        valuationComplete: acctTotals.valuationComplete,
         netInvested: roundMoney(standaloneNetInvested),
       });
     }
@@ -1823,7 +2067,7 @@ export class PortfolioCalculationService {
     holdings: Holding[],
     totalCashValue: number,
     defaultCurrency: string,
-    rateCache: Map<string, number>,
+    rateCache: FxRateCache,
   ): Promise<AllocationItem[]> {
     const allocation: AllocationItem[] = [];
     const colors = [
@@ -1860,6 +2104,10 @@ export class PortfolioCalculationService {
         defaultCurrency,
         rateCache,
       );
+      // A holding with no rate into the reporting currency cannot be ranked
+      // against the others; omitting it is honest, entering it at 1:1 would put
+      // it in the wrong place in the list.
+      if (convertedValue === null) continue;
       const existing = consolidated.get(holding.securityId);
       if (existing) {
         existing.value += convertedValue;
@@ -2304,7 +2552,7 @@ export class PortfolioCalculationService {
     userId: string,
     holdingsAccountIds: string[],
     defaultCurrency: string,
-    rateCache: Map<string, number>,
+    rateCache: FxRateCache,
     getLatestPrices: (securityIds: string[]) => Promise<Map<string, number>>,
   ): Promise<number | null> {
     if (holdingsAccountIds.length === 0) return null;
@@ -2352,25 +2600,43 @@ export class PortfolioCalculationService {
     // M16: Batch-fetch all latest prices once to avoid N+1 queries
     const latestPriceCache = await getLatestPrices(securityIds);
 
+    // TWR chains period-over-period factors, so one period value missing an
+    // unconvertible position poisons every factor after it -- and unlike the
+    // summary's totals, the ratio carries no missingRatePairs field a consumer
+    // could check. When any period value had an FX gap the chained return is a
+    // return on a portfolio nobody owns: unknown, not approximated, the same
+    // treatment CAGR gets from its completeness gate.
+    let fxIncomplete = false;
+
     // Helper: compute portfolio value from holdings state (current prices)
     const computeValue = async (
       holdings: Map<string, number>,
     ): Promise<number> => {
-      let total = 0;
+      const value = new FxAggregate();
       for (const [secId, qty] of holdings) {
         if (qty === 0) continue;
         const price = latestPriceCache.get(secId);
         if (price != null) {
           const currency = currencyMap.get(secId) || defaultCurrency;
-          total += await this.convertToDefault(
-            qty * price,
+          value.add(
+            await this.convertToDefault(
+              qty * price,
+              currency,
+              defaultCurrency,
+              rateCache,
+            ),
             currency,
             defaultCurrency,
-            rateCache,
           );
         }
       }
-      return total;
+      if (!value.isComplete) {
+        this.logger.warn(
+          `Portfolio value omits positions with no exchange rate (${value.missingPairs.join(", ")})`,
+        );
+        fxIncomplete = true;
+      }
+      return value.knownSubtotal;
     };
 
     // Helper: compute portfolio value from holdings state at a specific date
@@ -2378,21 +2644,31 @@ export class PortfolioCalculationService {
       holdings: Map<string, number>,
       date: string,
     ): Promise<number> => {
-      let total = 0;
+      const value = new FxAggregate();
       for (const [secId, qty] of holdings) {
         if (qty === 0) continue;
         const price = this.lookupPrice(secId, date, allPrices);
         if (price != null) {
           const currency = currencyMap.get(secId) || defaultCurrency;
-          total += await this.convertToDefault(
-            qty * price,
+          value.add(
+            await this.convertToDefault(
+              qty * price,
+              currency,
+              defaultCurrency,
+              rateCache,
+            ),
             currency,
             defaultCurrency,
-            rateCache,
           );
         }
       }
-      return total;
+      if (!value.isComplete) {
+        this.logger.warn(
+          `Portfolio value at ${date} omits positions with no exchange rate (${value.missingPairs.join(", ")})`,
+        );
+        fxIncomplete = true;
+      }
+      return value.knownSubtotal;
     };
 
     // Forward-simulate holdings and chain sub-period returns
@@ -2448,6 +2724,9 @@ export class PortfolioCalculationService {
     }
 
     if (subPeriodFactors.length === 0) return null;
+
+    // A factor chain built over an FX gap is not a return; see fxIncomplete.
+    if (fxIncomplete) return null;
 
     // Chain: TWR = product of all factors - 1
     let product = 1;

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -822,7 +822,7 @@ describe("PortfolioService", () => {
         expect(result.totalHoldingsValue).toBeCloseTo(expectedHoldingsValue, 2);
       });
 
-      it("uses rate of 1 when neither direct nor reverse rate available", async () => {
+      it("omits a holding it cannot convert instead of using a rate of 1", async () => {
         prefRepository.findOne.mockResolvedValue(mockPref);
         accountsRepository.find.mockResolvedValue([
           mockBrokerageAccount,
@@ -841,8 +841,11 @@ describe("PortfolioService", () => {
 
         const result = await service.getPortfolioSummary(userId);
 
-        // Falls back to rate of 1, so USD values treated as-is
-        expect(result.totalHoldingsValue).toBe(10 * 175);
+        // A USD holding with no USD->CAD rate is NOT reported as though 1 USD
+        // were 1 CAD (audit P5-009). This assertion previously read
+        // `toBe(10 * 175)` under the name "uses rate of 1 ...", documenting the
+        // defect as intended behaviour.
+        expect(result.totalHoldingsValue).toBe(0);
       });
 
       it("caches exchange rates for repeated conversions", async () => {
@@ -1382,6 +1385,174 @@ describe("PortfolioService", () => {
     });
   });
 
+  describe("FX completeness covers every returned total", () => {
+    it("marks the summary incomplete when only net invested cannot convert (RR2-005)", async () => {
+      // A EUR brokerage account with no linked cash account and no holdings, so
+      // the cash and holdings aggregates never touch EUR -- but its investment
+      // flows give it a non-zero `netInvested`, which is denominated in the
+      // brokerage account's currency. `netInvestedAgg`'s gap was only logged, so
+      // the response carried a net-invested subtotal of 0 under
+      // `fxComplete: true` and fed it to CAGR as a complete denominator.
+      prefRepository.findOne.mockResolvedValue(mockPref);
+      accountsRepository.find.mockResolvedValue([
+        {
+          ...mockBrokerageAccount,
+          id: "acct-eur",
+          name: "Europe - Brokerage",
+          currencyCode: "EUR",
+          linkedAccountId: null,
+        },
+      ]);
+      holdingsRepository.find.mockResolvedValue([]);
+      securityPriceRepository.query.mockResolvedValue([]);
+      // The investment-flows aggregate: 1,000 EUR of buys, nothing sold.
+      accountsRepository.query.mockImplementation(async (sql: string) =>
+        /investment_transactions/.test(sql)
+          ? [
+              {
+                account_id: "acct-eur",
+                buys: "1000",
+                sells: "0",
+                income: "0",
+              },
+            ]
+          : [],
+      );
+      // No EUR->CAD rate in either direction.
+      exchangeRateService.getLatestRate.mockResolvedValue(null);
+
+      const result = await service.getPortfolioSummary(userId);
+
+      expect(result.missingRatePairs).toContain("EUR->CAD");
+      expect(result.fxComplete).toBe(false);
+      // Growth over an unknown amount invested is not a growth rate.
+      expect(result.cagr).toBeNull();
+    });
+
+    it("marks the valuation incomplete when a held position has no price (RR3-004)", async () => {
+      // The unpriced holding was skipped out of the total with nothing recorded,
+      // so a portfolio holding one priced position and one unpriced one reported a
+      // confident total of the priced one with `fxComplete: true`. A subtotal under
+      // a total's name is what section 1 of the contract forbids -- and it seeded
+      // Monte Carlo.
+      prefRepository.findOne.mockResolvedValue(mockPref);
+      accountsRepository.find.mockResolvedValue([
+        mockBrokerageAccount,
+        mockCashAccount,
+      ]);
+      holdingsRepository.find.mockResolvedValue([
+        mockHoldingAAPL,
+        mockHoldingVFV,
+      ]);
+      // Only AAPL has a price; VFV has none.
+      securityPriceRepository.query.mockResolvedValue([
+        { security_id: "sec-1", close_price: "175", price_date: "2026-02-07" },
+      ]);
+      exchangeRateService.getLatestRate.mockImplementation(
+        (from: string, to: string) =>
+          Promise.resolve(from === "USD" && to === "CAD" ? 1.35 : null),
+      );
+
+      const result = await service.getPortfolioSummary(userId);
+
+      expect(result.pricesComplete).toBe(false);
+      expect(result.unpricedSecurityIds).toEqual(["sec-2"]);
+      // FX is fine; the valuation is not. Two causes, two flags, one gate.
+      expect(result.fxComplete).toBe(true);
+      expect(result.valuationComplete).toBe(false);
+      // Growth to an unknown value is not a growth rate.
+      expect(result.cagr).toBeNull();
+    });
+
+    it("stays complete when every held position is priced", async () => {
+      // The control: the price gate must not fire on a fully priced portfolio.
+      prefRepository.findOne.mockResolvedValue(mockPref);
+      accountsRepository.find.mockResolvedValue([
+        mockBrokerageAccount,
+        mockCashAccount,
+      ]);
+      holdingsRepository.find.mockResolvedValue([
+        mockHoldingAAPL,
+        mockHoldingVFV,
+      ]);
+      securityPriceRepository.query.mockResolvedValue([
+        { security_id: "sec-1", close_price: "175", price_date: "2026-02-07" },
+        { security_id: "sec-2", close_price: "95", price_date: "2026-02-07" },
+      ]);
+      exchangeRateService.getLatestRate.mockImplementation(
+        (from: string, to: string) =>
+          Promise.resolve(from === "USD" && to === "CAD" ? 1.35 : null),
+      );
+
+      const result = await service.getPortfolioSummary(userId);
+
+      expect(result.pricesComplete).toBe(true);
+      expect(result.unpricedSecurityIds).toEqual([]);
+      expect(result.valuationComplete).toBe(true);
+    });
+
+    it("reports a per-account gap the global flag cannot see (RR3-005)", async () => {
+      // The two conversions are different paths: the top-level total converts the
+      // security straight into the user's default currency, the account total
+      // converts it into the account's own. So a USD-reporting portfolio holding a
+      // USD security in a JPY account is complete at the top and missing USD->JPY
+      // underneath -- and that gap was only logged, leaving an account screen or an
+      // AI answer free to report a confident zero for the account.
+      prefRepository.findOne.mockResolvedValue(mockPref);
+      const jpyBrokerage = {
+        ...mockBrokerageAccount,
+        currencyCode: "JPY",
+        linkedAccountId: null,
+      };
+      accountsRepository.find.mockResolvedValue([jpyBrokerage]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+      securityPriceRepository.query.mockResolvedValue([
+        { security_id: "sec-1", close_price: "175", price_date: "2026-02-07" },
+      ]);
+      // USD converts into the reporting currency (CAD) but not into JPY.
+      exchangeRateService.getLatestRate.mockImplementation(
+        (from: string, to: string) =>
+          Promise.resolve(from === "USD" && to === "CAD" ? 1.35 : null),
+      );
+
+      const result = await service.getPortfolioSummary(userId);
+
+      // Complete at the top: every component of the CAD totals converted.
+      expect(result.fxComplete).toBe(true);
+      // Not complete for the account, whose totals are in JPY.
+      const account = result.holdingsByAccount[0];
+      expect(account.fxComplete).toBe(false);
+      expect(account.missingRatePairs).toContain("USD->JPY");
+      expect(account.valuationComplete).toBe(false);
+    });
+
+    it("stays complete for an empty foreign account with no rate", async () => {
+      // The control for the zero-conversion rule: an account holding nothing
+      // needs no rate, so it must not make the portfolio's totals unknown.
+      // "Nothing to report" and "could not be worked out" are different answers.
+      prefRepository.findOne.mockResolvedValue(mockPref);
+      accountsRepository.find.mockResolvedValue([
+        {
+          ...mockBrokerageAccount,
+          id: "acct-eur",
+          name: "Europe - Brokerage",
+          currencyCode: "EUR",
+          linkedAccountId: null,
+        },
+      ]);
+      holdingsRepository.find.mockResolvedValue([]);
+      securityPriceRepository.query.mockResolvedValue([]);
+      accountsRepository.query.mockResolvedValue([]);
+      exchangeRateService.getLatestRate.mockResolvedValue(null);
+
+      const result = await service.getPortfolioSummary(userId);
+
+      expect(result.missingRatePairs).toEqual([]);
+      expect(result.fxComplete).toBe(true);
+      expect(result.totalNetInvested).toBe(0);
+    });
+  });
+
   describe("getLlmSummary", () => {
     it("attaches the country and asset-class look-through when asked", async () => {
       jest.spyOn(service, "getPortfolioSummary").mockResolvedValue({
@@ -1392,6 +1563,11 @@ describe("PortfolioService", () => {
         totalPortfolioValue: 1000,
         totalGainLoss: 100,
         totalGainLossPercent: 11.11,
+        fxComplete: true,
+        missingRatePairs: [],
+        pricesComplete: true,
+        unpricedSecurityIds: [],
+        valuationComplete: true,
         timeWeightedReturn: null,
         cagr: null,
         holdings: [],
@@ -1431,6 +1607,11 @@ describe("PortfolioService", () => {
           totalPortfolioValue: 10000.6913,
           totalGainLoss: 900.5544,
           totalGainLossPercent: 10.123456,
+          fxComplete: true,
+          missingRatePairs: [],
+          pricesComplete: true,
+          unpricedSecurityIds: [],
+          valuationComplete: true,
           timeWeightedReturn: 8.56789,
           cagr: null,
           holdings: [
@@ -1511,6 +1692,11 @@ describe("PortfolioService", () => {
         totalPortfolioValue: 0,
         totalGainLoss: 0,
         totalGainLossPercent: 0,
+        fxComplete: true,
+        missingRatePairs: [],
+        pricesComplete: true,
+        unpricedSecurityIds: [],
+        valuationComplete: true,
         timeWeightedReturn: null,
         cagr: null,
         holdings: [],
@@ -1523,6 +1709,38 @@ describe("PortfolioService", () => {
       expect(spy).toHaveBeenCalledWith("user-1", ["acc-1", "acc-2"]);
     });
 
+    it("carries FX incompleteness across the LLM boundary (RR2-007)", async () => {
+      // The compact shape is what the AI Assistant and the MCP server hand to a
+      // model. It dropped `fxComplete` and `missingRatePairs`, so the same
+      // numeric subtotal the UI knew was partial was quoted to the user as a
+      // complete balance. A subtotal must not cross a consumer boundary under a
+      // `total*` name without its incompleteness.
+      jest.spyOn(service, "getPortfolioSummary").mockResolvedValue({
+        totalCashValue: 100,
+        totalHoldingsValue: 0,
+        totalCostBasis: 0,
+        totalNetInvested: 0,
+        totalPortfolioValue: 100,
+        totalGainLoss: 0,
+        totalGainLossPercent: 0,
+        fxComplete: false,
+        missingRatePairs: ["EUR->USD"],
+        pricesComplete: true,
+        unpricedSecurityIds: [],
+        valuationComplete: false,
+        timeWeightedReturn: null,
+        cagr: null,
+        holdings: [],
+        holdingsByAccount: [],
+        allocation: [],
+      });
+
+      const result = await service.getLlmSummary("user-1");
+
+      expect(result.fxComplete).toBe(false);
+      expect(result.missingRatePairs).toEqual(["EUR->USD"]);
+    });
+
     it("preserves null averageCost", async () => {
       jest.spyOn(service, "getPortfolioSummary").mockResolvedValue({
         totalCashValue: 0,
@@ -1532,6 +1750,11 @@ describe("PortfolioService", () => {
         totalPortfolioValue: 100,
         totalGainLoss: 0,
         totalGainLossPercent: 0,
+        fxComplete: true,
+        missingRatePairs: [],
+        pricesComplete: true,
+        unpricedSecurityIds: [],
+        valuationComplete: true,
         timeWeightedReturn: null,
         cagr: null,
         holdings: [
@@ -1573,6 +1796,11 @@ describe("PortfolioService", () => {
         totalPortfolioValue: 1800,
         totalGainLoss: 300,
         totalGainLossPercent: 20,
+        fxComplete: true,
+        missingRatePairs: [],
+        pricesComplete: true,
+        unpricedSecurityIds: [],
+        valuationComplete: true,
         timeWeightedReturn: null,
         cagr: null,
         holdings: [],
@@ -1608,6 +1836,13 @@ describe("PortfolioService", () => {
             totalGainLoss: 300.4444,
             totalGainLossPercent: 20.123456,
             netInvested: 1500,
+            // The real producer always sets these; a fixture without them is a row
+            // the service could not have built.
+            fxComplete: true,
+            missingRatePairs: [],
+            pricesComplete: true,
+            unpricedSecurityIds: [],
+            valuationComplete: true,
           },
         ],
         allocation: [],
@@ -3818,6 +4053,11 @@ describe("PortfolioService", () => {
         totalPortfolioValue: 200,
         totalGainLoss: 0,
         totalGainLossPercent: 0,
+        fxComplete: true,
+        missingRatePairs: [],
+        pricesComplete: true,
+        unpricedSecurityIds: [],
+        valuationComplete: true,
         timeWeightedReturn: null,
         cagr: null,
         holdings: [],

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -1,12 +1,14 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { DataSource, In } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
+import { FxAggregate } from "../common/fx-aggregate";
 import { Holding } from "./entities/holding.entity";
 import { Account, AccountType } from "../accounts/entities/account.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import {
   PortfolioCalculationService,
   DailyRateIndex,
+  FxRateCache,
 } from "./portfolio-calculation.service";
 import {
   SectorWeightingService,
@@ -67,8 +69,13 @@ export interface HoldingWithMarketValue {
    * historical exchange rates stored on the original BUY transactions.
    * When no transaction history is available, this falls back to a
    * current-rate conversion of `costBasis`.
+   *
+   * `null` when neither is possible because no exchange rate exists for the
+   * pair. It used to fall back to `costBasis` unconverted -- an implicit 1:1
+   * that a consumer could not tell from a real one (audit P5-009), and which
+   * fed a gain figure computed against a market value in a different currency.
    */
-  costBasisAccountCurrency: number;
+  costBasisAccountCurrency: number | null;
   currentPrice: number | null;
   marketValue: number | null;
   gainLoss: number | null;
@@ -98,6 +105,26 @@ export interface AccountHoldings {
   totalGainLoss: number;
   totalGainLossPercent: number;
   netInvested: number;
+  /**
+   * Completeness of *this account's* totals, which is a different question from
+   * the summary's.
+   *
+   * The top-level figures convert each security straight into the user's default
+   * currency; these convert it into the account's own currency. So a portfolio can
+   * be complete at the top while a JPY account's total is missing `EUR->JPY`
+   * entirely -- and before these fields existed that gap was only written to the
+   * log, leaving an account screen or an AI answer free to report a confident zero
+   * for an account whose holdings could not be converted (recheck RR3-005).
+   */
+  fxComplete: boolean;
+  /** `"EUR->JPY"` for each pair with no rate into this account's currency. */
+  missingRatePairs: string[];
+  /** False when a position held in this account has no current price. */
+  pricesComplete: boolean;
+  /** Securities held here in a non-zero quantity with no current price. */
+  unpricedSecurityIds: string[];
+  /** `fxComplete && pricesComplete` -- gate this account's totals on this. */
+  valuationComplete: boolean;
 }
 
 export interface PortfolioSummary {
@@ -110,6 +137,38 @@ export interface PortfolioSummary {
   totalGainLossPercent: number;
   timeWeightedReturn: number | null;
   cagr: number | null;
+  /**
+   * False when a component of these totals could not be converted into the
+   * reporting currency, which makes every `total*` field above a subtotal of what
+   * did convert.
+   *
+   * A consumer that treats a total as complete must check this first. Making the
+   * total fields themselves nullable is the end state and is staged -- see
+   * `docs/specs/fx-conversion-completeness.md` section 4a -- but the signal has
+   * to exist now, because without it an incomplete cash subtotal was accepted as
+   * a complete portfolio value by the simulation (review finding FR-005).
+   */
+  fxComplete: boolean;
+  /** `"EUR->USD"` for each pair with no available rate; empty when complete. */
+  missingRatePairs: string[];
+  /**
+   * False when a held position has no current price, which also makes every
+   * `total*` field above a subtotal.
+   *
+   * Separate from `fxComplete` because the two have different causes and different
+   * fixes -- a missing rate is a currencies problem, a missing price is a quotes
+   * problem -- and because `fxComplete` alone was already being consumed. A
+   * consumer deciding whether it may treat a total as a total wants
+   * `valuationComplete`, which is both.
+   */
+  pricesComplete: boolean;
+  /** Securities held in a non-zero quantity with no current price. */
+  unpricedSecurityIds: string[];
+  /**
+   * The single flag a consumer should gate a `total*` field on: every component of
+   * every total above is known. `fxComplete && pricesComplete`.
+   */
+  valuationComplete: boolean;
   holdings: HoldingWithMarketValue[];
   holdingsByAccount: AccountHoldings[];
   allocation: AllocationItem[]; // Include allocation to avoid duplicate API call
@@ -177,11 +236,38 @@ export interface LlmAccountHoldings {
   totalMarketValue: number;
   totalGainLoss: number;
   totalGainLossPercent: number;
+  /**
+   * This account's own completeness, carried for the same reason the top-level
+   * flags are: a model reading `totalMarketValue: 0` for a JPY account cannot
+   * otherwise tell "holds nothing" from "could not be converted into JPY", and the
+   * global flag answers a different question (recheck RR3-005).
+   */
+  fxComplete: boolean;
+  missingRatePairs: string[];
+  pricesComplete: boolean;
+  valuationComplete: boolean;
   holdings: LlmPortfolioHolding[];
 }
 
 export interface LlmPortfolioSummary {
   holdingCount: number;
+  /**
+   * Same meaning as `PortfolioSummary.fxComplete`, and present for the same
+   * reason: this shape is what the AI Assistant and the MCP server quote back to
+   * a user. Dropping the flag here let a model state a cash subtotal as a
+   * complete balance while the UI-facing summary knew it was not (recheck
+   * RR2-007). A subtotal must not cross a consumer boundary under a `total*`
+   * name without its incompleteness.
+   */
+  fxComplete: boolean;
+  /** `"EUR->USD"` for each pair with no available rate; empty when complete. */
+  missingRatePairs: string[];
+  /** False when a held position has no current price. */
+  pricesComplete: boolean;
+  /** Symbols held in a non-zero quantity with no current price. */
+  unpricedSymbols: string[];
+  /** `fxComplete && pricesComplete` -- gate a total on this one. */
+  valuationComplete: boolean;
   totalCashValue: number;
   totalHoldingsValue: number;
   totalCostBasis: number;
@@ -208,7 +294,15 @@ export interface LlmPortfolioSummary {
 interface IntradayFxSeries {
   times: number[];
   rates: number[];
-  latest: number;
+  /**
+   * Fallback rate for a bar the intraday and daily series do not cover.
+   *
+   * `null` when the pair has no rate at all -- distinct from a rate that
+   * happens to be 1. The intraday resolver used to fall back to a bare `1`,
+   * which valued a foreign holding at its face number and made the chart look
+   * right while being wrong by the whole FX difference (audit P5-009).
+   */
+  latest: number | null;
 }
 
 /**
@@ -258,7 +352,7 @@ interface IntradayLoaded {
   fxByCurrency: Map<string, IntradayFxSeries>;
   dailyRateIndex: DailyRateIndex;
   /** Latest spot rate per `${currency}->${display}` fallback. */
-  spotRate: Map<string, number>;
+  spotRate: FxRateCache;
 }
 
 interface IntradayCacheEntry {
@@ -412,7 +506,7 @@ export class PortfolioService {
       m.getRepository(UserPreference).findOne({ where: { userId } }),
     );
     const defaultCurrency = pref?.defaultCurrency || "CAD";
-    const rateCache = new Map<string, number>();
+    const rateCache: FxRateCache = new Map();
 
     // Get investment accounts
     const accounts = await this.resolveAccounts(userId, accountIds);
@@ -443,12 +537,13 @@ export class PortfolioService {
       );
 
     // Calculate total cash value (converted to default currency)
-    const totalCashValue = await this.calculationService.computeTotalCashValue(
+    const cashResult = await this.calculationService.computeTotalCashValue(
       [...categorised.cashAccounts, ...categorised.standaloneAccounts],
       effectiveBalances,
       defaultCurrency,
       rateCache,
     );
+    const totalCashValue = cashResult.total;
 
     // Compute per-account investment transaction sums for Net Invested
     const investmentFlows =
@@ -487,15 +582,25 @@ export class PortfolioService {
         : 0;
 
     // Calculate total net invested (converted to default currency)
-    let totalNetInvested = 0;
+    const netInvestedAgg = new FxAggregate();
     for (const acct of holdingsByAccount) {
-      totalNetInvested += await this.calculationService.convertToDefault(
-        acct.netInvested,
+      netInvestedAgg.add(
+        await this.calculationService.convertToDefault(
+          acct.netInvested,
+          acct.currencyCode,
+          defaultCurrency,
+          rateCache,
+        ),
         acct.currencyCode,
         defaultCurrency,
-        rateCache,
       );
     }
+    if (!netInvestedAgg.isComplete) {
+      this.logger.warn(
+        `Net invested omits accounts with no exchange rate (${netInvestedAgg.missingPairs.join(", ")})`,
+      );
+    }
+    const totalNetInvested = netInvestedAgg.knownSubtotal;
 
     // Sort holdings by market value
     const sortedHoldings = [...holdingsResult.holdingsWithValues].sort(
@@ -525,13 +630,43 @@ export class PortfolioService {
       (ids) => this.getLatestPrices(ids),
     );
 
-    // Calculate CAGR
-    const cagr = await this.calculationService.calculateCAGR(
-      userId,
-      categorised.holdingsAccountIds,
-      totalNetInvested,
-      totalPortfolioValue,
-    );
+    // CAGR divides the portfolio value by what was invested to get there, so an
+    // incomplete numerator or denominator produces a growth rate for a portfolio
+    // nobody owns: with one unconvertible EUR account, 100 USD of known net
+    // invested against a 210 USD true figure overstates the return by more than
+    // half, and an unpriced position understates the value it grew to. Unknown, not
+    // approximated.
+    const cagr =
+      netInvestedAgg.isComplete &&
+      holdingsResult.fxComplete &&
+      holdingsResult.pricesComplete &&
+      cashResult.fxComplete
+        ? await this.calculationService.calculateCAGR(
+            userId,
+            categorised.holdingsAccountIds,
+            totalNetInvested,
+            totalPortfolioValue,
+          )
+        : null;
+
+    // Whether every component of these totals could be converted into the
+    // reporting currency. A log entry is invisible to an API consumer, so the
+    // completeness state travels with the numbers: without it an incomplete cash
+    // subtotal reached a Monte Carlo starting balance and was treated as a
+    // complete portfolio value (review finding FR-005).
+    // Every aggregate that feeds a returned `total*` field contributes here.
+    // `netInvestedAgg` was left out and only logged, so a portfolio whose cash
+    // and holdings converted cleanly could still return an incomplete
+    // `totalNetInvested` under `fxComplete: true` -- and feed that subtotal to
+    // CAGR as a complete denominator (recheck RR2-005). The flag documents itself
+    // as covering every total above, so it has to.
+    const missingRatePairs = [
+      ...new Set([
+        ...cashResult.missingRatePairs,
+        ...holdingsResult.missingRatePairs,
+        ...netInvestedAgg.missingPairs,
+      ]),
+    ].sort();
 
     return {
       totalCashValue,
@@ -543,6 +678,12 @@ export class PortfolioService {
       totalGainLossPercent,
       timeWeightedReturn,
       cagr,
+      fxComplete: missingRatePairs.length === 0,
+      missingRatePairs,
+      pricesComplete: holdingsResult.pricesComplete,
+      unpricedSecurityIds: holdingsResult.unpricedSecurityIds,
+      valuationComplete:
+        missingRatePairs.length === 0 && holdingsResult.pricesComplete,
       holdings: sortedHoldings,
       holdingsByAccount,
       allocation,
@@ -601,6 +742,10 @@ export class PortfolioService {
         totalMarketValue: roundMoneyValue(acct.totalMarketValue),
         totalGainLoss: roundMoneyValue(acct.totalGainLoss),
         totalGainLossPercent: roundPct(acct.totalGainLossPercent) ?? 0,
+        fxComplete: acct.fxComplete,
+        missingRatePairs: acct.missingRatePairs,
+        pricesComplete: acct.pricesComplete,
+        valuationComplete: acct.valuationComplete,
         holdings: acct.holdings.map(toLlmHolding),
       }));
 
@@ -624,6 +769,18 @@ export class PortfolioService {
       totalGainLossPercent: roundPct(summary.totalGainLossPercent) ?? 0,
       timeWeightedReturn: roundPct(summary.timeWeightedReturn),
       cagr: roundPct(summary.cagr),
+      fxComplete: summary.fxComplete,
+      missingRatePairs: summary.missingRatePairs,
+      pricesComplete: summary.pricesComplete,
+      // Symbols rather than ids: an id means nothing to a model or a reader.
+      unpricedSymbols: summary.unpricedSecurityIds
+        .map(
+          (id) =>
+            summary.holdings.find((holding) => holding.securityId === id)
+              ?.symbol ?? id,
+        )
+        .sort(),
+      valuationComplete: summary.valuationComplete,
       holdings,
       holdingsByAccount,
       allocation,
@@ -904,7 +1061,7 @@ export class PortfolioService {
     const accountCurrency = new Map<string, string>();
     for (const a of accounts) accountCurrency.set(a.id, a.currencyCode);
 
-    const rateCache = new Map<string, number>();
+    const rateCache: FxRateCache = new Map();
     const result = new Map<string, number>();
     for (const h of holdings) {
       if (Math.abs(Number(h.quantity)) < 0.0001) continue;
@@ -923,6 +1080,9 @@ export class PortfolioService {
           rateCache,
         );
 
+      // No rate for this security's currency into the account's: the position
+      // is left out rather than counted at face value in the wrong currency.
+      if (valueInAccountCurrency === null) continue;
       result.set(
         h.accountId,
         (result.get(h.accountId) ?? 0) + valueInAccountCurrency,
@@ -1138,29 +1298,39 @@ export class PortfolioService {
     const cursors = loaded.sources.map(() => -1);
     const points: IntradayValuePoint[] = [];
 
+    // Pairs no rate could be resolved for at any bar. A contribution with no
+    // rate is omitted rather than valued at 1:1 (audit P5-009), and named once
+    // at the end rather than per bar.
+    const unratedCurrencies = new Set<string>();
+    const contribution = this.makeIntradayContribution(fxAt, unratedCurrencies);
+
     for (const ts of loaded.timestamps) {
       let totalCents = 0; // integer arithmetic to avoid float drift
       // Cash contributions, valued at the FX rate prevailing at this bar.
       for (const [ccy, amount] of loaded.cashByCurrency) {
-        totalCents += Math.round(amount * fxAt(ccy, ts) * 10000);
+        totalCents += contribution(amount, ccy, ts);
       }
       // Stale-holding contributions (last daily close * quantity), grouped by
       // currency so the per-currency rounding matches the historical total.
       for (const [ccy, amount] of loaded.staleByCurrency) {
-        totalCents += Math.round(amount * fxAt(ccy, ts) * 10000);
+        totalCents += contribution(amount, ccy, ts);
       }
       for (let i = 0; i < loaded.sources.length; i++) {
         const src = loaded.sources[i];
         cursors[i] = this.advanceIntradayCursor(src.times, cursors[i], ts);
         const price = this.intradayPriceAt(src, cursors[i], ts);
-        totalCents += Math.round(
-          src.quantity * price * fxAt(src.currencyCode, ts) * 10000,
-        );
+        totalCents += contribution(src.quantity * price, src.currencyCode, ts);
       }
       points.push({
         timestamp: new Date(ts).toISOString(),
         value: totalCents / 10000,
       });
+    }
+
+    if (unratedCurrencies.size > 0) {
+      this.logger.warn(
+        `Intraday series omits holdings in ${[...unratedCurrencies].sort().join(", ")}: no exchange rate into ${loaded.currency}`,
+      );
     }
 
     return { points, ...meta };
@@ -1206,6 +1376,9 @@ export class PortfolioService {
     const secValues = new Map<string, number[]>();
     const secMeta = new Map<string, { symbol: string; name: string }>();
     const cash = new Array<number>(n).fill(0);
+    const unratedCurrencies = new Set<string>();
+    const contribution = this.makeIntradayContribution(fxAt, unratedCurrencies);
+
     const ensureSec = (id: string, symbol: string, name: string) => {
       if (!secValues.has(id)) {
         secValues.set(id, new Array<number>(n).fill(0));
@@ -1217,7 +1390,7 @@ export class PortfolioService {
       const ts = loaded.timestamps[ti];
       let cashCents = 0;
       for (const [ccy, amount] of loaded.cashByCurrency) {
-        cashCents += Math.round(amount * fxAt(ccy, ts) * 10000);
+        cashCents += contribution(amount, ccy, ts);
       }
       cash[ti] = cashCents / 10000;
       // Stale (last-close) holdings keep their own band, unlike the total
@@ -1225,7 +1398,7 @@ export class PortfolioService {
       for (const s of loaded.staleSources) {
         ensureSec(s.securityId, s.symbol, s.name);
         secValues.get(s.securityId)![ti] =
-          Math.round(s.amount * fxAt(s.currencyCode, ts) * 10000) / 10000;
+          contribution(s.amount, s.currencyCode, ts) / 10000;
       }
       for (let i = 0; i < loaded.sources.length; i++) {
         const src = loaded.sources[i];
@@ -1233,10 +1406,14 @@ export class PortfolioService {
         const price = this.intradayPriceAt(src, cursors[i], ts);
         ensureSec(src.securityId, src.symbol, src.name);
         secValues.get(src.securityId)![ti] =
-          Math.round(
-            src.quantity * price * fxAt(src.currencyCode, ts) * 10000,
-          ) / 10000;
+          contribution(src.quantity * price, src.currencyCode, ts) / 10000;
       }
+    }
+
+    if (unratedCurrencies.size > 0) {
+      this.logger.warn(
+        `Intraday breakdown omits holdings in ${[...unratedCurrencies].sort().join(", ")}: no exchange rate into ${loaded.currency}`,
+      );
     }
 
     const { series, points } = this.groupIntradayBreakdown(
@@ -1283,6 +1460,29 @@ export class PortfolioService {
   }
 
   /**
+   * Value one contribution in ten-thousandths of the display currency.
+   *
+   * Returns 0 and records the currency when no rate could be resolved for the
+   * bar: a holding whose pair has no rate is left out of the series rather than
+   * valued at its face number, which is what an implicit 1:1 did. Shared by the
+   * total series and the per-security breakdown so the two cannot disagree
+   * about which bars a currency contributed to.
+   */
+  private makeIntradayContribution(
+    fxAt: (currency: string, ts: number) => number | null,
+    unrated: Set<string>,
+  ): (amount: number, currency: string, ts: number) => number {
+    return (amount: number, currency: string, ts: number): number => {
+      const rate = fxAt(currency, ts);
+      if (rate === null) {
+        unrated.add(currency);
+        return 0;
+      }
+      return Math.round(amount * rate * 10000);
+    };
+  }
+
+  /**
    * Build a fresh FX lookup over the loaded intraday/daily rate series. Each
    * call owns its cursor state, so the total-value and breakdown views can each
    * walk the (ascending) grid independently. See the original inline notes:
@@ -1291,7 +1491,7 @@ export class PortfolioService {
    */
   private makeIntradayFxAt(
     loaded: IntradayLoaded,
-  ): (currency: string, ts: number) => number {
+  ): (currency: string, ts: number) => number | null {
     const display = loaded.currency;
     const cursors = new Map<string, number>();
     const dailyRateCache = new Map<string, number | undefined>();
@@ -1308,10 +1508,12 @@ export class PortfolioService {
       dailyRateCache.set(memoKey, rate);
       return rate;
     };
-    return (currency: string, ts: number): number => {
+    // `null` means "no rate for this pair", never 1. Rate 1 is returned only
+    // when the currency already IS the display currency.
+    return (currency: string, ts: number): number | null => {
       if (currency === display) return 1;
       const fx = loaded.fxByCurrency.get(currency);
-      if (!fx) return loaded.spotRate.get(`${currency}->${display}`) ?? 1;
+      if (!fx) return loaded.spotRate.get(`${currency}->${display}`) ?? null;
       if (fx.times.length > 0) {
         let c = cursors.get(currency) ?? -1;
         while (c + 1 < fx.times.length && fx.times[c + 1] <= ts) c++;
@@ -1690,7 +1892,7 @@ export class PortfolioService {
     // chart is then valued at the FX rate that prevailed at that moment,
     // not the latest spot. Latest-spot is kept as a per-currency fallback
     // for when the FX series fetch fails (rate limited, unsupported pair).
-    const rateCache = new Map<string, number>();
+    const rateCache: FxRateCache = new Map();
     const fxCurrencies = new Set<string>([
       ...intradayHoldings.map((h) => h.currencyCode),
       ...cashByCurrency.keys(),

--- a/backend/src/securities/sector-weighting.service.ts
+++ b/backend/src/securities/sector-weighting.service.ts
@@ -5,7 +5,10 @@ import { Security } from "./entities/security.entity";
 import { Holding } from "./entities/holding.entity";
 import { Account, AccountType } from "../accounts/entities/account.entity";
 import { YahooFinanceService } from "./yahoo-finance.service";
-import { PortfolioCalculationService } from "./portfolio-calculation.service";
+import {
+  PortfolioCalculationService,
+  FxRateCache,
+} from "./portfolio-calculation.service";
 import { roundMoney, sumMoney } from "../common/round.util";
 import {
   EXCHANGE_TO_COUNTRY,
@@ -375,7 +378,7 @@ export class SectorWeightingService {
     await this.ensureSectorData(uniqueSecurities);
 
     // 5. Build sector maps
-    const rateCache = new Map<string, number>();
+    const rateCache: FxRateCache = new Map();
     // Determine default currency from first account
     const defaultCurrency =
       investmentAccounts.length > 0
@@ -391,15 +394,18 @@ export class SectorWeightingService {
       const price = priceMap.get(holding.securityId);
       if (price == null) continue;
 
-      let marketValue = quantity * price;
-
-      // Convert to default currency
-      marketValue = await this.portfolioCalculationService.convertToDefault(
-        marketValue,
+      // `null` means no rate exists for the pair. A sector weighting is a share
+      // of a total, so counting an unconverted foreign value would misstate
+      // this sector's share and every other sector's with it (audit P5-009).
+      // Skipping is the honest option; the conversion logs the missing pair.
+      const converted = await this.portfolioCalculationService.convertToDefault(
+        quantity * price,
         holding.security.currencyCode,
         defaultCurrency,
         rateCache,
       );
+      if (converted === null) continue;
+      const marketValue = converted;
 
       const sec = holding.security;
       const isStock =
@@ -618,7 +624,7 @@ export class SectorWeightingService {
     const uniqueSecurityIds = [...new Set(holdings.map((h) => h.securityId))];
     const priceMap = await this.getLatestPrices(uniqueSecurityIds);
 
-    const rateCache = new Map<string, number>();
+    const rateCache: FxRateCache = new Map();
     const defaultCurrency =
       investmentAccounts.length > 0
         ? investmentAccounts[0].currencyCode
@@ -647,13 +653,16 @@ export class SectorWeightingService {
       const price = priceMap.get(holding.securityId);
       if (price == null) continue;
 
-      let marketValue = quantity * price;
-      marketValue = await this.portfolioCalculationService.convertToDefault(
-        marketValue,
+      // See the note above: an unconvertible holding is skipped, not counted
+      // at its face value in the wrong currency.
+      const converted = await this.portfolioCalculationService.convertToDefault(
+        quantity * price,
         holding.security.currencyCode,
         defaultCurrency,
         rateCache,
       );
+      if (converted === null) continue;
+      const marketValue = converted;
 
       const classification = classify(holding.security);
 

--- a/backend/src/securities/security-detail.service.ts
+++ b/backend/src/securities/security-detail.service.ts
@@ -215,7 +215,7 @@ export class SecurityDetailService {
           costBasis:
             holding === undefined ? null : roundMoney(holding.costBasis),
           costBasisAccountCurrency:
-            holding === undefined
+            holding?.costBasisAccountCurrency == null
               ? null
               : roundMoney(holding.costBasisAccountCurrency),
           marketValue:

--- a/docs/financial-calculation-contract.md
+++ b/docs/financial-calculation-contract.md
@@ -42,6 +42,29 @@ component required for that calculation is known.
   affected ids, or an `incomplete: true` flag) -- silence is what turns a
   subtotal into a lie.
 
+### 1.1 A missing exchange rate is not a rate of 1
+
+Rate `1` is reachable only when the source and destination currency codes are
+equal. There is no other branch that may produce it, and in particular a failed
+lookup may not: 1,000 USD reported into a EUR total as 1,000 EUR is an 11%
+overstatement that is *numerically plausible*, which is what makes it dangerous.
+A consumer given a bare number cannot tell a real 1:1 pair from an absent one.
+
+A conversion has three outcomes and they stay distinguishable -- converted,
+same-currency (no conversion needed), and unknown. Aggregate through `FxAggregate`
+(`backend/src/common/fx-aggregate.ts`), which cannot silently absorb a missing
+component: it records each unresolvable pair, and `total` is `null` while
+`knownSubtotal` carries what did convert. Note that an aggregate nothing was added
+to is `0`, not `null` -- an empty account holds zero.
+
+Zero and negative are not rates either, and are treated as absent rather than
+applied: multiplying by 0 reports a real holding as worthless.
+
+`docs/specs/fx-conversion-completeness.md` has the invariants, the numerical
+example table, the staged rollout of nullable response totals, and the recorded
+decision on look-ahead before the rate history begins.
+`backend/src/common/fx-fallback.guard.spec.ts` scans for a new silent fallback.
+
 ## 2. Cost basis and tax
 
 Realized result is market value minus cost basis; tax applies only to gains.

--- a/docs/specs/fx-conversion-completeness.md
+++ b/docs/specs/fx-conversion-completeness.md
@@ -1,0 +1,163 @@
+# Spec: FX conversion completeness
+
+Status: approved for implementation on `claude/detailed-error-review-54i3b3`.
+Governs: audit finding P5-009 (missing exchange rates silently treated as 1:1)
+and design risk DR-02 (look-ahead to a future rate before history begins).
+
+Read `docs/financial-calculation-contract.md` section 1 first; this spec applies
+that rule to currency conversion specifically.
+
+## 1. The defect this replaces
+
+Two conversion paths turned "no rate available" into "rate 1.0":
+
+```typescript
+// net-worth.service.ts
+const result = convertWithRateLookup(amount, from, to, getRate);
+return result ?? amount;                    // <- 1:1
+
+// portfolio-calculation.service.ts
+rate = reverseRate !== null ? 1 / reverseRate : 1;   // <- 1:1
+```
+
+`convertWithRateLookup` returns `null` precisely so the caller can decide, and
+both callers decided to lie. 1,000 USD reported into a EUR total came out as
+1,000 EUR rather than 900 EUR: an 11.11% overstatement that is *numerically
+plausible*, which is what makes it dangerous. Nothing in the response let a
+consumer tell a real 1:1 pair (USD/USD, or a genuinely pegged pair) from an
+absent one.
+
+## 2. Invariants
+
+1. **Rate 1 is only ever used when the source and destination currency are the
+   same string.** No other branch may produce it as a fallback.
+2. A conversion has three outcomes, and they stay distinguishable:
+   - `{ value, rate, known: true }` -- a rate was found (or none was needed).
+   - `{ value: null, rate: null, known: false }` -- no rate exists for the pair.
+   - It is never `{ value: amount, rate: 1 }` for differing currencies.
+3. **A total containing an unconverted component is not a total.** Per the
+   financial calculation contract section 1, the total field is `null` and the
+   partial sum, when still useful, goes in a separately named field with the
+   reason attached.
+4. A conversion gap is **named**, following the existing `ReplayedLot.basisGap`
+   precedent: the response says which pair could not be resolved, not merely
+   that something was wrong.
+5. Zero is not a valid rate. `convertWithRateLookup` already rejects an inverse
+   rate of 0; a direct rate of 0 or a negative rate is equally invalid and is
+   treated as absent rather than applied.
+
+## 3. Shape
+
+```typescript
+type FxGap = "missing_rate";
+
+interface FxTotal {
+  /** null unless every component converted. */
+  total: number | null;
+  /** Sum of the components that did convert. Always present. */
+  knownSubtotal: number;
+  /** "USD->EUR" for each pair that had no rate. Empty when complete. */
+  missingPairs: string[];
+}
+```
+
+`FxAggregate` (`backend/src/common/fx-aggregate.ts`) accumulates this. Callers
+add signed amounts and read the triple at the end; they never branch on `null`
+themselves, which is what kept the old code's `?? amount` out of sight.
+
+## 4. Numerical examples
+
+| Components | Rates available | total | knownSubtotal | missingPairs |
+| --- | --- | ---: | ---: | --- |
+| 1,000 USD into EUR | USD->EUR 0.9 | 900 | 900 | [] |
+| 1,000 USD into EUR | EUR->USD 1.1111 (inverse only) | 900.0090 | 900.0090 | [] |
+| 1,000 USD into EUR | none | `null` | 0 | ["USD->EUR"] |
+| 500 EUR + 1,000 USD into EUR | none for USD | `null` | 500 | ["USD->EUR"] |
+| 500 EUR + 1,000 USD into EUR | USD->EUR 0.9 | 1,400 | 1,400 | [] |
+| 0 USD into EUR | none | 0 | 0 | [] |
+| 1,000 EUR into EUR | n/a, same currency | 1,000 | 1,000 | [] |
+| 1,000 USD into EUR | USD->EUR 0 | `null` | 0 | ["USD->EUR"] |
+
+Note row 6: **zero needs no rate.** Zero converts to zero at any rate, so a
+zero component records no gap -- an emptied foreign account is a settled zero,
+not an unknowable value, and both conversion doors (`convertToDefault` and
+net worth's `convertCurrency`) short-circuit it before the rate lookup. Note
+also row 3 vs row 8: a `knownSubtotal` of 0 can mean "nothing converted"; only
+`missingPairs` distinguishes it from a real zero, which is why it is not
+optional.
+
+Note the last row: an empty portfolio holds zero and reports `total: 0` with no
+missing pairs -- zero is a known answer. `null` is reserved for "not known", per
+the root `CLAUDE.md` rule that the two must not be conflated.
+
+## 4a. Staging: what lands now, and what follows
+
+Making `assets` / `liabilities` / `netWorth` / `totalPortfolioValue` nullable is
+the correct end state and it changes public response shapes, every chart that
+reads them, and the copy that explains a partial total in 22 locales. That is a
+separate change with its own frontend work; landing it half-done would leave
+charts rendering `null` as a gap in the line with nothing telling the user why,
+which is a worse failure than the one being fixed.
+
+**Stage 1 (this branch).** The silent lie is removed and the gap is made
+visible:
+
+- `convertToDefault` and `convertCurrency` return `null` for an unresolvable
+  pair. Rate 1 is unreachable unless the currency codes are equal.
+- Every aggregation accumulates through `FxAggregate`, so an unconvertible
+  component is *recorded*, never folded in at 1:1.
+- The existing numeric total field carries `knownSubtotal`, and the response
+  gains `missingRatePairs` (and `fxComplete`) beside it. A consumer can see
+  exactly which pair is missing -- which satisfies the contract's "silence is
+  what turns a subtotal into a lie" requirement even before the field goes
+  nullable.
+- Every such aggregation logs at warn level with the pair and the date.
+
+**Stage 2 (follow-up).** `total*` fields become `number | null`, frontend charts
+render an explicit "incomplete" state, and the copy is translated. The
+`FxAggregate.total` getter already implements the nullable semantics and is
+covered by tests, so stage 2 is a matter of changing the field each call site
+reads (`knownSubtotal` -> `total`) plus the consumer work.
+
+Stage 1 is therefore strictly better than the previous behaviour and does not
+pretend to be stage 2. `fxComplete: false` with a numeric subtotal is a known,
+documented interim state, not an assertion that the total is complete.
+
+## 5. Persisted snapshots (deliberately out of scope here)
+
+`monthly_account_balances` stores converted values. Marking a persisted snapshot
+incomplete needs a schema column and a migration, and is therefore a separate
+change; this spec covers the calculation and response layers. Until that lands,
+a snapshot row whose conversion was incomplete is written from the
+`knownSubtotal` **and** logged at warn level with the missing pairs, so the gap
+is observable rather than silent. This is recorded as a known limitation, not as
+correct behaviour.
+
+## 6. DR-02: look-ahead
+
+`findBestRate` falls back to the *earliest* available rate when none exists on
+or before the valuation date, which values a historical point using a rate from
+its future. That is look-ahead, and the time-series contract forbids it.
+
+Decision: keep the fallback -- a pre-history chart point is more useful with an
+approximate rate than absent -- but stop it being invisible. In this stage the
+fallback is logged by `findBestRate` (once per pair per computation), naming
+the pair and the valuation date it predates. Reporting it to API consumers as a
+named gap (`rate_from_after_valuation_date`), so a chart can label the point,
+is deliberately staged with the nullable-totals rollout (section 8) and is
+**not implemented yet** -- until then the log is the only signal. Changing the
+fallback itself is a product decision and is not made here.
+
+## 7. Test matrix
+
+Every row of section 4, plus:
+
+- same currency, no rates loaded at all;
+- direct rate present, inverse absent, and the reverse;
+- direct rate of 0 and a negative direct rate (treated as absent);
+- a mixed portfolio where exactly one of three currencies is unresolvable --
+  asserts `total === null` while `knownSubtotal` covers the other two;
+- a liability component (negative amount) that cannot convert;
+- the look-ahead case: rate history starts after the valuation date;
+- assertion that no code path returns `amount` unchanged for differing
+  currencies (source-scanning guard on `?? amount` beside a conversion).

--- a/frontend/src/components/investments/GroupedHoldingsList.tsx
+++ b/frontend/src/components/investments/GroupedHoldingsList.tsx
@@ -370,8 +370,10 @@ const HoldingRow = memo(function HoldingRow({
     holding.marketValue !== null
       ? convert(holding.marketValue, holding.currencyCode, accountCurrency)
       : null;
+  // A gain needs both sides known: an unconvertible basis makes it unknown,
+  // not "market value minus zero".
   const gainLossAcct =
-    marketValueAcct !== null
+    marketValueAcct !== null && holding.costBasisAccountCurrency !== null
       ? marketValueAcct - holding.costBasisAccountCurrency
       : null;
 

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -221,6 +221,46 @@ describe('DividendIncomeReport', () => {
     expect(screen.getAllByText('$-500.00').length).toBeGreaterThan(0);
   });
 
+  it('renders an unknown capital-gain entry as unknown, never as a zero', async () => {
+    // The backend sends null for a gain it could not value (no rate between
+    // the security's currency and the account's). `bucket.capitalGains += null`
+    // coerced it to 0, so real gains vanished into a confident $0.00 summary.
+    mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([
+      {
+        month: '2024-08',
+        accountId: 'acc-1',
+        accountName: 'TFSA',
+        accountCurrencyCode: 'CAD',
+        securityId: 'sec-1',
+        symbol: 'ABC',
+        securityName: 'ABC Corp',
+        securityCurrencyCode: 'EUR',
+        startQuantity: 10,
+        endQuantity: 10,
+        startValue: null,
+        endValue: null,
+        buys: 0,
+        sells: 0,
+        realizedGain: 0,
+        unrealizedGain: null,
+        totalCapitalGain: null,
+      },
+    ]);
+    render(<DividendIncomeReport />);
+    await waitFor(() => {
+      expect(screen.getAllByText('Capital Gains').length).toBeGreaterThan(0);
+    });
+    // The capital-gains card and the total (which contains it) show the
+    // unknown marker; only dividends and interest -- genuine known zeros from
+    // an empty transaction list -- may read $0.00.
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('$0.00')).toHaveLength(2);
+  });
+
   it('renders summary cards with data', async () => {
     mockGetTransactions.mockResolvedValue({
       data: [

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -42,15 +42,21 @@ type MonthlyIncomeSortField = 'month' | 'startValue' | 'endValue' | 'dividends' 
 type DailyIncomeSortField = 'date' | 'startValue' | 'endValue' | 'dividends' | 'interest' | 'capitalGains' | 'total';
 type SecurityIncomeSortField = 'symbol' | 'dividends' | 'interest' | 'capitalGains' | 'total';
 
+/**
+ * `startValue`/`endValue`/`capitalGains`/`total` are `null` when any entry
+ * folded into the bucket carried an unknown (unconvertible) value: a sum with
+ * an unknown component is unknown, never the partial sum under the same name.
+ * `dividends`/`interest` come from transaction rows and stay known.
+ */
 interface MonthlyIncome {
   month: string;
   label: string;
-  startValue: number;
-  endValue: number;
+  startValue: number | null;
+  endValue: number | null;
   dividends: number;
   interest: number;
-  capitalGains: number;
-  total: number;
+  capitalGains: number | null;
+  total: number | null;
 }
 
 interface SecurityIncome {
@@ -58,19 +64,19 @@ interface SecurityIncome {
   name: string;
   dividends: number;
   interest: number;
-  capitalGains: number;
-  total: number;
+  capitalGains: number | null;
+  total: number | null;
 }
 
 interface DailyIncome {
   date: string;
   label: string;
-  startValue: number;
-  endValue: number;
+  startValue: number | null;
+  endValue: number | null;
   dividends: number;
   interest: number;
-  capitalGains: number;
-  total: number;
+  capitalGains: number | null;
+  total: number | null;
 }
 
 const SERIES_COLORS: Record<SeriesKey, { positive: string; negative: string }> = {
@@ -328,7 +334,10 @@ export function DividendIncomeReport() {
   // Backend already returns each capital gain entry in the holding account's
   // currency. Convert to the default currency for multi-account views; pass
   // through when a single account is selected.
-  const convertCapitalGain = useCallback((entry: CapitalGainEntry): number => {
+  const convertCapitalGain = useCallback((entry: CapitalGainEntry): number | null => {
+    // A null gain is unknown (no rate between the security's currency and the
+    // account's); it must not survive conversion as a 0.
+    if (entry.totalCapitalGain === null) return null;
     if (isSingleAccount) return entry.totalCapitalGain;
     return convertToDefault(entry.totalCapitalGain, entry.accountCurrencyCode || defaultCurrency);
   }, [isSingleAccount, defaultCurrency, convertToDefault]);
@@ -336,14 +345,21 @@ export function DividendIncomeReport() {
   // Same conversion as convertCapitalGain but applied to an arbitrary amount
   // denominated in the entry's account currency (e.g. start/end market values).
   const convertFromAccountCurrency = useCallback(
-    (amount: number, accountCurrencyCode: string | null): number => {
+    (amount: number | null, accountCurrencyCode: string | null): number | null => {
+      if (amount === null) return null;
       if (isSingleAccount) return amount;
       return convertToDefault(amount, accountCurrencyCode || defaultCurrency);
     },
     [isSingleAccount, defaultCurrency, convertToDefault],
   );
 
-  const fmtValue = useCallback((value: number): string => {
+  // A sum with an unknown component is unknown. Used everywhere a nullable
+  // entry value folds into a bucket, so `+=` cannot coerce null to 0.
+  const addOrUnknown = (a: number | null, b: number | null): number | null =>
+    a === null || b === null ? null : a + b;
+
+  const fmtValue = useCallback((value: number | null): string => {
+    if (value === null) return '\u2014';
     if (isForeign) {
       return `${formatCurrencyFull(value, displayCurrency)} ${displayCurrency}`;
     }
@@ -408,10 +424,10 @@ export function DividendIncomeReport() {
           bucket.interest += contribution;
           break;
         case 'CAPITAL_GAIN':
-          bucket.capitalGains += contribution;
+          bucket.capitalGains = addOrUnknown(bucket.capitalGains, contribution);
           break;
       }
-      bucket.total += contribution;
+      bucket.total = addOrUnknown(bucket.total, contribution);
     });
 
     filteredCapitalGains.forEach((entry) => {
@@ -420,17 +436,17 @@ export function DividendIncomeReport() {
       const monthDate = parseLocalDate(`${entry.month}-15`);
       const bucket = getOrCreateBucket(monthDate);
       const gain = convertCapitalGain(entry);
-      bucket.capitalGains += gain;
-      bucket.total += gain;
+      bucket.capitalGains = addOrUnknown(bucket.capitalGains, gain);
+      bucket.total = addOrUnknown(bucket.total, gain);
       // Start/end market values sum across securities to give a portfolio
       // mark-to-market snapshot at each month boundary.
-      bucket.startValue += convertFromAccountCurrency(
-        entry.startValue,
-        entry.accountCurrencyCode,
+      bucket.startValue = addOrUnknown(
+        bucket.startValue,
+        convertFromAccountCurrency(entry.startValue, entry.accountCurrencyCode),
       );
-      bucket.endValue += convertFromAccountCurrency(
-        entry.endValue,
-        entry.accountCurrencyCode,
+      bucket.endValue = addOrUnknown(
+        bucket.endValue,
+        convertFromAccountCurrency(entry.endValue, entry.accountCurrencyCode),
       );
     });
 
@@ -473,10 +489,10 @@ export function DividendIncomeReport() {
           bucket.interest += contribution;
           break;
         case 'CAPITAL_GAIN':
-          bucket.capitalGains += contribution;
+          bucket.capitalGains = addOrUnknown(bucket.capitalGains, contribution);
           break;
       }
-      bucket.total += contribution;
+      bucket.total = addOrUnknown(bucket.total, contribution);
     });
 
     filteredDailyCapitalGains.forEach((entry) => {
@@ -487,10 +503,16 @@ export function DividendIncomeReport() {
       const txDate = parseLocalDate(entry.month);
       const bucket = getOrCreateBucket(entry.month, txDate);
       const gain = convertCapitalGain(entry);
-      bucket.capitalGains += gain;
-      bucket.total += gain;
-      bucket.startValue += convertFromAccountCurrency(entry.startValue, entry.accountCurrencyCode);
-      bucket.endValue += convertFromAccountCurrency(entry.endValue, entry.accountCurrencyCode);
+      bucket.capitalGains = addOrUnknown(bucket.capitalGains, gain);
+      bucket.total = addOrUnknown(bucket.total, gain);
+      bucket.startValue = addOrUnknown(
+        bucket.startValue,
+        convertFromAccountCurrency(entry.startValue, entry.accountCurrencyCode),
+      );
+      bucket.endValue = addOrUnknown(
+        bucket.endValue,
+        convertFromAccountCurrency(entry.endValue, entry.accountCurrencyCode),
+      );
     });
 
     return Array.from(dayMap.values()).sort((a, b) => a.date.localeCompare(b.date));
@@ -519,11 +541,11 @@ export function DividendIncomeReport() {
   // instead of being hidden inside a stack. Memoized so the per-render array
   // scans don't run on every keystroke/interaction.
   const hasNegativeCapitalGains = useMemo(
-    () => monthlyData.some((m) => m.capitalGains < 0),
+    () => monthlyData.some((m) => m.capitalGains !== null && m.capitalGains < 0),
     [monthlyData],
   );
   const dailyHasNegativeCapitalGains = useMemo(
-    () => displayedDailyData.some((d) => d.capitalGains < 0),
+    () => displayedDailyData.some((d) => d.capitalGains !== null && d.capitalGains < 0),
     [displayedDailyData],
   );
 
@@ -566,10 +588,10 @@ export function DividendIncomeReport() {
           bucket.interest += contribution;
           break;
         case 'CAPITAL_GAIN':
-          bucket.capitalGains += contribution;
+          bucket.capitalGains = addOrUnknown(bucket.capitalGains, contribution);
           break;
       }
-      bucket.total += contribution;
+      bucket.total = addOrUnknown(bucket.total, contribution);
     });
 
     filteredCapitalGains.forEach((entry) => {
@@ -577,12 +599,30 @@ export function DividendIncomeReport() {
       const name = entry.securityName || 'Unknown Security';
       const bucket = getOrCreateBucket(symbol, name);
       const gain = convertCapitalGain(entry);
-      bucket.capitalGains += gain;
-      bucket.total += gain;
+      bucket.capitalGains = addOrUnknown(bucket.capitalGains, gain);
+      bucket.total = addOrUnknown(bucket.total, gain);
     });
 
     return Array.from(securityMap.values());
   }, [filteredTransactions, filteredCapitalGains, getTxAmount, convertCapitalGain]);
+
+  // The row total restricted to the visible series. Unknown-aware: with the
+  // capital-gains series visible, a row whose gains are unknown has an unknown
+  // total (sorted last by compareValues, rendered as the unknown marker).
+  const visibleTotal = useCallback(
+    (
+      dividends: number,
+      interest: number,
+      capitalGains: number | null,
+    ): number | null => {
+      const known =
+        (visibleSeries.dividends ? dividends : 0) +
+        (visibleSeries.interest ? interest : 0);
+      if (!visibleSeries.capitalGains) return known;
+      return capitalGains === null ? null : known + capitalGains;
+    },
+    [visibleSeries],
+  );
 
   const sortedMonthlyData = useMemo(() => {
     const sorted = [...monthlyData];
@@ -609,19 +649,15 @@ export function DividendIncomeReport() {
           break;
         case 'total':
           comparison = compareValues(
-            (visibleSeries.dividends ? a.dividends : 0) +
-              (visibleSeries.interest ? a.interest : 0) +
-              (visibleSeries.capitalGains ? a.capitalGains : 0),
-            (visibleSeries.dividends ? b.dividends : 0) +
-              (visibleSeries.interest ? b.interest : 0) +
-              (visibleSeries.capitalGains ? b.capitalGains : 0),
+            visibleTotal(a.dividends, a.interest, a.capitalGains),
+            visibleTotal(b.dividends, b.interest, b.capitalGains),
           );
           break;
       }
       return monthlySort.sortDirection === 'asc' ? comparison : -comparison;
     });
     return sorted;
-  }, [monthlyData, monthlySort.sortField, monthlySort.sortDirection, visibleSeries]);
+  }, [monthlyData, monthlySort.sortField, monthlySort.sortDirection, visibleTotal]);
 
   const sortedDailyData = useMemo(() => {
     const sorted = [...displayedDailyData];
@@ -648,19 +684,15 @@ export function DividendIncomeReport() {
           break;
         case 'total':
           comparison = compareValues(
-            (visibleSeries.dividends ? a.dividends : 0) +
-              (visibleSeries.interest ? a.interest : 0) +
-              (visibleSeries.capitalGains ? a.capitalGains : 0),
-            (visibleSeries.dividends ? b.dividends : 0) +
-              (visibleSeries.interest ? b.interest : 0) +
-              (visibleSeries.capitalGains ? b.capitalGains : 0),
+            visibleTotal(a.dividends, a.interest, a.capitalGains),
+            visibleTotal(b.dividends, b.interest, b.capitalGains),
           );
           break;
       }
       return dailySort.sortDirection === 'asc' ? comparison : -comparison;
     });
     return sorted;
-  }, [displayedDailyData, dailySort.sortField, dailySort.sortDirection, visibleSeries]);
+  }, [displayedDailyData, dailySort.sortField, dailySort.sortDirection, visibleTotal]);
 
   const sortedSecurityData = useMemo(() => {
     const sorted = [...securityData];
@@ -698,16 +730,16 @@ export function DividendIncomeReport() {
     const manualCapitalGains = filteredTransactions
       .filter((t) => t.action === 'CAPITAL_GAIN')
       .reduce((sum, t) => sum + getTxAmount(t), 0);
-    const periodCapitalGains = filteredCapitalGains.reduce(
-      (sum, entry) => sum + convertCapitalGain(entry),
+    const periodCapitalGains = filteredCapitalGains.reduce<number | null>(
+      (sum, entry) => addOrUnknown(sum, convertCapitalGain(entry)),
       0,
     );
-    const totalGains = manualCapitalGains + periodCapitalGains;
+    const totalGains = addOrUnknown(manualCapitalGains, periodCapitalGains);
     return {
       dividends,
       interest,
       capitalGains: totalGains,
-      total: dividends + interest + totalGains,
+      total: addOrUnknown(dividends + interest, totalGains),
     };
   }, [filteredTransactions, filteredCapitalGains, getTxAmount, convertCapitalGain]);
 
@@ -719,7 +751,10 @@ export function DividendIncomeReport() {
     (viewType === 'monthly' && monthlyDisplay === 'table') ||
     (viewType === 'daily' && monthlyDisplay === 'table');
 
-  const round4 = (n: number) => Math.round(n * 10000) / 10000;
+  // '' (an empty cell), not 0, for an unknown value: a spreadsheet summing the
+  // column must not absorb an unknown as a zero.
+  const round4 = (n: number | null): number | '' =>
+    n === null ? '' : Math.round(n * 10000) / 10000;
 
   const handleExportCsv = () => {
     const accountLabel = selectedAccount
@@ -760,20 +795,13 @@ export function DividendIncomeReport() {
       headers.push(t('dividendIncome.colTotal'), t('dividendIncome.colCurrency'));
       const rows = displayedDailyData.map((row) => {
         const out: (string | number)[] = [row.date, round4(row.startValue), round4(row.endValue)];
-        let total = 0;
-        if (visibleSeries.dividends) {
-          out.push(round4(row.dividends));
-          total += row.dividends;
-        }
-        if (visibleSeries.interest) {
-          out.push(round4(row.interest));
-          total += row.interest;
-        }
-        if (visibleSeries.capitalGains) {
-          out.push(round4(row.capitalGains));
-          total += row.capitalGains;
-        }
-        out.push(round4(total), currencyCode);
+        if (visibleSeries.dividends) out.push(round4(row.dividends));
+        if (visibleSeries.interest) out.push(round4(row.interest));
+        if (visibleSeries.capitalGains) out.push(round4(row.capitalGains));
+        out.push(
+          round4(visibleTotal(row.dividends, row.interest, row.capitalGains)),
+          currencyCode,
+        );
         return out;
       });
       exportToCsv(`${filenameBase}-daily-${scope}`, headers, rows);
@@ -794,20 +822,13 @@ export function DividendIncomeReport() {
         round4(row.startValue),
         round4(row.endValue),
       ];
-      let total = 0;
-      if (visibleSeries.dividends) {
-        out.push(round4(row.dividends));
-        total += row.dividends;
-      }
-      if (visibleSeries.interest) {
-        out.push(round4(row.interest));
-        total += row.interest;
-      }
-      if (visibleSeries.capitalGains) {
-        out.push(round4(row.capitalGains));
-        total += row.capitalGains;
-      }
-      out.push(round4(total), currencyCode);
+      if (visibleSeries.dividends) out.push(round4(row.dividends));
+      if (visibleSeries.interest) out.push(round4(row.interest));
+      if (visibleSeries.capitalGains) out.push(round4(row.capitalGains));
+      out.push(
+        round4(visibleTotal(row.dividends, row.interest, row.capitalGains)),
+        currencyCode,
+      );
       return out;
     });
     exportToCsv(`${filenameBase}-monthly-${scope}`, headers, rows);
@@ -855,45 +876,39 @@ export function DividendIncomeReport() {
       headers.push(t('dividendIncome.colTotal'));
       const rows = displayedDailyData.map((row) => {
         const out: (string | number)[] = [row.label, fmtValue(row.startValue), fmtValue(row.endValue)];
-        let rowTotal = 0;
-        if (visibleSeries.dividends) {
-          out.push(fmtValue(row.dividends));
-          rowTotal += row.dividends;
-        }
-        if (visibleSeries.interest) {
-          out.push(fmtValue(row.interest));
-          rowTotal += row.interest;
-        }
-        if (visibleSeries.capitalGains) {
-          out.push(fmtValue(row.capitalGains));
-          rowTotal += row.capitalGains;
-        }
-        out.push(fmtValue(rowTotal));
+        if (visibleSeries.dividends) out.push(fmtValue(row.dividends));
+        if (visibleSeries.interest) out.push(fmtValue(row.interest));
+        if (visibleSeries.capitalGains) out.push(fmtValue(row.capitalGains));
+        out.push(
+          fmtValue(visibleTotal(row.dividends, row.interest, row.capitalGains)),
+        );
         return out;
       });
       const dailyTotals = displayedDailyData.reduce(
         (acc, row) => ({
           dividends: acc.dividends + row.dividends,
           interest: acc.interest + row.interest,
-          capitalGains: acc.capitalGains + row.capitalGains,
+          capitalGains: addOrUnknown(acc.capitalGains, row.capitalGains),
         }),
-        { dividends: 0, interest: 0, capitalGains: 0 },
+        {
+          dividends: 0,
+          interest: 0,
+          capitalGains: 0 as number | null,
+        },
       );
       const totalRow: (string | number)[] = [t('dividendIncome.colTotal'), '', ''];
-      let grandTotal = 0;
-      if (visibleSeries.dividends) {
-        totalRow.push(fmtValue(dailyTotals.dividends));
-        grandTotal += dailyTotals.dividends;
-      }
-      if (visibleSeries.interest) {
-        totalRow.push(fmtValue(dailyTotals.interest));
-        grandTotal += dailyTotals.interest;
-      }
-      if (visibleSeries.capitalGains) {
-        totalRow.push(fmtValue(dailyTotals.capitalGains));
-        grandTotal += dailyTotals.capitalGains;
-      }
-      totalRow.push(fmtValue(grandTotal));
+      if (visibleSeries.dividends) totalRow.push(fmtValue(dailyTotals.dividends));
+      if (visibleSeries.interest) totalRow.push(fmtValue(dailyTotals.interest));
+      if (visibleSeries.capitalGains) totalRow.push(fmtValue(dailyTotals.capitalGains));
+      totalRow.push(
+        fmtValue(
+          visibleTotal(
+            dailyTotals.dividends,
+            dailyTotals.interest,
+            dailyTotals.capitalGains,
+          ),
+        ),
+      );
       tableData = { headers, rows, totalRow };
     } else if (viewType === 'monthly' && monthlyDisplay === 'table') {
       const headers: string[] = [t('dividendIncome.colMonth'), t('dividendIncome.colStartValue'), t('dividendIncome.colEndValue')];
@@ -907,40 +922,26 @@ export function DividendIncomeReport() {
           fmtValue(row.startValue),
           fmtValue(row.endValue),
         ];
-        let rowTotal = 0;
-        if (visibleSeries.dividends) {
-          out.push(fmtValue(row.dividends));
-          rowTotal += row.dividends;
-        }
-        if (visibleSeries.interest) {
-          out.push(fmtValue(row.interest));
-          rowTotal += row.interest;
-        }
-        if (visibleSeries.capitalGains) {
-          out.push(fmtValue(row.capitalGains));
-          rowTotal += row.capitalGains;
-        }
-        out.push(fmtValue(rowTotal));
+        if (visibleSeries.dividends) out.push(fmtValue(row.dividends));
+        if (visibleSeries.interest) out.push(fmtValue(row.interest));
+        if (visibleSeries.capitalGains) out.push(fmtValue(row.capitalGains));
+        out.push(
+          fmtValue(visibleTotal(row.dividends, row.interest, row.capitalGains)),
+        );
         return out;
       });
       // Column totals across the whole window, respecting hidden series so the
       // footer sum matches the visible columns. Start/End values are point-in-
       // time snapshots so a column sum would be meaningless — leave them blank.
       const totalRow: (string | number)[] = [t('dividendIncome.colTotal'), '', ''];
-      let grandTotal = 0;
-      if (visibleSeries.dividends) {
-        totalRow.push(fmtValue(totals.dividends));
-        grandTotal += totals.dividends;
-      }
-      if (visibleSeries.interest) {
-        totalRow.push(fmtValue(totals.interest));
-        grandTotal += totals.interest;
-      }
-      if (visibleSeries.capitalGains) {
-        totalRow.push(fmtValue(totals.capitalGains));
-        grandTotal += totals.capitalGains;
-      }
-      totalRow.push(fmtValue(grandTotal));
+      if (visibleSeries.dividends) totalRow.push(fmtValue(totals.dividends));
+      if (visibleSeries.interest) totalRow.push(fmtValue(totals.interest));
+      if (visibleSeries.capitalGains) totalRow.push(fmtValue(totals.capitalGains));
+      totalRow.push(
+        fmtValue(
+          visibleTotal(totals.dividends, totals.interest, totals.capitalGains),
+        ),
+      );
       tableData = { headers, rows, totalRow };
     }
 
@@ -950,7 +951,7 @@ export function DividendIncomeReport() {
       summaryCards: [
         { label: t('dividendIncome.summaryDividends'), value: fmtValue(totals.dividends), color: '#16a34a' },
         { label: t('dividendIncome.summaryInterest'), value: fmtValue(totals.interest), color: '#2563eb' },
-        { label: t('dividendIncome.summaryCapitalGains'), value: fmtValue(totals.capitalGains), color: totals.capitalGains < 0 ? '#dc2626' : '#9333ea' },
+        { label: t('dividendIncome.summaryCapitalGains'), value: fmtValue(totals.capitalGains), color: totals.capitalGains !== null && totals.capitalGains < 0 ? '#dc2626' : '#9333ea' },
         { label: t('dividendIncome.summaryTotalIncome'), value: fmtValue(totals.total), color: '#111827' },
       ],
       chartContainer: tableData ? undefined : chartRef.current,
@@ -1029,9 +1030,9 @@ export function DividendIncomeReport() {
             {fmtValue(totals.interest)}
           </div>
         </div>
-        <div className={`rounded-lg p-4 ${totals.capitalGains < 0 ? 'bg-red-50 dark:bg-red-900/20' : 'bg-purple-50 dark:bg-purple-900/20'}`}>
-          <div className={`text-sm ${totals.capitalGains < 0 ? 'text-red-600 dark:text-red-400' : 'text-purple-600 dark:text-purple-400'}`}>{t('dividendIncome.summaryCapitalGains')}</div>
-          <div className={`text-xl font-bold ${totals.capitalGains < 0 ? 'text-red-700 dark:text-red-300' : 'text-purple-700 dark:text-purple-300'}`}>
+        <div className={`rounded-lg p-4 ${totals.capitalGains !== null && totals.capitalGains < 0 ? 'bg-red-50 dark:bg-red-900/20' : 'bg-purple-50 dark:bg-purple-900/20'}`}>
+          <div className={`text-sm ${totals.capitalGains !== null && totals.capitalGains < 0 ? 'text-red-600 dark:text-red-400' : 'text-purple-600 dark:text-purple-400'}`}>{t('dividendIncome.summaryCapitalGains')}</div>
+          <div className={`text-xl font-bold ${totals.capitalGains !== null && totals.capitalGains < 0 ? 'text-red-700 dark:text-red-300' : 'text-purple-700 dark:text-purple-300'}`}>
             {fmtValue(totals.capitalGains)}
           </div>
         </div>
@@ -1259,7 +1260,7 @@ export function DividendIncomeReport() {
                       <Cell
                         key={entry.month}
                         fill={
-                          entry.capitalGains < 0
+                          entry.capitalGains !== null && entry.capitalGains < 0
                             ? SERIES_COLORS.capitalGains.negative
                             : SERIES_COLORS.capitalGains.positive
                         }
@@ -1362,10 +1363,11 @@ export function DividendIncomeReport() {
               </thead>
               <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                 {sortedMonthlyData.map((row) => {
-                  const rowTotal =
-                    (visibleSeries.dividends ? row.dividends : 0) +
-                    (visibleSeries.interest ? row.interest : 0) +
-                    (visibleSeries.capitalGains ? row.capitalGains : 0);
+                  const rowTotal = visibleTotal(
+                    row.dividends,
+                    row.interest,
+                    row.capitalGains,
+                  );
                   return (
                     <tr key={row.month} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
                       <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
@@ -1390,7 +1392,7 @@ export function DividendIncomeReport() {
                       {visibleSeries.capitalGains && (
                         <td
                           className={`px-4 py-3 text-right text-sm ${
-                            row.capitalGains < 0
+                            row.capitalGains !== null && row.capitalGains < 0
                               ? 'text-red-600 dark:text-red-400'
                               : 'text-purple-600 dark:text-purple-400'
                           }`}
@@ -1400,7 +1402,7 @@ export function DividendIncomeReport() {
                       )}
                       <td
                         className={`px-4 py-3 text-right text-sm font-medium ${
-                          rowTotal < 0
+                          rowTotal !== null && rowTotal < 0
                             ? 'text-red-600 dark:text-red-400'
                             : 'text-gray-900 dark:text-gray-100'
                         }`}
@@ -1461,7 +1463,7 @@ export function DividendIncomeReport() {
                         <Cell
                           key={entry.date}
                           fill={
-                            entry.capitalGains < 0
+                            entry.capitalGains !== null && entry.capitalGains < 0
                               ? SERIES_COLORS.capitalGains.negative
                               : SERIES_COLORS.capitalGains.positive
                           }
@@ -1570,10 +1572,11 @@ export function DividendIncomeReport() {
                 </thead>
                 <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                   {sortedDailyData.map((row) => {
-                    const rowTotal =
-                      (visibleSeries.dividends ? row.dividends : 0) +
-                      (visibleSeries.interest ? row.interest : 0) +
-                      (visibleSeries.capitalGains ? row.capitalGains : 0);
+                    const rowTotal = visibleTotal(
+                      row.dividends,
+                      row.interest,
+                      row.capitalGains,
+                    );
                     return (
                       <tr key={row.date} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
                         <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
@@ -1598,7 +1601,7 @@ export function DividendIncomeReport() {
                         {visibleSeries.capitalGains && (
                           <td
                             className={`px-4 py-3 text-right text-sm ${
-                              row.capitalGains < 0
+                              row.capitalGains !== null && row.capitalGains < 0
                                 ? 'text-red-600 dark:text-red-400'
                                 : 'text-purple-600 dark:text-purple-400'
                             }`}
@@ -1608,7 +1611,7 @@ export function DividendIncomeReport() {
                         )}
                         <td
                           className={`px-4 py-3 text-right text-sm font-medium ${
-                            rowTotal < 0
+                            rowTotal !== null && rowTotal < 0
                               ? 'text-red-600 dark:text-red-400'
                               : 'text-gray-900 dark:text-gray-100'
                           }`}
@@ -1705,7 +1708,7 @@ export function DividendIncomeReport() {
                     </td>
                     <td
                       className={`px-4 py-3 text-right text-sm ${
-                        security.capitalGains < 0
+                        security.capitalGains !== null && security.capitalGains < 0
                           ? 'text-red-600 dark:text-red-400'
                           : 'text-purple-600 dark:text-purple-400'
                       }`}
@@ -1714,7 +1717,7 @@ export function DividendIncomeReport() {
                     </td>
                     <td
                       className={`px-4 py-3 text-right text-sm font-medium ${
-                        security.total < 0
+                        security.total !== null && security.total < 0
                           ? 'text-red-600 dark:text-red-400'
                           : 'text-gray-900 dark:text-gray-100'
                       }`}

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -286,6 +286,48 @@ describe('InvestmentReportViewer', () => {
     expect(screen.getByText('$100 USD')).toBeInTheDocument();
   });
 
+  it('renders an unknown marker in base mode when a row has no rate to base', async () => {
+    // baseExchangeRate is null when no rate exists for the pair. `num * null`
+    // coerces to 0, so without the guard a real foreign holding rendered as
+    // $0.00 in base currency -- unknown shown as a measured zero, worse than
+    // the 1:1 relabelling the nullable rate replaced.
+    mockGetById.mockResolvedValue(report);
+    mockExecute.mockResolvedValue({
+      ...result,
+      baseCurrency: 'CAD',
+      columns: ['symbol', 'marketValue'],
+      groups: [
+        {
+          key: 'all',
+          label: '',
+          rows: [
+            { id: '1', currency: 'USD', baseExchangeRate: null, values: { symbol: 'AAA', marketValue: 100 } },
+          ],
+        },
+      ],
+      rowCount: 1,
+    });
+    await renderViewer();
+    await screen.findByText('AAA');
+    // Native display is unaffected: the value is known in USD.
+    expect(screen.getByText('$100 USD')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'CAD' }));
+    });
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByText('$0')).not.toBeInTheDocument();
+
+    // The CSV mirrors the unknown as an empty cell, never a 0 a spreadsheet
+    // would sum.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+    });
+    const exportedRows = mockExportToCsv.mock.calls.at(-1)?.[2];
+    expect(exportedRows[0]).toContain('');
+    expect(exportedRows[0]).not.toContain(0);
+  });
+
   it('exports group headings for symbol and currency groupings', async () => {
     for (const [groupBy, heading] of [
       ['SYMBOL', 'Symbol'],

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -149,6 +149,9 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
         const num = Number(value);
         // Native values are in the holding's currency; convert to base when toggled.
         if (currencyMode === 'base' && result) {
+          // No rate for this row's pair: the base-currency value is unknown.
+          // `num * null` would render it as 0.00 -- a confident wrong number.
+          if (row.baseExchangeRate === null) return '—';
           return formatCurrency(num * row.baseExchangeRate, result.baseCurrency);
         }
         const formatted = formatCurrency(num, row.currency);
@@ -199,12 +202,15 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
         ...cols.map((key) => {
           const v = row.values[key];
           if (v === null || v === undefined) return '';
-          // Mirror the on-screen currency mode in the exported numbers.
+          // Mirror the on-screen currency mode in the exported numbers,
+          // including the unknown marker for a row with no rate to base.
           if (
             currencyMode === 'base' &&
             INVESTMENT_COLUMN_MAP[key]?.type === 'currency'
           ) {
-            return Number(v) * row.baseExchangeRate;
+            return row.baseExchangeRate === null
+              ? ''
+              : Number(v) * row.baseExchangeRate;
           }
           return v;
         }),

--- a/frontend/src/lib/aggregate-holdings.test.ts
+++ b/frontend/src/lib/aggregate-holdings.test.ts
@@ -66,12 +66,31 @@ describe('aggregateHoldingsBySecurity', () => {
     expect(result[0].gainLossPercent).toBeNull();
   });
 
-  it('treats null market value as 0 when the other holding has a market value', () => {
+  it('an unpriced account makes the aggregate market value unknown, not a subtotal', () => {
+    // This assertion previously read `expect(result[0].marketValue).toBe(550)`
+    // under the name "treats null market value as 0 when the other holding has
+    // a market value" -- it documented the defect as intended behaviour. A sum
+    // with an unknown component is unknown; 550 is the priced half's subtotal
+    // and must not ship under the aggregate's marketValue.
     const h1 = holding({ id: 'h1', securityId: 'AAPL', accountId: 'acc-1', quantity: 10, costBasis: 1000, costBasisAccountCurrency: 1000, marketValue: null, gainLoss: null, gainLossPercent: null });
     const h2 = holding({ id: 'h2', securityId: 'AAPL', accountId: 'acc-2', quantity: 5, costBasis: 500, costBasisAccountCurrency: 500, marketValue: 550, gainLoss: 50, gainLossPercent: 10 });
     const result = aggregateHoldingsBySecurity([h1, h2]);
-    expect(result[0].marketValue).toBe(550);
-    expect(result[0].gainLoss).toBe(550 - 1500);
+    expect(result[0].marketValue).toBeNull();
+    expect(result[0].gainLoss).toBeNull();
+    expect(result[0].gainLossPercent).toBeNull();
+  });
+
+  it('an unconvertible basis in one account makes the aggregate basis unknown', () => {
+    // Number(null) is 0, so the old `Number(a) + Number(b)` silently dropped a
+    // whole account's cost basis from the rollup and overstated the gain
+    // computed against it.
+    const h1 = holding({ id: 'h1', securityId: 'AAPL', accountId: 'acc-1', quantity: 10, costBasis: 1000, costBasisAccountCurrency: null, marketValue: 1100, gainLoss: 100, gainLossPercent: 10 });
+    const h2 = holding({ id: 'h2', securityId: 'AAPL', accountId: 'acc-2', quantity: 5, costBasis: 500, costBasisAccountCurrency: 500, marketValue: 550, gainLoss: 50, gainLossPercent: 10 });
+    const result = aggregateHoldingsBySecurity([h1, h2]);
+    expect(result[0].costBasisAccountCurrency).toBeNull();
+    // The native-currency basis is still known, so the aggregate gain (which is
+    // derived from costBasis, not the account-currency basis) survives.
+    expect(result[0].costBasis).toBe(1500);
   });
 
   it('returns null gainLossPercent when costBasis is 0', () => {

--- a/frontend/src/lib/aggregate-holdings.ts
+++ b/frontend/src/lib/aggregate-holdings.ts
@@ -28,15 +28,20 @@ export function aggregateHoldingsBySecurity(
 
     const totalQuantity = Number(existing.quantity) + Number(h.quantity);
     const totalCostBasis = Number(existing.costBasis) + Number(h.costBasis);
+    // A sum with an unknown component is unknown: `Number(null)` is 0, which
+    // silently dropped a whole account's basis from the rollup and overstated
+    // the gain computed against it.
     const totalCostBasisAccountCurrency =
-      Number(existing.costBasisAccountCurrency) +
-      Number(h.costBasisAccountCurrency);
+      existing.costBasisAccountCurrency === null ||
+      h.costBasisAccountCurrency === null
+        ? null
+        : existing.costBasisAccountCurrency + h.costBasisAccountCurrency;
     const existingMv = existing.marketValue;
     const addMv = h.marketValue;
+    // Same rule for market value: one unpriced account makes the security's
+    // aggregate value unknown, not the priced accounts' subtotal.
     const totalMarketValue =
-      existingMv === null && addMv === null
-        ? null
-        : (existingMv ?? 0) + (addMv ?? 0);
+      existingMv === null || addMv === null ? null : existingMv + addMv;
     const gainLoss =
       totalMarketValue !== null ? totalMarketValue - totalCostBasis : null;
     const gainLossPercent =

--- a/frontend/src/types/investment-report.ts
+++ b/frontend/src/types/investment-report.ts
@@ -140,8 +140,12 @@ export interface InvestmentReportRow {
   id: string;
   /** The holding's own (security) currency, for formatting native values. */
   currency: string;
-  /** Multiply this row's native monetary values by this to get base currency. */
-  baseExchangeRate: number;
+  /**
+   * Multiply this row's native monetary values by this to get base currency.
+   * `null` when no rate exists for the pair: the base-currency value is
+   * unknown, never 0 and never the native amount relabelled.
+   */
+  baseExchangeRate: number | null;
   values: Record<string, InvestmentCellValue>;
 }
 

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -134,8 +134,10 @@ export interface HoldingWithMarketValue {
   /**
    * Cost basis in the holding account's currency, calculated using the
    * historical exchange rates stored on the original BUY transactions.
+   * `null` when no rate exists to denominate the basis in the account's
+   * currency: unknown, never 0 and never the native amount relabelled.
    */
-  costBasisAccountCurrency: number;
+  costBasisAccountCurrency: number | null;
   currentPrice: number | null;
   marketValue: number | null;
   gainLoss: number | null;
@@ -550,13 +552,21 @@ export interface CapitalGainEntry {
   securityCurrencyCode: string | null;
   startQuantity: number;
   endQuantity: number;
-  startValue: number;
-  endValue: number;
+  /**
+   * Period-boundary market values in the account's currency, and the gains
+   * derived from them. `null` when the security's currency could not be
+   * converted into the account's: the value at each boundary is unknown, so a
+   * gain measured between them is too -- never 0, never the native amount
+   * relabelled. `buys`, `sells` and `realizedGain` stay known: they come from
+   * the exchange rate stored on each transaction.
+   */
+  startValue: number | null;
+  endValue: number | null;
   buys: number;
   sells: number;
   realizedGain: number;
-  unrealizedGain: number;
-  totalCapitalGain: number;
+  unrealizedGain: number | null;
+  totalCapitalGain: number | null;
 }
 
 // --- Performance comparison (Security Performance report) -------------------


### PR DESCRIPTION

## Linked discussion / issue

Closes # TODO
Approved in: TODO - add the approved discussion or issue before requesting review.

## Summary

This PR makes missing exchange rates explicit instead of silently treating them as 1:1 conversions or passing the original amount through under a different currency label.

It introduces a shared FX aggregation contract, carries valuation-completeness metadata through portfolio and account summaries, and propagates that metadata to AI and MCP consumers so a known subtotal cannot be mistaken for a complete total without a signal describing what is missing.

## Why

A missing FX rate is unknown data, not a rate of 1. For example, 1,000 USD must never become 1,000 EUR merely because USD->EUR could not be resolved. The same rule applies to totals, gains, tax values, cost basis, and any other derived financial result.

This PR addresses the Phase 5 financial-correctness findings around missing-rate fallbacks and incomplete valuation propagation.

## What changes

- Adds `FxAggregate` as the shared mechanism for summing converted amounts while tracking unresolved currency pairs.
- Distinguishes a complete total from `knownSubtotal` when one or more components cannot be converted.
- Makes equal-currency conversion the only path where a rate of 1 is implicit; zero or negative rates are treated as unavailable.
- Adds `fxComplete`, `missingRatePairs`, `pricesComplete`, `unpricedSecurityIds`, and `valuationComplete` to portfolio-level and per-account results.
- Includes net-invested conversion failures in the top-level completeness state and returns `null` for CAGR when its inputs are incomplete.
- Propagates completeness metadata through the compact LLM portfolio summary and MCP output schemas.
- Propagates unknown values as `null` in row/period-level calculations where a valid result cannot be derived.
- Prevents sector weighting from treating an unconvertible foreign holding as if it were denominated in the reporting currency.
- Adds a guard test intended to catch reintroduced silent FX fallbacks.
- Documents the staged rollout toward nullable financial totals.

## Financial correctness invariants

- Missing FX is unknown, never 1:1.
- A financial total is complete only when every required component is known.
- `0` means a known zero; `null` means unknown/unavailable.
- Per-account completeness is evaluated in the account's own conversion graph, independently of portfolio-level completeness.

## Tests and validation

Changed or added coverage includes:

- `backend/src/common/fx-aggregate.spec.ts`
- `backend/src/common/fx-fallback.guard.spec.ts`
- `backend/src/common/currency-conversion.util.spec.ts`
- `backend/src/net-worth/net-worth.service.spec.ts`
- `backend/src/securities/portfolio-calculation.service.spec.ts`
- `backend/src/securities/portfolio.service.spec.ts`
- AI/MCP schema and consumer tests

Read-only review confirmed that this branch is exactly one commit above its original merge base. The full test suite was not independently executed during this packaging pass, and GitHub exposed no commit status contexts for the reviewed head.

## Stack position

- Head branch: `pr/05a-fx-completeness`
- Reviewed head SHA: `db96a5b5411204781f55edd7a089be7f307bb125`
- PR base: `main`
- Original merge base: `c605d2b1e23edd19c435b42e365a36c4249dffe3`
- Reviewed `main` SHA: `249390cedbc10d2c0c4c167e2611d999cff90b12`

This is PR 1 of 7 in the Phase 05 financial-correctness stack. At packaging time the stack was 116 commits behind the reviewed `main`; rebase and conflict resolution are required before requesting final review.

## Known limitations / follow-ups

- This is Stage 1 of the completeness rollout: response totals remain numeric known subtotals accompanied by completeness metadata. Making incomplete totals and derived percentages nullable is intentionally staged for a later step.
- This PR establishes backend and API contracts; the Investments frontend presentation of those contracts is handled later in `pr/05g-frontend-completeness`.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a single concern in the Phase 05 stack.
- [ ] New behavior has tests, and the existing suite passes. Tests are present; the full suite was not independently run in this review.
- [x] User-facing localization requirements are satisfied for the changes in this PR, or no new catalog copy is introduced.
- [ ] Shared/core areas were changed; confirm the approving discussion explicitly covers this scope.
- [ ] The branch is rebased on the latest `main`. It was 116 commits behind at packaging time.
- [ ] AI assistance is disclosed below, and the maintainer has reviewed and owns the result.

## AI assistance disclosure

AI assistance was used in the implementation of this change and is disclosed in the commit metadata. The maintainer should complete human review and take ownership of correctness, conventions, and test results before marking this PR ready for merge.
