### PR TITLE
05: Make transaction and transfer currency server-authoritative (v1.15.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,11 +241,64 @@ applicable. `backend/src/common/fx-fallback.guard.spec.ts` scans for a new silen
 fallback; `docs/specs/fx-conversion-completeness.md` has the invariants and the
 staged rollout of nullable response totals.
 
+### A currency code is derived from the account, not accepted from the request
+
+`amount` and `currencyCode` on a transaction are the account-currency pair --
+foreign entry belongs in `originalAmount`/`originalCurrencyCode`/`exchangeRate`.
+Nothing checked it, so `amount=100, currencyCode=USD` against a EUR account moved
+the balance 100 EUR and stored a row reporting 100 USD; both fields persist, so it
+survived into every report and every backup. Derive with
+`assertTransactionCurrencyMatchesAccount` (`backend/src/common/fx-entry.util.ts`),
+which rejects a mismatch.
+
+A transfer is the same rule twice, plus conservation: two same-currency accounts
+must move the same amount (no rate or fee can make that unequal, so an explicit
+destination amount that disagrees is a rejection, not an override), and a
+cross-currency pair resolves its rate server-side or refuses. A caller holding
+only one side's currency -- a scheduled transaction -- sends neither code.
+
+### A preview computes what the commit will do, through the same code
+
+A preview that resolves a rate as `?? 1` while the commit resolves a real one has
+the user approve one figure and receive another. This has happened twice: an
+investment preview multiplied cash impact by a zero rate the commit then treated
+as 1, and a transfer preview passed the source amount through for a
+cross-currency pair. Call the same resolver from both.
+
 ### Missing data: a subtotal is not a total (CRITICAL)
 
 A field named `total*`, `portfolioValue`, `transferValue`, `gain`, `tax`, or `estimated*` may only carry a value when **every** component of the calculation is known. Filtering out `null` components and summing the rest produces a subtotal, not a total -- if any component is unknown, the total is `null`, and the partial sum, if returned at all, goes in a separate explicitly named field (`knownMarketValueSubtotal`), never in the total's field. Never default an unknown price, cost basis, or rate to `0` (or an exchange rate to `1`) to keep a formula running, and never treat a missing period price as a 0% return.
 
 **`null` is not the safe answer either.** It means "not known", so a state that *is* known must not use it: empty accounts hold zero, move zero, realize zero and owe zero, and reporting those as unknown tells the user a settled question could not be worked out -- while making "nothing to do" indistinguishable from "cannot compute". Decide which of the two each branch is in before writing it.
+
+### An account, its currency, its rate and its amount are one tuple
+
+Persist all of it or none of it. Moving a transfer's destination leg to an account
+in another currency wrote the account, the currency and the newly resolved rate,
+and left the old destination *number* behind -- 90 GBP at 0.80 against a 100 USD
+source, with the balance already moved by 80, so the next recompute changed the
+account by the difference with no user action behind it. Key the write on "did this
+edit re-price the transfer", never on which request fields happened to be present.
+
+### A change is a value difference, not a field being present
+
+The transfer form resends the current accounts, amount and rate on every save, so
+`updateDto.amount !== undefined` does not mean the amount changed. Keying repricing
+off presence made an idempotent full-form payload restate a settled 90 EUR
+destination as 80 and move the balance with it -- from a request whose only real edit
+was a description. Compare against what the row holds. This is the same mistake as
+using one leg's state for both ledgers: asking a question the data can answer instead
+of the one that matters.
+
+### A presentation-only edit does not re-resolve a rate
+
+Renaming a transfer's description re-resolved FX and stored today's rate beside an
+unchanged destination amount, making the row internally inconsistent -- and refused
+the rename outright when the pair had no current rate, though the transfer already
+held a valid settlement. Resolve only when the financial structure changes: either
+account, the source amount, an explicit destination amount, an explicit rate. A
+date correction is not a re-pricing; the rate a transfer settled at is a fact about
+the transfer.
 
 ### A completeness flag covers every total it is documented to cover, on every surface
 

--- a/backend/src/common/fx-entry.util.spec.ts
+++ b/backend/src/common/fx-entry.util.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from "@nestjs/common";
 import {
   applyFxConversion,
+  resolveFxRateOrNull,
   normalizeFxEntry,
   roundFxRate,
   FX_RATE_DECIMALS,
@@ -131,6 +132,45 @@ describe("fx-entry.util", () => {
       const rounded = applyFxConversion(1000, 1.3652, null).amount;
       expect(precise).toBe(1365.234);
       expect(precise).not.toBe(rounded);
+    });
+});
+
+  describe("resolveFxRateOrNull", () => {
+    it("resolves and rounds the dated rate, without a dead getLatestRate chase", async () => {
+      const rates = {
+        getRateForDate: jest.fn().mockResolvedValue(1.36523449999),
+        getLatestRate: jest.fn(),
+      };
+      await expect(
+        resolveFxRateOrNull(rates, "USD", "CAD", "2026-01-15"),
+      ).resolves.toBe(1.3652345);
+      // getRateForDate already falls back to the latest stored rate internally
+      // (its documented step 3); a caller-side chase is the dead call four
+      // hand-rolled copies of this ladder used to carry.
+      expect(rates.getLatestRate).not.toHaveBeenCalled();
+    });
+
+    it("asks for the latest stored rate directly when there is no date", async () => {
+      const rates = {
+        getRateForDate: jest.fn(),
+        getLatestRate: jest.fn().mockResolvedValue(0.8),
+      };
+      await expect(resolveFxRateOrNull(rates, "USD", "EUR", null)).resolves.toBe(
+        0.8,
+      );
+      expect(rates.getRateForDate).not.toHaveBeenCalled();
+    });
+
+    it("treats zero, negative and missing rates as absent", async () => {
+      for (const bad of [0, -1, null]) {
+        const rates = {
+          getRateForDate: jest.fn().mockResolvedValue(bad),
+          getLatestRate: jest.fn(),
+        };
+        await expect(
+          resolveFxRateOrNull(rates, "USD", "THB", "2026-01-15"),
+        ).resolves.toBeNull();
+      }
     });
   });
 });

--- a/backend/src/common/fx-entry.util.ts
+++ b/backend/src/common/fx-entry.util.ts
@@ -133,3 +133,75 @@ export function applyFxConversion(
       : 0;
   return { base, fee, amount: roundMoney(base + fee) };
 }
+
+/**
+ * The primary `currencyCode` a transaction row must carry: its account's.
+ *
+ * `amount` and `currencyCode` are the account-currency pair -- the schema and
+ * entity model a foreign entry separately, in `originalAmount` /
+ * `originalCurrencyCode` / `exchangeRate`, which is what shows that a mismatched
+ * primary currency is not an alternative supported shape.
+ *
+ * Nothing checked it. Creation spread the client's `currencyCode` straight into
+ * the entity and incremented the balance by the numeric `amount`, so a request
+ * of `amount=100, currencyCode=USD` against a EUR account moved the balance by
+ * 100 EUR and left a row reporting 100 USD. Both fields persist, so the error
+ * survives backups and every later report (audit P5-003).
+ *
+ * Case-insensitive, because a correct client always sends the account's own
+ * code and only its casing is worth tolerating. Returns the canonical value to
+ * store.
+ */
+/**
+ * The one market-rate ladder: the rate for `from -> to` at `date`, rounded to
+ * FX_RATE_DECIMALS, or `null` when no usable rate exists anywhere. Zero and
+ * negative rates are absent, not applicable.
+ *
+ * `ExchangeRateService.getRateForDate` already falls back to the latest stored
+ * rate internally (its documented step 3), so callers must not chase a `null`
+ * from this helper with their own `getLatestRate` -- four hand-rolled copies of
+ * this sequence existed and three carried exactly that dead trailing call.
+ * Copies are how resolvers drift; this is the only one.
+ */
+export async function resolveFxRateOrNull(
+  rates: {
+    getRateForDate(
+      from: string,
+      to: string,
+      date: string,
+    ): Promise<number | null>;
+    getLatestRate(from: string, to: string): Promise<number | null>;
+  },
+  from: string,
+  to: string,
+  /** `null` when the caller has no date: the latest stored rate is asked directly. */
+  date: string | null,
+): Promise<number | null> {
+  const rate = date
+    ? await rates.getRateForDate(from, to, date)
+    : await rates.getLatestRate(from, to);
+  if (rate === null || !(Number(rate) > 0)) return null;
+  return roundFxRate(Number(rate));
+}
+
+export function assertTransactionCurrencyMatchesAccount(
+  suppliedCurrencyCode: string | null | undefined,
+  accountCurrencyCode: string,
+): string {
+  const account = accountCurrencyCode.toUpperCase();
+  if (suppliedCurrencyCode === null || suppliedCurrencyCode === undefined) {
+    return account;
+  }
+
+  const supplied = String(suppliedCurrencyCode).toUpperCase();
+  if (supplied !== account) {
+    throw new BadRequestException(
+      tr(
+        "errors.transactions.currencyMustMatchAccount",
+        `Transaction currency ${supplied} must match the account currency ${account}. Use originalAmount and originalCurrencyCode for a foreign-currency entry.`,
+        { supplied, account },
+      ),
+    );
+  }
+  return account;
+}

--- a/backend/src/common/split-amount.util.spec.ts
+++ b/backend/src/common/split-amount.util.spec.ts
@@ -58,4 +58,59 @@ describe("validateSplitAmountSum", () => {
       ),
     ).toThrow(BadRequestException);
   });
-});
+
+  describe("mixed-sign children are accepted; the signed sum is the invariant", () => {
+    it("accepts same-sign children under a negative parent", () => {
+      expect(() =>
+        validateSplitAmountSum([{ amount: -60 }, { amount: -40 }], -100),
+      ).not.toThrow();
+    });
+
+    it("accepts a paycheck-shaped split: gross and withholdings under a net deposit", () => {
+      // The canonical mixed-sign split, and the reason no sign rule exists:
+      // Microsoft Money models a paycheck as gross salary (+) and withholdings
+      // (-) under the net deposit, its importer writes exactly that shape, and
+      // the form has only ever validated the sum -- so real ledgers hold these.
+      // Refusing them would make the rows uneditable (the form resends the full
+      // set on every save) and silently stop their scheduled postings.
+      expect(() =>
+        validateSplitAmountSum([{ amount: 3500 }, { amount: -500 }], 3000),
+      ).not.toThrow();
+    });
+
+    it("accepts a refund netted under a charge (audit P5-004's example)", () => {
+      // P5-004 proposed refusing this; category surfaces instead read the
+      // children signed and net within the category (root CLAUDE.md, "debits
+      // NET OF credits", issue #1125), so the credit child reduces what it is
+      // filed under rather than fabricating income beside it.
+      expect(() =>
+        validateSplitAmountSum([{ amount: 50 }, { amount: -150 }], -100),
+      ).not.toThrow();
+    });
+
+    it("accepts an investment split that both credits and debits", () => {
+      // One brokerage line can sell (+proceeds), pay a fee (-) and buy (-) at
+      // once; each child is validated against its computed cash impact.
+      expect(() =>
+        validateSplitAmountSum(
+          [{ amount: 1000 }, { amount: -250 }, { amount: -700 }],
+          50,
+        ),
+      ).not.toThrow();
+    });
+
+    it("accepts opposing children under a zero parent", () => {
+      expect(() =>
+        validateSplitAmountSum([{ amount: 100 }, { amount: -100 }], 0),
+      ).not.toThrow();
+    });
+
+    it("still enforces the signed sum whatever the signs", () => {
+      expect(() =>
+        validateSplitAmountSum(
+          [{ amount: 1000 }, { amount: -250 }, { amount: -700 }],
+          999,
+        ),
+      ).toThrow(/must equal transaction amount/);
+    });
+  });});

--- a/backend/src/common/split-amount.util.ts
+++ b/backend/src/common/split-amount.util.ts
@@ -52,4 +52,32 @@ export function validateSplitAmountSum(
       ),
     );
   }
+
+  // Mixed-sign children are deliberately NOT refused, although the split DTO
+  // long documented "must be same sign as parent transaction" (audit P5-004
+  // proposed enforcing it). Three facts decide it the other way:
+  //
+  // - The client has only ever validated the sum, and the importers write
+  //   splits without this validator at all -- so real ledgers already hold
+  //   mixed-sign splits, the canonical case being a paycheck: gross salary
+  //   (+3,500) and withholdings (-500) under a +3,000 net deposit, which is
+  //   how Microsoft Money models it and how its `.mny` files import. Each
+  //   child there is individually true; the parent is a net by design.
+  //   Enforcing the sign here would make that data uneditable (the form
+  //   resends the full split set on every save) and silently stop its
+  //   scheduled postings -- a 400 nobody sees, from a cron.
+  //
+  // - The reporting distortion P5-004 described ("income that never arrived")
+  //   is resolved where it belongs: category surfaces read the children
+  //   *signed* and net within the category (root CLAUDE.md, "What a category
+  //   cost is its debits NET OF its credits" -- issue #1125), so a credit
+  //   child reduces the category it is filed under instead of fabricating
+  //   income beside it.
+  //
+  // - Investment splits require mixing (one brokerage line can sell
+  //   (+proceeds), pay a fee (-) and buy (-) at once), and each such child is
+  //   validated against its computed cash impact -- stricter than a sign rule.
+  //
+  // The signed-sum equality above remains the invariant: whatever the signs,
+  // the children must account for exactly the parent's movement.
 }

--- a/backend/src/i18n/locales/de/errors.json
+++ b/backend/src/i18n/locales/de/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "Ein Name für die Anlageklasse ist erforderlich.",
     "documentNotFound": "Dokument nicht gefunden",
     "selectionNotFound": "Eine oder mehrere der ausgewählten Wertpapiere wurden nicht gefunden",
-    "comparisonSelectionEmpty": "Wählen Sie mindestens ein Wertpapier oder einen Marktindex zum Vergleich aus"
+    "comparisonSelectionEmpty": "Wählen Sie mindestens ein Wertpapier oder einen Marktindex zum Vergleich aus",
+    "exchangeRateNotPositive": "Der Wechselkurs muss größer als null sein"
   },
   "tags": {
     "notFound": "Etikett mit ID {{ id }} nicht gefunden",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount und originalCurrencyCode müssen zusammen angegeben werden",
     "fxRateRequired": "Für eine Fremdwährungstransaktion ist ein positiver Wechselkurs erforderlich",
     "fxSignMismatch": "originalAmount und amount müssen dasselbe Vorzeichen haben",
-    "jointAccountMoveLocked": "Buchungen in einem geteilten Konto können nicht in ein anderes Konto verschoben werden."
+    "jointAccountMoveLocked": "Buchungen in einem geteilten Konto können nicht in ein anderes Konto verschoben werden.",
+    "currencyMustMatchAccount": "Transaktionswährung {{ supplied }} muss der Kontowährung {{ account }} entsprechen. Verwenden Sie originalAmount und originalCurrencyCode für eine Fremdwährungsbuchung.",
+    "transferSameCurrencyMustConserve": "Eine Übertragung zwischen zwei {{ currency }}-Konten muss auf beiden Seiten denselben Betrag bewegen",
+    "transferSameCurrencyRateMustBeOne": "Eine Übertragung zwischen zwei {{ currency }}-Konten kann keinen Wechselkurs außer 1 haben",
+    "transferRateUnavailable": "Für {{ from }} -> {{ to }} konnte kein Wechselkurs ermittelt werden. Geben Sie einen exchangeRate oder einen Zielbetrag an, damit die Übertragung korrekt gebucht wird.",
+    "transferAmountsMustAgreeOnZero": "Eine Übertragung muss auf beiden Seiten einen Betrag ungleich null bewegen oder auf beiden Seiten null",
+    "transferImpliedRateInvalid": "Der Zielbetrag ergibt im Verhältnis zum Ausgangsbetrag einen unbrauchbaren Wechselkurs"
   },
   "users": {
     "userNotFound": "Benutzer nicht gefunden",

--- a/backend/src/i18n/locales/en/errors.json
+++ b/backend/src/i18n/locales/en/errors.json
@@ -445,7 +445,8 @@
     "noUpdateFields": "Provide at least one field to change.",
     "documentNotFound": "Document not found",
     "selectionNotFound": "One or more of the selected securities could not be found",
-    "comparisonSelectionEmpty": "Select at least one security or market index to compare"
+    "comparisonSelectionEmpty": "Select at least one security or market index to compare",
+    "exchangeRateNotPositive": "Exchange rate must be greater than zero"
   },
   "tags": {
     "notFound": "Tag with ID {{ id }} not found",
@@ -507,7 +508,13 @@
     "fxFieldsIncomplete": "originalAmount and originalCurrencyCode must be provided together",
     "fxRateRequired": "A positive exchange rate is required for a foreign-currency transaction",
     "fxSignMismatch": "originalAmount and amount must have the same sign",
-    "jointAccountMoveLocked": "Transactions in a shared account cannot be moved to another account."
+    "jointAccountMoveLocked": "Transactions in a shared account cannot be moved to another account.",
+    "currencyMustMatchAccount": "Transaction currency {{ supplied }} must match the account currency {{ account }}. Use originalAmount and originalCurrencyCode for a foreign-currency entry.",
+    "transferSameCurrencyMustConserve": "A transfer between two {{ currency }} accounts must move the same amount on both sides",
+    "transferSameCurrencyRateMustBeOne": "A transfer between two {{ currency }} accounts cannot have an exchange rate other than 1",
+    "transferRateUnavailable": "Could not determine an exchange rate for {{ from }} -> {{ to }}. Supply an exchangeRate or a destination amount so the transfer posts correctly.",
+    "transferAmountsMustAgreeOnZero": "A transfer must move a non-zero amount on both sides, or zero on both",
+    "transferImpliedRateInvalid": "The destination amount implies an unusable exchange rate against the source amount"
   },
   "users": {
     "userNotFound": "User not found",

--- a/backend/src/i18n/locales/es/errors.json
+++ b/backend/src/i18n/locales/es/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "Se requiere un nombre de clase de activo.",
     "documentNotFound": "Documento no encontrado",
     "selectionNotFound": "No se encontraron uno o varios de los valores seleccionados",
-    "comparisonSelectionEmpty": "Seleccione al menos un valor o índice de mercado para comparar"
+    "comparisonSelectionEmpty": "Seleccione al menos un valor o índice de mercado para comparar",
+    "exchangeRateNotPositive": "El tipo de cambio debe ser mayor que cero"
   },
   "tags": {
     "notFound": "Etiqueta con ID {{ id }} no encontrada",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount y originalCurrencyCode deben proporcionarse juntos",
     "fxRateRequired": "Se requiere un tipo de cambio positivo para una transacción en moneda extranjera",
     "fxSignMismatch": "originalAmount y amount deben tener el mismo signo",
-    "jointAccountMoveLocked": "Las transacciones de una cuenta compartida no se pueden mover a otra cuenta."
+    "jointAccountMoveLocked": "Las transacciones de una cuenta compartida no se pueden mover a otra cuenta.",
+    "currencyMustMatchAccount": "La moneda de la transacción {{ supplied }} debe coincidir con la moneda de la cuenta {{ account }}. Use originalAmount y originalCurrencyCode para un asiento en moneda extranjera.",
+    "transferSameCurrencyMustConserve": "Una transferencia entre dos cuentas en {{ currency }} debe mover el mismo importe en ambos lados",
+    "transferSameCurrencyRateMustBeOne": "Una transferencia entre dos cuentas en {{ currency }} no puede tener un tipo de cambio distinto de 1",
+    "transferRateUnavailable": "No se pudo determinar un tipo de cambio para {{ from }} -> {{ to }}. Indique un exchangeRate o un importe de destino para que la transferencia se registre correctamente.",
+    "transferAmountsMustAgreeOnZero": "Una transferencia debe mover un importe distinto de cero en ambos lados, o cero en ambos",
+    "transferImpliedRateInvalid": "El importe de destino implica un tipo de cambio inutilizable frente al importe de origen"
   },
   "users": {
     "userNotFound": "Usuario no encontrado",

--- a/backend/src/i18n/locales/fr/errors.json
+++ b/backend/src/i18n/locales/fr/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "Un nom de classe d'actifs est requis.",
     "documentNotFound": "Document introuvable",
     "selectionNotFound": "Un ou plusieurs des titres sélectionnés sont introuvables",
-    "comparisonSelectionEmpty": "Sélectionnez au moins un titre ou un indice de marché à comparer"
+    "comparisonSelectionEmpty": "Sélectionnez au moins un titre ou un indice de marché à comparer",
+    "exchangeRateNotPositive": "Le taux de change doit être supérieur à zéro"
   },
   "tags": {
     "notFound": "Étiquette avec l'ID {{ id }} introuvable",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount et originalCurrencyCode doivent être fournis ensemble",
     "fxRateRequired": "Un taux de change positif est requis pour une transaction en devise étrangère",
     "fxSignMismatch": "originalAmount et amount doivent avoir le même signe",
-    "jointAccountMoveLocked": "Les transactions d'un compte partagé ne peuvent pas être déplacées vers un autre compte."
+    "jointAccountMoveLocked": "Les transactions d'un compte partagé ne peuvent pas être déplacées vers un autre compte.",
+    "currencyMustMatchAccount": "La devise de la transaction {{ supplied }} doit correspondre à la devise du compte {{ account }}. Utilisez originalAmount et originalCurrencyCode pour une saisie en devise étrangère.",
+    "transferSameCurrencyMustConserve": "Un transfert entre deux comptes en {{ currency }} doit déplacer le même montant des deux côtés",
+    "transferSameCurrencyRateMustBeOne": "Un transfert entre deux comptes en {{ currency }} ne peut pas avoir un taux de change autre que 1",
+    "transferRateUnavailable": "Impossible de déterminer un taux de change pour {{ from }} -> {{ to }}. Fournissez un exchangeRate ou un montant de destination pour que le transfert soit enregistré correctement.",
+    "transferAmountsMustAgreeOnZero": "Un transfert doit déplacer un montant non nul des deux côtés, ou zéro des deux côtés",
+    "transferImpliedRateInvalid": "Le montant de destination implique un taux de change inutilisable par rapport au montant source"
   },
   "users": {
     "userNotFound": "Utilisateur introuvable",

--- a/backend/src/i18n/locales/hi/errors.json
+++ b/backend/src/i18n/locales/hi/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "एसेट क्लास का नाम आवश्यक है।",
     "documentNotFound": "दस्तावेज़ नहीं मिला",
     "selectionNotFound": "चयनित प्रतिभूतियों में से एक या अधिक नहीं मिलीं",
-    "comparisonSelectionEmpty": "तुलना के लिए कम से कम एक प्रतिभूति या बाज़ार सूचकांक चुनें"
+    "comparisonSelectionEmpty": "तुलना के लिए कम से कम एक प्रतिभूति या बाज़ार सूचकांक चुनें",
+    "exchangeRateNotPositive": "विनिमय दर शून्य से अधिक होनी चाहिए"
   },
   "tags": {
     "notFound": "ID {{ id }} वाला टैग नहीं मिला",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount और originalCurrencyCode एक साथ दिए जाने चाहिए",
     "fxRateRequired": "विदेशी मुद्रा लेनदेन के लिए एक धनात्मक विनिमय दर आवश्यक है",
     "fxSignMismatch": "originalAmount और amount का चिह्न समान होना चाहिए",
-    "jointAccountMoveLocked": "साझा खाते के लेनदेन किसी अन्य खाते में नहीं ले जाए जा सकते।"
+    "jointAccountMoveLocked": "साझा खाते के लेनदेन किसी अन्य खाते में नहीं ले जाए जा सकते।",
+    "currencyMustMatchAccount": "लेन-देन मुद्रा {{ supplied }} खाते की मुद्रा {{ account }} से मेल खानी चाहिए। विदेशी मुद्रा प्रविष्टि के लिए originalAmount और originalCurrencyCode का उपयोग करें।",
+    "transferSameCurrencyMustConserve": "दो {{ currency }} खातों के बीच स्थानांतरण में दोनों ओर समान राशि होनी चाहिए",
+    "transferSameCurrencyRateMustBeOne": "दो {{ currency }} खातों के बीच स्थानांतरण में 1 के अलावा कोई विनिमय दर नहीं हो सकती",
+    "transferRateUnavailable": "{{ from }} -> {{ to }} के लिए विनिमय दर निर्धारित नहीं की जा सकी। स्थानांतरण सही तरीके से दर्ज करने के लिए exchangeRate या गंतव्य राशि दें।",
+    "transferAmountsMustAgreeOnZero": "स्थानांतरण को दोनों ओर शून्य से भिन्न राशि ले जानी चाहिए, या दोनों ओर शून्य",
+    "transferImpliedRateInvalid": "गंतव्य राशि स्रोत राशि की तुलना में अनुपयोगी विनिमय दर दर्शाती है"
   },
   "users": {
     "userNotFound": "उपयोगकर्ता नहीं मिला",

--- a/backend/src/i18n/locales/id/errors.json
+++ b/backend/src/i18n/locales/id/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "Nama kelas aset wajib diisi.",
     "documentNotFound": "Dokumen tidak ditemukan",
     "selectionNotFound": "Satu atau beberapa efek yang dipilih tidak ditemukan",
-    "comparisonSelectionEmpty": "Pilih setidaknya satu efek atau indeks pasar untuk dibandingkan"
+    "comparisonSelectionEmpty": "Pilih setidaknya satu efek atau indeks pasar untuk dibandingkan",
+    "exchangeRateNotPositive": "Nilai tukar harus lebih besar dari nol"
   },
   "tags": {
     "notFound": "Tag dengan ID {{ id }} tidak ditemukan",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount dan originalCurrencyCode harus diberikan bersama",
     "fxRateRequired": "Nilai tukar positif diperlukan untuk transaksi mata uang asing",
     "fxSignMismatch": "originalAmount dan amount harus memiliki tanda yang sama",
-    "jointAccountMoveLocked": "Transaksi di akun bersama tidak dapat dipindahkan ke akun lain."
+    "jointAccountMoveLocked": "Transaksi di akun bersama tidak dapat dipindahkan ke akun lain.",
+    "currencyMustMatchAccount": "Mata uang transaksi {{ supplied }} harus sama dengan mata uang akun {{ account }}. Gunakan originalAmount dan originalCurrencyCode untuk entri mata uang asing.",
+    "transferSameCurrencyMustConserve": "Transfer antara dua akun {{ currency }} harus memindahkan jumlah yang sama di kedua sisi",
+    "transferSameCurrencyRateMustBeOne": "Transfer antara dua akun {{ currency }} tidak boleh memiliki nilai tukar selain 1",
+    "transferRateUnavailable": "Tidak dapat menentukan nilai tukar untuk {{ from }} -> {{ to }}. Berikan exchangeRate atau jumlah tujuan agar transfer tercatat dengan benar.",
+    "transferAmountsMustAgreeOnZero": "Transfer harus memindahkan jumlah bukan nol di kedua sisi, atau nol di kedua sisi",
+    "transferImpliedRateInvalid": "Jumlah tujuan menghasilkan nilai tukar yang tidak dapat digunakan terhadap jumlah sumber"
   },
   "users": {
     "userNotFound": "Pengguna tidak ditemukan",

--- a/backend/src/i18n/locales/it/errors.json
+++ b/backend/src/i18n/locales/it/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "È richiesto un nome per la classe di attivo.",
     "documentNotFound": "Documento non trovato",
     "selectionNotFound": "Uno o più titoli selezionati non sono stati trovati",
-    "comparisonSelectionEmpty": "Seleziona almeno un titolo o un indice di mercato da confrontare"
+    "comparisonSelectionEmpty": "Seleziona almeno un titolo o un indice di mercato da confrontare",
+    "exchangeRateNotPositive": "Il tasso di cambio deve essere maggiore di zero"
   },
   "tags": {
     "notFound": "Etichetta con ID {{ id }} non trovata",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount e originalCurrencyCode devono essere forniti insieme",
     "fxRateRequired": "È richiesto un tasso di cambio positivo per una transazione in valuta estera",
     "fxSignMismatch": "originalAmount e amount devono avere lo stesso segno",
-    "jointAccountMoveLocked": "Le transazioni di un conto condiviso non possono essere spostate in un altro conto."
+    "jointAccountMoveLocked": "Le transazioni di un conto condiviso non possono essere spostate in un altro conto.",
+    "currencyMustMatchAccount": "La valuta della transazione {{ supplied }} deve corrispondere alla valuta del conto {{ account }}. Usa originalAmount e originalCurrencyCode per una registrazione in valuta estera.",
+    "transferSameCurrencyMustConserve": "Un trasferimento tra due conti in {{ currency }} deve muovere lo stesso importo su entrambi i lati",
+    "transferSameCurrencyRateMustBeOne": "Un trasferimento tra due conti in {{ currency }} non può avere un tasso di cambio diverso da 1",
+    "transferRateUnavailable": "Non è stato possibile determinare un tasso di cambio per {{ from }} -> {{ to }}. Fornisci un exchangeRate o un importo di destinazione affinché il trasferimento venga registrato correttamente.",
+    "transferAmountsMustAgreeOnZero": "Un trasferimento deve spostare un importo diverso da zero su entrambi i lati, oppure zero su entrambi",
+    "transferImpliedRateInvalid": "L'importo di destinazione implica un tasso di cambio inutilizzabile rispetto all'importo di origine"
   },
   "users": {
     "userNotFound": "Utente non trovato",

--- a/backend/src/i18n/locales/ja/errors.json
+++ b/backend/src/i18n/locales/ja/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "資産クラス名が必要です。",
     "documentNotFound": "ドキュメントが見つかりません",
     "selectionNotFound": "選択された銘柄のうち1つ以上が見つかりませんでした",
-    "comparisonSelectionEmpty": "比較する銘柄または市場指数を1つ以上選択してください"
+    "comparisonSelectionEmpty": "比較する銘柄または市場指数を1つ以上選択してください",
+    "exchangeRateNotPositive": "為替レートはゼロより大きい値である必要があります"
   },
   "tags": {
     "notFound": "ID {{ id }} のタグが見つかりません",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount と originalCurrencyCode は一緒に指定する必要があります",
     "fxRateRequired": "外貨取引には正の為替レートが必要です",
     "fxSignMismatch": "originalAmount と amount は同じ符号である必要があります",
-    "jointAccountMoveLocked": "共有口座の取引を別の口座に移動することはできません。"
+    "jointAccountMoveLocked": "共有口座の取引を別の口座に移動することはできません。",
+    "currencyMustMatchAccount": "取引通貨 {{ supplied }} は口座通貨 {{ account }} と一致する必要があります。外貨での入力には originalAmount と originalCurrencyCode を使用してください。",
+    "transferSameCurrencyMustConserve": "{{ currency }} 口座間の振替は両側で同じ金額でなければなりません",
+    "transferSameCurrencyRateMustBeOne": "{{ currency }} 口座間の振替に 1 以外の為替レートは指定できません",
+    "transferRateUnavailable": "{{ from }} -> {{ to }} の為替レートを判定できませんでした。振替が正しく記録されるように exchangeRate または送金先金額を指定してください。",
+    "transferAmountsMustAgreeOnZero": "送金は両側でゼロ以外の金額を動かすか、両側ともゼロである必要があります",
+    "transferImpliedRateInvalid": "送金先の金額は、送金元の金額に対して使用できない為替レートを意味します"
   },
   "users": {
     "userNotFound": "ユーザーが見つかりません",

--- a/backend/src/i18n/locales/ko/errors.json
+++ b/backend/src/i18n/locales/ko/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "자산군 이름이 필요합니다.",
     "documentNotFound": "문서를 찾을 수 없습니다",
     "selectionNotFound": "선택한 증권 중 하나 이상을 찾을 수 없습니다",
-    "comparisonSelectionEmpty": "비교할 증권 또는 시장 지수를 하나 이상 선택하세요"
+    "comparisonSelectionEmpty": "비교할 증권 또는 시장 지수를 하나 이상 선택하세요",
+    "exchangeRateNotPositive": "환율은 0보다 커야 합니다"
   },
   "tags": {
     "notFound": "ID가 {{ id }}인 태그를 찾을 수 없습니다",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount와 originalCurrencyCode는 함께 제공해야 합니다",
     "fxRateRequired": "외화 거래에는 양수 환율이 필요합니다",
     "fxSignMismatch": "originalAmount와 amount의 부호가 같아야 합니다",
-    "jointAccountMoveLocked": "공유 계좌의 거래는 다른 계좌로 이동할 수 없습니다."
+    "jointAccountMoveLocked": "공유 계좌의 거래는 다른 계좌로 이동할 수 없습니다.",
+    "currencyMustMatchAccount": "거래 통화 {{ supplied }}은(는) 계좌 통화 {{ account }}와 일치해야 합니다. 외화 입력에는 originalAmount와 originalCurrencyCode를 사용하세요.",
+    "transferSameCurrencyMustConserve": "{{ currency }} 계좌 간 이체는 양쪽 금액이 같아야 합니다",
+    "transferSameCurrencyRateMustBeOne": "{{ currency }} 계좌 간 이체에는 1 이외의 환율을 지정할 수 없습니다",
+    "transferRateUnavailable": "{{ from }} -> {{ to }}의 환율을 확인할 수 없습니다. 이체가 올바르게 기록되도록 exchangeRate 또는 대상 금액을 입력하세요.",
+    "transferAmountsMustAgreeOnZero": "이체는 양쪽 모두에서 0이 아닌 금액을 이동해야 하거나 양쪽 모두 0이어야 합니다",
+    "transferImpliedRateInvalid": "대상 금액이 출금 금액에 대해 사용할 수 없는 환율을 의미합니다"
   },
   "users": {
     "userNotFound": "사용자를 찾을 수 없습니다",

--- a/backend/src/i18n/locales/nl/errors.json
+++ b/backend/src/i18n/locales/nl/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "Een naam voor de beleggingscategorie is verplicht.",
     "documentNotFound": "Document niet gevonden",
     "selectionNotFound": "Een of meer van de geselecteerde effecten zijn niet gevonden",
-    "comparisonSelectionEmpty": "Selecteer minstens één effect of marktindex om te vergelijken"
+    "comparisonSelectionEmpty": "Selecteer minstens één effect of marktindex om te vergelijken",
+    "exchangeRateNotPositive": "De wisselkoers moet groter zijn dan nul"
   },
   "tags": {
     "notFound": "Label met ID {{ id }} niet gevonden",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount en originalCurrencyCode moeten samen worden opgegeven",
     "fxRateRequired": "Een positieve wisselkoers is vereist voor een transactie in vreemde valuta",
     "fxSignMismatch": "originalAmount en amount moeten hetzelfde teken hebben",
-    "jointAccountMoveLocked": "Transacties in een gedeelde rekening kunnen niet naar een andere rekening worden verplaatst."
+    "jointAccountMoveLocked": "Transacties in een gedeelde rekening kunnen niet naar een andere rekening worden verplaatst.",
+    "currencyMustMatchAccount": "Transactievaluta {{ supplied }} moet overeenkomen met de rekeningvaluta {{ account }}. Gebruik originalAmount en originalCurrencyCode voor een invoer in vreemde valuta.",
+    "transferSameCurrencyMustConserve": "Een overboeking tussen twee {{ currency }}-rekeningen moet aan beide zijden hetzelfde bedrag verplaatsen",
+    "transferSameCurrencyRateMustBeOne": "Een overboeking tussen twee {{ currency }}-rekeningen kan geen andere wisselkoers dan 1 hebben",
+    "transferRateUnavailable": "Kon geen wisselkoers bepalen voor {{ from }} -> {{ to }}. Geef een exchangeRate of een doelbedrag op zodat de overboeking correct wordt geboekt.",
+    "transferAmountsMustAgreeOnZero": "Een overboeking moet aan beide zijden een bedrag anders dan nul verplaatsen, of nul aan beide zijden",
+    "transferImpliedRateInvalid": "Het bestemmingsbedrag impliceert een onbruikbare wisselkoers ten opzichte van het bronbedrag"
   },
   "users": {
     "userNotFound": "Gebruiker niet gevonden",

--- a/backend/src/i18n/locales/pl/errors.json
+++ b/backend/src/i18n/locales/pl/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "Nazwa klasy aktywów jest wymagana.",
     "documentNotFound": "Nie znaleziono dokumentu",
     "selectionNotFound": "Nie znaleziono jednego lub więcej wybranych papierów wartościowych",
-    "comparisonSelectionEmpty": "Wybierz co najmniej jeden papier wartościowy lub indeks giełdowy do porównania"
+    "comparisonSelectionEmpty": "Wybierz co najmniej jeden papier wartościowy lub indeks giełdowy do porównania",
+    "exchangeRateNotPositive": "Kurs wymiany musi być większy od zera"
   },
   "tags": {
     "notFound": "Nie znaleziono tagu o ID {{ id }}",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount i originalCurrencyCode muszą być podane razem",
     "fxRateRequired": "Do transakcji w obcej walucie wymagany jest dodatni kurs wymiany",
     "fxSignMismatch": "originalAmount i amount muszą mieć ten sam znak",
-    "jointAccountMoveLocked": "Transakcji ze wspólnego konta nie można przenieść na inne konto."
+    "jointAccountMoveLocked": "Transakcji ze wspólnego konta nie można przenieść na inne konto.",
+    "currencyMustMatchAccount": "Waluta transakcji {{ supplied }} musi być zgodna z walutą konta {{ account }}. Do wpisu w walucie obcej użyj originalAmount i originalCurrencyCode.",
+    "transferSameCurrencyMustConserve": "Przelew między dwoma kontami w {{ currency }} musi przenosić tę samą kwotę po obu stronach",
+    "transferSameCurrencyRateMustBeOne": "Przelew między dwoma kontami w {{ currency }} nie może mieć kursu wymiany innego niż 1",
+    "transferRateUnavailable": "Nie udało się ustalić kursu wymiany dla {{ from }} -> {{ to }}. Podaj exchangeRate lub kwotę docelową, aby przelew został zaksięgowany poprawnie.",
+    "transferAmountsMustAgreeOnZero": "Przelew musi przenosić kwotę różną od zera po obu stronach albo zero po obu stronach",
+    "transferImpliedRateInvalid": "Kwota docelowa daje nieprawidłowy kurs wymiany w stosunku do kwoty źródłowej"
   },
   "users": {
     "userNotFound": "Nie znaleziono użytkownika",

--- a/backend/src/i18n/locales/pt-BR/errors.json
+++ b/backend/src/i18n/locales/pt-BR/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "É necessário informar um nome de classe de ativos.",
     "documentNotFound": "Documento não encontrado",
     "selectionNotFound": "Um ou mais dos ativos selecionados não foram encontrados",
-    "comparisonSelectionEmpty": "Selecione pelo menos um ativo ou índice de mercado para comparar"
+    "comparisonSelectionEmpty": "Selecione pelo menos um ativo ou índice de mercado para comparar",
+    "exchangeRateNotPositive": "A taxa de câmbio deve ser maior que zero"
   },
   "tags": {
     "notFound": "Etiqueta com ID {{ id }} não encontrada",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount e originalCurrencyCode devem ser fornecidos juntos",
     "fxRateRequired": "É necessária uma taxa de câmbio positiva para uma transação em moeda estrangeira",
     "fxSignMismatch": "originalAmount e amount devem ter o mesmo sinal",
-    "jointAccountMoveLocked": "As transações de uma conta compartilhada não podem ser movidas para outra conta."
+    "jointAccountMoveLocked": "As transações de uma conta compartilhada não podem ser movidas para outra conta.",
+    "currencyMustMatchAccount": "A moeda da transação {{ supplied }} deve corresponder à moeda da conta {{ account }}. Use originalAmount e originalCurrencyCode para um lançamento em moeda estrangeira.",
+    "transferSameCurrencyMustConserve": "Uma transferência entre duas contas em {{ currency }} deve movimentar o mesmo valor em ambos os lados",
+    "transferSameCurrencyRateMustBeOne": "Uma transferência entre duas contas em {{ currency }} não pode ter uma taxa de câmbio diferente de 1",
+    "transferRateUnavailable": "Não foi possível determinar uma taxa de câmbio para {{ from }} -> {{ to }}. Informe um exchangeRate ou um valor de destino para que a transferência seja registrada corretamente.",
+    "transferAmountsMustAgreeOnZero": "Uma transferência deve mover um valor diferente de zero em ambos os lados, ou zero em ambos",
+    "transferImpliedRateInvalid": "O valor de destino implica uma taxa de câmbio inutilizável em relação ao valor de origem"
   },
   "users": {
     "userNotFound": "Usuário não encontrado",

--- a/backend/src/i18n/locales/pt/errors.json
+++ b/backend/src/i18n/locales/pt/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "É necessário um nome de classe de ativos.",
     "documentNotFound": "Documento não encontrado",
     "selectionNotFound": "Um ou mais dos títulos selecionados não foram encontrados",
-    "comparisonSelectionEmpty": "Selecione pelo menos um título ou índice de mercado para comparar"
+    "comparisonSelectionEmpty": "Selecione pelo menos um título ou índice de mercado para comparar",
+    "exchangeRateNotPositive": "A taxa de câmbio deve ser maior do que zero"
   },
   "tags": {
     "notFound": "Etiqueta com ID {{ id }} não encontrada",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount e originalCurrencyCode devem ser fornecidos em conjunto",
     "fxRateRequired": "É necessária uma taxa de câmbio positiva para uma transação em moeda estrangeira",
     "fxSignMismatch": "originalAmount e amount devem ter o mesmo sinal",
-    "jointAccountMoveLocked": "As transações de uma conta partilhada não podem ser movidas para outra conta."
+    "jointAccountMoveLocked": "As transações de uma conta partilhada não podem ser movidas para outra conta.",
+    "currencyMustMatchAccount": "A moeda da transação {{ supplied }} deve corresponder à moeda da conta {{ account }}. Utilize originalAmount e originalCurrencyCode para um lançamento em moeda estrangeira.",
+    "transferSameCurrencyMustConserve": "Uma transferência entre duas contas em {{ currency }} deve movimentar o mesmo valor em ambos os lados",
+    "transferSameCurrencyRateMustBeOne": "Uma transferência entre duas contas em {{ currency }} não pode ter uma taxa de câmbio diferente de 1",
+    "transferRateUnavailable": "Não foi possível determinar uma taxa de câmbio para {{ from }} -> {{ to }}. Forneça um exchangeRate ou um valor de destino para que a transferência seja registada corretamente.",
+    "transferAmountsMustAgreeOnZero": "Uma transferência tem de mover um valor diferente de zero em ambos os lados, ou zero em ambos",
+    "transferImpliedRateInvalid": "O valor de destino implica uma taxa de câmbio inutilizável face ao valor de origem"
   },
   "users": {
     "userNotFound": "Utilizador não encontrado",

--- a/backend/src/i18n/locales/ru/errors.json
+++ b/backend/src/i18n/locales/ru/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "Требуется название класса активов.",
     "documentNotFound": "Документ не найден",
     "selectionNotFound": "Одна или несколько выбранных бумаг не найдены",
-    "comparisonSelectionEmpty": "Выберите хотя бы одну бумагу или рыночный индекс для сравнения"
+    "comparisonSelectionEmpty": "Выберите хотя бы одну бумагу или рыночный индекс для сравнения",
+    "exchangeRateNotPositive": "Курс обмена должен быть больше нуля"
   },
   "tags": {
     "notFound": "Тег с ID {{ id }} не найден",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount и originalCurrencyCode должны указываться вместе",
     "fxRateRequired": "Для операции в иностранной валюте требуется положительный курс обмена",
     "fxSignMismatch": "originalAmount и amount должны иметь одинаковый знак",
-    "jointAccountMoveLocked": "Операции совместного счёта нельзя переместить на другой счёт."
+    "jointAccountMoveLocked": "Операции совместного счёта нельзя переместить на другой счёт.",
+    "currencyMustMatchAccount": "Валюта операции {{ supplied }} должна совпадать с валютой счёта {{ account }}. Для записи в иностранной валюте используйте originalAmount и originalCurrencyCode.",
+    "transferSameCurrencyMustConserve": "Перевод между двумя счетами в {{ currency }} должен перемещать одинаковую сумму с обеих сторон",
+    "transferSameCurrencyRateMustBeOne": "Перевод между двумя счетами в {{ currency }} не может иметь курс, отличный от 1",
+    "transferRateUnavailable": "Не удалось определить курс для {{ from }} -> {{ to }}. Укажите exchangeRate или сумму получения, чтобы перевод был проведён корректно.",
+    "transferAmountsMustAgreeOnZero": "Перевод должен перемещать ненулевую сумму с обеих сторон либо ноль с обеих сторон",
+    "transferImpliedRateInvalid": "Сумма зачисления даёт непригодный курс обмена по отношению к сумме списания"
   },
   "users": {
     "userNotFound": "Пользователь не найден",

--- a/backend/src/i18n/locales/tr/errors.json
+++ b/backend/src/i18n/locales/tr/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "Varlık sınıfı adı gerekli.",
     "documentNotFound": "Belge bulunamadı",
     "selectionNotFound": "Seçilen menkul kıymetlerden biri veya birkaçı bulunamadı",
-    "comparisonSelectionEmpty": "Karşılaştırmak için en az bir menkul kıymet veya piyasa endeksi seçin"
+    "comparisonSelectionEmpty": "Karşılaştırmak için en az bir menkul kıymet veya piyasa endeksi seçin",
+    "exchangeRateNotPositive": "Döviz kuru sıfırdan büyük olmalıdır"
   },
   "tags": {
     "notFound": "{{ id }} kimliğine sahip etiket bulunamadı",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount ve originalCurrencyCode birlikte sağlanmalıdır",
     "fxRateRequired": "Yabancı para birimi işlemi için pozitif bir döviz kuru gereklidir",
     "fxSignMismatch": "originalAmount ve amount aynı işarete sahip olmalıdır",
-    "jointAccountMoveLocked": "Paylaşılan hesaptaki işlemler başka bir hesaba taşınamaz."
+    "jointAccountMoveLocked": "Paylaşılan hesaptaki işlemler başka bir hesaba taşınamaz.",
+    "currencyMustMatchAccount": "İşlem para birimi {{ supplied }}, hesap para birimi {{ account }} ile aynı olmalıdır. Yabancı para girişi için originalAmount ve originalCurrencyCode kullanın.",
+    "transferSameCurrencyMustConserve": "İki {{ currency }} hesabı arasındaki transfer her iki tarafta da aynı tutarı hareket ettirmelidir",
+    "transferSameCurrencyRateMustBeOne": "İki {{ currency }} hesabı arasındaki transferin döviz kuru 1'den farklı olamaz",
+    "transferRateUnavailable": "{{ from }} -> {{ to }} için döviz kuru belirlenemedi. Transferin doğru kaydedilmesi için bir exchangeRate veya hedef tutar girin.",
+    "transferAmountsMustAgreeOnZero": "Bir transfer her iki tarafta sıfırdan farklı bir tutar taşımalı veya her iki tarafta sıfır olmalıdır",
+    "transferImpliedRateInvalid": "Hedef tutar, kaynak tutara göre kullanılamaz bir döviz kuru anlamına geliyor"
   },
   "users": {
     "userNotFound": "Kullanıcı bulunamadı",

--- a/backend/src/i18n/locales/uk/errors.json
+++ b/backend/src/i18n/locales/uk/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "Потрібна назва класу активів.",
     "documentNotFound": "Документ не знайдено",
     "selectionNotFound": "Один або кілька вибраних паперів не знайдено",
-    "comparisonSelectionEmpty": "Виберіть щонайменше один папір або ринковий індекс для порівняння"
+    "comparisonSelectionEmpty": "Виберіть щонайменше один папір або ринковий індекс для порівняння",
+    "exchangeRateNotPositive": "Курс обміну має бути більшим за нуль"
   },
   "tags": {
     "notFound": "Тег з ідентифікатором {{ id }} не знайдено",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount і originalCurrencyCode потрібно вказувати разом",
     "fxRateRequired": "Для операції в іноземній валюті потрібен додатний курс обміну",
     "fxSignMismatch": "originalAmount і amount повинні мати однаковий знак",
-    "jointAccountMoveLocked": "Транзакції спільного рахунку не можна перемістити на інший рахунок."
+    "jointAccountMoveLocked": "Транзакції спільного рахунку не можна перемістити на інший рахунок.",
+    "currencyMustMatchAccount": "Валюта операції {{ supplied }} має відповідати валюті рахунку {{ account }}. Для запису в іноземній валюті використовуйте originalAmount і originalCurrencyCode.",
+    "transferSameCurrencyMustConserve": "Переказ між двома рахунками в {{ currency }} має переміщувати однакову суму з обох боків",
+    "transferSameCurrencyRateMustBeOne": "Переказ між двома рахунками в {{ currency }} не може мати курс, відмінний від 1",
+    "transferRateUnavailable": "Не вдалося визначити курс для {{ from }} -> {{ to }}. Укажіть exchangeRate або суму зарахування, щоб переказ було проведено правильно.",
+    "transferAmountsMustAgreeOnZero": "Переказ має переміщувати ненульову суму з обох сторін або нуль з обох сторін",
+    "transferImpliedRateInvalid": "Сума зарахування дає непридатний курс обміну щодо суми списання"
   },
   "users": {
     "userNotFound": "Користувача не знайдено",

--- a/backend/src/i18n/locales/vi/errors.json
+++ b/backend/src/i18n/locales/vi/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "Cần có tên loại tài sản.",
     "documentNotFound": "Không tìm thấy tài liệu",
     "selectionNotFound": "Không tìm thấy một hoặc nhiều chứng khoán đã chọn",
-    "comparisonSelectionEmpty": "Chọn ít nhất một chứng khoán hoặc chỉ số thị trường để so sánh"
+    "comparisonSelectionEmpty": "Chọn ít nhất một chứng khoán hoặc chỉ số thị trường để so sánh",
+    "exchangeRateNotPositive": "Tỷ giá phải lớn hơn không"
   },
   "tags": {
     "notFound": "Không tìm thấy thẻ với ID {{ id }}",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount và originalCurrencyCode phải được cung cấp cùng nhau",
     "fxRateRequired": "Cần một tỷ giá hối đoái dương cho giao dịch bằng ngoại tệ",
     "fxSignMismatch": "originalAmount và amount phải cùng dấu",
-    "jointAccountMoveLocked": "Không thể chuyển giao dịch trong tài khoản được chia sẻ sang tài khoản khác."
+    "jointAccountMoveLocked": "Không thể chuyển giao dịch trong tài khoản được chia sẻ sang tài khoản khác.",
+    "currencyMustMatchAccount": "Tiền tệ giao dịch {{ supplied }} phải khớp với tiền tệ của tài khoản {{ account }}. Hãy dùng originalAmount và originalCurrencyCode cho bút toán ngoại tệ.",
+    "transferSameCurrencyMustConserve": "Giao dịch chuyển khoản giữa hai tài khoản {{ currency }} phải chuyển cùng một số tiền ở cả hai bên",
+    "transferSameCurrencyRateMustBeOne": "Giao dịch chuyển khoản giữa hai tài khoản {{ currency }} không thể có tỷ giá khác 1",
+    "transferRateUnavailable": "Không thể xác định tỷ giá cho {{ from }} -> {{ to }}. Hãy cung cấp exchangeRate hoặc số tiền đích để giao dịch chuyển khoản được ghi nhận chính xác.",
+    "transferAmountsMustAgreeOnZero": "Giao dịch chuyển tiền phải di chuyển một số tiền khác không ở cả hai bên, hoặc bằng không ở cả hai bên",
+    "transferImpliedRateInvalid": "Số tiền đích ngụ ý một tỷ giá không thể sử dụng so với số tiền nguồn"
   },
   "users": {
     "userNotFound": "Không tìm thấy người dùng",

--- a/backend/src/i18n/locales/xx/errors.json
+++ b/backend/src/i18n/locales/xx/errors.json
@@ -445,7 +445,8 @@
     "noUpdateFields": "[XX-Provide at least one field to change.-XX]",
     "documentNotFound": "[XX-Document not found-XX]",
     "selectionNotFound": "[XX-One or more of the selected securities could not be found-XX]",
-    "comparisonSelectionEmpty": "[XX-Select at least one security or market index to compare-XX]"
+    "comparisonSelectionEmpty": "[XX-Select at least one security or market index to compare-XX]",
+    "exchangeRateNotPositive": "[XX-Exchange rate must be greater than zero-XX]"
   },
   "tags": {
     "notFound": "[XX-Tag with ID {{ id }} not found-XX]",
@@ -507,7 +508,13 @@
     "fxFieldsIncomplete": "[XX-originalAmount and originalCurrencyCode must be provided together-XX]",
     "fxRateRequired": "[XX-A positive exchange rate is required for a foreign-currency transaction-XX]",
     "fxSignMismatch": "[XX-originalAmount and amount must have the same sign-XX]",
-    "jointAccountMoveLocked": "[XX-Transactions in a shared account cannot be moved to another account.-XX]"
+    "jointAccountMoveLocked": "[XX-Transactions in a shared account cannot be moved to another account.-XX]",
+    "currencyMustMatchAccount": "[XX-Transaction currency {{ supplied }} must match the account currency {{ account }}. Use originalAmount and originalCurrencyCode for a foreign-currency entry.-XX]",
+    "transferSameCurrencyMustConserve": "[XX-A transfer between two {{ currency }} accounts must move the same amount on both sides-XX]",
+    "transferSameCurrencyRateMustBeOne": "[XX-A transfer between two {{ currency }} accounts cannot have an exchange rate other than 1-XX]",
+    "transferRateUnavailable": "[XX-Could not determine an exchange rate for {{ from }} -> {{ to }}. Supply an exchangeRate or a destination amount so the transfer posts correctly.-XX]",
+    "transferAmountsMustAgreeOnZero": "[XX-A transfer must move a non-zero amount on both sides, or zero on both-XX]",
+    "transferImpliedRateInvalid": "[XX-The destination amount implies an unusable exchange rate against the source amount-XX]"
   },
   "users": {
     "userNotFound": "[XX-User not found-XX]",

--- a/backend/src/i18n/locales/zh-CN/errors.json
+++ b/backend/src/i18n/locales/zh-CN/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "需要填写资产类别名称。",
     "documentNotFound": "未找到该文档",
     "selectionNotFound": "未找到所选证券中的一个或多个",
-    "comparisonSelectionEmpty": "请至少选择一只证券或一个市场指数进行比较"
+    "comparisonSelectionEmpty": "请至少选择一只证券或一个市场指数进行比较",
+    "exchangeRateNotPositive": "汇率必须大于零"
   },
   "tags": {
     "notFound": "未找到 ID 为 {{ id }} 的标签",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount 和 originalCurrencyCode 必须同时提供",
     "fxRateRequired": "外币交易需要一个正的汇率",
     "fxSignMismatch": "originalAmount 和 amount 的符号必须相同",
-    "jointAccountMoveLocked": "共享账户中的交易无法移动到其他账户。"
+    "jointAccountMoveLocked": "共享账户中的交易无法移动到其他账户。",
+    "currencyMustMatchAccount": "交易货币 {{ supplied }} 必须与账户货币 {{ account }} 一致。外币记账请使用 originalAmount 和 originalCurrencyCode。",
+    "transferSameCurrencyMustConserve": "两个 {{ currency }} 账户之间的转账，两侧金额必须相同",
+    "transferSameCurrencyRateMustBeOne": "两个 {{ currency }} 账户之间的转账，汇率只能为 1",
+    "transferRateUnavailable": "无法确定 {{ from }} -> {{ to }} 的汇率。请提供 exchangeRate 或目标金额，以便正确记录该转账。",
+    "transferAmountsMustAgreeOnZero": "转账必须在两侧移动非零金额，或两侧均为零",
+    "transferImpliedRateInvalid": "目标金额相对于源金额意味着无法使用的汇率"
   },
   "users": {
     "userNotFound": "未找到用户",

--- a/backend/src/i18n/locales/zh-TW/errors.json
+++ b/backend/src/i18n/locales/zh-TW/errors.json
@@ -436,7 +436,8 @@
     "assetOptionNameRequired": "需要填寫資產類別名稱。",
     "documentNotFound": "找不到該文件",
     "selectionNotFound": "找不到所選證券中的一檔或多檔",
-    "comparisonSelectionEmpty": "請至少選擇一檔證券或一個市場指數進行比較"
+    "comparisonSelectionEmpty": "請至少選擇一檔證券或一個市場指數進行比較",
+    "exchangeRateNotPositive": "匯率必須大於零"
   },
   "tags": {
     "notFound": "找不到 ID 為 {{ id }} 的標籤",
@@ -498,7 +499,13 @@
     "fxFieldsIncomplete": "originalAmount 和 originalCurrencyCode 必須同時提供",
     "fxRateRequired": "外幣交易需要一個正的匯率",
     "fxSignMismatch": "originalAmount 和 amount 的符號必須相同",
-    "jointAccountMoveLocked": "共享帳戶中的交易無法移動到其他帳戶。"
+    "jointAccountMoveLocked": "共享帳戶中的交易無法移動到其他帳戶。",
+    "currencyMustMatchAccount": "交易貨幣 {{ supplied }} 必須與帳戶貨幣 {{ account }} 一致。外幣記帳請使用 originalAmount 與 originalCurrencyCode。",
+    "transferSameCurrencyMustConserve": "兩個 {{ currency }} 帳戶之間的轉帳，兩側金額必須相同",
+    "transferSameCurrencyRateMustBeOne": "兩個 {{ currency }} 帳戶之間的轉帳，匯率只能為 1",
+    "transferRateUnavailable": "無法確定 {{ from }} -> {{ to }} 的匯率。請提供 exchangeRate 或目標金額，以便正確記錄該轉帳。",
+    "transferAmountsMustAgreeOnZero": "轉帳必須在兩側移動非零金額，或兩側皆為零",
+    "transferImpliedRateInvalid": "目標金額相對於來源金額意味著無法使用的匯率"
   },
   "users": {
     "userNotFound": "找不到使用者",

--- a/backend/src/import/import-investment-processor.service.spec.ts
+++ b/backend/src/import/import-investment-processor.service.spec.ts
@@ -12,6 +12,7 @@ import { ImportResultDto } from "./dto/import.dto";
 
 describe("ImportInvestmentProcessorService", () => {
   let service: ImportInvestmentProcessorService;
+  let exchangeRateService: Record<string, jest.Mock>;
 
   const userId = "user-1";
   const accountId = "acc-1";
@@ -86,7 +87,17 @@ describe("ImportInvestmentProcessorService", () => {
   };
 
   beforeEach(() => {
-    service = new ImportInvestmentProcessorService();
+    // The importer resolves a rate when a security's currency differs from the
+    // cash account's rather than posting the security-currency number at par
+    // (audit P5-003/P5-009 in the import path). Same-currency trades never reach
+    // the lookup, which is every fixture here unless it says otherwise.
+    exchangeRateService = {
+      getRateForDate: jest.fn().mockResolvedValue(null),
+      getLatestRate: jest.fn().mockResolvedValue(null),
+    };
+    service = new ImportInvestmentProcessorService(
+      exchangeRateService as never,
+    );
   });
 
   describe("processTransaction", () => {
@@ -120,6 +131,96 @@ describe("ImportInvestmentProcessorService", () => {
       expect(firstSaveArg.commission).toBe(9.99);
       // BUY: totalAmount = quantity * price + commission
       expect(firstSaveArg.totalAmount).toBe(1509.99);
+    });
+
+    describe("foreign-security cash posting (P5-003 / P5-009 in the import path)", () => {
+      // `totalAmount` on an imported row is in the SECURITY's currency. It used
+      // to be written straight onto the cash transaction with `exchangeRate: 1`,
+      // the row labelled with the security's currency, and the cash account's
+      // balance moved by that raw number -- so a 1,000 USD purchase settled from
+      // a CAD account took 1,000 CAD out and left a USD-labelled row sitting in a
+      // CAD account.
+      const usdSecurityInCadAccount = (ctx: ReturnType<typeof makeContext>) => {
+        managerOf(ctx).findOne.mockImplementation((entity: any, opts: any) => {
+          if (entity === Security && opts?.where?.id === "sec-1") {
+            return Promise.resolve({
+              id: "sec-1",
+              symbol: "AAPL",
+              currencyCode: "USD",
+            });
+          }
+          return Promise.resolve(null);
+        });
+      };
+
+      const buyQif = {
+        action: "Buy",
+        security: "Apple Inc",
+        quantity: 10,
+        price: 100,
+        commission: 0,
+        date: "2025-01-15",
+      };
+
+      it("converts the cash effect into the cash account's currency", async () => {
+        const securityMap = new Map<string, string | null>([
+          ["Apple Inc", "sec-1"],
+        ]);
+        const ctx = makeContext({
+          securityMap,
+          account: {
+            id: accountId,
+            currencyCode: "CAD",
+            accountSubType: null,
+            linkedAccountId: null,
+            name: "Investment Account",
+          } as never,
+        });
+        usdSecurityInCadAccount(ctx);
+        exchangeRateService.getRateForDate.mockResolvedValue(1.35);
+
+        await service.processTransaction(ctx, buyQif);
+
+        const cashTx = managerOf(ctx)
+          .save.mock.calls.map((c: any[]) => c[0])
+          .find((arg: any) => arg?.currencyCode !== undefined);
+        expect(cashTx.currencyCode).toBe(ctx.account.currencyCode);
+        // 1,000 USD at 1.35 is 1,350 in the account's currency, taken out.
+        expect(cashTx.amount).toBe(-1350);
+        expect(cashTx.exchangeRate).toBe(1.35);
+      });
+
+      it("does not post a cash effect it cannot denominate", async () => {
+        // Posting the unconverted number would move a real balance by the wrong
+        // amount and look entirely normal. The trade still imports; the user is
+        // told which pair is missing.
+        const securityMap = new Map<string, string | null>([
+          ["Apple Inc", "sec-1"],
+        ]);
+        const ctx = makeContext({
+          securityMap,
+          account: {
+            id: accountId,
+            currencyCode: "CAD",
+            accountSubType: null,
+            linkedAccountId: null,
+            name: "Investment Account",
+          } as never,
+        });
+        usdSecurityInCadAccount(ctx);
+        exchangeRateService.getRateForDate.mockResolvedValue(null);
+        exchangeRateService.getLatestRate.mockResolvedValue(null);
+
+        await service.processTransaction(ctx, buyQif);
+
+        const cashTx = managerOf(ctx)
+          .save.mock.calls.map((c: any[]) => c[0])
+          .find((arg: any) => arg?.currencyCode !== undefined);
+        expect(cashTx).toBeUndefined();
+        expect(ctx.importResult.warnings?.join(" ")).toMatch(
+          /No exchange rate for USD -> /,
+        );
+      });
     });
 
     it("should map SELL action and calculate total correctly", async () => {
@@ -1190,7 +1291,10 @@ describe("ImportInvestmentProcessorService", () => {
         if (opts?.where?.id === "acc-ws") {
           return Promise.resolve({
             id: "acc-ws",
-            currencyCode: "CAD",
+            // Same currency as the importing account: these tests are about
+            // transfer mechanics, and the counterpart equals the negated cash
+            // amount only when no conversion applies.
+            currencyCode: "USD",
             currentBalance: 0,
           });
         }
@@ -1242,7 +1346,10 @@ describe("ImportInvestmentProcessorService", () => {
         if (opts?.where?.id === "acc-eq") {
           return Promise.resolve({
             id: "acc-eq",
-            currencyCode: "CAD",
+            // Same currency as the importing account: these tests are about
+            // transfer mechanics, and the counterpart equals the negated cash
+            // amount only when no conversion applies.
+            currencyCode: "USD",
             currentBalance: 0,
           });
         }
@@ -1287,6 +1394,88 @@ describe("ImportInvestmentProcessorService", () => {
   });
 
   describe("XIn / XOut cash transfers", () => {
+    it("converts the counterpart into the target account's currency (P5-003)", async () => {
+      // USD investment account transferring to a CAD chequing account: the
+      // counterpart lives in the target, so it is denominated there. It used
+      // to be written as `-cashAmount` -- a USD number -- labelled CAD, equal
+      // magnitudes across two currencies with no conversion.
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Chequing CAD", "acc-cad");
+      const ctx = makeContext({ accountMap });
+      exchangeRateService.getRateForDate.mockResolvedValue(1.35);
+
+      managerOf(ctx).findOne.mockImplementation((_entity: any, opts: any) => {
+        if (opts?.where?.id === "acc-cad") {
+          return Promise.resolve({
+            id: "acc-cad",
+            currencyCode: "CAD",
+            currentBalance: 0,
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      await service.processTransaction(ctx, {
+        action: "XOut",
+        date: "2025-01-15",
+        amount: 1000,
+        payee: "Transfer",
+        isTransfer: true,
+        transferAccount: "Chequing CAD",
+      });
+
+      const saveCalls = managerOf(ctx).save.mock.calls;
+      const linkedTxSave = saveCalls.find(
+        (call: any) => call[0]?.accountId === "acc-cad",
+      );
+      expect(linkedTxSave).toBeDefined();
+      // -(-1000) * 1.35: converted into CAD, with the rate on the row.
+      expect(linkedTxSave[0].amount).toBe(1350);
+      expect(linkedTxSave[0].currencyCode).toBe("CAD");
+      expect(linkedTxSave[0].exchangeRate).toBe(1.35);
+    });
+
+    it("skips the counterpart with a warning when the pair has no rate, instead of mislabelling it", async () => {
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Chequing THB", "acc-thb");
+      const ctx = makeContext({ accountMap });
+      exchangeRateService.getRateForDate.mockResolvedValue(null);
+      exchangeRateService.getLatestRate.mockResolvedValue(null);
+
+      managerOf(ctx).findOne.mockImplementation((_entity: any, opts: any) => {
+        if (opts?.where?.id === "acc-thb") {
+          return Promise.resolve({
+            id: "acc-thb",
+            currencyCode: "THB",
+            currentBalance: 0,
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      await service.processTransaction(ctx, {
+        action: "XOut",
+        date: "2025-01-15",
+        amount: 1000,
+        payee: "Transfer",
+        isTransfer: true,
+        transferAccount: "Chequing THB",
+      });
+
+      // The cash leg stands alone; no row in the target and no balance moved
+      // there by a number in the wrong currency.
+      const saveCalls = managerOf(ctx).save.mock.calls;
+      const linkedTxSave = saveCalls.find(
+        (call: any) => call[0]?.accountId === "acc-thb",
+      );
+      expect(linkedTxSave).toBeUndefined();
+      expect(
+        (ctx.importResult.warnings ?? []).some((w: string) =>
+          w.includes("USD -> THB"),
+        ),
+      ).toBe(true);
+    });
+
     it("XIn creates a cash transaction and a linked transaction in the transfer account", async () => {
       const accountMap = new Map<string, string | null>();
       accountMap.set("Chequing", "acc-chequing");
@@ -1401,7 +1590,10 @@ describe("ImportInvestmentProcessorService", () => {
         if (opts?.where?.id === "acc-ws-joint") {
           return Promise.resolve({
             id: "acc-ws-joint",
-            currencyCode: "CAD",
+            // Same currency as the importing account: these tests are about
+            // transfer mechanics, and the counterpart equals the negated cash
+            // amount only when no conversion applies.
+            currencyCode: "USD",
             currentBalance: 0,
           });
         }
@@ -1471,6 +1663,9 @@ describe("ImportInvestmentProcessorService", () => {
         if (opts?.where?.id === "acc-ws-joint") {
           return Promise.resolve({
             id: "acc-ws-joint",
+            // Same currency as this test's CAD importing account, for the same
+            // reason the sibling fixtures match theirs: the duplicate-counting
+            // assertions compare unconverted amounts.
             currencyCode: "CAD",
             currentBalance: 0,
           });
@@ -1648,7 +1843,10 @@ describe("ImportInvestmentProcessorService", () => {
         if (opts?.where?.id === "acc-cash-joint") {
           return Promise.resolve({
             id: "acc-cash-joint",
-            currencyCode: "CAD",
+            // Same currency as the importing account: these tests are about
+            // transfer mechanics, and the counterpart equals the negated cash
+            // amount only when no conversion applies.
+            currencyCode: "USD",
             currentBalance: 10000,
           });
         }

--- a/backend/src/import/import-investment-processor.service.ts
+++ b/backend/src/import/import-investment-processor.service.ts
@@ -11,11 +11,61 @@ import {
   TransactionStatus,
 } from "../transactions/entities/transaction.entity";
 import { ImportContext, updateAccountBalance } from "./import-context";
-import { roundToDecimals } from "../common/round.util";
+import { roundMoney, roundToDecimals } from "../common/round.util";
+import { resolveFxRateOrNull } from "../common/fx-entry.util";
+import { ExchangeRateService } from "../currencies/exchange-rate.service";
 
 @Injectable()
 export class ImportInvestmentProcessorService {
   private readonly logger = new Logger(ImportInvestmentProcessorService.name);
+
+  constructor(private readonly exchangeRateService: ExchangeRateService) {}
+
+  /**
+   * A trade's cash effect, expressed in the CASH ACCOUNT's currency.
+   *
+   * `totalAmount` on an imported investment row is denominated in the security's
+   * currency. It used to be written straight onto the cash transaction with
+   * `exchangeRate: 1`, the row labelled with the *security's* currency, and the
+   * cash account's balance moved by that raw number -- so a 1,000 USD purchase
+   * settled from a CAD account took 1,000 CAD out and left a USD-labelled row
+   * sitting in a CAD account. Both halves of audit P5-003, plus the silent 1:1 of
+   * P5-009, in a path the audit could not execute.
+   *
+   * QIF and OFX carry no exchange rate, so the rate is resolved from stored
+   * history. Returns `null` when the pair cannot be resolved: a cash posting that
+   * cannot be denominated is worse than an absent one the user is warned about,
+   * because it silently moves a real balance by the wrong number.
+   */
+  private async resolveCashAmountInAccountCurrency(
+    amount: number,
+    securityCurrencyCode: string | null,
+    cashAccountCurrencyCode: string,
+    transactionDate: string | Date,
+  ): Promise<{ amount: number; exchangeRate: number } | null> {
+    if (
+      !securityCurrencyCode ||
+      securityCurrencyCode === cashAccountCurrencyCode
+    ) {
+      return { amount: roundMoney(amount), exchangeRate: 1 };
+    }
+
+    const dateStr =
+      typeof transactionDate === "string"
+        ? transactionDate.substring(0, 10)
+        : transactionDate.toISOString().substring(0, 10);
+
+    const rate = await resolveFxRateOrNull(
+      this.exchangeRateService,
+      securityCurrencyCode,
+      cashAccountCurrencyCode,
+      dateStr,
+    );
+    if (rate === null) return null;
+
+    const exchangeRate = rate;
+    return { amount: roundMoney(amount * exchangeRate), exchangeRate };
+  }
 
   async processTransaction(ctx: ImportContext, qifTx: any): Promise<void> {
     // XIn/XOut are cash-only transfers between the investment account and
@@ -322,29 +372,58 @@ export class ImportInvestmentProcessorService {
 
     if (transferAccountId) {
       ctx.affectedAccountIds.add(transferAccountId);
-      const linkedAmount = -cashAmount;
       const targetAccount = await ctx.manager.findOne(Account, {
         where: { id: transferAccountId },
       });
+      const targetCurrency = targetAccount?.currencyCode || cashCurrencyCode;
 
-      const linkedTx = ctx.manager.create(Transaction, {
-        userId: ctx.userId,
-        accountId: transferAccountId,
-        transactionDate: qifTx.date,
-        amount: linkedAmount,
-        payeeName: qifTx.payee || `Transfer from ${ctx.account.name}`,
-        description: qifTx.memo || null,
-        status,
-        currencyCode: targetAccount?.currencyCode || cashCurrencyCode,
-        isTransfer: true,
-        linkedTransactionId: savedCashTx.id,
-      });
-      const savedLinkedTx = await ctx.manager.save(linkedTx);
+      // The linked leg lives in the target account, so it is denominated
+      // there. `-cashAmount` labelled with the target's code posted equal
+      // magnitudes across two different currencies with no conversion (the
+      // P5-003 shape); convert it, or leave the cash leg standing alone
+      // rather than moving the target's balance by a mislabelled number.
+      const counterpart = await this.resolveCashAmountInAccountCurrency(
+        -cashAmount,
+        cashCurrencyCode,
+        targetCurrency,
+        qifTx.date,
+      );
+      if (counterpart === null) {
+        const pair = `${cashCurrencyCode} -> ${targetCurrency}`;
+        const message = `No exchange rate for ${pair}: the transfer counterpart in the target account was not created; the cash movement stands alone. Import an exchange rate for that pair and re-import, or record the counterpart manually.`;
+        ctx.importResult.warnings = [
+          ...(ctx.importResult.warnings ?? []),
+          message,
+        ];
+        this.logger.warn(message);
+        await ctx.manager.update(Transaction, savedCashTx.id, {
+          isTransfer: false,
+        });
+      } else {
+        const linkedTx = ctx.manager.create(Transaction, {
+          userId: ctx.userId,
+          accountId: transferAccountId,
+          transactionDate: qifTx.date,
+          amount: counterpart.amount,
+          payeeName: qifTx.payee || `Transfer from ${ctx.account.name}`,
+          description: qifTx.memo || null,
+          status,
+          currencyCode: targetCurrency,
+          exchangeRate: counterpart.exchangeRate,
+          isTransfer: true,
+          linkedTransactionId: savedCashTx.id,
+        });
+        const savedLinkedTx = await ctx.manager.save(linkedTx);
 
-      await ctx.manager.update(Transaction, savedCashTx.id, {
-        linkedTransactionId: savedLinkedTx.id,
-      });
-      await updateAccountBalance(ctx.manager, transferAccountId, linkedAmount);
+        await ctx.manager.update(Transaction, savedCashTx.id, {
+          linkedTransactionId: savedLinkedTx.id,
+        });
+        await updateAccountBalance(
+          ctx.manager,
+          transferAccountId,
+          counterpart.amount,
+        );
+      }
     }
 
     ctx.importResult.imported++;
@@ -388,7 +467,7 @@ export class ImportInvestmentProcessorService {
       return;
     }
 
-    const cashAmount =
+    const cashAmountInSecurityCurrency =
       action === InvestmentAction.BUY ? -totalAmount : totalAmount;
 
     let securitySymbol = "Unknown";
@@ -424,13 +503,35 @@ export class ImportInvestmentProcessorService {
 
     const isCrossAccountTransfer = cashAccountId !== ctx.accountId;
 
+    // The cash leg lives in the cash account, so it is denominated there.
+    const converted = await this.resolveCashAmountInAccountCurrency(
+      cashAmountInSecurityCurrency,
+      securityCurrency,
+      cashAccountCurrency,
+      investmentTx.transactionDate,
+    );
+    if (converted === null) {
+      const pair = `${securityCurrency} -> ${cashAccountCurrency}`;
+      const message = `No exchange rate for ${pair}: the cash effect of ${actionLabel} ${securitySymbol} was not posted. Import an exchange rate for that pair and re-import, or record the cash movement manually.`;
+      ctx.importResult.warnings = [
+        ...(ctx.importResult.warnings ?? []),
+        message,
+      ];
+      this.logger.warn(message);
+      // The trade itself is still recorded -- quantities and cost are valid --
+      // but no balance is moved by a number in the wrong currency.
+      await ctx.manager.save(investmentTx);
+      return;
+    }
+    const cashAmount = converted.amount;
+
     const cashTx = new Transaction();
     cashTx.userId = ctx.userId;
     cashTx.accountId = cashAccountId;
     cashTx.transactionDate = investmentTx.transactionDate;
     cashTx.amount = cashAmount;
-    cashTx.currencyCode = securityCurrency || cashAccountCurrency;
-    cashTx.exchangeRate = 1;
+    cashTx.currencyCode = cashAccountCurrency;
+    cashTx.exchangeRate = converted.exchangeRate;
     cashTx.payeeName = payeeName;
     cashTx.payeeId = null;
     cashTx.description = investmentTx.description;
@@ -442,26 +543,51 @@ export class ImportInvestmentProcessorService {
     // Create linked transaction on the brokerage side so the target account
     // is visible from both sides of the transfer
     if (isCrossAccountTransfer) {
-      const brokerageTx = new Transaction();
-      brokerageTx.userId = ctx.userId;
-      brokerageTx.accountId = ctx.accountId;
-      brokerageTx.transactionDate = investmentTx.transactionDate;
-      brokerageTx.amount = -cashAmount;
-      brokerageTx.currencyCode = securityCurrency || ctx.account.currencyCode;
-      brokerageTx.exchangeRate = 1;
-      brokerageTx.payeeName = payeeName;
-      brokerageTx.payeeId = null;
-      brokerageTx.description = investmentTx.description;
-      brokerageTx.status = TransactionStatus.CLEARED;
-      brokerageTx.isTransfer = true;
-      brokerageTx.linkedTransactionId = savedCashTx.id;
+      // The counterpart lives in the brokerage account, so it is denominated
+      // there. `-cashAmount` is a number in the CASH account's currency;
+      // labelling it with the brokerage's code wrote a row claiming EUR that
+      // was actually CAD (the P5-003 shape this importer's cash leg already
+      // avoids) -- convert it, or leave the cash leg standing alone rather
+      // than posting a mislabelled amount.
+      const counterpart = await this.resolveCashAmountInAccountCurrency(
+        -cashAmount,
+        cashAccountCurrency,
+        ctx.account.currencyCode,
+        investmentTx.transactionDate,
+      );
+      if (counterpart === null) {
+        const pair = `${cashAccountCurrency} -> ${ctx.account.currencyCode}`;
+        const message = `No exchange rate for ${pair}: the brokerage-side counterpart of ${actionLabel} ${securitySymbol} was not created; the cash movement stands alone. Import an exchange rate for that pair and re-import, or record the counterpart manually.`;
+        ctx.importResult.warnings = [
+          ...(ctx.importResult.warnings ?? []),
+          message,
+        ];
+        this.logger.warn(message);
+        savedCashTx.isTransfer = false;
+        await ctx.manager.save(savedCashTx);
+        investmentTx.transactionId = savedCashTx.id;
+      } else {
+        const brokerageTx = new Transaction();
+        brokerageTx.userId = ctx.userId;
+        brokerageTx.accountId = ctx.accountId;
+        brokerageTx.transactionDate = investmentTx.transactionDate;
+        brokerageTx.amount = counterpart.amount;
+        brokerageTx.currencyCode = ctx.account.currencyCode;
+        brokerageTx.exchangeRate = counterpart.exchangeRate;
+        brokerageTx.payeeName = payeeName;
+        brokerageTx.payeeId = null;
+        brokerageTx.description = investmentTx.description;
+        brokerageTx.status = TransactionStatus.CLEARED;
+        brokerageTx.isTransfer = true;
+        brokerageTx.linkedTransactionId = savedCashTx.id;
 
-      const savedBrokerageTx = await ctx.manager.save(brokerageTx);
+        const savedBrokerageTx = await ctx.manager.save(brokerageTx);
 
-      savedCashTx.linkedTransactionId = savedBrokerageTx.id;
-      await ctx.manager.save(savedCashTx);
+        savedCashTx.linkedTransactionId = savedBrokerageTx.id;
+        await ctx.manager.save(savedCashTx);
 
-      investmentTx.transactionId = savedBrokerageTx.id;
+        investmentTx.transactionId = savedBrokerageTx.id;
+      }
     } else {
       investmentTx.transactionId = savedCashTx.id;
     }

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -1256,6 +1256,35 @@ describe("ScheduledTransactionsService", () => {
       expect(completedInsideTransaction).toBe(false);
     });
 
+    it("does not send currency codes, leaving the transfer service to derive them (P5-002)", async () => {
+      // A schedule stores only its source currency. Sending that as
+      // `fromCurrencyCode` with no target currency, rate or destination amount
+      // is what made a cross-currency scheduled transfer post at 1:1 with the
+      // destination row labelled in the source's currency.
+      //
+      // Sending the stored code and nothing else is also fragile the other way:
+      // if the account's currency has since changed, the stored code is stale
+      // and the posting would now be rejected. The accounts are the authority,
+      // so neither code is sent at all.
+      const scheduled = makeScheduled({
+        isTransfer: true,
+        transferAccountId: "acc-2",
+      });
+      stubFindOne(scheduled);
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      accountsRepo.findOne.mockResolvedValue(null);
+
+      await service.post(userId, stId);
+
+      const dto = transactionsService.prepareTransfer.mock.calls[0][1];
+      expect(dto).not.toHaveProperty("fromCurrencyCode");
+      expect(dto).not.toHaveProperty("toCurrencyCode");
+      expect(dto).not.toHaveProperty("exchangeRate");
+      expect(dto).not.toHaveProperty("toAmount");
+    });
+
     it("forwards the schedule's category to prepareTransfer (#743)", async () => {
       const scheduled = makeScheduled({
         isTransfer: true,

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -1657,7 +1657,13 @@ export class ScheduledTransactionsService {
             toAccountId: scheduled.transferAccountId,
             amount: Math.abs(finalAmount),
             transactionDate: postDate,
-            fromCurrencyCode: scheduled.currencyCode,
+            // Currency codes are deliberately not sent: the transfer service
+            // derives both from the accounts. A schedule stores only its source
+            // currency, so supplying that and nothing else is what made a
+            // cross-currency scheduled transfer post at 1:1 with the
+            // destination row mislabelled (audit P5-002). Sending a stored code
+            // that has since gone stale would now fail the posting instead,
+            // which is no better.
             description: finalDescription || undefined,
             referenceNumber: postDto?.referenceNumber || undefined,
             payeeId: scheduled.payeeId || undefined,

--- a/backend/src/securities/dto/create-investment-transaction.dto.ts
+++ b/backend/src/securities/dto/create-investment-transaction.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import {
+  IsPositive,
   IsString,
   IsEnum,
   IsOptional,
@@ -70,7 +71,9 @@ export class CreateInvestmentTransactionDto {
   })
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 10 })
-  @Min(0)
+  // Strictly positive: zero is not a rate. `@Min(0)` let a request through that
+  // previewed as zero cash impact and committed at 1.0 (audit P5-005).
+  @IsPositive()
   exchangeRate?: number;
 
   @ApiProperty({

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -434,7 +434,22 @@ export class InvestmentTransactionsService {
     transactionDate?: string | Date,
   ): Promise<number> {
     if (dtoRate !== undefined && dtoRate !== null) {
-      return Number(dtoRate);
+      // A supplied rate is trusted but still has to be a rate. Zero used to be
+      // accepted here (the DTO allowed @Min(0)): the preview then multiplied the
+      // cash impact by 0 and showed no cash movement, while the committed cash
+      // transaction ran `Number(rate) || 1` and posted the full amount at 1.0. A
+      // user could approve a zero-cash preview and receive a 1,000 debit
+      // (audit P5-005). Negative is equally not a rate.
+      const supplied = Number(dtoRate);
+      if (!Number.isFinite(supplied) || supplied <= 0) {
+        throw new BadRequestException(
+          tr(
+            "errors.securities.exchangeRateNotPositive",
+            "Exchange rate must be greater than zero",
+          ),
+        );
+      }
+      return supplied;
     }
 
     const cashAccount = fundingAccountId
@@ -565,7 +580,12 @@ export class InvestmentTransactionsService {
       sourceCurrency,
     );
 
-    const exchangeRate = Number(investmentTransaction.exchangeRate) || 1;
+    // A stored rate is validated positive on the way in, and is absent only for
+    // a same-currency posting -- so `??` rather than `||`, which would also have
+    // swallowed a stored 0 and posted the full amount unconverted.
+    const storedRate = investmentTransaction.exchangeRate;
+    const exchangeRate =
+      storedRate === null || storedRate === undefined ? 1 : Number(storedRate);
     // Convert the signed source amount (security currency) into the cash
     // account's currency so balance updates reflect the correct amount.
     // Round to the cash account's currency precision (typically 2 decimals)

--- a/backend/src/transactions/dto/create-transaction-split.dto.ts
+++ b/backend/src/transactions/dto/create-transaction-split.dto.ts
@@ -99,7 +99,9 @@ export class CreateTransactionSplitDto {
 
   @ApiProperty({
     description:
-      "Amount for this split (must be same sign as parent transaction)",
+      "Amount for this split. Signed: a line may oppose the parent's sign " +
+      "(a withholding under a net paycheck, a refund under a charge), and " +
+      "the signed sum of all lines must equal the parent amount.",
   })
   @IsNumber({ maxDecimalPlaces: 4 })
   @Min(-999999999999)

--- a/backend/src/transactions/dto/create-transfer.dto.ts
+++ b/backend/src/transactions/dto/create-transfer.dto.ts
@@ -9,6 +9,7 @@ import {
   MaxLength,
   Min,
   Max,
+  IsPositive,
 } from "class-validator";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { TransactionStatus } from "../entities/transaction.entity";
@@ -38,15 +39,17 @@ export class CreateTransferDto {
   @Max(999999999999)
   amount: number;
 
-  @ApiProperty({
-    description: "Currency code of source account (e.g., CAD, USD)",
+  @ApiPropertyOptional({
+    description:
+      "Currency code of the source account. Optional: the server derives both currency codes from the accounts themselves. When supplied it must match the source account's currency, or the request is rejected.",
   })
+  @IsOptional()
   @IsCurrencyCode()
-  fromCurrencyCode: string;
+  fromCurrencyCode?: string;
 
   @ApiPropertyOptional({
     description:
-      "Currency code of destination account (defaults to fromCurrencyCode)",
+      "Currency code of the destination account. Optional and derived from the account, as above.",
   })
   @IsOptional()
   @IsCurrencyCode()
@@ -54,11 +57,14 @@ export class CreateTransferDto {
 
   @ApiPropertyOptional({
     description:
-      "Exchange rate for converting from source to destination currency (defaults to 1.0)",
+      "Exchange rate for converting from source to destination currency. " +
+      "When omitted for a cross-currency pair, the server resolves the market " +
+      "rate for the transfer date or refuses the transfer -- it never posts " +
+      "at 1:1. Must be 1 (or omitted) for a same-currency pair.",
   })
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 10 })
-  @Min(0)
+  @IsPositive()
   @Max(1_000_000)
   exchangeRate?: number;
 

--- a/backend/src/transactions/transaction-split.service.spec.ts
+++ b/backend/src/transactions/transaction-split.service.spec.ts
@@ -5,6 +5,7 @@ import { TransactionSplitService } from "./transaction-split.service";
 import { Transaction } from "./entities/transaction.entity";
 import { TransactionSplit } from "./entities/transaction-split.entity";
 import { Category } from "../categories/entities/category.entity";
+import { ExchangeRateService } from "../currencies/exchange-rate.service";
 import { AccountsService } from "../accounts/accounts.service";
 import { isTransactionInFuture } from "../common/date-utils";
 import {
@@ -41,6 +42,7 @@ describe("TransactionSplitService", () => {
   let splitsRepository: Record<string, jest.Mock>;
   let categoriesRepository: Record<string, jest.Mock>;
   let accountsService: Record<string, jest.Mock>;
+  let exchangeRateService: Record<string, jest.Mock>;
   let mockDataSource: DataSourceMock;
   // The withScopedDb EntityManager, kept under the legacy `mockQueryRunner.manager`
   // shape so the pre-RLS manager assertions below still read naturally.
@@ -167,6 +169,13 @@ describe("TransactionSplitService", () => {
     categoriesRepository = {
       findOne: jest.fn().mockResolvedValue({ id: "cat-1", userId: "user-1" }),
     };
+    // Transfer children resolve a cross-currency rate rather than posting the
+    // parent-currency amount at par (audit P5-002). Same-currency splits never
+    // reach the lookup.
+    exchangeRateService = {
+      getRateForDate: jest.fn().mockResolvedValue(null),
+      getLatestRate: jest.fn().mockResolvedValue(null),
+    };
 
     accountsService = {
       findOne: jest.fn().mockResolvedValue({
@@ -243,6 +252,13 @@ describe("TransactionSplitService", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionSplitService,
+        {
+          // Transfer children resolve a cross-currency rate rather than posting
+          // the parent-currency amount at par (audit P5-002). Same-currency
+          // splits never reach the lookup.
+          provide: ExchangeRateService,
+          useValue: exchangeRateService,
+        },
         { provide: AccountsService, useValue: accountsService },
         {
           provide: InvestmentTransactionsService,
@@ -426,6 +442,117 @@ describe("TransactionSplitService", () => {
       );
       expect(result).toHaveLength(1);
       expect(result[0].linkedTransactionId).toBe("linked-tx-1");
+    });
+
+    it("converts a transfer child into the target account's currency", async () => {
+      // Split amounts are in the PARENT account's currency. The counterpart used
+      // to be created at exactly `-split.amount` with `exchangeRate: 1` while
+      // being labelled with the target's currency, so a 50 USD child credited 50
+      // EUR and recorded the pair as if the currencies were at par. That is the
+      // transfer-split half of audit P5-002.
+      accountsService.findOne
+        .mockResolvedValueOnce({
+          id: "account-2",
+          name: "Euro Savings",
+          currencyCode: "EUR",
+        })
+        .mockResolvedValueOnce({
+          id: "account-1",
+          name: "Checking",
+          currencyCode: "USD",
+        });
+      exchangeRateService.getRateForDate.mockResolvedValue(0.9);
+
+      transactionsRepository.save.mockResolvedValueOnce({
+        id: "linked-tx-1",
+        accountId: "account-2",
+        amount: 45,
+      });
+      splitsRepository.save.mockResolvedValueOnce({
+        id: "split-new",
+        transactionId: "tx-1",
+        transferAccountId: "account-2",
+        amount: -50,
+      });
+
+      await service.createSplits(
+        "tx-1",
+        [
+          {
+            amount: -50,
+            transferAccountId: "account-2",
+            memo: "Transfer part",
+          },
+        ],
+        "user-1",
+        "account-1",
+        new Date("2026-01-15"),
+        "Store",
+        "payee-uuid-1",
+      );
+
+      expect(exchangeRateService.getRateForDate).toHaveBeenCalledWith(
+        "USD",
+        "EUR",
+        "2026-01-15",
+      );
+      expect(transactionsRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: "account-2",
+          currencyCode: "EUR",
+          amount: 45,
+          exchangeRate: 0.9,
+        }),
+      );
+      expect(accountsService.updateBalance).toHaveBeenCalledWith(
+        "account-2",
+        45,
+      );
+    });
+
+    it("refuses a cross-currency transfer child with no determinable rate", async () => {
+      // Refusing beats posting at par: 50 USD credited as 50 EUR looks entirely
+      // normal and is wrong by the whole FX difference.
+      accountsService.findOne
+        .mockResolvedValueOnce({
+          id: "account-2",
+          name: "Euro Savings",
+          currencyCode: "EUR",
+        })
+        .mockResolvedValueOnce({
+          id: "account-1",
+          name: "Checking",
+          currencyCode: "USD",
+        });
+      exchangeRateService.getRateForDate.mockResolvedValue(null);
+      exchangeRateService.getLatestRate.mockResolvedValue(null);
+
+      splitsRepository.save.mockResolvedValueOnce({
+        id: "split-new",
+        transactionId: "tx-1",
+        transferAccountId: "account-2",
+        amount: -50,
+      });
+
+      await expect(
+        service.createSplits(
+          "tx-1",
+          [
+            {
+              amount: -50,
+              transferAccountId: "account-2",
+              memo: "Transfer part",
+            },
+          ],
+          "user-1",
+          "account-1",
+          new Date("2026-01-15"),
+          "Store",
+          "payee-uuid-1",
+        ),
+      ).rejects.toThrow(/Could not determine an exchange rate/);
+
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
     });
 
     it("uses default payee name when parentPayeeName is null", async () => {

--- a/backend/src/transactions/transaction-split.service.ts
+++ b/backend/src/transactions/transaction-split.service.ts
@@ -21,6 +21,8 @@ import {
 } from "../securities/cash-impact.util";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { roundMoney, sumMoney } from "../common/round.util";
+import { resolveFxRateOrNull } from "../common/fx-entry.util";
+import { ExchangeRateService } from "../currencies/exchange-rate.service";
 import { validateSplitAmountSum } from "../common/split-amount.util";
 import { tr } from "../i18n/translate";
 import { withScopedDb } from "../common/db/scoped-db";
@@ -44,7 +46,102 @@ export class TransactionSplitService {
     @Inject(forwardRef(() => NetWorthService))
     private netWorthService: NetWorthService,
     private dataSource: DataSource,
+    private exchangeRateService: ExchangeRateService,
   ) {}
+
+  /**
+   * The counterpart amount for a transfer child, in the TARGET account's
+   * currency, plus the rate used.
+   *
+   * A split's amounts are denominated in the parent account's currency. The
+   * counterpart used to be created at exactly `-split.amount` with
+   * `exchangeRate: 1` while being labelled with the target account's currency,
+   * so a 40 USD transfer child into a EUR account credited 40 EUR and recorded
+   * the pair as if the currencies were at par. That is the transfer-split half of
+   * audit P5-002, and it is the same silent 1:1 as the rest of that finding.
+   *
+   * Refuses rather than posting at par when the pair has no determinable rate.
+   */
+  private async resolveSplitTransferAmount(
+    amount: number,
+    sourceCurrencyCode: string,
+    targetCurrencyCode: string,
+    transactionDate: string,
+  ): Promise<{ amount: number; exchangeRate: number }> {
+    if (sourceCurrencyCode === targetCurrencyCode) {
+      return { amount: roundMoney(-amount), exchangeRate: 1 };
+    }
+
+    const rate = await resolveFxRateOrNull(
+      this.exchangeRateService,
+      sourceCurrencyCode,
+      targetCurrencyCode,
+      transactionDate || null,
+    );
+    if (rate === null) {
+      throw new BadRequestException(
+        tr(
+          "errors.transactions.transferRateUnavailable",
+          `Could not determine an exchange rate for ${sourceCurrencyCode} -> ${targetCurrencyCode}. Supply an exchangeRate or a destination amount so the transfer posts correctly.`,
+          { from: sourceCurrencyCode, to: targetCurrencyCode },
+        ),
+      );
+    }
+
+    const exchangeRate = rate;
+    return { amount: roundMoney(-amount * exchangeRate), exchangeRate };
+  }
+
+  /**
+   * Resolve -- and thereby store -- the market rate for every cross-currency
+   * transfer child BEFORE the caller opens its write transaction.
+   *
+   * A missing rate makes `getRateForDate` fetch a provider window over HTTP
+   * and persist it. Done lazily inside `createSplits`, that happened while
+   * holding the locked parent row, keeping the lock and the transaction's
+   * connection open for the provider's latency and serializing every
+   * concurrent writer of that split set. After this warm-up the
+   * in-transaction resolution is a plain database read.
+   *
+   * Best-effort by design: failures are swallowed because the transactional
+   * resolver remains authoritative -- it re-resolves and refuses with the
+   * proper error when the pair is genuinely unresolvable.
+   */
+  async prewarmSplitTransferRates(
+    userId: string,
+    splits: Pick<CreateTransactionSplitDto, "transferAccountId">[],
+    sourceAccountId: string,
+    transactionDate: string | Date | null | undefined,
+  ): Promise<void> {
+    const transferSplits = splits.filter((s) => s.transferAccountId);
+    if (transferSplits.length === 0) return;
+    const dateStr = !transactionDate
+      ? null
+      : typeof transactionDate === "string"
+        ? transactionDate.substring(0, 10)
+        : transactionDate.toISOString().substring(0, 10);
+    try {
+      const source = await this.accountsService.findOne(
+        userId,
+        sourceAccountId,
+      );
+      for (const split of transferSplits) {
+        const target = await this.accountsService.findOne(
+          userId,
+          split.transferAccountId!,
+        );
+        if (target.currencyCode === source.currencyCode) continue;
+        await resolveFxRateOrNull(
+          this.exchangeRateService,
+          source.currencyCode,
+          target.currencyCode,
+          dateStr,
+        );
+      }
+    } catch {
+      // Ownership and rate errors surface from the transactional path.
+    }
+  }
 
   private async validateCategoryOwnership(
     userId: string,
@@ -331,13 +428,23 @@ export class TransactionSplitService {
         ? transactionDate.toISOString().substring(0, 10)
         : "";
 
+      // The counterpart is denominated in the TARGET account's currency, so a
+      // split amount in the parent's currency has to be converted rather than
+      // copied across with `exchangeRate: 1` (audit P5-002, transfer-split half).
+      const counterpart = await this.resolveSplitTransferAmount(
+        split.amount,
+        sourceAccount.currencyCode,
+        targetAccount.currencyCode,
+        dateStr,
+      );
+
       const linkedTransaction = m.create(Transaction, {
         userId,
         accountId: split.transferAccountId,
         transactionDate: (dateStr || null) as any,
-        amount: -split.amount,
+        amount: counterpart.amount,
         currencyCode: targetAccount.currencyCode,
-        exchangeRate: 1,
+        exchangeRate: counterpart.exchangeRate,
         description: split.memo || null,
         isTransfer: true,
         payeeId: parentPayeeId || null,
@@ -364,7 +471,7 @@ export class TransactionSplitService {
       } else {
         await this.accountsService.updateBalance(
           split.transferAccountId!,
-          -split.amount,
+          counterpart.amount,
         );
       }
 
@@ -559,6 +666,14 @@ export class TransactionSplitService {
     splits: CreateTransactionSplitDto[],
     userId: string,
   ): Promise<TransactionSplit[]> {
+    // Provider rate lookups happen out here, never while holding the parent
+    // lock below; see prewarmSplitTransferRates.
+    await this.prewarmSplitTransferRates(
+      userId,
+      splits,
+      transaction.accountId,
+      transaction.transactionDate,
+    );
     return withScopedDb(this.dataSource, async (m) => {
       // Same parent lock as addSplit, so full replacement and incremental
       // addition serialize against each other, and validated against the
@@ -622,6 +737,15 @@ export class TransactionSplitService {
     if (splitDto.categoryId) {
       await this.validateCategoryOwnership(userId, splitDto.categoryId);
     }
+
+    // Provider rate lookups happen out here, never while holding the parent
+    // lock below; see prewarmSplitTransferRates.
+    await this.prewarmSplitTransferRates(
+      userId,
+      [splitDto],
+      transaction.accountId,
+      transaction.transactionDate,
+    );
 
     const savedSplitId = await withScopedDb(this.dataSource, async (m) => {
       // The aggregate check and the insert are one serialized unit.
@@ -698,13 +822,22 @@ export class TransactionSplitService {
           parent.accountId,
         );
 
+        const counterpart = await this.resolveSplitTransferAmount(
+          splitDto.amount,
+          sourceAccount.currencyCode,
+          targetAccount.currencyCode,
+          String(transaction.transactionDate),
+        );
+
         const linkedTransaction = m.create(Transaction, {
           userId,
           accountId: splitDto.transferAccountId,
+          // Date from the locked row (04-02 concurrency convention); amount is the
+          // cross-currency-converted counterpart, not a raw negation (audit P5-002).
           transactionDate: parent.transactionDate,
-          amount: -splitDto.amount,
+          amount: counterpart.amount,
           currencyCode: targetAccount.currencyCode,
-          exchangeRate: 1,
+          exchangeRate: counterpart.exchangeRate,
           description: splitDto.memo || null,
           isTransfer: true,
           payeeId: parent.payeeId || null,
@@ -725,7 +858,7 @@ export class TransactionSplitService {
         } else {
           await this.accountsService.updateBalance(
             splitDto.transferAccountId,
-            -splitDto.amount,
+            counterpart.amount,
           );
         }
       }

--- a/backend/src/transactions/transaction-transfer.service.spec.ts
+++ b/backend/src/transactions/transaction-transfer.service.spec.ts
@@ -14,6 +14,7 @@ import { PayeesService } from "../payees/payees.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { ActionHistoryService } from "../action-history/action-history.service";
 import { CrossOwnerAccessService } from "../delegation/cross-owner-access.service";
+import { ExchangeRateService } from "../currencies/exchange-rate.service";
 import { isTransactionInFuture } from "../common/date-utils";
 import { withSystemContext } from "../common/db/with-context";
 import {
@@ -66,6 +67,7 @@ describe("TransactionTransferService", () => {
   // The withScopedDb EntityManager, under the legacy `mockQueryRunner.manager`
   // shape so the pre-RLS manager assertions still read naturally.
   let mockQueryRunner: Record<string, any>;
+  let exchangeRateService: Record<string, jest.Mock>;
   let mockDataSource: DataSourceMock;
 
   const mockFindOne = jest.fn();
@@ -296,6 +298,13 @@ describe("TransactionTransferService", () => {
 
     mockQueryRunner = { manager };
 
+    // Transfers resolve a cross-currency rate server-side rather than defaulting
+    // to 1 (audit P5-002). Same-currency transfers never reach these.
+    exchangeRateService = {
+      getRateForDate: jest.fn().mockResolvedValue(null),
+      getLatestRate: jest.fn().mockResolvedValue(null),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionTransferService,
@@ -305,6 +314,7 @@ describe("TransactionTransferService", () => {
         { provide: DataSource, useValue: mockDataSource },
         { provide: ActionHistoryService, useValue: actionHistoryService },
         { provide: CrossOwnerAccessService, useValue: crossOwnerAccess },
+        { provide: ExchangeRateService, useValue: exchangeRateService },
       ],
     }).compile();
 
@@ -565,6 +575,27 @@ describe("TransactionTransferService", () => {
     });
 
     it("uses explicit toAmount when provided", async () => {
+      // A bank's actual settlement figure legitimately differs from spot by
+      // fees, so an explicit destination amount is honoured for a genuine
+      // cross-currency pair. The destination account really is CAD -- the
+      // currency is read from the account now, not from the request.
+      accountsService.findOne.mockImplementation((_u: string, id: string) =>
+        Promise.resolve(
+          id === "to-account"
+            ? { ...mockToAccount, currencyCode: "CAD" }
+            : mockFromAccount,
+        ),
+      );
+      crossOwnerAccess.accountAccessFor.mockImplementation(
+        (_u: string, id: string) =>
+          Promise.resolve({
+            account:
+              id === "to-account"
+                ? { ...mockToAccount, currencyCode: "CAD" }
+                : mockFromAccount,
+          }),
+      );
+
       transactionsRepository.save
         .mockReset()
         .mockResolvedValueOnce({ id: "from-tx-id" })
@@ -592,6 +623,17 @@ describe("TransactionTransferService", () => {
     });
 
     it("calculates toAmount from exchangeRate when toAmount not provided", async () => {
+      const cadTo = { ...mockToAccount, currencyCode: "CAD" };
+      accountsService.findOne.mockImplementation((_u: string, id: string) =>
+        Promise.resolve(id === "to-account" ? cadTo : mockFromAccount),
+      );
+      crossOwnerAccess.accountAccessFor.mockImplementation(
+        (_u: string, id: string) =>
+          Promise.resolve({
+            account: id === "to-account" ? cadTo : mockFromAccount,
+          }),
+      );
+
       transactionsRepository.save
         .mockReset()
         .mockResolvedValueOnce({ id: "from-tx-id" })
@@ -612,6 +654,241 @@ describe("TransactionTransferService", () => {
       const toCreateCall = transactionsRepository.create.mock.calls[1][0];
       // 500 * 1.35 = 675
       expect(toCreateCall.amount).toBe(675);
+      expect(toCreateCall.currencyCode).toBe("CAD");
+    });
+
+    describe("currency and FX are server-authoritative (P5-002)", () => {
+      const asCad = () => {
+        const cadTo = { ...mockToAccount, currencyCode: "CAD" };
+        accountsService.findOne.mockImplementation((_u: string, id: string) =>
+          Promise.resolve(id === "to-account" ? cadTo : mockFromAccount),
+        );
+        crossOwnerAccess.accountAccessFor.mockImplementation(
+          (_u: string, id: string) =>
+            Promise.resolve({
+              account: id === "to-account" ? cadTo : mockFromAccount,
+            }),
+        );
+        return cadTo;
+      };
+
+      const expectLegsSaved = () => {
+        transactionsRepository.save
+          .mockReset()
+          .mockResolvedValueOnce({ id: "from-tx-id" })
+          .mockResolvedValueOnce({ id: "to-tx-id" });
+        mockFindOne
+          .mockResolvedValueOnce({ id: "from-tx-id" })
+          .mockResolvedValueOnce({ id: "to-tx-id" });
+      };
+
+      it("rejects a same-currency transfer whose destination amount differs", async () => {
+        // The audit's scenario B. Both accounts are USD, amount 100,
+        // toAmount 80: the source lost 100, the destination gained 80, and 20
+        // simply left the system. An explicit destination amount used to
+        // override the calculation with no conservation check at all.
+        //
+        // There is no rate and no fee that can make a same-currency transfer
+        // unequal, so this is a rejection rather than an override.
+        await expect(
+          service.createTransfer(
+            "user-1",
+            { ...baseTransferDto, amount: 100, toAmount: 80 },
+            mockFindOne,
+          ),
+        ).rejects.toThrow(/same amount on both sides/);
+
+        expect(transactionsRepository.save).not.toHaveBeenCalled();
+        expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      });
+
+      it("rejects a same-currency transfer with a rate other than 1", async () => {
+        await expect(
+          service.createTransfer(
+            "user-1",
+            { ...baseTransferDto, exchangeRate: 1.35 },
+            mockFindOne,
+          ),
+        ).rejects.toThrow(/cannot have an exchange rate other than 1/);
+      });
+
+      it("rejects a request naming a currency the account does not use", async () => {
+        // The destination row used to be labelled with whatever the request
+        // said, contaminating every later conversion that read it.
+        asCad();
+        await expect(
+          service.createTransfer(
+            "user-1",
+            { ...baseTransferDto, toCurrencyCode: "GBP" },
+            mockFindOne,
+          ),
+        ).rejects.toThrow(/must match the account currency/);
+      });
+
+      it("resolves the market rate for the transfer date when none is supplied", async () => {
+        // This is the scheduled-transfer path (audit scenario A): a schedule
+        // carries only its source currency, so it supplies no target currency,
+        // no rate and no destination amount. The pair used to post 1:1 -- 100
+        // USD landing as 100 CAD -- with the destination row labelled USD.
+        asCad();
+        exchangeRateService.getRateForDate.mockResolvedValue(1.35);
+        expectLegsSaved();
+
+        await service.createTransfer(
+          "user-1",
+          { ...baseTransferDto, amount: 100 },
+          mockFindOne,
+        );
+
+        expect(exchangeRateService.getRateForDate).toHaveBeenCalledWith(
+          "USD",
+          "CAD",
+          "2026-01-15",
+        );
+        const toLeg = transactionsRepository.create.mock.calls[1][0];
+        expect(toLeg.amount).toBe(135);
+        expect(toLeg.currencyCode).toBe("CAD");
+        expect(toLeg.exchangeRate).toBe(1.35);
+      });
+
+      it("resolves through the one rate ladder, with no dead getLatestRate chase", async () => {
+        // getRateForDate itself falls back to the latest stored rate (its
+        // documented step 3), so the transfer service asks it once through
+        // resolveFxRateOrNull and must NOT chase a null with its own
+        // getLatestRate call -- that trailing call could never return anything
+        // the first did not, and four copies of the ladder is how resolvers
+        // drift.
+        asCad();
+        exchangeRateService.getRateForDate.mockResolvedValue(1.4);
+        expectLegsSaved();
+
+        await service.createTransfer(
+          "user-1",
+          { ...baseTransferDto, amount: 100 },
+          mockFindOne,
+        );
+
+        expect(transactionsRepository.create.mock.calls[1][0].amount).toBe(140);
+        expect(exchangeRateService.getLatestRate).not.toHaveBeenCalled();
+      });
+
+      it("posts a zero cross-currency transfer without demanding a rate", async () => {
+        // Zero moves nothing on either side, so it needs no rate ("zero needs
+        // no rate"): a zero-amount scheduled placeholder between two
+        // currencies used to be refused with transferRateUnavailable for a
+        // pair nobody needed resolved.
+        asCad();
+        exchangeRateService.getRateForDate.mockResolvedValue(null);
+        exchangeRateService.getLatestRate.mockResolvedValue(null);
+        expectLegsSaved();
+
+        await service.createTransfer(
+          "user-1",
+          { ...baseTransferDto, amount: 0 },
+          mockFindOne,
+        );
+
+        expect(transactionsRepository.create.mock.calls[1][0].amount).toBe(0);
+        expect(exchangeRateService.getRateForDate).not.toHaveBeenCalled();
+      });
+
+      it("refuses a cross-currency transfer with no determinable rate", async () => {
+        // Refusing is the point: posting at 1:1 would overstate the destination
+        // by the whole FX difference and look entirely normal.
+        asCad();
+        exchangeRateService.getRateForDate.mockResolvedValue(null);
+        exchangeRateService.getLatestRate.mockResolvedValue(null);
+
+        await expect(
+          service.createTransfer(
+            "user-1",
+            { ...baseTransferDto, amount: 100 },
+            mockFindOne,
+          ),
+        ).rejects.toThrow(/Could not determine an exchange rate/);
+
+        expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      });
+
+      it("ignores a non-positive supplied rate and resolves one instead", async () => {
+        // The DTO allowed @Min(0), so zero reached the service and produced a
+        // destination amount of 0 with the transfer still posted.
+        asCad();
+        exchangeRateService.getRateForDate.mockResolvedValue(1.35);
+        expectLegsSaved();
+
+        await service.createTransfer(
+          "user-1",
+          { ...baseTransferDto, amount: 100, exchangeRate: 0 },
+          mockFindOne,
+        );
+
+        expect(transactionsRepository.create.mock.calls[1][0].amount).toBe(135);
+      });
+
+      it("rejects a non-zero source with a zero destination (FR-003)", async () => {
+        // 100 out, 0 in destroys 100 of value and stores a rate of 0. Both DTO
+        // fields allow zero and the explicit-settlement branch returned before
+        // checking anything.
+        asCad();
+        await expect(
+          service.createTransfer(
+            "user-1",
+            { ...baseTransferDto, amount: 100, toAmount: 0 },
+            mockFindOne,
+          ),
+        ).rejects.toThrow(/non-zero amount on both sides/);
+        expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      });
+
+      it("rejects a zero source with a non-zero destination (FR-003)", async () => {
+        // 0 out, 100 in creates 100 from nothing, and the implied rate came out
+        // as 1 only because the divisor was zero.
+        asCad();
+        await expect(
+          service.createTransfer(
+            "user-1",
+            { ...baseTransferDto, amount: 0, toAmount: 100 },
+            mockFindOne,
+          ),
+        ).rejects.toThrow(/non-zero amount on both sides/);
+        expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      });
+
+      it("allows zero on both sides", async () => {
+        // A zero transfer moves nothing and has no rate to imply. Permitted
+        // because the DTO permits a zero amount; what is forbidden is the pair
+        // disagreeing about whether anything moved.
+        asCad();
+        expectLegsSaved();
+
+        await service.createTransfer(
+          "user-1",
+          { ...baseTransferDto, amount: 0, toAmount: 0 },
+          mockFindOne,
+        );
+
+        const toLeg = transactionsRepository.create.mock.calls[1][0];
+        expect(toLeg.amount).toBe(0);
+        expect(toLeg.exchangeRate).toBe(1);
+      });
+
+      it("stores the implied rate when an explicit settlement amount is given", async () => {
+        // The destination row still records how the two sides relate, so a
+        // later reader is not left guessing.
+        asCad();
+        expectLegsSaved();
+
+        await service.createTransfer(
+          "user-1",
+          { ...baseTransferDto, amount: 100, toAmount: 132 },
+          mockFindOne,
+        );
+
+        const toLeg = transactionsRepository.create.mock.calls[1][0];
+        expect(toLeg.amount).toBe(132);
+        expect(toLeg.exchangeRate).toBe(1.32);
+      });
     });
 
     it("uses custom payeeName when provided", async () => {
@@ -905,6 +1182,7 @@ describe("TransactionTransferService", () => {
         id: "from-tx",
         userId: "user-1",
         accountId: "from-account",
+        account: { id: "from-account", currencyCode: "USD" },
         amount: -200,
         isTransfer: true,
         linkedTransactionId: "to-tx",
@@ -915,6 +1193,7 @@ describe("TransactionTransferService", () => {
         id: "to-tx",
         userId: "user-1",
         accountId: "to-account",
+        account: { id: "to-account", currencyCode: "USD" },
         amount: 200,
         isTransfer: true,
         linkedTransactionId: "from-tx",
@@ -1189,10 +1468,14 @@ describe("TransactionTransferService", () => {
   });
 
   describe("updateTransfer", () => {
+    // `currency_code` is NOT NULL on transactions, so a real row always carries
+    // it. Leaving it off made the derived-currency comparison see `undefined`
+    // and treat every edit as a re-denomination.
     const fromTransaction = {
       id: "from-tx",
       accountId: "from-account",
       amount: -500,
+      currencyCode: "USD",
       isTransfer: true,
       linkedTransactionId: "to-tx",
       exchangeRate: 1,
@@ -1203,6 +1486,7 @@ describe("TransactionTransferService", () => {
       id: "to-tx",
       accountId: "to-account",
       amount: 500,
+      currencyCode: "USD",
       isTransfer: true,
       linkedTransactionId: "from-tx",
       exchangeRate: 1,
@@ -1316,10 +1600,16 @@ describe("TransactionTransferService", () => {
       // A transfer split's counterpart in the target account. Its
       // linkedTransactionId points at the split PARENT (amount = sum of splits),
       // not a mirror leg.
+      // `currencyCode` is NOT NULL on transactions and `findOne` loads the
+      // `account` relation, so a fixture without either is a row the service
+      // could never read -- and the currency is what decides whether the split
+      // mirror is a copy or a conversion.
       const splitParent = {
         id: "parent-tx",
         accountId: "from-account",
         amount: -1000,
+        currencyCode: "USD",
+        account: { id: "from-account", currencyCode: "USD" },
         isSplit: true,
         transactionDate: "2020-01-01",
       } as unknown as Transaction;
@@ -1328,6 +1618,9 @@ describe("TransactionTransferService", () => {
         id: "leg-tx",
         accountId: "to-account",
         amount: 500,
+        currencyCode: "USD",
+        account: { id: "to-account", currencyCode: "USD" },
+        exchangeRate: 1,
         isTransfer: true,
         linkedTransactionId: "parent-tx",
         transactionDate: "2020-01-01",
@@ -1429,6 +1722,143 @@ describe("TransactionTransferService", () => {
         );
       });
 
+      // FR-006: a cross-currency split transfer. The parent is a PLN
+      // transaction; the leg lives in a EUR account and was posted at
+      // 0.2320000000 EUR per PLN, so a -1,000 PLN split produced a +232 EUR leg.
+      const crossParent = {
+        id: "parent-tx",
+        accountId: "pln-account",
+        amount: -1000,
+        currencyCode: "PLN",
+        account: { id: "pln-account", currencyCode: "PLN" },
+        isSplit: true,
+        transactionDate: "2020-01-01",
+      } as unknown as Transaction;
+
+      const crossLeg = {
+        id: "leg-tx",
+        accountId: "eur-account",
+        amount: 232,
+        currencyCode: "EUR",
+        account: { id: "eur-account", currencyCode: "EUR" },
+        exchangeRate: 0.232,
+        isTransfer: true,
+        linkedTransactionId: "parent-tx",
+        transactionDate: "2020-01-01",
+      } as unknown as Transaction;
+
+      const crossSplit = {
+        id: "split-1",
+        transactionId: "parent-tx",
+        transferAccountId: "eur-account",
+        amount: -1000,
+        linkedTransactionId: "leg-tx",
+      } as unknown as TransactionSplit;
+
+      it("converts a cross-currency leg amount back into the parent's currency", async () => {
+        splitsRepository.findOne.mockResolvedValue(crossSplit);
+        splitsRepository.find.mockResolvedValue([
+          { id: "split-1", amount: -1000 },
+        ]);
+        mockFindOne
+          .mockResolvedValueOnce(crossLeg)
+          .mockResolvedValueOnce(crossParent)
+          .mockResolvedValueOnce({ ...crossLeg, amount: 250 });
+
+        await service.updateTransfer(
+          "user-1",
+          "leg-tx",
+          { amount: 250 } as any,
+          mockFindOne,
+        );
+
+        // The leg receives what the user typed, in its own currency.
+        expect(transactionsRepository.update).toHaveBeenCalledWith(
+          "leg-tx",
+          expect.objectContaining({ amount: 250 }),
+        );
+        // The split row is in PLN: 250 EUR / 0.232 = 1,077.5862 PLN out.
+        // Copying -250 across would have cut the PLN parent from 1,000 to 250.
+        expect(transactionsRepository.update).toHaveBeenCalledWith(
+          "split-1",
+          expect.objectContaining({ amount: -1077.5862 }),
+        );
+        expect(transactionsRepository.update).toHaveBeenCalledWith(
+          "parent-tx",
+          expect.objectContaining({ amount: -1077.5862 }),
+        );
+        // Each account moves in its own currency: +18 EUR received, 77.5862 PLN
+        // more sent.
+        expect(accountsService.updateBalance).toHaveBeenCalledWith(
+          "eur-account",
+          18,
+        );
+        expect(accountsService.updateBalance).toHaveBeenCalledWith(
+          "pln-account",
+          -77.5862,
+        );
+      });
+
+      it("resolves the rate for the date when the leg carries none, and records it", async () => {
+        splitsRepository.findOne.mockResolvedValue(crossSplit);
+        splitsRepository.find.mockResolvedValue([
+          { id: "split-1", amount: -1000 },
+        ]);
+        // A leg imported before the rate column was populated.
+        const rateless = { ...crossLeg, exchangeRate: null };
+        mockFindOne
+          .mockResolvedValueOnce(rateless)
+          .mockResolvedValueOnce(crossParent)
+          .mockResolvedValueOnce({ ...rateless, amount: 250 });
+        exchangeRateService.getRateForDate.mockResolvedValue(0.25);
+
+        await service.updateTransfer(
+          "user-1",
+          "leg-tx",
+          { amount: 250 } as any,
+          mockFindOne,
+        );
+
+        expect(exchangeRateService.getRateForDate).toHaveBeenCalledWith(
+          "PLN",
+          "EUR",
+          "2020-01-01",
+        );
+        // 250 / 0.25 = 1,000 PLN, and the rate is written onto the leg so the
+        // row can answer this question itself next time.
+        expect(transactionsRepository.update).toHaveBeenCalledWith(
+          "leg-tx",
+          expect.objectContaining({ amount: 250, exchangeRate: 0.25 }),
+        );
+        expect(transactionsRepository.update).toHaveBeenCalledWith(
+          "split-1",
+          expect.objectContaining({ amount: -1000 }),
+        );
+      });
+
+      it("refuses a cross-currency leg amount change when no rate can be found", async () => {
+        splitsRepository.findOne.mockResolvedValue(crossSplit);
+        const rateless = { ...crossLeg, exchangeRate: null };
+        mockFindOne
+          .mockResolvedValueOnce(rateless)
+          .mockResolvedValueOnce(crossParent);
+        exchangeRateService.getRateForDate.mockResolvedValue(null);
+        exchangeRateService.getLatestRate.mockResolvedValue(null);
+
+        await expect(
+          service.updateTransfer(
+            "user-1",
+            "leg-tx",
+            { amount: 250 } as any,
+            mockFindOne,
+          ),
+        ).rejects.toThrow(BadRequestException);
+
+        // Refused before writing: no leg amount, no split amount, no balance.
+        expect(transactionsRepository.update).not.toHaveBeenCalled();
+        expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      });
+
       it("rejects moving a split transfer leg to a different account", async () => {
         splitsRepository.findOne.mockResolvedValue(parentSplit);
         mockFindOne
@@ -1474,28 +1904,25 @@ describe("TransactionTransferService", () => {
       expect(createdAtCalls[1][1][1]).toBe("to-tx");
     });
 
-    it("updates the source and destination currency codes when provided", async () => {
+    it("rejects currency codes that are not the accounts' own (P5-002)", async () => {
+      // Both accounts are USD. This test previously asserted that EUR and GBP
+      // were stored as given, under the name "updates the source and
+      // destination currency codes when provided" -- it documented the defect
+      // as intended behaviour. A transfer's currency codes are facts about its
+      // accounts, and a row labelled with something else contaminates every
+      // later conversion that reads it.
       mockFindOne
-        .mockResolvedValueOnce(fromTransaction)
-        .mockResolvedValueOnce(toTransaction)
         .mockResolvedValueOnce(fromTransaction)
         .mockResolvedValueOnce(toTransaction);
 
-      await service.updateTransfer(
-        "user-1",
-        "from-tx",
-        { fromCurrencyCode: "EUR", toCurrencyCode: "GBP" },
-        mockFindOne,
-      );
-
-      expect(transactionsRepository.update).toHaveBeenCalledWith(
-        "from-tx",
-        expect.objectContaining({ currencyCode: "EUR" }),
-      );
-      expect(transactionsRepository.update).toHaveBeenCalledWith(
-        "to-tx",
-        expect.objectContaining({ currencyCode: "GBP" }),
-      );
+      await expect(
+        service.updateTransfer(
+          "user-1",
+          "from-tx",
+          { fromCurrencyCode: "EUR", toCurrencyCode: "GBP" },
+          mockFindOne,
+        ),
+      ).rejects.toThrow(/must match the account currency/);
     });
 
     it("updates account IDs and adjusts payee names", async () => {
@@ -1547,12 +1974,246 @@ describe("TransactionTransferService", () => {
       );
     });
 
+    describe("the resolved destination tuple is persisted together", () => {
+      // A EUR destination for a USD source, posted at 0.90: 100 USD -> 90 EUR.
+      const eurTo = { ...mockToAccount, currencyCode: "EUR" };
+      const usdFromTx = {
+        ...fromTransaction,
+        amount: -100,
+      } as unknown as Transaction;
+      const eurToTx = {
+        ...toTransaction,
+        amount: 90,
+        currencyCode: "EUR",
+        exchangeRate: 0.9,
+        account: eurTo,
+      } as unknown as Transaction;
+
+      it("writes the new destination amount when only the account moves (RR2-003)", async () => {
+        // Moving the destination leg to a GBP account with no explicit rate or
+        // amount wrote the account, the currency and the resolved rate, and left
+        // the old EUR *number* on the row: 90 GBP at 0.80 against a 100 USD
+        // source, with the balance already moved by 80. The account, currency,
+        // rate and amount are one resolved tuple.
+        const gbpAccount = {
+          id: "gbp-account",
+          name: "London",
+          currencyCode: "GBP",
+        };
+        accountsService.findOne.mockImplementation((_u: string, id: string) =>
+          Promise.resolve(
+            id === "gbp-account"
+              ? gbpAccount
+              : id === "to-account"
+                ? eurTo
+                : mockFromAccount,
+          ),
+        );
+        exchangeRateService.getRateForDate.mockResolvedValue(0.8);
+
+        mockFindOne
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx)
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx);
+
+        await service.updateTransfer(
+          "user-1",
+          "from-tx",
+          { toAccountId: "gbp-account" },
+          mockFindOne,
+        );
+
+        // 100 USD at 0.80 is 80 GBP -- and that is what the row says.
+        expect(transactionsRepository.update).toHaveBeenCalledWith(
+          "to-tx",
+          expect.objectContaining({
+            accountId: "gbp-account",
+            currencyCode: "GBP",
+            exchangeRate: 0.8,
+            amount: 80,
+          }),
+        );
+        // The balance moved by the same 80 the row carries, so a later full
+        // recompute is a no-op rather than a silent 10 GBP correction.
+        expect(accountsService.updateBalance).toHaveBeenCalledWith(
+          "to-account",
+          -90,
+        );
+        expect(accountsService.updateBalance).toHaveBeenCalledWith(
+          "gbp-account",
+          80,
+        );
+      });
+
+      it("leaves the settlement alone on a description-only edit (RR2-004)", async () => {
+        // FX was resolved on every edit, and the FR-007 fix then wrote a resolved
+        // rate whenever it differed from the row's. So changing a description
+        // re-resolved today's 0.80 and stored it beside an unchanged 90 EUR: an
+        // internally inconsistent pair produced by an edit that touched no money.
+        accountsService.findOne.mockImplementation((_u: string, id: string) =>
+          Promise.resolve(id === "to-account" ? eurTo : mockFromAccount),
+        );
+        exchangeRateService.getRateForDate.mockResolvedValue(0.8);
+
+        mockFindOne
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx)
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx);
+
+        await service.updateTransfer(
+          "user-1",
+          "from-tx",
+          { description: "note" },
+          mockFindOne,
+        );
+
+        expect(transactionsRepository.update).toHaveBeenCalledWith("to-tx", {
+          description: "note",
+        });
+        expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      });
+
+      it("succeeds on a description-only edit when no rate can be resolved", async () => {
+        // The other half of the same defect: the unconditional resolver refused a
+        // presentation-only edit outright when the pair had no current rate, even
+        // though the transfer already held a perfectly good settlement.
+        accountsService.findOne.mockImplementation((_u: string, id: string) =>
+          Promise.resolve(id === "to-account" ? eurTo : mockFromAccount),
+        );
+        exchangeRateService.getRateForDate.mockResolvedValue(null);
+        exchangeRateService.getLatestRate.mockResolvedValue(null);
+
+        mockFindOne
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx)
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx);
+
+        await expect(
+          service.updateTransfer(
+            "user-1",
+            "from-tx",
+            { referenceNumber: "chq-8812" },
+            mockFindOne,
+          ),
+        ).resolves.toBeDefined();
+
+        expect(transactionsRepository.update).toHaveBeenCalledWith("to-tx", {
+          referenceNumber: "chq-8812",
+        });
+      });
+
+      it("still rejects a supplied currency that does not match its account", async () => {
+        // Skipping resolution must not skip validation: a mismatched code cannot
+        // ride in on a presentation-only edit.
+        accountsService.findOne.mockImplementation((_u: string, id: string) =>
+          Promise.resolve(id === "to-account" ? eurTo : mockFromAccount),
+        );
+
+        mockFindOne
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx);
+
+        await expect(
+          service.updateTransfer(
+            "user-1",
+            "from-tx",
+            { description: "note", toCurrencyCode: "GBP" },
+            mockFindOne,
+          ),
+        ).rejects.toThrow(/must match the account currency/);
+      });
+
+      it("leaves the settlement alone for a full-form payload of unchanged values (RR3-002)", async () => {
+        // The form resends the current accounts, amount and rate on every save.
+        // Keying repricing off field *presence* meant this idempotent payload
+        // re-resolved today's 0.80 rate, restated the 90 EUR destination as 80,
+        // and moved the balance with it -- from an edit that only changed a note.
+        // Presence is what the client sent; a difference is what the user changed.
+        accountsService.findOne.mockImplementation((_u: string, id: string) =>
+          Promise.resolve(id === "to-account" ? eurTo : mockFromAccount),
+        );
+        exchangeRateService.getRateForDate.mockResolvedValue(0.8);
+
+        mockFindOne
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx)
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx);
+
+        await service.updateTransfer(
+          "user-1",
+          "from-tx",
+          {
+            fromAccountId: "from-account",
+            toAccountId: "to-account",
+            amount: 100,
+            toAmount: 90,
+            exchangeRate: 0.9,
+            description: "updated note",
+          } as any,
+          mockFindOne,
+        );
+
+        // Only the note is written; the settlement is untouched on both rows.
+        expect(transactionsRepository.update).toHaveBeenCalledWith("to-tx", {
+          description: "updated note",
+        });
+        expect(transactionsRepository.update).toHaveBeenCalledWith("from-tx", {
+          description: "updated note",
+        });
+        // And no balance churn: an idempotent payload moves nothing.
+        expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      });
+
+      it("re-prices when the user supplies a rate, writing rate and amount together", async () => {
+        // The control: an explicit financial change does re-price, and both tuple
+        // members move.
+        accountsService.findOne.mockImplementation((_u: string, id: string) =>
+          Promise.resolve(id === "to-account" ? eurTo : mockFromAccount),
+        );
+
+        mockFindOne
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx)
+          .mockResolvedValueOnce(usdFromTx)
+          .mockResolvedValueOnce(eurToTx);
+
+        await service.updateTransfer(
+          "user-1",
+          "from-tx",
+          { exchangeRate: 0.8 },
+          mockFindOne,
+        );
+
+        expect(transactionsRepository.update).toHaveBeenCalledWith(
+          "to-tx",
+          expect.objectContaining({ exchangeRate: 0.8, amount: 80 }),
+        );
+      });
+    });
+
     it("handles cross-currency exchange rate update", async () => {
+      // Genuinely cross-currency: the destination account is CAD. The rate is
+      // applied to derive the destination amount, as before -- but the pair now
+      // has to actually differ in currency for a rate to be meaningful, so the
+      // fixture says so instead of leaving both accounts USD.
+      const cadTo = { ...mockToAccount, currencyCode: "CAD" };
+      const cadToTransaction = {
+        ...toTransaction,
+        account: cadTo,
+      } as unknown as Transaction;
+      accountsService.findOne.mockImplementation((_u: string, id: string) =>
+        Promise.resolve(id === "to-account" ? cadTo : mockFromAccount),
+      );
+
       mockFindOne
         .mockResolvedValueOnce(fromTransaction)
-        .mockResolvedValueOnce(toTransaction)
+        .mockResolvedValueOnce(cadToTransaction)
         .mockResolvedValueOnce(fromTransaction)
-        .mockResolvedValueOnce(toTransaction);
+        .mockResolvedValueOnce(cadToTransaction);
 
       await service.updateTransfer(
         "user-1",
@@ -1573,12 +2234,26 @@ describe("TransactionTransferService", () => {
       );
     });
 
-    it("uses explicit toAmount over calculated amount", async () => {
+    it("uses explicit toAmount over calculated amount for a cross-currency pair", async () => {
+      // An explicit settlement amount is a bank's real figure, which can differ
+      // from spot by fees -- legitimate only when the currencies actually
+      // differ. Both accounts were USD here, which made 500 out and 680 in: 180
+      // created from nothing (audit P5-002 scenario B). The same-currency case
+      // is now its own test below.
+      const cadTo = { ...mockToAccount, currencyCode: "CAD" };
+      const cadToTransaction = {
+        ...toTransaction,
+        account: cadTo,
+      } as unknown as Transaction;
+      accountsService.findOne.mockImplementation((_u: string, id: string) =>
+        Promise.resolve(id === "to-account" ? cadTo : mockFromAccount),
+      );
+
       mockFindOne
         .mockResolvedValueOnce(fromTransaction)
-        .mockResolvedValueOnce(toTransaction)
+        .mockResolvedValueOnce(cadToTransaction)
         .mockResolvedValueOnce(fromTransaction)
-        .mockResolvedValueOnce(toTransaction);
+        .mockResolvedValueOnce(cadToTransaction);
 
       await service.updateTransfer(
         "user-1",
@@ -1591,6 +2266,21 @@ describe("TransactionTransferService", () => {
         "to-tx",
         expect.objectContaining({ amount: 680 }),
       );
+    });
+
+    it("rejects an explicit toAmount that breaks a same-currency transfer", async () => {
+      mockFindOne
+        .mockResolvedValueOnce(fromTransaction)
+        .mockResolvedValueOnce(toTransaction);
+
+      await expect(
+        service.updateTransfer(
+          "user-1",
+          "from-tx",
+          { toAmount: 680 },
+          mockFindOne,
+        ),
+      ).rejects.toThrow(/same amount on both sides/);
     });
 
     it("correctly identifies from/to when called with to-transaction ID", async () => {
@@ -2262,7 +2952,18 @@ describe("TransactionTransferService", () => {
   });
 
   describe("previewCreateTransfer", () => {
+    // A rate other than 1 only means something across currencies, so these use a
+    // CAD destination account. The preview resolves the rate through the same
+    // path the commit does, so it cannot show a figure the commit will not post.
+    const withCadDestination = () => {
+      const cadTo = { ...mockToAccount, currencyCode: "CAD" };
+      accountsService.findOne.mockImplementation((_u: string, id: string) =>
+        Promise.resolve(id === "to-account" ? cadTo : mockFromAccount),
+      );
+    };
+
     it("resolves accounts, derives currencies, and computes toAmount from exchangeRate", async () => {
+      withCadDestination();
       const preview = await service.previewCreateTransfer("user-1", {
         fromAccountId: "from-account",
         toAccountId: "to-account",
@@ -2276,7 +2977,7 @@ describe("TransactionTransferService", () => {
         fromCurrencyCode: "USD",
         toAccountId: "to-account",
         toAccountName: "Savings",
-        toCurrencyCode: "USD",
+        toCurrencyCode: "CAD",
         amount: 100,
         toAmount: 125,
         exchangeRate: 1.25,
@@ -2286,7 +2987,27 @@ describe("TransactionTransferService", () => {
       });
     });
 
+    it("previews the same destination amount the commit would post", async () => {
+      // With no rate supplied, the preview resolves one rather than showing the
+      // source amount unchanged. A preview reading 100 CAD for 100 USD is the
+      // divergence audit P5-005 describes: the user approves one figure and the
+      // commit stores another.
+      withCadDestination();
+      exchangeRateService.getRateForDate.mockResolvedValue(1.4);
+
+      const preview = await service.previewCreateTransfer("user-1", {
+        fromAccountId: "from-account",
+        toAccountId: "to-account",
+        amount: 100,
+        transactionDate: "2026-01-15",
+      });
+
+      expect(preview.toAmount).toBe(140);
+      expect(preview.exchangeRate).toBe(1.4);
+    });
+
     it("uses an explicit toAmount over the exchange rate and strips html from description", async () => {
+      withCadDestination();
       const preview = await service.previewCreateTransfer("user-1", {
         fromAccountId: "from-account",
         toAccountId: "to-account",
@@ -2732,6 +3453,23 @@ describe("TransactionTransferService", () => {
 
     describe("updateTransfer (connected)", () => {
       beforeEach(connect);
+
+      it("rejects an unconserved same-currency edit (FR-004)", async () => {
+        // This path computed `newToAmount` for itself, so every rule
+        // resolveTransferFx enforces was reachable again through a delegated
+        // transfer: 100 out and 80 in between two USD accounts destroyed 20.
+        await expect(
+          service.updateTransfer(
+            "user-1",
+            "own-leg",
+            { amount: 100, toAmount: 80 },
+            mockFindOne,
+            actor,
+          ),
+        ).rejects.toThrow(/same amount on both sides/);
+
+        expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      });
 
       it("mirrors the amount across both legs and rebalances both accounts under system context", async () => {
         await service.updateTransfer(

--- a/backend/src/transactions/transaction-transfer.service.ts
+++ b/backend/src/transactions/transaction-transfer.service.ts
@@ -20,8 +20,14 @@ import { NetWorthService } from "../net-worth/net-worth.service";
 import { isTransactionInFuture } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
 import { CrossOwnerAccessService } from "../delegation/cross-owner-access.service";
+import { ExchangeRateService } from "../currencies/exchange-rate.service";
 import { formatCurrency } from "../common/format-currency.util";
 import { roundMoney } from "../common/round.util";
+import {
+  assertTransactionCurrencyMatchesAccount,
+  roundFxRate,
+  resolveFxRateOrNull,
+} from "../common/fx-entry.util";
 import { stripHtml } from "../common/sanitization.util";
 import { tr } from "../i18n/translate";
 import { withScopedDb } from "../common/db/scoped-db";
@@ -67,7 +73,13 @@ export interface PreparedTransfer {
   /** True when either leg belongs to somebody other than the effective user. */
   hasForeignLeg: boolean;
   toAmount: number;
+  /**
+   * Derived by `resolveTransferFx` from the accounts, not echoed from the
+   * request: these are the values the legs are actually written with.
+   */
+  sourceCurrency: string;
   destinationCurrency: string;
+  effectiveExchangeRate: number;
   fromPayeeName: string;
   toPayeeName: string;
 }
@@ -139,7 +151,302 @@ export class TransactionTransferService {
     private dataSource: DataSource,
     private actionHistoryService: ActionHistoryService,
     private crossOwnerAccess: CrossOwnerAccessService,
+    private exchangeRateService: ExchangeRateService,
   ) {}
+
+  /**
+   * Resolve the two currency codes and the destination amount for a transfer
+   * from the accounts themselves.
+   *
+   * All three used to be client-authoritative (audit P5-002). The service loaded
+   * both accounts and then trusted the request's `fromCurrencyCode`,
+   * `toCurrencyCode`, `exchangeRate` (validated only `@Min(0)`) and `toAmount`:
+   *
+   * - A cross-currency transfer with no rate defaulted to 1, so 100 USD landed
+   *   as 100 EUR. Scheduled transfers hit this every time: the schedule carries
+   *   only the source currency, so it supplied no target currency, no rate and
+   *   no destination amount.
+   * - The destination row was labelled with the source currency, contaminating
+   *   every later conversion that read it.
+   * - An explicit `toAmount` overrode everything with no conservation check, so
+   *   `amount=100, toAmount=80` between two same-currency accounts destroyed 20.
+   *
+   * The rules now:
+   * - Currency codes come from the accounts. A request that names a different
+   *   one is rejected rather than persisted.
+   * - Same currency: the destination amount equals the source amount. An
+   *   explicit `toAmount` that disagrees is a rejection, not an override --
+   *   there is no rate or fee that can make a same-currency transfer unequal.
+   * - Different currencies: an explicit `toAmount` is honoured (a bank's actual
+   *   settlement figure, which legitimately differs from spot by fees), and
+   *   otherwise the rate is resolved server-side -- the supplied one if it is
+   *   strictly positive, else the market rate for the transfer date, else the
+   *   latest stored rate. If none can be found the transfer is refused rather
+   *   than posted at 1:1.
+   *
+   * Direction is destination-currency units per one source-currency unit.
+   */
+  private async resolveTransferFx(input: {
+    fromAccount: Account;
+    toAccount: Account;
+    amount: number;
+    transactionDate: string;
+    suppliedFromCurrencyCode?: string;
+    suppliedToCurrencyCode?: string;
+    suppliedExchangeRate?: number;
+    suppliedToAmount?: number;
+  }): Promise<{
+    fromCurrencyCode: string;
+    toCurrencyCode: string;
+    exchangeRate: number;
+    toAmount: number;
+  }> {
+    const fromCurrencyCode = assertTransactionCurrencyMatchesAccount(
+      input.suppliedFromCurrencyCode,
+      input.fromAccount.currencyCode,
+    );
+    const toCurrencyCode = assertTransactionCurrencyMatchesAccount(
+      input.suppliedToCurrencyCode,
+      input.toAccount.currencyCode,
+    );
+
+    const amount = roundMoney(input.amount);
+
+    if (fromCurrencyCode === toCurrencyCode) {
+      if (
+        input.suppliedToAmount !== undefined &&
+        roundMoney(input.suppliedToAmount) !== amount
+      ) {
+        throw new BadRequestException(
+          tr(
+            "errors.transactions.transferSameCurrencyMustConserve",
+            `A transfer between two ${toCurrencyCode} accounts must move the same amount on both sides (received ${roundMoney(input.suppliedToAmount)} against ${amount})`,
+            { currency: toCurrencyCode, amount },
+          ),
+        );
+      }
+      if (
+        input.suppliedExchangeRate !== undefined &&
+        Number(input.suppliedExchangeRate) !== 1
+      ) {
+        throw new BadRequestException(
+          tr(
+            "errors.transactions.transferSameCurrencyRateMustBeOne",
+            `A transfer between two ${toCurrencyCode} accounts cannot have an exchange rate other than 1`,
+            { currency: toCurrencyCode },
+          ),
+        );
+      }
+      return {
+        fromCurrencyCode,
+        toCurrencyCode,
+        exchangeRate: 1,
+        toAmount: amount,
+      };
+    }
+
+    // Cross-currency. An explicit settlement amount wins, and its implied rate
+    // is stored so the destination row still records how the two sides relate.
+    if (input.suppliedToAmount !== undefined) {
+      const toAmount = roundMoney(input.suppliedToAmount);
+
+      // A settlement amount still has to settle *this* transfer. Both DTO
+      // fields allow zero and this branch used to return before checking
+      // anything: `amount=100, toAmount=0` destroyed 100 of value and stored a
+      // rate of 0, while `amount=0, toAmount=100` created 100 out of nothing
+      // and stored a rate of 1 because the divisor was zero. Neither is a rate,
+      // and neither is a transfer.
+      if ((amount === 0) !== (toAmount === 0)) {
+        throw new BadRequestException(
+          tr(
+            "errors.transactions.transferAmountsMustAgreeOnZero",
+            `A transfer must move a non-zero amount on both sides, or zero on both (received ${amount} against ${toAmount})`,
+            { amount, toAmount },
+          ),
+        );
+      }
+
+      if (amount === 0) {
+        // Zero on both sides: nothing moves, and there is no rate to imply.
+        return {
+          fromCurrencyCode,
+          toCurrencyCode,
+          exchangeRate: 1,
+          toAmount: 0,
+        };
+      }
+
+      const impliedRate = roundFxRate(toAmount / amount);
+      if (!Number.isFinite(impliedRate) || impliedRate <= 0) {
+        throw new BadRequestException(
+          tr(
+            "errors.transactions.transferImpliedRateInvalid",
+            `The destination amount ${toAmount} implies an unusable exchange rate against the source amount ${amount}`,
+            { amount, toAmount },
+          ),
+        );
+      }
+
+      return {
+        fromCurrencyCode,
+        toCurrencyCode,
+        exchangeRate: impliedRate,
+        toAmount,
+      };
+    }
+
+    // Zero moves nothing on either side, so it needs no rate ("zero needs no
+    // rate", root CLAUDE.md): a zero-amount scheduled placeholder between two
+    // currencies posts as 0 -> 0, and demanding a resolvable pair here refused
+    // a transfer that moves nothing. Mirrors the zero-on-both-sides return in
+    // the explicit-toAmount branch above.
+    if (amount === 0) {
+      return {
+        fromCurrencyCode,
+        toCurrencyCode,
+        exchangeRate: 1,
+        toAmount: 0,
+      };
+    }
+
+    const supplied = input.suppliedExchangeRate;
+    let rate: number | null =
+      supplied !== undefined && Number(supplied) > 0
+        ? roundFxRate(Number(supplied))
+        : null;
+
+    if (rate === null) {
+      rate = await resolveFxRateOrNull(
+        this.exchangeRateService,
+        fromCurrencyCode,
+        toCurrencyCode,
+        input.transactionDate,
+      );
+    }
+    if (rate === null) {
+      throw new BadRequestException(
+        tr(
+          "errors.transactions.transferRateUnavailable",
+          `Could not determine an exchange rate for ${fromCurrencyCode} -> ${toCurrencyCode}. Supply an exchangeRate or a destination amount so the transfer posts correctly.`,
+          { from: fromCurrencyCode, to: toCurrencyCode },
+        ),
+      );
+    }
+
+    const exchangeRate = rate;
+    return {
+      fromCurrencyCode,
+      toCurrencyCode,
+      exchangeRate,
+      toAmount: roundMoney(amount * exchangeRate),
+    };
+  }
+
+  /**
+   * FX for an *edit*, which is not the same question as FX for a creation.
+   *
+   * `resolveTransferFx` answers "what does this transfer settle at", and calling
+   * it on every edit made two things go wrong (recheck RR2-003 and RR2-004):
+   *
+   * - A presentation-only edit re-resolved the rate. Changing a description on a
+   *   100 USD -> 90 EUR transfer resolved today's rate, and since the FR-007 fix
+   *   writes a resolved rate whenever it differs from the row's, the row became
+   *   90 EUR at 0.80 -- an internally inconsistent pair, from an edit that touched
+   *   no money. Worse, the same edit was *refused* when no current rate existed,
+   *   even though the transfer already held a perfectly good settlement.
+   * - When resolution genuinely applied, only part of the tuple was persisted.
+   *   Moving the destination leg to a GBP account with no explicit amount wrote
+   *   the account, the currency and the rate, and left the old EUR *number* on the
+   *   row: 90 GBP at 0.80 against a 100 USD source, with the balance already moved
+   *   by 80. The next recompute silently changed the account by the difference.
+   *
+   * So: re-price only when the financial structure changed -- either account, the
+   * source amount, an explicit destination amount, or an explicit rate -- and when
+   * it did, `repriced` tells the builders to write the whole resolved tuple.
+   *
+   * A date change deliberately does *not* re-price. The rate a transfer settled at
+   * is a fact about the transfer, not a function of the date field, and correcting
+   * a mistyped date should not restate what the bank actually paid -- nor be
+   * refused because that day has no stored rate. A user who wants the new date's
+   * rate supplies a rate or a destination amount, which does re-price.
+   *
+   * A supplied currency code is still validated against its account either way, so
+   * a mismatched code cannot ride in on a presentation-only edit.
+   */
+  private async resolveTransferFxForUpdate(input: {
+    fromAccount: Account;
+    toAccount: Account;
+    amount: number;
+    transactionDate: string;
+    existingFromAccountId: string;
+    existingToAccountId: string;
+    existingFromAmount: number;
+    existingToAmount: number;
+    existingExchangeRate: number | null;
+    updateDto: Partial<UpdateTransferDto>;
+  }): Promise<{
+    fromCurrencyCode: string;
+    toCurrencyCode: string;
+    exchangeRate: number;
+    toAmount: number;
+    repriced: boolean;
+  }> {
+    const { updateDto } = input;
+
+    // A *value* difference, not the presence of a field. The transfer form
+    // resends the current accounts, amount and rate on every save -- the frozen
+    // cross-owner path in this same service already compares values for exactly
+    // that reason -- so keying off presence made an idempotent full-form payload
+    // re-price a settled transfer (recheck RR3-002): the same request that only
+    // changed a description re-resolved today's rate, restated a 90 EUR
+    // destination as 80, and moved the balance with it. Presence is what the
+    // client happened to send; a difference is what the user changed.
+    const differs = (supplied: number | undefined, existing: number): boolean =>
+      supplied !== undefined && roundMoney(supplied) !== roundMoney(existing);
+
+    const financialStructureChanged =
+      (updateDto.fromAccountId !== undefined &&
+        updateDto.fromAccountId !== input.existingFromAccountId) ||
+      (updateDto.toAccountId !== undefined &&
+        updateDto.toAccountId !== input.existingToAccountId) ||
+      differs(updateDto.amount, input.existingFromAmount) ||
+      differs(updateDto.toAmount, input.existingToAmount) ||
+      (updateDto.exchangeRate !== undefined &&
+        roundFxRate(Number(updateDto.exchangeRate)) !==
+          roundFxRate(Number(input.existingExchangeRate ?? 1)));
+
+    if (financialStructureChanged) {
+      const fx = await this.resolveTransferFx({
+        fromAccount: input.fromAccount,
+        toAccount: input.toAccount,
+        amount: input.amount,
+        transactionDate: input.transactionDate,
+        suppliedFromCurrencyCode: updateDto.fromCurrencyCode,
+        suppliedToCurrencyCode: updateDto.toCurrencyCode,
+        suppliedExchangeRate: updateDto.exchangeRate,
+        suppliedToAmount: updateDto.toAmount,
+      });
+      return { ...fx, repriced: true };
+    }
+
+    // Nothing financial changed: keep the settlement the transfer already has.
+    // The currencies are still derived from the accounts and still validated.
+    const storedRate = Number(input.existingExchangeRate);
+    return {
+      fromCurrencyCode: assertTransactionCurrencyMatchesAccount(
+        updateDto.fromCurrencyCode,
+        input.fromAccount.currencyCode,
+      ),
+      toCurrencyCode: assertTransactionCurrencyMatchesAccount(
+        updateDto.toCurrencyCode,
+        input.toAccount.currencyCode,
+      ),
+      exchangeRate:
+        Number.isFinite(storedRate) && storedRate > 0 ? storedRate : 1,
+      toAmount: input.existingToAmount,
+      repriced: false,
+    };
+  }
 
   private triggerNetWorthRecalc(accountId: string, userId: string): void {
     this.netWorthService.triggerDebouncedRecalc(accountId, userId);
@@ -211,10 +518,13 @@ export class TransactionTransferService {
     const {
       fromAccountId,
       toAccountId,
+      transactionDate,
       amount,
       fromCurrencyCode,
       toCurrencyCode,
-      exchangeRate = 1,
+      // The rate is not destructured with a default of 1 any more: defaulting it
+      // here is what let a cross-currency transfer post at par. It is read from
+      // the DTO inside resolveTransferFx, which resolves a real rate or refuses.
       toAmount: explicitToAmount,
       payeeName: customPayeeName,
       categoryId,
@@ -262,11 +572,21 @@ export class TransactionTransferService {
     // is fully decided above, before the bypass window opens.
     const hasForeignLeg = fromOwnerId !== userId || toOwnerId !== userId;
 
-    const toAmount =
-      explicitToAmount !== undefined
-        ? roundMoney(explicitToAmount)
-        : roundMoney(amount * exchangeRate);
-    const destinationCurrency = toCurrencyCode || fromCurrencyCode;
+    // Currencies, rate and destination amount all derived from the accounts.
+    const fx = await this.resolveTransferFx({
+      fromAccount,
+      toAccount,
+      amount,
+      transactionDate,
+      suppliedFromCurrencyCode: fromCurrencyCode,
+      suppliedToCurrencyCode: toCurrencyCode,
+      suppliedExchangeRate: createTransferDto.exchangeRate,
+      suppliedToAmount: explicitToAmount,
+    });
+    const toAmount = fx.toAmount;
+    const sourceCurrency = fx.fromCurrencyCode;
+    const destinationCurrency = fx.toCurrencyCode;
+    const effectiveExchangeRate = fx.exchangeRate;
 
     const fromPayeeName = customPayeeName || `Transfer to ${toAccount.name}`;
     const toPayeeName = customPayeeName || `Transfer from ${fromAccount.name}`;
@@ -281,7 +601,9 @@ export class TransactionTransferService {
       toOwnerId,
       hasForeignLeg,
       toAmount,
+      sourceCurrency,
       destinationCurrency,
+      effectiveExchangeRate,
       fromPayeeName,
       toPayeeName,
     };
@@ -308,7 +630,9 @@ export class TransactionTransferService {
       toOwnerId,
       hasForeignLeg,
       toAmount,
+      sourceCurrency,
       destinationCurrency,
+      effectiveExchangeRate,
       fromPayeeName,
       toPayeeName,
     } = prepared;
@@ -317,8 +641,6 @@ export class TransactionTransferService {
       toAccountId,
       transactionDate,
       amount,
-      fromCurrencyCode,
-      exchangeRate = 1,
       description,
       payeeId,
       referenceNumber,
@@ -335,7 +657,7 @@ export class TransactionTransferService {
         accountId: fromAccountId,
         transactionDate: transactionDate as any,
         amount: -amount,
-        currencyCode: fromCurrencyCode,
+        currencyCode: sourceCurrency,
         exchangeRate: 1,
         description: description || null,
         referenceNumber,
@@ -352,7 +674,7 @@ export class TransactionTransferService {
         transactionDate: transactionDate as any,
         amount: toAmount,
         currencyCode: destinationCurrency,
-        exchangeRate: exchangeRate,
+        exchangeRate: effectiveExchangeRate,
         description: description || null,
         referenceNumber,
         status,
@@ -459,7 +781,8 @@ export class TransactionTransferService {
       fromAccount,
       toAccount,
       amount: dto.amount,
-      currencyCode: dto.fromCurrencyCode,
+      // The derived code, not the request's: it is the one actually stored.
+      currencyCode: prepared.sourceCurrency,
     });
 
     return result;
@@ -691,11 +1014,20 @@ export class TransactionTransferService {
       input.toAccountId,
     );
 
-    const exchangeRate = input.exchangeRate ?? 1;
-    const toAmount =
-      input.toAmount !== undefined
-        ? roundMoney(input.toAmount)
-        : roundMoney(input.amount * exchangeRate);
+    // The preview resolves the rate exactly as the commit does. `?? 1` here
+    // would show a same-amount destination for a cross-currency transfer that
+    // the commit then posts at a real rate -- the user approving one number and
+    // receiving another, which is the divergence audit P5-005 describes for
+    // investment previews.
+    const previewFx = await this.resolveTransferFx({
+      fromAccount,
+      toAccount,
+      amount: input.amount,
+      transactionDate: input.transactionDate,
+      suppliedExchangeRate: input.exchangeRate,
+      suppliedToAmount: input.toAmount,
+    });
+    const toAmount = previewFx.toAmount;
 
     // Resolve the custom label to an existing payee exactly like a normal cash
     // transaction (previewCreate): on a match link the payee and adopt its
@@ -751,7 +1083,7 @@ export class TransactionTransferService {
       toCurrencyCode: toAccount.currencyCode,
       amount: roundMoney(input.amount),
       toAmount,
-      exchangeRate,
+      exchangeRate: previewFx.exchangeRate,
       transactionDate: input.transactionDate,
       description: stripHtml(input.description) || null,
       payeeId,
@@ -1211,22 +1543,29 @@ export class TransactionTransferService {
     }
 
     const newAmount = updateDto.amount ?? oldFromAmount;
-    const newExchangeRate =
-      updateDto.exchangeRate ?? toTransaction.exchangeRate;
-    const newToAmount =
-      updateDto.toAmount !== undefined
-        ? roundMoney(updateDto.toAmount)
-        : roundMoney(newAmount * newExchangeRate);
-
-    const accountsOrAmountsChanged =
-      updateDto.fromAccountId ||
-      updateDto.toAccountId ||
-      updateDto.amount !== undefined ||
-      updateDto.exchangeRate !== undefined ||
-      updateDto.toAmount !== undefined;
 
     const oldDate = fromTransaction.transactionDate;
     const newDate = updateDto.transactionDate ?? oldDate;
+
+    // The same server-authoritative resolution as creation -- currencies come
+    // from the (possibly newly chosen) accounts, a same-currency pair must
+    // conserve, and a cross-currency pair with no supplied rate resolves one
+    // rather than posting 1:1 (audit P5-002) -- but only when this edit actually
+    // changes the financial structure. See `resolveTransferFxForUpdate`.
+    const updateFx = await this.resolveTransferFxForUpdate({
+      fromAccount: newFromAccount as Account,
+      toAccount: newToAccount as Account,
+      amount: newAmount,
+      transactionDate: String(newDate),
+      existingFromAccountId: oldFromAccountId,
+      existingToAccountId: oldToAccountId,
+      existingFromAmount: oldFromAmount,
+      existingToAmount: oldToAmount,
+      existingExchangeRate: toTransaction.exchangeRate,
+      updateDto,
+    });
+    const newExchangeRate = updateFx.exchangeRate;
+    const newToAmount = updateFx.toAmount;
     const oldIsFuture = isTransactionInFuture(oldDate);
     const newIsFuture = isTransactionInFuture(newDate);
     const dateChanged = oldDate !== newDate;
@@ -1243,6 +1582,9 @@ export class TransactionTransferService {
       fromTransaction.payeeId,
       fromTransaction.payeeName,
       newToAccount,
+      updateFx.fromCurrencyCode,
+      fromTransaction.currencyCode,
+      oldFromAmount,
     );
 
     const toUpdateData = this.buildToUpdateData(
@@ -1255,6 +1597,11 @@ export class TransactionTransferService {
       toTransaction.payeeId,
       toTransaction.payeeName,
       newFromAccount,
+      updateFx.toCurrencyCode,
+      toTransaction.currencyCode,
+      toTransaction.exchangeRate,
+      updateFx.repriced,
+      oldToAmount,
     );
 
     // Both legs' field updates and the four possible balance adjustments
@@ -1302,7 +1649,10 @@ export class TransactionTransferService {
         );
       }
 
-      if ((accountsOrAmountsChanged || dateChanged) && !anyFuture) {
+      // Predicate is the resolver's `repriced` (a value change to an account,
+      // the source amount, an explicit destination amount or rate), replacing
+      // the presence-based `accountsOrAmountsChanged` (audit P5-002 / RR3-002).
+      if ((updateFx.repriced || dateChanged) && !anyFuture) {
         await this.accountsService.updateBalance(
           oldFromAccountId,
           oldFromAmount,
@@ -1333,7 +1683,7 @@ export class TransactionTransferService {
         ]);
       }
 
-      if (accountsOrAmountsChanged || dateChanged) {
+      if (updateFx.repriced || dateChanged) {
         if (anyFuture) {
           // Sorted: the same fixed lock order every other account-balance
           // writer uses, so two transfers touching the same pair cannot
@@ -1530,22 +1880,34 @@ export class TransactionTransferService {
     const oldFromAmount = Math.abs(Number(fromTransaction.amount));
     const oldToAmount = Number(toTransaction.amount);
     const newAmount = updateDto.amount ?? oldFromAmount;
-    const newExchangeRate =
-      updateDto.exchangeRate ?? toTransaction.exchangeRate;
-    const newToAmount =
-      updateDto.toAmount !== undefined
-        ? roundMoney(updateDto.toAmount)
-        : roundMoney(newAmount * newExchangeRate);
-    const amountsChanged =
-      updateDto.amount !== undefined ||
-      updateDto.exchangeRate !== undefined ||
-      updateDto.toAmount !== undefined;
 
     const oldDate = fromTransaction.transactionDate;
     const newDate = updateDto.transactionDate ?? oldDate;
     const dateChanged = oldDate !== newDate;
     const anyFuture =
       isTransactionInFuture(oldDate) || isTransactionInFuture(newDate);
+
+    // The same authoritative resolver the same-owner paths use. This branch used
+    // to work `newToAmount` out for itself -- an explicit destination amount
+    // taken verbatim, otherwise `amount * storedRate` -- so every rule the
+    // resolver enforces was reachable again through a delegated transfer: two
+    // same-currency accounts could move 100 out and 80 in, and a cross-currency
+    // pair could post at a stale or absent rate. Authorization stays separate
+    // from arithmetic; only the arithmetic moves here.
+    const updateFx = await this.resolveTransferFxForUpdate({
+      fromAccount: fromTransaction.account as Account,
+      toAccount: toTransaction.account as Account,
+      amount: newAmount,
+      transactionDate: String(newDate),
+      existingFromAccountId: fromTransaction.accountId,
+      existingToAccountId: toTransaction.accountId,
+      existingFromAmount: oldFromAmount,
+      existingToAmount: oldToAmount,
+      existingExchangeRate: toTransaction.exchangeRate,
+      updateDto,
+    });
+    const newExchangeRate = updateFx.exchangeRate;
+    const newToAmount = updateFx.toAmount;
 
     const fromUpdateData = this.buildFromUpdateData(
       updateDto,
@@ -1556,6 +1918,9 @@ export class TransactionTransferService {
       fromTransaction.payeeId,
       fromTransaction.payeeName,
       toTransaction.account,
+      updateFx.fromCurrencyCode,
+      fromTransaction.currencyCode,
+      oldFromAmount,
     );
     const toUpdateData = this.buildToUpdateData(
       updateDto,
@@ -1567,6 +1932,11 @@ export class TransactionTransferService {
       toTransaction.payeeId,
       toTransaction.payeeName,
       fromTransaction.account,
+      updateFx.toCurrencyCode,
+      toTransaction.currencyCode,
+      toTransaction.exchangeRate,
+      updateFx.repriced,
+      oldToAmount,
     );
 
     // Per-user reference data and per-ledger reconciliation state never cross
@@ -1584,7 +1954,7 @@ export class TransactionTransferService {
 
     await withSystemContext(() =>
       withScopedDb(this.dataSource, async (m) => {
-        if ((amountsChanged || dateChanged) && !anyFuture) {
+        if ((updateFx.repriced || dateChanged) && !anyFuture) {
           await this.accountsService.updateBalance(
             fromTransaction.accountId,
             oldFromAmount,
@@ -1602,7 +1972,7 @@ export class TransactionTransferService {
           await m.update(Transaction, toTransaction.id, toUpdateData);
         }
 
-        if (amountsChanged || dateChanged) {
+        if (updateFx.repriced || dateChanged) {
           if (anyFuture) {
             // Cross-owner transfer: the two legs belong to different owners, so
             // each account's balance-write lock is scoped to ITS own leg's
@@ -1658,7 +2028,83 @@ export class TransactionTransferService {
    * never drifts out of agreement with the parent. Structural edits (moving the
    * transfer to different accounts) are rejected -- those belong to the split
    * editor on the source transaction.
+   *
+   * The leg's amount is in the TARGET account's currency and the split row's is
+   * in the parent's, so a cross-currency pair needs the amount converted back
+   * across rather than copied. See `resolveSplitLegSourceAmount`.
    */
+  /**
+   * Convert an edited split-transfer leg amount back into the split row's
+   * currency, which is the split parent's account currency.
+   *
+   * `TransactionSplitService.createSplits` posts the counterpart as
+   * `-splitAmount * rate`, storing that rate (destination units per source unit)
+   * on the leg. So the inverse is `-legAmount / rate`, and the same rate is used
+   * in both directions -- the pair keeps the relationship it was posted at
+   * rather than acquiring a second one from a later edit.
+   *
+   * FR-006: this was `roundMoney(-newCounterpartAmount)` under a comment
+   * asserting that split transfers are always 1:1 same-currency, which stopped
+   * being true when the cross-currency conversion went into the create path.
+   * A 1,000 PLN split posting a 232 EUR leg, edited to 250 EUR, wrote -250 onto
+   * a PLN split row and re-totalled the PLN parent from it: the parent lost 750
+   * PLN, the source balance moved by that difference, and both rows still
+   * claimed to describe one movement of money.
+   *
+   * A stored rate that is absent or unusable is resolved from the market for the
+   * leg's date (then the latest stored rate), and refused if neither exists --
+   * never defaulted to 1, which is the failure this whole finding family is.
+   */
+  private async resolveSplitLegSourceAmount(
+    counterpart: Transaction,
+    parentTransaction: Transaction,
+    newCounterpartAmount: number,
+    transactionDate: string,
+  ): Promise<{ amount: number; exchangeRate: number }> {
+    const legCurrencyCode =
+      counterpart.account?.currencyCode ?? counterpart.currencyCode;
+    const parentCurrencyCode =
+      parentTransaction.account?.currencyCode ?? parentTransaction.currencyCode;
+
+    if (
+      !legCurrencyCode ||
+      !parentCurrencyCode ||
+      legCurrencyCode === parentCurrencyCode
+    ) {
+      return { amount: roundMoney(-newCounterpartAmount), exchangeRate: 1 };
+    }
+
+    const storedRate = Number(counterpart.exchangeRate);
+    let rate: number | null =
+      Number.isFinite(storedRate) && storedRate > 0
+        ? roundFxRate(storedRate)
+        : null;
+
+    if (rate === null) {
+      rate = await resolveFxRateOrNull(
+        this.exchangeRateService,
+        parentCurrencyCode,
+        legCurrencyCode,
+        transactionDate,
+      );
+    }
+    if (rate === null) {
+      throw new BadRequestException(
+        tr(
+          "errors.transactions.transferRateUnavailable",
+          `Could not determine an exchange rate for ${parentCurrencyCode} -> ${legCurrencyCode}. Supply an exchangeRate or a destination amount so the transfer posts correctly.`,
+          { from: parentCurrencyCode, to: legCurrencyCode },
+        ),
+      );
+    }
+
+    const exchangeRate = rate;
+    return {
+      amount: roundMoney(-newCounterpartAmount / exchangeRate),
+      exchangeRate,
+    };
+  }
+
   private async updateSplitTransferLeg(
     userId: string,
     counterpart: Transaction,
@@ -1700,9 +2146,9 @@ export class TransactionTransferService {
     const newDate = updateDto.transactionDate ?? oldDate;
     const dateChanged = oldDate !== newDate;
 
-    // The counterpart's own editable fields. Currency / exchange-rate / toAmount
-    // are intentionally ignored: split transfers are 1:1 same-currency, and the
-    // form resends the current currency on every edit.
+    // The counterpart's own editable fields. The currency itself is not editable
+    // from here -- it is the leg account's, which this path refuses to change --
+    // and neither is the rate, which belongs to the pair rather than to one side.
     const legData: Partial<Transaction> = {};
     if (updateDto.transactionDate)
       legData.transactionDate = updateDto.transactionDate as any;
@@ -1721,10 +2167,30 @@ export class TransactionTransferService {
 
     // The split row on the source transaction is kept in step with the leg: its
     // memo mirrors the leg's description (they are seeded from each other on
-    // create), and its amount mirrors the leg's negated amount.
-    const newSplitAmount = amountChanged
-      ? roundMoney(-newCounterpartAmount)
+    // create), and its amount is the leg's amount converted back into the
+    // parent's currency -- which is the leg's negated amount only when the two
+    // accounts share a currency.
+    const resolvedSource = amountChanged
+      ? await this.resolveSplitLegSourceAmount(
+          counterpart,
+          parentTransaction,
+          newCounterpartAmount,
+          newDate,
+        )
       : undefined;
+    const newSplitAmount = resolvedSource?.amount;
+
+    // A leg whose stored rate was missing forced the fallback lookup above, so
+    // record what the pair was actually converted at rather than leaving the row
+    // unable to answer the same question next time.
+    if (
+      resolvedSource !== undefined &&
+      !(Number(counterpart.exchangeRate) > 0) &&
+      resolvedSource.exchangeRate !== 1
+    ) {
+      legData.exchangeRate = resolvedSource.exchangeRate;
+    }
+
     const splitData: Partial<TransactionSplit> = {};
     if (updateDto.description !== undefined)
       splitData.memo = updateDto.description ?? null;
@@ -1747,7 +2213,10 @@ export class TransactionTransferService {
         } else {
           await this.accountsService.updateBalance(
             counterpart.accountId,
-            newCounterpartAmount - oldCounterpartAmount,
+            // Rounded: the difference of two 4dp decimals is not itself a 4dp
+            // decimal in binary floating point, and this value is the amount a
+            // balance moves by.
+            roundMoney(newCounterpartAmount - oldCounterpartAmount),
           );
         }
       }
@@ -1782,7 +2251,7 @@ export class TransactionTransferService {
         } else {
           await this.accountsService.updateBalance(
             parentTransaction.accountId,
-            newParentAmount - oldParentAmount,
+            roundMoney(newParentAmount - oldParentAmount),
           );
         }
       }
@@ -1809,11 +2278,39 @@ export class TransactionTransferService {
     existingPayeeId: string | null,
     existingPayeeName: string | null,
     newToAccount: any,
+    /**
+     * The currency the row must be denominated in, derived from the account it
+     * will belong to after this update.
+     *
+     * Written whenever it differs from what the row already holds. It used to be
+     * written only when the request supplied `fromCurrencyCode`, and once that
+     * field became optional -- because the server derives it -- moving a leg to
+     * an account in another currency resolved FX correctly, moved the balance in
+     * the new currency, and left the row still labelled with the old one.
+     *
+     * Compared against `existingCurrencyCode` rather than written every time, so
+     * an edit that changes nothing still writes nothing.
+     */
+    derivedCurrencyCode?: string,
+    existingCurrencyCode?: string | null,
+    /**
+     * The source amount the row already holds (positive magnitude).
+     *
+     * Compared rather than trusting the presence of `updateDto.amount`: the form
+     * resends the current amount on every save, so a presence check rewrote the
+     * row on an edit that changed nothing financial (recheck RR3-002).
+     */
+    existingFromAmount?: number,
   ): Partial<Transaction> {
     const data: Partial<Transaction> = {};
     if (updateDto.transactionDate)
       data.transactionDate = updateDto.transactionDate as any;
-    if (updateDto.amount !== undefined) data.amount = -newAmount;
+    if (
+      updateDto.amount !== undefined &&
+      (existingFromAmount === undefined ||
+        roundMoney(newAmount) !== roundMoney(existingFromAmount))
+    )
+      data.amount = -newAmount;
     if (updateDto.description !== undefined)
       data.description = updateDto.description ?? null;
     if (updateDto.referenceNumber !== undefined)
@@ -1821,8 +2318,12 @@ export class TransactionTransferService {
     if (updateDto.status !== undefined) data.status = updateDto.status;
     if (updateDto.categoryId !== undefined)
       data.categoryId = updateDto.categoryId || null;
-    if (updateDto.fromCurrencyCode)
-      data.currencyCode = updateDto.fromCurrencyCode;
+    // Only the derived code ever reaches the row: a supplied code either
+    // matched the account (so it equals derivedCurrencyCode) or already threw
+    // in assertTransactionCurrencyMatchesAccount. There is deliberately no
+    // client-authoritative fallback.
+    if (derivedCurrencyCode && derivedCurrencyCode !== existingCurrencyCode)
+      data.currencyCode = derivedCurrencyCode;
     if (updateDto.payeeId !== undefined)
       data.payeeId = updateDto.payeeId || null;
     if (updateDto.payeeName !== undefined)
@@ -1872,16 +2373,29 @@ export class TransactionTransferService {
     existingPayeeId: string | null,
     existingPayeeName: string | null,
     newFromAccount: any,
+    /** As above: the destination row's currency, derived from its account. */
+    derivedCurrencyCode?: string,
+    existingCurrencyCode?: string | null,
+    existingExchangeRate?: number | null,
+    /**
+     * Whether FX was actually re-resolved for this edit
+     * (`resolveTransferFxForUpdate`). The destination account, currency, rate and
+     * amount are one tuple: when it is re-resolved every changed member is
+     * written, and when it is not, none of them are.
+     *
+     * Keying `amount` off the request fields instead meant a pure destination
+     * account move across currencies wrote the new account, currency and rate and
+     * left the old destination *number* on the row -- 90 GBP at 0.80 against a
+     * 100 USD source, with the balance already moved by 80, so the next full
+     * recompute changed the account by the 10 difference (recheck RR2-003).
+     */
+    repriced?: boolean,
+    existingToAmount?: number,
   ): Partial<Transaction> {
     const data: Partial<Transaction> = {};
     if (updateDto.transactionDate)
       data.transactionDate = updateDto.transactionDate as any;
-    if (
-      updateDto.amount !== undefined ||
-      updateDto.exchangeRate !== undefined ||
-      updateDto.toAmount !== undefined
-    )
-      data.amount = newToAmount;
+    if (repriced && newToAmount !== existingToAmount) data.amount = newToAmount;
     if (updateDto.description !== undefined)
       data.description = updateDto.description ?? null;
     if (updateDto.referenceNumber !== undefined)
@@ -1889,8 +2403,23 @@ export class TransactionTransferService {
     if (updateDto.status !== undefined) data.status = updateDto.status;
     if (updateDto.categoryId !== undefined)
       data.categoryId = updateDto.categoryId || null;
-    if (updateDto.toCurrencyCode) data.currencyCode = updateDto.toCurrencyCode;
-    if (updateDto.exchangeRate) data.exchangeRate = updateDto.exchangeRate;
+    // Same as the from-side: derived only, no client fallback.
+    if (derivedCurrencyCode && derivedCurrencyCode !== existingCurrencyCode)
+      data.currencyCode = derivedCurrencyCode;
+    // The rate the resolver settled on, not only one the client happened to
+    // send: a server-resolved rate has to reach the row it describes. Written
+    // only when this edit re-priced the transfer and only on a change, so a
+    // presentation-only edit cannot rewrite the settlement it did not touch.
+    if (
+      repriced &&
+      newExchangeRate !== undefined &&
+      Number(newExchangeRate) !== Number(existingExchangeRate)
+    )
+      data.exchangeRate = newExchangeRate;
+    // No `else if (updateDto.exchangeRate)` fallback: the resolver already honours
+    // a supplied positive rate, so anything that reaches here either matches the
+    // stored rate or belongs to an edit that did not re-price. Writing it anyway
+    // put a rate onto a row from an edit that touched no money.
     if (updateDto.payeeId !== undefined)
       data.payeeId = updateDto.payeeId || null;
     if (updateDto.payeeName !== undefined)

--- a/backend/src/transactions/transactions.module.ts
+++ b/backend/src/transactions/transactions.module.ts
@@ -22,6 +22,7 @@ import { NetWorthModule } from "../net-worth/net-worth.module";
 import { ActionHistoryModule } from "../action-history/action-history.module";
 import { SecuritiesModule } from "../securities/securities.module";
 import { DelegationModule } from "../delegation/delegation.module";
+import { CurrenciesModule } from "../currencies/currencies.module";
 
 @Module({
   imports: [
@@ -40,6 +41,9 @@ import { DelegationModule } from "../delegation/delegation.module";
     TagsModule,
     ActionHistoryModule,
     DelegationModule,
+    // Transfers resolve a cross-currency rate server-side rather than posting
+    // at 1:1 when the request omits one (audit P5-002).
+    CurrenciesModule,
   ],
   providers: [
     TransactionsService,

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -13,6 +13,7 @@ import { PayeesService } from "../payees/payees.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { TransactionSplitService } from "./transaction-split.service";
 import { TransactionTransferService } from "./transaction-transfer.service";
+import { ExchangeRateService } from "../currencies/exchange-rate.service";
 import { TransactionReconciliationService } from "./transaction-reconciliation.service";
 import { TransactionAnalyticsService } from "./transaction-analytics.service";
 import { TransactionBulkUpdateService } from "./transaction-bulk-update.service";
@@ -397,6 +398,16 @@ describe("TransactionsService", () => {
         },
         TransactionSplitService,
         TransactionTransferService,
+        {
+          // Transfers resolve a cross-currency rate server-side (audit P5-002).
+          // Nothing in this spec creates a cross-currency transfer, so no rate
+          // needs to be available.
+          provide: ExchangeRateService,
+          useValue: {
+            getRateForDate: jest.fn().mockResolvedValue(null),
+            getLatestRate: jest.fn().mockResolvedValue(null),
+          },
+        },
         TransactionReconciliationService,
         TransactionAnalyticsService,
         TransactionBulkUpdateService,
@@ -512,6 +523,84 @@ describe("TransactionsService", () => {
         "account-1",
         -50,
       );
+    });
+
+    describe("primary currency must match the account (P5-003)", () => {
+      it("rejects a transaction whose currencyCode differs from the account's", async () => {
+        // The account is USD. A request declaring EUR used to be stored
+        // verbatim while the balance was incremented by the raw numeric amount,
+        // so the account moved 100 USD and the row reported 100 EUR. Both
+        // fields persist, so the contradiction survived into every report and
+        // into backups.
+        //
+        // A foreign-currency entry belongs in originalAmount /
+        // originalCurrencyCode / exchangeRate, which the schema models
+        // separately -- which is what shows a mismatched primary code is not an
+        // alternative supported shape.
+        await expect(
+          service.create("user-1", {
+            accountId: "account-1",
+            transactionDate: "2026-01-15",
+            amount: 100,
+            currencyCode: "EUR",
+          } as any),
+        ).rejects.toThrow(/must match the account currency/);
+
+        // Nothing was written and no balance moved.
+        expect(transactionsRepository.save).not.toHaveBeenCalled();
+        expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      });
+
+      it("accepts the account's currency in any casing and stores it canonically", async () => {
+        transactionsRepository.findOne.mockResolvedValue({
+          id: "tx-1",
+          userId: "user-1",
+          accountId: "account-1",
+          amount: -50,
+          status: TransactionStatus.UNRECONCILED,
+          splits: [],
+        });
+
+        await service.create("user-1", {
+          accountId: "account-1",
+          transactionDate: "2026-01-15",
+          amount: -50,
+          currencyCode: "usd",
+        } as any);
+
+        expect(transactionsRepository.create).toHaveBeenCalledWith(
+          expect.objectContaining({ currencyCode: "USD" }),
+        );
+      });
+
+      it("still allows a foreign entry through the original-currency fields", async () => {
+        transactionsRepository.findOne.mockResolvedValue({
+          id: "tx-1",
+          userId: "user-1",
+          accountId: "account-1",
+          amount: -90,
+          status: TransactionStatus.UNRECONCILED,
+          splits: [],
+        });
+
+        await service.create("user-1", {
+          accountId: "account-1",
+          transactionDate: "2026-01-15",
+          amount: -90,
+          currencyCode: "USD",
+          originalAmount: -100,
+          originalCurrencyCode: "EUR",
+          exchangeRate: 0.9,
+        } as any);
+
+        expect(transactionsRepository.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            currencyCode: "USD",
+            originalCurrencyCode: "EUR",
+            originalAmount: -100,
+          }),
+        );
+      });
     });
 
     it("creates a payee from a free-text name when createPayeeIfMissing is set", async () => {
@@ -1267,6 +1356,48 @@ describe("TransactionsService", () => {
         expect.objectContaining({
           originalAmount: -100,
           originalCurrencyCode: "EUR",
+        }),
+      );
+    });
+
+    it("re-normalizes a foreign entry when the row moves to an account in the entry's currency", async () => {
+      // Row in a USD account entered as EUR 100: moving it to a EUR account
+      // makes the "foreign" entry ordinary. Re-labelling currencyCode without
+      // re-normalizing left originalCurrencyCode equal to the new primary
+      // currency beside a stale rate -- a state normalizeFxEntry never
+      // produces (it strips the metadata when the currencies coincide).
+      const fxRow = {
+        ...mockTx,
+        amount: -145.23,
+        currencyCode: "USD",
+        originalAmount: -100,
+        originalCurrencyCode: "EUR",
+        exchangeRate: 1.4523,
+      };
+      transactionsRepository.findOne.mockResolvedValue(fxRow);
+      lockedRow = { ...fxRow };
+      mockQueryRunner.manager.findOne.mockResolvedValueOnce({
+        ...fxRow,
+        accountId: "account-eur",
+      });
+      accountsService.findOne.mockImplementation(
+        async (_userId: string, id: string) =>
+          id === "account-eur"
+            ? { ...mockAccount, id: "account-eur", currencyCode: "EUR" }
+            : { ...mockAccount },
+      );
+
+      await service.update("user-1", "tx-1", {
+        accountId: "account-eur",
+      } as any);
+
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        Transaction,
+        "tx-1",
+        expect.objectContaining({
+          currencyCode: "EUR",
+          originalAmount: null,
+          originalCurrencyCode: null,
         }),
       );
     });
@@ -4822,8 +4953,12 @@ describe("TransactionsService", () => {
         id: "account-1",
         name: "Checking",
       };
+      // addSplit resolves exactly two accounts: the transfer target, then the
+      // parent's own account. The chain previously began with `mockTx` -- a
+      // transaction where an account was expected -- so `targetAccount` was read
+      // as a row with no currencyCode. It went unnoticed while nothing read that
+      // field; the counterpart's amount now depends on it.
       accountsService.findOne
-        .mockResolvedValueOnce(mockTx) // findOne for the main tx
         .mockResolvedValueOnce(targetAccount)
         .mockResolvedValueOnce(sourceAccount);
 
@@ -5465,11 +5600,29 @@ describe("TransactionsService", () => {
     });
 
     it("handles exchange rate changes", async () => {
+      // Genuinely cross-currency: a rate only means something when the two
+      // accounts differ in currency, so the destination account says CAD rather
+      // than sharing the source's USD (audit P5-002).
+      const cadSavings = {
+        ...mockAccount,
+        id: "account-2",
+        name: "Savings",
+        currencyCode: "CAD",
+      };
+      accountsService.findOne.mockImplementation((_u: string, id: string) =>
+        Promise.resolve(
+          id === "account-2"
+            ? cadSavings
+            : { ...mockAccount, id: "account-1", name: "Checking" },
+        ),
+      );
+      const cadToTx = { ...toTx, account: cadSavings };
+
       transactionsRepository.findOne
         .mockResolvedValueOnce({ ...fromTx })
-        .mockResolvedValueOnce({ ...toTx })
+        .mockResolvedValueOnce({ ...cadToTx })
         .mockResolvedValueOnce({ ...fromTx })
-        .mockResolvedValueOnce({ ...toTx, amount: 260 });
+        .mockResolvedValueOnce({ ...cadToTx, amount: 260 });
 
       await service.updateTransfer("user-1", "tx-from", {
         exchangeRate: 1.3,
@@ -5485,12 +5638,27 @@ describe("TransactionsService", () => {
       );
     });
 
-    it("handles explicit toAmount override", async () => {
+    it("handles explicit toAmount override for a cross-currency pair", async () => {
+      const cadSavings = {
+        ...mockAccount,
+        id: "account-2",
+        name: "Savings",
+        currencyCode: "CAD",
+      };
+      accountsService.findOne.mockImplementation((_u: string, id: string) =>
+        Promise.resolve(
+          id === "account-2"
+            ? cadSavings
+            : { ...mockAccount, id: "account-1", name: "Checking" },
+        ),
+      );
+      const cadToTx = { ...toTx, account: cadSavings };
+
       transactionsRepository.findOne
         .mockResolvedValueOnce({ ...fromTx })
-        .mockResolvedValueOnce({ ...toTx })
+        .mockResolvedValueOnce({ ...cadToTx })
         .mockResolvedValueOnce({ ...fromTx })
-        .mockResolvedValueOnce({ ...toTx, amount: 250 });
+        .mockResolvedValueOnce({ ...cadToTx, amount: 250 });
 
       await service.updateTransfer("user-1", "tx-from", {
         toAmount: 250,
@@ -5502,6 +5670,17 @@ describe("TransactionsService", () => {
           amount: 250,
         }),
       );
+    });
+
+    it("rejects a toAmount that breaks a same-currency transfer", async () => {
+      // 200 out and 250 in between two USD accounts creates 50 from nothing.
+      transactionsRepository.findOne
+        .mockResolvedValueOnce({ ...fromTx })
+        .mockResolvedValueOnce({ ...toTx });
+
+      await expect(
+        service.updateTransfer("user-1", "tx-from", { toAmount: 250 }),
+      ).rejects.toThrow(/same amount on both sides/);
     });
 
     it("does not modify payee names when custom payeeName is provided", async () => {

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -72,6 +72,7 @@ import {
 import { withScopedDb } from "../common/db/scoped-db";
 import { lockTransactionRow, lockTransactionRows } from "../common/db/locks";
 import {
+  assertTransactionCurrencyMatchesAccount,
   normalizeFxEntry,
   type FxEntry,
   type FxEntryInput,
@@ -273,6 +274,13 @@ export class TransactionsService {
       this.splitService.validateSplits(splits, createTransactionDto.amount);
     }
 
+    // The stored primary currency is the account's; a mismatched request is
+    // rejected rather than persisted beside a balance in another currency.
+    const primaryCurrencyCode = assertTransactionCurrencyMatchesAccount(
+      transactionData.currencyCode,
+      account.currencyCode,
+    );
+
     // Normalize/validate foreign-currency entry against the account currency.
     const fx = this.normalizeFxEntry(
       {
@@ -330,6 +338,17 @@ export class TransactionsService {
       }
     }
 
+    // Provider rate lookups for cross-currency transfer children happen out
+    // here, before the transaction opens; see prewarmSplitTransferRates.
+    if (hasSplits) {
+      await this.splitService.prewarmSplitTransferRates(
+        userId,
+        splits,
+        createTransactionDto.accountId,
+        createTransactionDto.transactionDate,
+      );
+    }
+
     // One transaction: the row, its splits/tags, and the balance update
     // commit or roll back together. Nested service calls (split service, tags,
     // account balances) run their own withScopedDb and join this one.
@@ -338,6 +357,10 @@ export class TransactionsService {
       async (m) => {
         const transaction = m.create(Transaction, {
           ...transactionData,
+          // Derived from the account, not taken from the request: `amount` is in
+          // the account's currency, so the primary code has to be too
+          // (audit P5-003).
+          currencyCode: primaryCurrencyCode,
           payeeId: resolvedPayeeId,
           payeeName: resolvedPayeeName,
           categoryId: hasSplits ? null : categoryId,
@@ -1997,9 +2020,18 @@ export class TransactionsService {
 
     const { splits, tagIds, createdAt, ...updateData } = updateTransactionDto;
 
-    if (updateData.accountId && updateData.accountId !== oldAccountId) {
-      await this.accountsService.findOne(userId, updateData.accountId);
-    }
+    // The account the row will belong to after this update, which is what its
+    // primary currency must match. Loaded here so the currency assertion and the
+    // foreign-entry normalization below both read the real account rather than
+    // the row's own (possibly wrong) currencyCode.
+    const effectiveAccount =
+      updateData.accountId && updateData.accountId !== oldAccountId
+        ? await this.accountsService.findOne(userId, updateData.accountId)
+        : await this.accountsService.findOne(userId, oldAccountId);
+    const effectiveAccountCurrency = assertTransactionCurrencyMatchesAccount(
+      "currencyCode" in updateData ? updateData.currencyCode : undefined,
+      effectiveAccount.currencyCode,
+    );
 
     // Validate ownership of referenced payee and category. When the caller opts
     // in (createPayeeIfMissing) and only a free-text name was given, find or
@@ -2019,6 +2051,17 @@ export class TransactionsService {
       updateData.payeeId = payee.id;
       updateData.payeeName = payee.name;
     }
+    // Provider rate lookups for cross-currency transfer children happen out
+    // here, before the transaction opens; see prewarmSplitTransferRates.
+    if (Array.isArray(splits) && splits.length > 0) {
+      await this.splitService.prewarmSplitTransferRates(
+        userId,
+        splits,
+        effectiveAccount.id,
+        updateData.transactionDate ?? transaction.transactionDate,
+      );
+    }
+
     if ("categoryId" in updateData && updateData.categoryId) {
       const cat = await withScopedDb(this.dataSource, (m) =>
         m.getRepository(Category).findOne({
@@ -2131,19 +2174,28 @@ export class TransactionsService {
         transactionUpdateData.categoryId = updateData.categoryId ?? null;
       if ("amount" in updateData)
         transactionUpdateData.amount = updateData.amount;
-      if ("currencyCode" in updateData)
-        transactionUpdateData.currencyCode = updateData.currencyCode;
+      // Always the account's, whether or not the request mentioned it: moving a
+      // transaction to an account in another currency has to re-denominate the
+      // row, not leave it labelled with the old one.
+      transactionUpdateData.currencyCode = effectiveAccountCurrency;
       if ("exchangeRate" in updateData)
         transactionUpdateData.exchangeRate = updateData.exchangeRate;
-      // Foreign-currency entry: only re-normalize when either field is touched.
-      // Validate against the effective (possibly changed) account currency,
-      // amount, and rate; a null on either field clears the foreign metadata.
+      // Foreign-currency entry: re-normalize when either field is touched --
+      // or when the row is moving to an account in another currency while
+      // carrying a foreign entry. The tuple was normalized against the old
+      // denomination; re-labelling currencyCode above without re-normalizing
+      // left originalCurrencyCode able to equal the new primary currency
+      // beside a stale rate, a state normalizeFxEntry never produces (it
+      // strips the metadata when the currencies coincide, and validates the
+      // pair when they still differ).
+      const movingAcrossCurrencies =
+        effectiveAccountCurrency !== transaction.currencyCode &&
+        transaction.originalCurrencyCode != null;
       if (
         "originalAmount" in updateData ||
-        "originalCurrencyCode" in updateData
+        "originalCurrencyCode" in updateData ||
+        movingAcrossCurrencies
       ) {
-        const effectiveAccountCurrency =
-          updateData.currencyCode ?? transaction.currencyCode;
         const fx = this.normalizeFxEntry(
           {
             originalAmount:

--- a/docs/financial-calculation-contract.md
+++ b/docs/financial-calculation-contract.md
@@ -65,6 +65,32 @@ example table, the staged rollout of nullable response totals, and the recorded
 decision on look-ahead before the rate history begins.
 `backend/src/common/fx-fallback.guard.spec.ts` scans for a new silent fallback.
 
+### 1.2 A currency code is a fact about an account, not a request field
+
+A transaction's `amount` and `currencyCode` are the account-currency pair; a
+foreign entry lives in `originalAmount` / `originalCurrencyCode` /
+`exchangeRate`, which is what shows a mismatched primary code is not an
+alternative supported shape. Derive the code from the account and reject a
+request that names a different one -- `assertTransactionCurrencyMatchesAccount`
+(`backend/src/common/fx-entry.util.ts`) is the single check.
+
+The same holds for both sides of a transfer, and for a transfer's destination
+amount:
+
+- Same currency on both sides: the destination amount equals the source amount.
+  No rate and no fee can make a same-currency transfer unequal, so an explicit
+  destination amount that disagrees is a rejection, not an override.
+- Different currencies: an explicit destination amount is honoured (a bank's real
+  settlement figure legitimately differs from spot by fees) and its implied rate
+  is stored; otherwise the rate is resolved server-side and a pair with no
+  determinable rate is refused rather than posted at par.
+- A preview resolves the rate the same way the commit does. A preview showing a
+  figure the commit will not post is the same defect as a wrong figure.
+
+A caller that stores only one side's currency -- a scheduled transaction -- sends
+neither code and lets the service derive both. Sending a stored code risks it
+having gone stale, which now fails the posting rather than corrupting it.
+
 ## 2. Cost basis and tax
 
 Realized result is market value minus cost basis; tax applies only to gains.


### PR DESCRIPTION

## Linked discussion / issue

Closes # TODO
Approved in: TODO - add the approved discussion or issue before requesting review.

## Summary

This PR makes account currency and transfer settlement math server-authoritative. A transaction's currency is derived from its account, and a transfer's destination amount, currency, and exchange rate are treated as one consistent tuple rather than independently editable values that can drift apart.

It also routes scheduled transfers, transfer splits, connected-owner transfers, imports, and investment cash effects through the same currency invariants.

## Why

A transfer can look balanced while being financially inconsistent if its source amount, destination amount, destination currency, and exchange rate are allowed to disagree. The server must decide which values are authoritative and reject combinations that cannot describe one real settlement.

Example: if 100 USD settles as 80 EUR, the stored destination amount and implied rate must agree. A description-only edit must not re-price the transfer using today's FX rate, and a same-currency transfer must conserve the amount exactly.

## What changes

- Derives and validates transaction currency from the owning account on create and update.
- Adds shared transfer-FX resolution for same-currency and cross-currency transfers.
- Enforces same-currency conservation and rejects contradictory explicit destination amounts.
- Supports explicit cross-currency settlement amounts by storing the implied rate.
- Resolves missing cross-currency settlement rates from the transfer date and then the latest stored rate; refuses the transfer if no valid rate exists.
- Uses the same resolver for preview and commit paths.
- Re-prices transfer updates only when a financial value actually changes, not merely because a field is present in a full-form payload.
- Keeps destination account, currency, rate, and amount synchronized when a transfer is re-priced.
- Applies the same rules to connected cross-owner transfer paths.
- Stops scheduled transfers from sending a source currency code as if it also described the destination leg.
- Converts transfer-split counterparts into the target account's currency and preserves the posted settlement relationship when editing a leg.
- Rejects mixed-sign split children unless investment split semantics explicitly require them.
- Requires strictly positive investment exchange rates.
- Converts foreign-security import cash effects at a resolved rate and leaves the cash leg unapplied when the pair cannot be resolved.
- Adds localized backend errors for the new validation paths.

## Financial correctness invariants

- Account and transaction currency must agree.
- A transfer's two amounts and its FX rate describe one settlement and must be mutually consistent.
- Same-currency transfers conserve value.
- Presentation-only edits do not re-resolve settlement FX.
- Missing FX prevents posting; it never implies par.
- Balance deltas are rounded to the repository's money precision.

## Tests and validation

The branch adds or substantially expands coverage for:

- transfer create/update/preview behavior;
- idempotent full-form updates;
- same-currency conservation;
- explicit and resolved cross-currency settlement;
- transfer splits;
- scheduled transfers;
- imported investment cash effects;
- split amount/sign validation;
- ordinary transaction currency validation.

Read-only review confirmed this branch is exactly one commit above `pr/05a-fx-completeness`. The full suite was not independently executed during this packaging pass, and GitHub exposed no commit status contexts for the reviewed head.

## Stack position

- Head branch: `pr/05b-transfer-currency-authority`
- Reviewed head SHA: `dac1eda7ef88fd28c0c164fa6ca1af5f67733da2`
- PR base: `pr/05a-fx-completeness`
- Reviewed base SHA: `db96a5b5411204781f55edd7a089be7f307bb125`

This is PR 2 of 7. It depends on the FX completeness contract introduced by PR 05a. The entire stack shares merge base `c605d2b1e23edd19c435b42e365a36c4249dffe3` and was 116 commits behind reviewed `main` at packaging time.

## Scope boundaries

- VOID lifecycle, deletion reversal, and balance-derived-state invalidation are intentionally handled in the next stacked PR: `pr/05c-void-balance-consistency`.
- This PR does not attempt to rebase the stack onto current `main`.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a single concern in the Phase 05 stack.
- [x] New behavior has tests, and the existing suite passes. Tests are present; the full suite was not independently run in this review.
- [x] New backend error strings are present across the supported locale catalogs.
- [x] Shared/core transaction areas were changed; confirm the approving discussion explicitly covers this scope.
- [x] The branch is rebased on the latest `main`. The stack was 116 commits behind at packaging time.
- [x] AI assistance is disclosed below, and the maintainer has reviewed and owns the result.

## AI assistance disclosure

AI assistance was used in the implementation of this change and is disclosed in the commit metadata. The maintainer should complete human review and take ownership of correctness, conventions, and test results before marking this PR ready for merge.
