### PR TITLE
05: Unify loan payment waterfall and count split transfers in budgets (v1.15.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,19 @@ account, the source amount, an explicit destination amount, an explicit rate. A
 date correction is not a re-pricing; the rate a transfer settled at is a fact about
 the transfer.
 
+### A clamp bounds the total, not one of its parts
+
+Two children retiring one debt are clamped together. The loan final-payment fix
+capped the amortized principal at the outstanding balance and left the extra
+principal transfer beside it uncapped, so 400 + 300 went into a 500 balance, the
+account crossed zero into a credit, and the payoff check waiting for `<= 0.01`
+never fired. Decide which part yields -- the amortized figure is owed, the
+discretionary extra absorbs the shortfall -- and write the yielding part back:
+shrinking the parent while a child still carries the unclamped number fails the
+split validator's exact-4dp equality at the moment the user expected the loan to
+close. The same rule caught two more instances in `LoanPaymentSetupService`, which
+wrote the first installment and clamped nothing at all.
+
 ### A completeness flag covers every total it is documented to cover, on every surface
 
 `fxComplete` claimed to describe all of `PortfolioSummary`'s `total*` fields while

--- a/backend/src/accounts/dto/setup-loan-payments.dto.ts
+++ b/backend/src/accounts/dto/setup-loan-payments.dto.ts
@@ -223,6 +223,12 @@ export class SetupLoanPaymentsResponseDto {
   @ApiProperty({ description: "Payment amount set on the account" })
   paymentAmount: number;
 
+  @ApiProperty({
+    description:
+      "Amount of the first scheduled installment after clamping against the outstanding balance -- equals paymentAmount except on a nearly-paid loan",
+  })
+  firstInstallmentAmount: number;
+
   @ApiProperty({ description: "Payment frequency set on the account" })
   paymentFrequency: string;
 

--- a/backend/src/accounts/entities/account.entity.ts
+++ b/backend/src/accounts/entities/account.entity.ts
@@ -172,6 +172,20 @@ export class Account {
   })
   paymentAmount: number | null;
 
+  // The standing extra-principal instruction inside paymentAmount. Durable
+  // configured source for the recalculation after each posting -- the template
+  // split alone ratchets, because a clamp written for one installment becomes
+  // the configured value on the next pass (review #1131).
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 4,
+    name: "extra_payment_amount",
+    nullable: true,
+    transformer: numericTransformer,
+  })
+  extraPaymentAmount: number | null;
+
   @Column({
     type: "varchar",
     length: 20,

--- a/backend/src/accounts/loan-payment-setup.service.spec.ts
+++ b/backend/src/accounts/loan-payment-setup.service.spec.ts
@@ -267,6 +267,123 @@ describe("LoanPaymentSetupService", () => {
       expect(createCall.splits[0].amount).toBe(-500);
     });
 
+    it("does not count extra principal twice on a zero-rate loan", async () => {
+      // Every other branch splits from `basePaymentAmount` (payment less extra);
+      // the zero-rate branch used the full payment, so a 0% loan with extra
+      // principal produced children summing to payment + extra against a parent
+      // of payment. `ScheduledTransactionsService.create` validates that sum to
+      // exact 4dp equality, so setup failed outright.
+      accountsRepository.findOne
+        .mockResolvedValueOnce(mockLoanAccount)
+        .mockResolvedValueOnce(mockSourceAccount);
+
+      await service.setupLoanPayments("user-1", "loan-1", {
+        paymentAmount: 500,
+        paymentFrequency: "MONTHLY",
+        sourceAccountId: "source-1",
+        nextDueDate: "2026-04-01",
+        interestRate: 0,
+        extraPrincipal: 100,
+      } as never);
+
+      const createCall = scheduledTransactionsService.create.mock.calls[0][1];
+      const sum = createCall.splits.reduce(
+        (acc: number, split: { amount: number }) => acc + split.amount,
+        0,
+      );
+      expect(createCall.amount).toBe(-500);
+      expect(sum).toBe(-500);
+      // 400 amortized principal plus the 100 the user asked to add.
+      expect(
+        createCall.splits.map((s: { memo: string; amount: number }) => [
+          s.memo,
+          s.amount,
+        ]),
+      ).toEqual([
+        ["Principal", -400],
+        ["Extra Principal", -100],
+      ]);
+    });
+
+    it("clamps the first installment to the outstanding balance", async () => {
+      // Setting up payments on a nearly-paid loan: 300 left, a 500 payment with
+      // 100 of extra principal. Nothing here clamped anything -- the
+      // recalculation after each posting does, but the first installment is
+      // written here -- so the schedule would have driven the balance to -300.
+      accountsRepository.findOne
+        .mockResolvedValueOnce({ ...mockLoanAccount, currentBalance: -300 })
+        .mockResolvedValueOnce(mockSourceAccount);
+
+      const response = await service.setupLoanPayments("user-1", "loan-1", {
+        paymentAmount: 500,
+        paymentFrequency: "MONTHLY",
+        sourceAccountId: "source-1",
+        nextDueDate: "2026-04-01",
+        interestRate: 0,
+        extraPrincipal: 100,
+      } as never);
+
+      const createCall = scheduledTransactionsService.create.mock.calls[0][1];
+      // Regular principal takes the 300 that is owed; the discretionary extra
+      // has nothing left to retire and is dropped.
+      expect(
+        createCall.splits.map((s: { memo: string; amount: number }) => [
+          s.memo,
+          s.amount,
+        ]),
+      ).toEqual([["Principal", -300]]);
+      expect(createCall.amount).toBe(-300);
+      // The account still records the payment the user configured; only this
+      // schedule's installment shrank. The standing extra instruction is
+      // recorded unclamped too -- it is what the recalculation grows back to.
+      expect(accountsRepository.update).toHaveBeenCalledWith(
+        "loan-1",
+        expect.objectContaining({
+          paymentAmount: 500,
+          extraPaymentAmount: 100,
+        }),
+      );
+      // And the caller is told what the schedule will actually post, not the
+      // figure it will never post (review #1131).
+      expect(response.paymentAmount).toBe(500);
+      expect(response.firstInstallmentAmount).toBe(-createCall.amount);
+    });
+
+    it("allocates the whole payment to interest when it does not cover the interest", async () => {
+      // A detected interest amount above the base payment left principal at 0
+      // and interest at the detected figure, so the children summed to more than
+      // the parent. A payment that does not cover the interest is applied
+      // entirely to interest.
+      accountsRepository.findOne
+        .mockResolvedValueOnce(mockLoanAccount)
+        .mockResolvedValueOnce(mockSourceAccount);
+
+      await service.setupLoanPayments("user-1", "loan-1", {
+        paymentAmount: 500,
+        paymentFrequency: "MONTHLY",
+        sourceAccountId: "source-1",
+        nextDueDate: "2026-04-01",
+        detectedInterestAmount: 620,
+      } as never);
+
+      const createCall = scheduledTransactionsService.create.mock.calls[0][1];
+      const sum = createCall.splits.reduce(
+        (acc: number, split: { amount: number }) => acc + split.amount,
+        0,
+      );
+      expect(sum).toBe(createCall.amount);
+      expect(createCall.amount).toBe(-500);
+      expect(
+        createCall.splits.map((s: { memo: string; amount: number }) => [
+          s.memo,
+          s.amount,
+        ]),
+      ).toEqual([
+        ["Principal", -0],
+        ["Interest", -500],
+      ]);
+    });
+
     it("sets mortgage-specific fields for mortgage accounts", async () => {
       const mortgageAccount = {
         ...mockLoanAccount,

--- a/backend/src/accounts/loan-payment-setup.service.ts
+++ b/backend/src/accounts/loan-payment-setup.service.ts
@@ -12,6 +12,7 @@ import {
   SetupLoanPaymentsDto,
   SetupLoanPaymentsResponseDto,
 } from "./dto/setup-loan-payments.dto";
+import { roundMoney } from "../common/round.util";
 import { CategoriesService } from "../categories/categories.service";
 import { ScheduledTransactionsService } from "../scheduled-transactions/scheduled-transactions.service";
 import {
@@ -22,6 +23,7 @@ import {
   calculateMortgagePaymentSplit,
   MortgagePaymentFrequency,
 } from "./mortgage-amortization.util";
+import { allocateLoanPayment } from "./loan-payment-waterfall.util";
 import { tr } from "../i18n/translate";
 import { withScopedDb } from "../common/db/scoped-db";
 
@@ -148,10 +150,36 @@ export class LoanPaymentSetupService {
       principalPayment = split.principal;
       interestPayment = split.interest;
     } else {
-      // No interest rate - entire payment goes to principal
-      principalPayment = dto.paymentAmount;
+      // No interest rate: the whole of the base payment goes to principal.
+      //
+      // This branch alone used `dto.paymentAmount` rather than
+      // `basePaymentAmount`, so extra principal was counted twice -- once inside
+      // the regular principal child and again in its own child. The children
+      // then summed to payment + extra against a parent of payment, and
+      // `ScheduledTransactionsService.create` validates that sum to exact 4dp
+      // equality: setting up payments on a 0% loan with any extra principal
+      // failed outright.
+      principalPayment = basePaymentAmount;
       interestPayment = 0;
     }
+
+    // The clamp sequence -- interest-first, balance caps, extra absorbing the
+    // shortfall -- is `allocateLoanPayment`, shared with the per-posting
+    // recalculation in `ScheduledTransactionLoanService` because the two must
+    // agree about what any installment looks like. A zero recorded balance
+    // here means the history has not been imported yet, not that the loan is
+    // paid off, so it does not bound the payment.
+    const allocation = allocateLoanPayment({
+      paymentAmount: dto.paymentAmount,
+      extraPrincipal,
+      interest: interestPayment,
+      principal: principalPayment,
+      currentBalance: currentBalance > 0 ? currentBalance : null,
+    });
+    principalPayment = allocation.principal;
+    interestPayment = allocation.interest;
+    const scheduledExtraPrincipal = allocation.extraPrincipal;
+    const parentAmount = allocation.total;
 
     // Map frequency for scheduled transactions
     // Mortgage frequencies like ACCELERATED_BIWEEKLY map to BIWEEKLY in scheduling
@@ -192,10 +220,10 @@ export class LoanPaymentSetupService {
 
     // Extra principal as a separate transfer split to the loan account,
     // matching the structure of imported transactions
-    if (extraPrincipal > 0) {
+    if (scheduledExtraPrincipal > 0) {
       splits.push({
         transferAccountId: accountId,
-        amount: -extraPrincipal,
+        amount: -scheduledExtraPrincipal,
         memo: "Extra Principal",
       });
     }
@@ -211,7 +239,7 @@ export class LoanPaymentSetupService {
         name: `${accountLabel} Payment - ${account.name}`,
         payeeId: dto.payeeId || undefined,
         payeeName: dto.payeeName || account.institution || undefined,
-        amount: -dto.paymentAmount,
+        amount: -parentAmount,
         currencyCode: account.currencyCode,
         frequency: scheduledFrequency as any,
         nextDueDate: dto.nextDueDate,
@@ -225,6 +253,10 @@ export class LoanPaymentSetupService {
     // Update the account with loan payment details
     const updateData: Partial<Account> = {
       paymentAmount: dto.paymentAmount,
+      // The configured standing instruction, not the possibly-clamped first
+      // installment: this is what the recalculation grows the extra back to
+      // once a transient clamp (an interest spike) has passed.
+      extraPaymentAmount: extraPrincipal,
       paymentFrequency: dto.paymentFrequency,
       paymentStartDate: new Date(dto.nextDueDate),
       sourceAccountId: dto.sourceAccountId,
@@ -263,13 +295,17 @@ export class LoanPaymentSetupService {
 
     this.logger.log(
       `Set up ${accountLabel.toLowerCase()} payments for account ${account.name}: ` +
-        `$${dto.paymentAmount} ${dto.paymentFrequency}, next due ${dto.nextDueDate}`,
+        `$${dto.paymentAmount} ${dto.paymentFrequency}, next due ${dto.nextDueDate}` +
+        (parentAmount !== roundMoney(dto.paymentAmount)
+          ? `, first installment clamped to $${parentAmount} against the outstanding balance`
+          : ""),
     );
 
     return {
       scheduledTransactionId: scheduledTransaction.id,
       accountId,
       paymentAmount: dto.paymentAmount,
+      firstInstallmentAmount: parentAmount,
       paymentFrequency: dto.paymentFrequency,
       nextDueDate: dto.nextDueDate,
     };

--- a/backend/src/accounts/loan-payment-waterfall.util.spec.ts
+++ b/backend/src/accounts/loan-payment-waterfall.util.spec.ts
@@ -1,0 +1,142 @@
+import { allocateLoanPayment } from "./loan-payment-waterfall.util";
+
+describe("allocateLoanPayment", () => {
+  it("passes an ordinary installment through unchanged", () => {
+    const result = allocateLoanPayment({
+      paymentAmount: 1000,
+      extraPrincipal: 300,
+      interest: 200,
+      principal: 500,
+      currentBalance: 100000,
+    });
+    expect(result).toEqual({
+      principal: 500,
+      interest: 200,
+      extraPrincipal: 300,
+      total: 1000,
+    });
+  });
+
+  it("applies the payment interest-first across the whole installment, extra included", () => {
+    // 1,000 payment with 300 extra against 800 of accrued interest: the extra
+    // instruction has no principal to reduce until the interest is met
+    // (recheck DR3-01).
+    const result = allocateLoanPayment({
+      paymentAmount: 1000,
+      extraPrincipal: 300,
+      interest: 800,
+      principal: 0,
+      currentBalance: 100000,
+    });
+    expect(result.interest).toBe(800);
+    expect(result.principal).toBe(0);
+    expect(result.extraPrincipal).toBe(200);
+    expect(result.total).toBe(1000);
+  });
+
+  it("bounds interest by the whole installment so a child cannot exceed the parent", () => {
+    // 5,000 accrued against a 1,000 payment previously wrote an interest child
+    // of -5,000 under a parent of -1,000 (recheck RR2-006).
+    const result = allocateLoanPayment({
+      paymentAmount: 1000,
+      extraPrincipal: 0,
+      interest: 5000,
+      principal: 0,
+      currentBalance: 100000,
+    });
+    expect(result).toEqual({
+      principal: 0,
+      interest: 1000,
+      extraPrincipal: 0,
+      total: 1000,
+    });
+  });
+
+  it("clamps regular and extra principal together against the balance (FR-009)", () => {
+    // 500 remaining against 400 amortized principal plus a 300 standing extra:
+    // the extra absorbs the shortfall, so 400 + 100 retires the debt exactly.
+    const result = allocateLoanPayment({
+      paymentAmount: 700,
+      extraPrincipal: 300,
+      interest: 10,
+      principal: 400,
+      currentBalance: 500,
+    });
+    expect(result.principal).toBe(400);
+    expect(result.extraPrincipal).toBe(100);
+    expect(result.total).toBe(510);
+  });
+
+  it("shrinks the final installment with the debt (audit P5-008)", () => {
+    const result = allocateLoanPayment({
+      paymentAmount: 1000,
+      extraPrincipal: 0,
+      interest: 1,
+      principal: 999,
+      currentBalance: 50,
+    });
+    expect(result.principal).toBe(50);
+    expect(result.interest).toBe(1);
+    expect(result.total).toBe(51);
+  });
+
+  it("does not clamp interest by the balance", () => {
+    // Interest accrued on the debt and is owed independently of how much
+    // principal is left to retire.
+    const result = allocateLoanPayment({
+      paymentAmount: 1000,
+      extraPrincipal: 0,
+      interest: 80,
+      principal: 920,
+      currentBalance: 30,
+    });
+    expect(result.interest).toBe(80);
+    expect(result.principal).toBe(30);
+    expect(result.total).toBe(110);
+  });
+
+  it("applies no balance clamp when the balance is unknown", () => {
+    const result = allocateLoanPayment({
+      paymentAmount: 1000,
+      extraPrincipal: 200,
+      interest: 100,
+      principal: 700,
+      currentBalance: null,
+    });
+    expect(result).toEqual({
+      principal: 700,
+      interest: 100,
+      extraPrincipal: 200,
+      total: 1000,
+    });
+  });
+
+  it("treats negative inputs as zero rather than crediting the borrower", () => {
+    const result = allocateLoanPayment({
+      paymentAmount: 1000,
+      extraPrincipal: -5,
+      interest: -10,
+      principal: -20,
+      currentBalance: 100000,
+    });
+    expect(result).toEqual({
+      principal: 0,
+      interest: 0,
+      extraPrincipal: 0,
+      total: 0,
+    });
+  });
+
+  it("rounds each part and the total to 4dp", () => {
+    const result = allocateLoanPayment({
+      paymentAmount: 100.00005,
+      extraPrincipal: 0,
+      interest: 33.33333,
+      principal: 66.66667,
+      currentBalance: 1000,
+    });
+    expect(result.interest).toBe(33.3333);
+    expect(result.principal).toBe(66.6667);
+    expect(result.total).toBe(100);
+  });
+});

--- a/backend/src/accounts/loan-payment-waterfall.util.ts
+++ b/backend/src/accounts/loan-payment-waterfall.util.ts
@@ -1,0 +1,97 @@
+import { roundMoney } from "../common/round.util";
+
+export interface LoanPaymentWaterfallInput {
+  /** Total configured installment, extra principal included. */
+  paymentAmount: number;
+  /** Standing extra-principal instruction (0 when there is none). */
+  extraPrincipal: number;
+  /** Accrued interest for the period, before any clamp. */
+  interest: number;
+  /** Regular amortized principal for the period, before any clamp. */
+  principal: number;
+  /**
+   * Outstanding debt to retire, as a positive number -- or null when the
+   * balance cannot bound the payment (an account whose history has not been
+   * recorded yet reads 0, which means "unknown", not "paid off"). With null,
+   * no balance clamp applies.
+   */
+  currentBalance: number | null;
+}
+
+export interface LoanPaymentAllocation {
+  principal: number;
+  interest: number;
+  extraPrincipal: number;
+  /** Sum of the three parts -- what the installment's parent row must carry. */
+  total: number;
+}
+
+/**
+ * The one place a loan installment is divided between interest, regular
+ * principal and extra principal. `LoanPaymentSetupService` (the first
+ * installment) and `ScheduledTransactionLoanService` (every recalculation
+ * after a posting) both call this, because the two must agree about what any
+ * given installment looks like -- the copy each held drifted twice before this
+ * existed (audit P5-008, recheck DR3-01, review #1131).
+ * `loan-waterfall.guard.spec.ts` fails on a new hand-rolled copy.
+ *
+ * Policy, decided once:
+ *
+ * - A payment that does not cover the accrued interest is applied
+ *   interest-first across the WHOLE installment, extra principal included. A
+ *   lender applies a payment to accrued interest before principal, so a
+ *   designated extra-principal transfer has no principal to reduce until the
+ *   interest is met. Interest itself is bounded by the whole installment so a
+ *   child can never exceed its parent.
+ * - Never schedule more principal than the loan still owes. Regular principal
+ *   is what the amortization says is owed, so it is filled first; the
+ *   discretionary extra absorbs the shortfall. Interest is not clamped by the
+ *   balance -- it accrued on the debt and is owed independently of how much
+ *   principal is left to retire.
+ * - What is left of the installment after interest is the most that can go to
+ *   principal in total, so the extra is bounded by that as well as by the
+ *   debt.
+ * - The parts only ever shrink from the configured figures, and the total is
+ *   the sum of the parts by construction, so the split validator's exact-4dp
+ *   equality between parent and children cannot be reached with a mismatch.
+ */
+export function allocateLoanPayment(
+  input: LoanPaymentWaterfallInput,
+): LoanPaymentAllocation {
+  const paymentAmount = roundMoney(input.paymentAmount);
+  const configuredExtra = Math.max(0, roundMoney(input.extraPrincipal));
+  const basePayment = roundMoney(paymentAmount - configuredExtra);
+  const balance =
+    input.currentBalance == null ? null : roundMoney(input.currentBalance);
+
+  let interest = Math.max(0, roundMoney(input.interest));
+  let principal = Math.max(0, roundMoney(input.principal));
+
+  if (interest > basePayment) {
+    interest = Math.min(interest, paymentAmount);
+    principal = 0;
+  }
+
+  if (balance !== null && principal > balance) {
+    principal = balance;
+  }
+
+  const availableForPrincipal = Math.max(
+    0,
+    roundMoney(paymentAmount - interest),
+  );
+  let extraPrincipal = Math.min(
+    configuredExtra,
+    Math.max(0, roundMoney(availableForPrincipal - principal)),
+  );
+  if (balance !== null && roundMoney(principal + extraPrincipal) > balance) {
+    extraPrincipal = Math.max(0, roundMoney(balance - principal));
+  }
+
+  return {
+    principal,
+    interest,
+    extraPrincipal,
+    total: roundMoney(principal + interest + extraPrincipal),
+  };
+}

--- a/backend/src/accounts/loan-waterfall.guard.spec.ts
+++ b/backend/src/accounts/loan-waterfall.guard.spec.ts
@@ -1,0 +1,64 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * The loan payment waterfall -- interest-first clamp, balance clamps, extra
+ * absorbing the shortfall -- lives once, in
+ * `accounts/loan-payment-waterfall.util.ts`. Two services used to carry their
+ * own ~50-line copies, and the copies drifted (one gated the balance clamps,
+ * the other did not; one clamped nothing at all in its first version). This
+ * scans `src/` for the shapes a hand-rolled copy cannot avoid:
+ *
+ * - the interest-first test `<something> > basePayment...`
+ * - a local `availableForPrincipal` computation
+ *
+ * A new caller allocates through `allocateLoanPayment` instead.
+ */
+describe("loan waterfall guard", () => {
+  const srcRoot = path.join(__dirname, "..");
+  const utilFile = path.join(__dirname, "loan-payment-waterfall.util.ts");
+
+  const sourceFiles = (dir: string): string[] =>
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return sourceFiles(full);
+      if (!entry.name.endsWith(".ts")) return [];
+      if (entry.name.endsWith(".spec.ts")) return [];
+      return [full];
+    });
+
+  const handRolledMarkers = [
+    /\bavailableForPrincipal\b/,
+    /\w+\s*>\s*basePayment\w*/,
+  ];
+
+  it("finds no hand-rolled waterfall outside the util", () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles(srcRoot)) {
+      if (path.resolve(file) === path.resolve(utilFile)) continue;
+      const source = fs.readFileSync(file, "utf8");
+      for (const marker of handRolledMarkers) {
+        if (marker.test(source)) {
+          offenders.push(
+            `${path.relative(srcRoot, file)} matches ${marker} -- allocate through allocateLoanPayment (accounts/loan-payment-waterfall.util.ts) instead of re-rolling the clamp sequence`,
+          );
+          break;
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("still recognises the shapes it scans for", () => {
+    expect(
+      handRolledMarkers.some((m) =>
+        m.test("if (newInterest > basePaymentAmount) {"),
+      ),
+    ).toBe(true);
+    expect(
+      handRolledMarkers.some((m) =>
+        m.test("const availableForPrincipal = Math.max(0, x);"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/backend/src/backup/support-backup/support-backup-rules.ts
+++ b/backend/src/backup/support-backup/support-backup-rules.ts
@@ -162,6 +162,7 @@ export const RULES: Record<string, TableRules> = {
     favourite_sort_order: keep,
     exclude_from_net_worth: keep,
     payment_amount: scale,
+    extra_payment_amount: scale, // money like payment_amount, scaled the same way
     payment_frequency: keep,
     payment_start_date: keep,
     source_account_id: keep,

--- a/backend/src/budgets/budget-activity-reports.service.spec.ts
+++ b/backend/src/budgets/budget-activity-reports.service.spec.ts
@@ -417,24 +417,34 @@ describe("BudgetActivityReportsService", () => {
           { date: "2026-02-15", total: "50.00" },
         ]),
       });
+      // A transfer recorded as one line of a split parent (audit P5-007):
+      // counted alongside the whole-row transfers.
+      const splitTransferQb = createMockQueryBuilder({
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ date: "2026-02-15", total: "25.00" }]),
+      });
 
-      // Direct spending query, split query, then transfer query
+      // Direct spending query, split query, then the two transfer queries
       transactionsRepository.createQueryBuilder
         .mockReturnValueOnce(directQb)
         .mockReturnValueOnce(transferQb);
-      splitsRepository.createQueryBuilder.mockReturnValueOnce(splitQb);
+      splitsRepository.createQueryBuilder
+        .mockReturnValueOnce(splitQb)
+        .mockReturnValueOnce(splitTransferQb);
 
       const result = await service.getDailySpending("user-1", "budget-1");
 
-      // 3 queries should have been created
+      // 4 queries should have been created
       expect(transactionsRepository.createQueryBuilder).toHaveBeenCalledTimes(
         2,
       );
-      expect(splitsRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
+      expect(splitsRepository.createQueryBuilder).toHaveBeenCalledTimes(2);
       expect(result).toHaveLength(2);
       // Feb 5: 100 direct + 200 transfer = 300
       expect(result[0]).toEqual({ date: "2026-02-05", amount: 300 });
-      expect(result[1]).toEqual({ date: "2026-02-15", amount: 50 });
+      // Feb 15: 50 whole-row transfer + 25 split-line transfer
+      expect(result[1]).toEqual({ date: "2026-02-15", amount: 75 });
     });
 
     it("should return empty array when no expense categories exist", async () => {
@@ -477,16 +487,22 @@ describe("BudgetActivityReportsService", () => {
           .fn()
           .mockResolvedValue([{ date: "2026-02-20", total: "150.00" }]),
       });
+      const splitTransferQb = createMockQueryBuilder({
+        getRawMany: jest.fn().mockResolvedValue([]),
+      });
 
       transactionsRepository.createQueryBuilder.mockReturnValueOnce(transferQb);
+      splitsRepository.createQueryBuilder.mockReturnValueOnce(splitTransferQb);
 
       const result = await service.getDailySpending("user-1", "budget-1");
 
-      // Only the transfer query should be created (no direct/split queries)
+      // Only the two transfer queries should be created (no direct/split
+      // category queries) -- the split-transfer read still runs, because a
+      // transfer can arrive as one line of a split parent (audit P5-007).
       expect(transactionsRepository.createQueryBuilder).toHaveBeenCalledTimes(
         1,
       );
-      expect(splitsRepository.createQueryBuilder).not.toHaveBeenCalled();
+      expect(splitsRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({ date: "2026-02-20", amount: 150 });
     });

--- a/backend/src/budgets/budget-activity-reports.service.ts
+++ b/backend/src/budgets/budget-activity-reports.service.ts
@@ -11,6 +11,12 @@ import {
   FlexGroupStatusResult,
 } from "./budget-reports.service";
 import { formatDateYMD, getMonthEndYMD } from "../common/date-utils";
+import {
+  outgoingParentTransfers,
+  outgoingSplitTransfers,
+  PARENT_TRANSFER_AMOUNT,
+  SPLIT_TRANSFER_AMOUNT,
+} from "./budget-spending.util";
 import { roundMoney, roundToDecimals, sumMoney } from "../common/round.util";
 
 const MONTH_NAMES = [
@@ -251,23 +257,29 @@ export class BudgetActivityReportsService {
     }
 
     if (transferAccountIds.length > 0) {
+      const window = { userId, periodStart, periodEnd, transferAccountIds };
+      // Both transfer shapes: whole-row transfers and split lines carrying a
+      // transfer_account_id (review #1131).
       queries.push(
         withScopedDb(this.dataSource, (m) =>
-          m
-            .getRepository(Transaction)
-            .createQueryBuilder("t")
-            .innerJoin("t.linkedTransaction", "lt")
+          outgoingParentTransfers(m.getRepository(Transaction), window)
             .select("DATE(t.transaction_date)", "date")
-            .addSelect("COALESCE(ABS(SUM(t.amount)), 0)", "total")
-            .where("t.user_id = :userId", { userId })
-            .andWhere("t.is_transfer = true")
-            .andWhere("t.amount < 0")
-            .andWhere("lt.account_id IN (:...transferAccountIds)", {
-              transferAccountIds,
-            })
-            .andWhere("t.transaction_date >= :start", { start: periodStart })
-            .andWhere("t.transaction_date <= :end", { end: periodEnd })
-            .andWhere("t.status != :void", { void: "VOID" })
+            .addSelect(
+              `COALESCE(ABS(SUM(${PARENT_TRANSFER_AMOUNT})), 0)`,
+              "total",
+            )
+            .groupBy("DATE(t.transaction_date)")
+            .getRawMany(),
+        ),
+      );
+      queries.push(
+        withScopedDb(this.dataSource, (m) =>
+          outgoingSplitTransfers(m.getRepository(TransactionSplit), window)
+            .select("DATE(t.transaction_date)", "date")
+            .addSelect(
+              `COALESCE(ABS(SUM(${SPLIT_TRANSFER_AMOUNT})), 0)`,
+              "total",
+            )
             .groupBy("DATE(t.transaction_date)")
             .getRawMany(),
         ),

--- a/backend/src/budgets/budget-generator.service.spec.ts
+++ b/backend/src/budgets/budget-generator.service.spec.ts
@@ -457,6 +457,74 @@ describe("BudgetGeneratorService", () => {
       }
     });
 
+    it("counts a transfer recorded as one line of a split parent in the transfer analysis", async () => {
+      const now = new Date();
+      const month1 = now.getMonth();
+      const year1 = now.getFullYear();
+      const prevMonth = month1 === 0 ? 12 : month1;
+      const prevYear = month1 === 0 ? year1 - 1 : year1;
+
+      const savingsRow = {
+        accountId: "acct-savings",
+        accountName: "Savings",
+        accountType: "SAVINGS",
+        year: prevYear,
+        month: prevMonth,
+        total: "200.00",
+      };
+
+      transactionsRepository.createQueryBuilder.mockImplementation(() => {
+        const qb = createMockQueryBuilder();
+        let isTransferQuery = false;
+        qb.andWhere = jest.fn().mockImplementation((...args: unknown[]) => {
+          const arg = typeof args[0] === "string" ? (args[0] as string) : "";
+          if (arg.includes("t.is_transfer = true")) isTransferQuery = true;
+          return qb;
+        });
+        qb.getRawMany = jest
+          .fn()
+          .mockImplementation(() =>
+            Promise.resolve(isTransferQuery ? [savingsRow] : []),
+          );
+        return qb;
+      });
+
+      // The same destination also receives 100 through a split line carrying
+      // transfer_account_id -- a savings habit recorded inside a split
+      // paycheque. Keyed off the split query's own marker predicate, so this
+      // fails when the split-transfer read is dropped (review #1131).
+      splitsRepository.createQueryBuilder.mockImplementation(() => {
+        const qb = createMockQueryBuilder();
+        let isSplitTransferQuery = false;
+        qb.andWhere = jest.fn().mockImplementation((...args: unknown[]) => {
+          const arg = typeof args[0] === "string" ? (args[0] as string) : "";
+          if (arg.includes("s.transfer_account_id IS NOT NULL"))
+            isSplitTransferQuery = true;
+          return qb;
+        });
+        qb.getRawMany = jest
+          .fn()
+          .mockImplementation(() =>
+            Promise.resolve(
+              isSplitTransferQuery ? [{ ...savingsRow, total: "100.00" }] : [],
+            ),
+          );
+        return qb;
+      });
+
+      const result = await service.generate("user-1", {
+        analysisMonths: 3,
+        profile: BudgetProfile.ON_TRACK,
+      });
+
+      const savings = result.transfers.find(
+        (t) => t.accountId === "acct-savings",
+      );
+      expect(savings).toBeDefined();
+      // 200 whole-row + 100 split-line in the same month
+      expect(savings!.max).toBe(300);
+    });
+
     it("prefers expense data when a refund causes a category to appear in both queries", async () => {
       const now = new Date();
       const month1 = now.getMonth();

--- a/backend/src/budgets/budget-generator.service.ts
+++ b/backend/src/budgets/budget-generator.service.ts
@@ -10,6 +10,12 @@ import { BudgetCategory } from "./entities/budget-category.entity";
 import { GenerateBudgetDto, BudgetProfile } from "./dto/generate-budget.dto";
 import { ApplyGeneratedBudgetDto } from "./dto/apply-generated-budget.dto";
 import { roundMoney, sumMoney } from "../common/round.util";
+import {
+  outgoingParentTransfers,
+  outgoingSplitTransfers,
+  PARENT_TRANSFER_AMOUNT,
+  SPLIT_TRANSFER_AMOUNT,
+} from "./budget-spending.util";
 
 export interface CategoryAnalysis {
   categoryId: string;
@@ -500,31 +506,44 @@ export class BudgetGeneratorService {
     endDate: string,
     analysisMonths: number,
   ): Promise<Omit<TransferAnalysis, "suggested">[]> {
-    const rows = await withScopedDb(this.dataSource, (m) =>
-      m
-        .getRepository(Transaction)
-        .createQueryBuilder("t")
-        .innerJoin("t.linkedTransaction", "lt")
-        .innerJoin("lt.account", "a")
-        .select("a.id", "accountId")
-        .addSelect("a.name", "accountName")
-        .addSelect("a.account_type", "accountType")
-        .addSelect("EXTRACT(YEAR FROM t.transaction_date)::int", "year")
-        .addSelect("EXTRACT(MONTH FROM t.transaction_date)::int", "month")
-        .addSelect("ABS(SUM(t.amount))", "total")
-        .where("t.user_id = :userId", { userId })
-        .andWhere("t.transaction_date >= :startDate", { startDate })
-        .andWhere("t.transaction_date <= :endDate", { endDate })
-        .andWhere("t.status != :void", { void: "VOID" })
-        .andWhere("t.is_transfer = true")
-        .andWhere("t.amount < 0")
-        .groupBy("a.id")
-        .addGroupBy("a.name")
-        .addGroupBy("a.account_type")
-        .addGroupBy("EXTRACT(YEAR FROM t.transaction_date)")
-        .addGroupBy("EXTRACT(MONTH FROM t.transaction_date)")
-        .getRawMany(),
+    // No destination filter: this sweeps every account transfers land in.
+    // Both transfer shapes -- whole-row transfers and split lines carrying a
+    // transfer_account_id -- or a savings habit recorded inside a split
+    // paycheque never surfaces as a suggested budget (review #1131).
+    const window = { userId, periodStart: startDate, periodEnd: endDate };
+    const [parentRows, splitRows] = await withScopedDb(this.dataSource, (m) =>
+      Promise.all([
+        outgoingParentTransfers(m.getRepository(Transaction), window)
+          .innerJoin("lt.account", "a")
+          .select("a.id", "accountId")
+          .addSelect("a.name", "accountName")
+          .addSelect("a.account_type", "accountType")
+          .addSelect("EXTRACT(YEAR FROM t.transaction_date)::int", "year")
+          .addSelect("EXTRACT(MONTH FROM t.transaction_date)::int", "month")
+          .addSelect(`ABS(SUM(${PARENT_TRANSFER_AMOUNT}))`, "total")
+          .groupBy("a.id")
+          .addGroupBy("a.name")
+          .addGroupBy("a.account_type")
+          .addGroupBy("EXTRACT(YEAR FROM t.transaction_date)")
+          .addGroupBy("EXTRACT(MONTH FROM t.transaction_date)")
+          .getRawMany(),
+        outgoingSplitTransfers(m.getRepository(TransactionSplit), window)
+          .innerJoin("s.transferAccount", "a")
+          .select("a.id", "accountId")
+          .addSelect("a.name", "accountName")
+          .addSelect("a.account_type", "accountType")
+          .addSelect("EXTRACT(YEAR FROM t.transaction_date)::int", "year")
+          .addSelect("EXTRACT(MONTH FROM t.transaction_date)::int", "month")
+          .addSelect(`ABS(SUM(${SPLIT_TRANSFER_AMOUNT}))`, "total")
+          .groupBy("a.id")
+          .addGroupBy("a.name")
+          .addGroupBy("a.account_type")
+          .addGroupBy("EXTRACT(YEAR FROM t.transaction_date)")
+          .addGroupBy("EXTRACT(MONTH FROM t.transaction_date)")
+          .getRawMany(),
+      ]),
     );
+    const rows = [...parentRows, ...splitRows];
 
     const accountMap = new Map<
       string,

--- a/backend/src/budgets/budget-period.service.spec.ts
+++ b/backend/src/budgets/budget-period.service.spec.ts
@@ -368,6 +368,67 @@ describe("BudgetPeriodService", () => {
         BadRequestException,
       );
     });
+
+    it("freezes transfer actuals from whole-row transfers AND split-line transfers", async () => {
+      // A transfer can arrive as one line of a split parent (audit P5-007). A
+      // closed period is never recomputed, so leaving that shape out here made
+      // the materialized month disagree with the live budget page for the same
+      // dates (review #1131).
+      const transferCategory: BudgetCategory = {
+        ...mockBudgetCategory,
+        id: "bc-transfer",
+        categoryId: null,
+        isTransfer: true,
+        transferAccountId: "acct-savings",
+      };
+      budgetsService.findOne.mockResolvedValue({
+        ...mockBudget,
+        categories: [transferCategory],
+      });
+
+      const openPeriod = {
+        ...mockPeriod,
+        status: PeriodStatus.OPEN,
+        periodCategories: [
+          {
+            ...mockPeriodCategory,
+            budgetCategoryId: "bc-transfer",
+            budgetCategory: transferCategory,
+          },
+        ],
+      };
+      periodsRepository.findOne.mockResolvedValue(openPeriod);
+      periodsRepository.save.mockImplementation((data) => data);
+
+      transactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder({
+          getRawMany: jest
+            .fn()
+            .mockResolvedValue([
+              { destinationAccountId: "acct-savings", total: "100" },
+            ]),
+        }),
+      );
+      splitsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder({
+          getRawMany: jest
+            .fn()
+            .mockResolvedValue([
+              { destinationAccountId: "acct-savings", total: "50" },
+            ]),
+        }),
+      );
+
+      await service.closePeriod("user-1", "budget-1");
+
+      expect(scopedManager.save).toHaveBeenCalledWith(
+        BudgetPeriodCategory,
+        expect.objectContaining({
+          budgetCategoryId: "bc-transfer",
+          actualAmount: 150,
+        }),
+      );
+    });
   });
 
   describe("getOrCreateCurrentPeriod", () => {

--- a/backend/src/budgets/budget-period.service.ts
+++ b/backend/src/budgets/budget-period.service.ts
@@ -15,6 +15,14 @@ import { Transaction } from "../transactions/entities/transaction.entity";
 import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
 import { BudgetsService } from "./budgets.service";
 import { getCurrentMonthPeriodDates } from "./budget-date.utils";
+import {
+  outgoingParentTransfers,
+  outgoingSplitTransfers,
+  PARENT_TRANSFER_AMOUNT,
+  PARENT_TRANSFER_DESTINATION,
+  SPLIT_TRANSFER_AMOUNT,
+  SPLIT_TRANSFER_DESTINATION,
+} from "./budget-spending.util";
 import { roundMoney, sumMoney } from "../common/round.util";
 
 @Injectable()
@@ -382,34 +390,46 @@ export class BudgetPeriodService {
     const transferSpendingMap = new Map<string, number>();
 
     if (transferBudgetCategories.length > 0) {
-      const transferAccountIds = transferBudgetCategories.map(
-        (bc) => bc.transferAccountId as string,
+      const window = {
+        userId,
+        periodStart,
+        periodEnd,
+        transferAccountIds: transferBudgetCategories.map(
+          (bc) => bc.transferAccountId as string,
+        ),
+      };
+
+      // Both transfer shapes -- whole-row transfers and split lines carrying a
+      // transfer_account_id -- or the materialized period disagrees with the
+      // live budget page for the same month (review #1131).
+      const [parentActuals, splitActuals] = await withScopedDb(
+        this.dataSource,
+        (m) =>
+          Promise.all([
+            outgoingParentTransfers(m.getRepository(Transaction), window)
+              .select(PARENT_TRANSFER_DESTINATION, "destinationAccountId")
+              .addSelect(
+                `COALESCE(ABS(SUM(${PARENT_TRANSFER_AMOUNT})), 0)`,
+                "total",
+              )
+              .groupBy(PARENT_TRANSFER_DESTINATION)
+              .getRawMany(),
+            outgoingSplitTransfers(m.getRepository(TransactionSplit), window)
+              .select(SPLIT_TRANSFER_DESTINATION, "destinationAccountId")
+              .addSelect(
+                `COALESCE(ABS(SUM(${SPLIT_TRANSFER_AMOUNT})), 0)`,
+                "total",
+              )
+              .groupBy(SPLIT_TRANSFER_DESTINATION)
+              .getRawMany(),
+          ]),
       );
 
-      const transferActuals = await withScopedDb(this.dataSource, (m) =>
-        m
-          .getRepository(Transaction)
-          .createQueryBuilder("t")
-          .innerJoin("t.linkedTransaction", "lt")
-          .select("lt.account_id", "destinationAccountId")
-          .addSelect("COALESCE(ABS(SUM(t.amount)), 0)", "total")
-          .where("t.user_id = :userId", { userId })
-          .andWhere("t.is_transfer = true")
-          .andWhere("t.amount < 0")
-          .andWhere("lt.account_id IN (:...transferAccountIds)", {
-            transferAccountIds,
-          })
-          .andWhere("t.transaction_date >= :periodStart", { periodStart })
-          .andWhere("t.transaction_date <= :periodEnd", { periodEnd })
-          .andWhere("t.status != :void", { void: "VOID" })
-          .groupBy("lt.account_id")
-          .getRawMany(),
-      );
-
-      for (const row of transferActuals) {
+      for (const row of [...parentActuals, ...splitActuals]) {
         transferSpendingMap.set(
           row.destinationAccountId,
-          parseFloat(row.total || "0"),
+          (transferSpendingMap.get(row.destinationAccountId) ?? 0) +
+            parseFloat(row.total || "0"),
         );
       }
     }

--- a/backend/src/budgets/budget-spending.util.spec.ts
+++ b/backend/src/budgets/budget-spending.util.spec.ts
@@ -218,6 +218,83 @@ describe("queryCategorySpending", () => {
     expect(result.transferSpendingMap.get("acc-1")).toBe(300);
   });
 
+  it("includes a transfer that is a child of a split (P5-007)", async () => {
+    // A monthly transfer budget to Savings of 100, spent as one mixed line:
+    // a -100 parent with a -60 Groceries child and a -40 transfer child.
+    //
+    // The transfer query keys off `is_transfer` on the PARENT, and a split
+    // parent is not a transfer row -- so this progress was invisible and the
+    // budget read 0 of 100 spent. Savings, debt-payment and
+    // investment-contribution budgets all under-reported whenever the user
+    // recorded the transfer alongside a category on one transaction.
+    const txRepo: any = {
+      createQueryBuilder: jest
+        .fn()
+        // No plain transfer rows in the period.
+        .mockImplementation(() => makeQbReturning([])),
+    };
+    const splitRepo: any = {
+      createQueryBuilder: jest
+        .fn()
+        .mockImplementation(() =>
+          makeQbReturning([{ destinationAccountId: "acc-1", total: "40" }]),
+        ),
+    };
+
+    const result = await queryCategorySpending(
+      txRepo,
+      splitRepo,
+      "user-1",
+      [
+        makeBudgetCategory({
+          categoryId: null,
+          isTransfer: true,
+          transferAccountId: "acc-1",
+        } as any),
+      ],
+      "2026-01-01",
+      "2026-01-31",
+    );
+
+    expect(result.transferSpendingMap.get("acc-1")).toBe(40);
+  });
+
+  it("sums a plain transfer and a split transfer to the same account", async () => {
+    // Counted once each, not once in total and not twice: the split query reads
+    // the split row's own target, and a counterpart row is not itself a split.
+    const txRepo: any = {
+      createQueryBuilder: jest
+        .fn()
+        .mockImplementation(() =>
+          makeQbReturning([{ destinationAccountId: "acc-1", total: "300" }]),
+        ),
+    };
+    const splitRepo: any = {
+      createQueryBuilder: jest
+        .fn()
+        .mockImplementation(() =>
+          makeQbReturning([{ destinationAccountId: "acc-1", total: "40" }]),
+        ),
+    };
+
+    const result = await queryCategorySpending(
+      txRepo,
+      splitRepo,
+      "user-1",
+      [
+        makeBudgetCategory({
+          categoryId: null,
+          isTransfer: true,
+          transferAccountId: "acc-1",
+        } as any),
+      ],
+      "2026-01-01",
+      "2026-01-31",
+    );
+
+    expect(result.transferSpendingMap.get("acc-1")).toBe(340);
+  });
+
   it("treats null totals as 0", async () => {
     const txRepo: any = {
       createQueryBuilder: jest

--- a/backend/src/budgets/budget-spending.util.ts
+++ b/backend/src/budgets/budget-spending.util.ts
@@ -1,7 +1,97 @@
-import { Repository } from "typeorm";
+import { Repository, SelectQueryBuilder } from "typeorm";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
 import { BudgetCategory } from "./entities/budget-category.entity";
+
+/**
+ * A transfer a budget (or a transfer analysis) counts arrives in one of two
+ * shapes, and every surface must read both:
+ *
+ * - a whole-row transfer: the parent carries `is_transfer = true` and the
+ *   destination hangs off the linked counterpart leg;
+ * - one component of a split: the parent is a split transaction rather than a
+ *   transfer row, and the split line carries `transfer_account_id` directly.
+ *
+ * A query keyed off `t.is_transfer` alone never sees the second shape, so a
+ * savings or debt-payment budget under-reported its progress by the whole
+ * transfer whenever the user recorded it alongside a category on one line
+ * (audit P5-007) -- and the same omission then survived on four more read
+ * surfaces (review #1131). These two builders are the one place the pair of
+ * predicates is written; callers add their own SELECT and GROUP BY on top,
+ * reading the amount and destination through the exported expressions.
+ *
+ * Filtering on the split's own target cannot double-count, because a
+ * counterpart row is not itself a split. Both builders keep outflows only
+ * (`amount < 0`): a transfer INTO the budgeted account is progress, one out of
+ * it is not.
+ */
+export interface OutgoingTransferWindow {
+  userId: string;
+  periodStart: string;
+  periodEnd: string;
+  /** Restrict to these destination accounts; omit to sweep every destination. */
+  transferAccountIds?: string[];
+}
+
+/** Destination account of a whole-row transfer (parent builder alias). */
+export const PARENT_TRANSFER_DESTINATION = "lt.account_id";
+/** Destination account of a split-line transfer (split builder alias). */
+export const SPLIT_TRANSFER_DESTINATION = "s.transfer_account_id";
+/** Amount moved by a whole-row transfer (parent builder alias). */
+export const PARENT_TRANSFER_AMOUNT = "t.amount";
+/** Amount moved by a split-line transfer (split builder alias). */
+export const SPLIT_TRANSFER_AMOUNT = "s.amount";
+
+export function outgoingParentTransfers(
+  repository: Repository<Transaction>,
+  window: OutgoingTransferWindow,
+): SelectQueryBuilder<Transaction> {
+  const qb = repository
+    .createQueryBuilder("t")
+    .innerJoin("t.linkedTransaction", "lt")
+    .where("t.user_id = :userId", { userId: window.userId })
+    .andWhere("t.is_transfer = true")
+    .andWhere("t.amount < 0")
+    .andWhere("t.transaction_date >= :periodStart", {
+      periodStart: window.periodStart,
+    })
+    .andWhere("t.transaction_date <= :periodEnd", {
+      periodEnd: window.periodEnd,
+    })
+    .andWhere("t.status != :void", { void: "VOID" });
+  if (window.transferAccountIds) {
+    qb.andWhere("lt.account_id IN (:...transferAccountIds)", {
+      transferAccountIds: window.transferAccountIds,
+    });
+  }
+  return qb;
+}
+
+export function outgoingSplitTransfers(
+  repository: Repository<TransactionSplit>,
+  window: OutgoingTransferWindow,
+): SelectQueryBuilder<TransactionSplit> {
+  const qb = repository
+    .createQueryBuilder("s")
+    .innerJoin("s.transaction", "t")
+    .where("t.user_id = :userId", { userId: window.userId })
+    .andWhere("s.amount < 0")
+    .andWhere("t.transaction_date >= :periodStart", {
+      periodStart: window.periodStart,
+    })
+    .andWhere("t.transaction_date <= :periodEnd", {
+      periodEnd: window.periodEnd,
+    })
+    .andWhere("t.status != :void", { void: "VOID" });
+  if (window.transferAccountIds) {
+    qb.andWhere("s.transfer_account_id IN (:...transferAccountIds)", {
+      transferAccountIds: window.transferAccountIds,
+    });
+  } else {
+    qb.andWhere("s.transfer_account_id IS NOT NULL");
+  }
+  return qb;
+}
 
 /**
  * Queries transaction and split spending for budget categories within a period.
@@ -80,35 +170,42 @@ export async function queryCategorySpending(
   }
 
   if (transferBudgetCategories.length > 0) {
-    const transferAccountIds = transferBudgetCategories.map(
-      (bc) => bc.transferAccountId as string,
+    const window: OutgoingTransferWindow = {
+      userId,
+      periodStart,
+      periodEnd,
+      transferAccountIds: transferBudgetCategories.map(
+        (bc) => bc.transferAccountId as string,
+      ),
+    };
+    const collect = (
+      rows: Array<{ destinationAccountId: string; total: string }>,
+    ) => {
+      for (const row of rows) {
+        transferSpendingMap.set(
+          row.destinationAccountId,
+          (transferSpendingMap.get(row.destinationAccountId) ?? 0) +
+            parseFloat(row.total || "0"),
+        );
+      }
+    };
+
+    queries.push(
+      outgoingParentTransfers(transactionsRepository, window)
+        .select(PARENT_TRANSFER_DESTINATION, "destinationAccountId")
+        .addSelect(`COALESCE(ABS(SUM(${PARENT_TRANSFER_AMOUNT})), 0)`, "total")
+        .groupBy(PARENT_TRANSFER_DESTINATION)
+        .getRawMany()
+        .then(collect),
     );
 
     queries.push(
-      transactionsRepository
-        .createQueryBuilder("t")
-        .innerJoin("t.linkedTransaction", "lt")
-        .select("lt.account_id", "destinationAccountId")
-        .addSelect("COALESCE(ABS(SUM(t.amount)), 0)", "total")
-        .where("t.user_id = :userId", { userId })
-        .andWhere("t.is_transfer = true")
-        .andWhere("t.amount < 0")
-        .andWhere("lt.account_id IN (:...transferAccountIds)", {
-          transferAccountIds,
-        })
-        .andWhere("t.transaction_date >= :periodStart", { periodStart })
-        .andWhere("t.transaction_date <= :periodEnd", { periodEnd })
-        .andWhere("t.status != :void", { void: "VOID" })
-        .groupBy("lt.account_id")
+      outgoingSplitTransfers(splitsRepository, window)
+        .select(SPLIT_TRANSFER_DESTINATION, "destinationAccountId")
+        .addSelect(`COALESCE(ABS(SUM(${SPLIT_TRANSFER_AMOUNT})), 0)`, "total")
+        .groupBy(SPLIT_TRANSFER_DESTINATION)
         .getRawMany()
-        .then((rows) => {
-          for (const row of rows) {
-            transferSpendingMap.set(
-              row.destinationAccountId,
-              parseFloat(row.total || "0"),
-            );
-          }
-        }),
+        .then(collect),
     );
   }
 

--- a/backend/src/budgets/budget-trend-reports.service.spec.ts
+++ b/backend/src/budgets/budget-trend-reports.service.spec.ts
@@ -468,17 +468,23 @@ describe("BudgetTrendReportsService", () => {
       const transferQb = createMockQueryBuilder({
         getRawOne: jest.fn().mockResolvedValue({ total: "-150" }),
       });
+      // a transfer recorded as one line of a split parent (audit P5-007)
+      const splitTransferQb = createMockQueryBuilder({
+        getRawOne: jest.fn().mockResolvedValue({ total: "-25" }),
+      });
 
       transactionsRepository.createQueryBuilder
         .mockReturnValueOnce(directQb)
         .mockReturnValueOnce(transferQb);
-      splitsRepository.createQueryBuilder.mockReturnValueOnce(splitQb);
+      splitsRepository.createQueryBuilder
+        .mockReturnValueOnce(splitQb)
+        .mockReturnValueOnce(splitTransferQb);
 
       const result = await service.getTrend("user-1", "budget-1", 6);
 
       expect(result).toHaveLength(2);
-      // actuals = -(-300 + -50 + -150) = 500
-      expect(result[1].actual).toBe(500);
+      // actuals = -(-300 + -50 + -150 + -25) = 525
+      expect(result[1].actual).toBe(525);
     });
 
     it("should handle budget with only transfer categories (no regular categories)", async () => {
@@ -516,13 +522,19 @@ describe("BudgetTrendReportsService", () => {
       const transferQb = createMockQueryBuilder({
         getRawOne: jest.fn().mockResolvedValue({ total: "-175" }),
       });
+      // The split-transfer read runs even with no regular categories: a
+      // transfer can arrive as one line of a split parent (audit P5-007).
+      const splitTransferQb = createMockQueryBuilder({
+        getRawOne: jest.fn().mockResolvedValue({ total: "-25" }),
+      });
 
       transactionsRepository.createQueryBuilder.mockReturnValueOnce(transferQb);
+      splitsRepository.createQueryBuilder.mockReturnValueOnce(splitTransferQb);
 
       const result = await service.getTrend("user-1", "budget-1", 6);
 
       expect(result).toHaveLength(2);
-      expect(result[1].actual).toBe(175);
+      expect(result[1].actual).toBe(200);
     });
   });
 
@@ -604,19 +616,27 @@ describe("BudgetTrendReportsService", () => {
           .fn()
           .mockResolvedValue([{ month: monthKey, total: "150" }]),
       });
+      // a transfer recorded as one line of a split parent (audit P5-007)
+      const splitTransferQb = createMockQueryBuilder({
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ month: monthKey, total: "30" }]),
+      });
 
       transactionsRepository.createQueryBuilder
         .mockReturnValueOnce(directQb)
         .mockReturnValueOnce(transferQb);
-      splitsRepository.createQueryBuilder.mockReturnValueOnce(splitQb);
+      splitsRepository.createQueryBuilder
+        .mockReturnValueOnce(splitQb)
+        .mockReturnValueOnce(splitTransferQb);
 
       const result = await service.getTrend("user-1", "budget-1", 3);
 
       expect(result).toHaveLength(3);
 
       const currentMonth = result[result.length - 1];
-      // 200 (direct) + 150 (transfer)
-      expect(currentMonth.actual).toBe(350);
+      // 200 (direct) + 150 (whole-row transfer) + 30 (split-line transfer)
+      expect(currentMonth.actual).toBe(380);
 
       // totalBudgeted = 500 (cat) + 200 (transfer) = 700
       expect(currentMonth.budgeted).toBe(700);
@@ -638,8 +658,12 @@ describe("BudgetTrendReportsService", () => {
           .fn()
           .mockResolvedValue([{ month: monthKey, total: "180" }]),
       });
+      const splitTransferQb = createMockQueryBuilder({
+        getRawMany: jest.fn().mockResolvedValue([]),
+      });
 
       transactionsRepository.createQueryBuilder.mockReturnValueOnce(transferQb);
+      splitsRepository.createQueryBuilder.mockReturnValueOnce(splitTransferQb);
 
       const result = await service.getTrend("user-1", "budget-1", 3);
 

--- a/backend/src/budgets/budget-trend-reports.service.ts
+++ b/backend/src/budgets/budget-trend-reports.service.ts
@@ -12,6 +12,12 @@ import {
   CategoryTrendSeries,
 } from "./budget-reports.service";
 import { roundMoney, roundToDecimals, sumMoney } from "../common/round.util";
+import {
+  outgoingParentTransfers,
+  outgoingSplitTransfers,
+  PARENT_TRANSFER_AMOUNT,
+  SPLIT_TRANSFER_AMOUNT,
+} from "./budget-spending.util";
 
 const MONTH_NAMES = [
   "January",
@@ -268,24 +274,25 @@ export class BudgetTrendReportsService {
     }
 
     if (transferAccountIds.length > 0) {
+      const window = {
+        userId,
+        periodStart: period.periodStart,
+        periodEnd: period.periodEnd,
+        transferAccountIds,
+      };
+      // Both transfer shapes: whole-row transfers and split lines carrying a
+      // transfer_account_id (review #1131).
       queries.push(
         withScopedDb(this.dataSource, (m) =>
-          m
-            .getRepository(Transaction)
-            .createQueryBuilder("t")
-            .innerJoin("t.linkedTransaction", "lt")
-            .select("COALESCE(SUM(t.amount), 0)", "total")
-            .where("t.user_id = :userId", { userId })
-            .andWhere("t.is_transfer = true")
-            .andWhere("t.amount < 0")
-            .andWhere("lt.account_id IN (:...transferAccountIds)", {
-              transferAccountIds,
-            })
-            .andWhere("t.transaction_date >= :start", {
-              start: period.periodStart,
-            })
-            .andWhere("t.transaction_date <= :end", { end: period.periodEnd })
-            .andWhere("t.status != :void", { void: "VOID" })
+          outgoingParentTransfers(m.getRepository(Transaction), window)
+            .select(`COALESCE(SUM(${PARENT_TRANSFER_AMOUNT}), 0)`, "total")
+            .getRawOne(),
+        ),
+      );
+      queries.push(
+        withScopedDb(this.dataSource, (m) =>
+          outgoingSplitTransfers(m.getRepository(TransactionSplit), window)
+            .select(`COALESCE(SUM(${SPLIT_TRANSFER_AMOUNT}), 0)`, "total")
             .getRawOne(),
         ),
       );
@@ -588,39 +595,58 @@ export class BudgetTrendReportsService {
     }
 
     if (transferAccountIds.length > 0) {
+      const window = {
+        userId,
+        periodStart: rangeStart,
+        periodEnd: rangeEnd,
+        transferAccountIds,
+      };
+      const collectMonthly = (
+        rows: Array<{ month: string; total: string }>,
+      ) => {
+        for (const row of rows) {
+          actualByMonth.set(
+            row.month,
+            (actualByMonth.get(row.month) || 0) + parseFloat(row.total || "0"),
+          );
+        }
+      };
+      // Both transfer shapes: whole-row transfers and split lines carrying a
+      // transfer_account_id (review #1131).
       queries.push(
         withScopedDb(this.dataSource, (m) =>
-          m
-            .getRepository(Transaction)
-            .createQueryBuilder("t")
-            .innerJoin("t.linkedTransaction", "lt")
+          outgoingParentTransfers(m.getRepository(Transaction), window)
             .select(
               "TO_CHAR(DATE_TRUNC('month', t.transaction_date), 'YYYY-MM')",
               "month",
             )
-            .addSelect("COALESCE(ABS(SUM(t.amount)), 0)", "total")
-            .where("t.user_id = :userId", { userId })
-            .andWhere("t.is_transfer = true")
-            .andWhere("t.amount < 0")
-            .andWhere("lt.account_id IN (:...transferAccountIds)", {
-              transferAccountIds,
-            })
-            .andWhere("t.transaction_date >= :start", { start: rangeStart })
-            .andWhere("t.transaction_date <= :end", { end: rangeEnd })
-            .andWhere("t.status != :void", { void: "VOID" })
+            .addSelect(
+              `COALESCE(ABS(SUM(${PARENT_TRANSFER_AMOUNT})), 0)`,
+              "total",
+            )
             .groupBy(
               "TO_CHAR(DATE_TRUNC('month', t.transaction_date), 'YYYY-MM')",
             )
             .getRawMany()
-            .then((rows) => {
-              for (const row of rows) {
-                actualByMonth.set(
-                  row.month,
-                  (actualByMonth.get(row.month) || 0) +
-                    parseFloat(row.total || "0"),
-                );
-              }
-            }),
+            .then(collectMonthly),
+        ),
+      );
+      queries.push(
+        withScopedDb(this.dataSource, (m) =>
+          outgoingSplitTransfers(m.getRepository(TransactionSplit), window)
+            .select(
+              "TO_CHAR(DATE_TRUNC('month', t.transaction_date), 'YYYY-MM')",
+              "month",
+            )
+            .addSelect(
+              `COALESCE(ABS(SUM(${SPLIT_TRANSFER_AMOUNT})), 0)`,
+              "total",
+            )
+            .groupBy(
+              "TO_CHAR(DATE_TRUNC('month', t.transaction_date), 'YYYY-MM')",
+            )
+            .getRawMany()
+            .then(collectMonthly),
         ),
       );
     }

--- a/backend/src/net-worth/net-worth.service.spec.ts
+++ b/backend/src/net-worth/net-worth.service.spec.ts
@@ -98,6 +98,7 @@ describe("NetWorthService", () => {
     statementDueDay: null,
     statementSettlementDay: null,
     paymentAmount: null,
+    extraPaymentAmount: null,
     paymentFrequency: null,
     paymentStartDate: null,
     sourceAccountId: null,

--- a/backend/src/scheduled-transactions/scheduled-transaction-loan.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-loan.service.spec.ts
@@ -128,6 +128,523 @@ describe("ScheduledTransactionLoanService", () => {
       expect(interestSave[0].amount).toBeLessThan(0);
     });
 
+    describe("final installment (P5-008)", () => {
+      it("reduces the parent amount with the principal when the balance is below one payment", async () => {
+        // The audit's worked example: 50 outstanding at 0%, regular payment 100.
+        //
+        // The principal child was capped to 50 and the parent left at -100, so
+        // the posting path submitted children summing -50 against a -100 parent
+        // and the shared split validator rejected it on exact 4dp equality. The
+        // final payment failed at exactly the moment the user expected the loan
+        // to close.
+        const loanAccount = makeLoanAccount({
+          currentBalance: -50,
+          interestRate: 0,
+        });
+        accountsRepository.findOne.mockResolvedValue(loanAccount);
+
+        // No usable previous split data, so the balance-based fallback runs.
+        const scheduledTx = makeScheduledTransaction({
+          amount: -100,
+          splits: [
+            {
+              id: "split-principal",
+              transferAccountId: loanAccountId,
+              categoryId: null,
+              amount: 0,
+              memo: "Principal",
+            },
+            {
+              id: "split-interest",
+              transferAccountId: null,
+              categoryId: "cat-interest",
+              amount: 0,
+              memo: "Interest",
+            },
+          ],
+        } as never);
+        scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
+
+        await service.recalculateLoanPaymentSplits(
+          scheduledTransactionId,
+          loanAccountId,
+        );
+
+        const principalSave = splitsRepository.save.mock.calls.find(
+          (call: any) => call[0].transferAccountId === loanAccountId,
+        );
+        const interestSave = splitsRepository.save.mock.calls.find(
+          (call: any) => call[0].categoryId === "cat-interest",
+        );
+        expect(principalSave[0].amount).toBe(-50);
+        expect(interestSave[0].amount).toBe(-0);
+
+        // The parent shrank to match, so parent and children reconcile exactly.
+        expect(scheduledTransactionsRepository.update).toHaveBeenCalledWith(
+          scheduledTransactionId,
+          { amount: -50 },
+        );
+      });
+
+      it("leaves the parent alone for an ordinary installment", async () => {
+        // The reduction must be a floor-following clamp, not a rewrite: a
+        // regular payment keeps the amount the user set.
+        const loanAccount = makeLoanAccount({ currentBalance: -20000 });
+        accountsRepository.findOne.mockResolvedValue(loanAccount);
+        scheduledTransactionsRepository.findOne.mockResolvedValue(
+          makeScheduledTransaction(),
+        );
+
+        await service.recalculateLoanPaymentSplits(
+          scheduledTransactionId,
+          loanAccountId,
+        );
+
+        expect(scheduledTransactionsRepository.update).not.toHaveBeenCalled();
+      });
+
+      it("caps interest at the payment when the payment does not cover it (RR2-006)", async () => {
+        // 100,000 outstanding at 60% annual (5% monthly) against a configured
+        // 1,000 payment. Neither branch bounded the interest and the parent
+        // update only ever shrinks, so the template held an interest child of
+        // -5,000 under a parent of -1,000 -- children 4,000 above the parent,
+        // which the posting path's split validator rejects outright, so the
+        // schedule stopped posting. `LoanPaymentSetupService` was corrected for
+        // the same underpayment and this sibling was not.
+        const loanAccount = makeLoanAccount({
+          currentBalance: -100000,
+          interestRate: 60,
+        });
+        accountsRepository.findOne.mockResolvedValue(loanAccount);
+
+        // No previous split values, so the balance-based branch runs.
+        const scheduledTx = makeScheduledTransaction({
+          amount: -1000,
+          splits: [
+            {
+              id: "split-principal",
+              transferAccountId: loanAccountId,
+              categoryId: null,
+              amount: 0,
+              memo: "Principal",
+            },
+            {
+              id: "split-interest",
+              transferAccountId: null,
+              categoryId: "cat-interest",
+              amount: 0,
+              memo: "Interest",
+            },
+          ],
+        } as never);
+        scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
+
+        await service.recalculateLoanPaymentSplits(
+          scheduledTransactionId,
+          loanAccountId,
+        );
+
+        const saved = Object.fromEntries(
+          splitsRepository.save.mock.calls.map((call: any) => [
+            call[0].id,
+            call[0].amount,
+          ]),
+        );
+        // The whole installment goes to interest; nothing retires principal.
+        expect(saved["split-interest"]).toBe(-1000);
+        expect(saved["split-principal"]).toBe(-0);
+        // Children sum to the parent exactly, so posting still validates. The
+        // parent keeps the amount the user configured -- the payment is not
+        // short of the debt, it is short of the interest.
+        expect(scheduledTransactionsRepository.update).not.toHaveBeenCalled();
+      });
+
+      it("applies interest first across the whole installment, extra included (DR3-01)", async () => {
+        // 1,000 payment with a 300 standing extra-principal transfer against 800 of
+        // accrued interest. Capping interest at the base payment (700) left the
+        // extra reducing principal while 100 of interest went unpaid. A lender
+        // applies a payment to accrued interest before principal, so the extra has
+        // no principal to reduce until the interest is met.
+        const loanAccount = makeLoanAccount({
+          currentBalance: -100000,
+          // 800 of interest on 100,000 is 0.8% per period; annual = 9.6%.
+          interestRate: 9.6,
+        });
+        accountsRepository.findOne.mockResolvedValue(loanAccount);
+
+        const scheduledTx = makeScheduledTransaction({
+          amount: -1000,
+          splits: [
+            {
+              id: "split-principal",
+              transferAccountId: loanAccountId,
+              categoryId: null,
+              amount: 0,
+              memo: "Principal",
+            },
+            {
+              id: "split-extra",
+              transferAccountId: loanAccountId,
+              categoryId: null,
+              amount: -300,
+              memo: "Extra Principal",
+            },
+            {
+              id: "split-interest",
+              transferAccountId: null,
+              categoryId: "cat-interest",
+              amount: 0,
+              memo: "Interest",
+            },
+          ],
+        } as never);
+        scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
+
+        await service.recalculateLoanPaymentSplits(
+          scheduledTransactionId,
+          loanAccountId,
+        );
+
+        const saved = Object.fromEntries(
+          splitsRepository.save.mock.calls.map((call: any) => [
+            call[0].id,
+            call[0].amount,
+          ]),
+        );
+        // The whole 800 of interest is paid; nothing is left for principal, so the
+        // extra comes down to 200 and the installment still sums to 1,000.
+        expect(saved["split-interest"]).toBe(-800);
+        expect(saved["split-principal"]).toBe(-0);
+        expect(saved["split-extra"]).toBe(-200);
+        expect(scheduledTransactionsRepository.update).not.toHaveBeenCalled();
+      });
+
+      it("clamps regular and extra principal together, not each on its own (FR-009)", async () => {
+        // 500 left on the loan, a 400 amortized principal and a standing 300
+        // extra-principal transfer. The clamp only ever looked at the regular
+        // child, which was already under the balance, so 700 of principal went
+        // into a 500 debt: the loan account crossed zero into a 200 credit, and
+        // the payoff branch waiting for `<= 0.01` never fired.
+        const loanAccount = makeLoanAccount({
+          currentBalance: -500,
+          interestRate: 0,
+        });
+        accountsRepository.findOne.mockResolvedValue(loanAccount);
+
+        // Zero rate and no previous interest, so the balance-based branch runs
+        // and the amortized principal is basePayment (700 - 300 = 400).
+        const scheduledTx = makeScheduledTransaction({
+          amount: -700,
+          splits: [
+            {
+              id: "split-principal",
+              transferAccountId: loanAccountId,
+              categoryId: null,
+              amount: 0,
+              memo: "Principal",
+            },
+            {
+              id: "split-extra",
+              transferAccountId: loanAccountId,
+              categoryId: null,
+              amount: -300,
+              memo: "Extra Principal",
+            },
+            {
+              id: "split-interest",
+              transferAccountId: null,
+              categoryId: "cat-interest",
+              amount: 0,
+              memo: "Interest",
+            },
+          ],
+        } as never);
+        scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
+
+        await service.recalculateLoanPaymentSplits(
+          scheduledTransactionId,
+          loanAccountId,
+        );
+
+        const saved = splitsRepository.save.mock.calls.map((call: any) => [
+          call[0].id,
+          call[0].amount,
+        ]);
+        // Amortization keeps its 400; the discretionary extra absorbs the
+        // shortfall and comes down to 100. Together they retire exactly 500.
+        expect(saved).toEqual(
+          expect.arrayContaining([
+            ["split-principal", -400],
+            ["split-extra", -100],
+          ]),
+        );
+
+        // The parent equals the sum of the children to the cent, which is what
+        // the posting path's split validator demands.
+        expect(scheduledTransactionsRepository.update).toHaveBeenCalledWith(
+          scheduledTransactionId,
+          { amount: -500 },
+        );
+      });
+
+      it("leaves the extra principal alone when the total still fits", async () => {
+        // The clamp must not touch a schedule that is not in its final
+        // installment: the extra transfer is the user's standing instruction.
+        const loanAccount = makeLoanAccount({
+          currentBalance: -20000,
+          interestRate: 0,
+        });
+        accountsRepository.findOne.mockResolvedValue(loanAccount);
+
+        scheduledTransactionsRepository.findOne.mockResolvedValue(
+          makeScheduledTransaction({
+            amount: -700,
+            splits: [
+              {
+                id: "split-principal",
+                transferAccountId: loanAccountId,
+                categoryId: null,
+                amount: 0,
+                memo: "Principal",
+              },
+              {
+                id: "split-extra",
+                transferAccountId: loanAccountId,
+                categoryId: null,
+                amount: -300,
+                memo: "Extra Principal",
+              },
+              {
+                id: "split-interest",
+                transferAccountId: null,
+                categoryId: "cat-interest",
+                amount: 0,
+                memo: "Interest",
+              },
+            ],
+          } as never),
+        );
+
+        await service.recalculateLoanPaymentSplits(
+          scheduledTransactionId,
+          loanAccountId,
+        );
+
+        const extraSave = splitsRepository.save.mock.calls.find(
+          (call: any) => call[0].id === "split-extra",
+        );
+        expect(extraSave).toBeUndefined();
+        expect(scheduledTransactionsRepository.update).not.toHaveBeenCalled();
+      });
+
+      it("drops the extra principal to zero when the amortized principal alone closes the loan", async () => {
+        // 200 outstanding against a 400 amortized principal: the regular child
+        // clamps to 200 and there is nothing left for the extra to retire.
+        // Paying it anyway is money into a settled debt.
+        const loanAccount = makeLoanAccount({
+          currentBalance: -200,
+          interestRate: 0,
+        });
+        accountsRepository.findOne.mockResolvedValue(loanAccount);
+
+        scheduledTransactionsRepository.findOne.mockResolvedValue(
+          makeScheduledTransaction({
+            amount: -700,
+            splits: [
+              {
+                id: "split-principal",
+                transferAccountId: loanAccountId,
+                categoryId: null,
+                amount: 0,
+                memo: "Principal",
+              },
+              {
+                id: "split-extra",
+                transferAccountId: loanAccountId,
+                categoryId: null,
+                amount: -300,
+                memo: "Extra Principal",
+              },
+              {
+                id: "split-interest",
+                transferAccountId: null,
+                categoryId: "cat-interest",
+                amount: 0,
+                memo: "Interest",
+              },
+            ],
+          } as never),
+        );
+
+        await service.recalculateLoanPaymentSplits(
+          scheduledTransactionId,
+          loanAccountId,
+        );
+
+        const saved = splitsRepository.save.mock.calls.map((call: any) => [
+          call[0].id,
+          call[0].amount,
+        ]);
+        expect(saved).toEqual(
+          expect.arrayContaining([
+            ["split-principal", -200],
+            ["split-extra", -0],
+          ]),
+        );
+        expect(scheduledTransactionsRepository.update).toHaveBeenCalledWith(
+          scheduledTransactionId,
+          { amount: -200 },
+        );
+      });
+
+      it("caps the principal to the balance on the recurrence path too", async () => {
+        // The amortization-recurrence branch had no cap at all, so a schedule
+        // with previous split values could pay more principal than the loan
+        // still owed and drive the balance past zero.
+        const loanAccount = makeLoanAccount({
+          currentBalance: -100,
+          interestRate: 5.5,
+        });
+        accountsRepository.findOne.mockResolvedValue(loanAccount);
+
+        // Previous principal/interest present, so the recurrence branch runs.
+        scheduledTransactionsRepository.findOne.mockResolvedValue(
+          makeScheduledTransaction({ amount: -500 }),
+        );
+
+        await service.recalculateLoanPaymentSplits(
+          scheduledTransactionId,
+          loanAccountId,
+        );
+
+        const principalSave = splitsRepository.save.mock.calls.find(
+          (call: any) => call[0].transferAccountId === loanAccountId,
+        );
+        // Never more principal than is owed.
+        expect(Math.abs(principalSave[0].amount)).toBeLessThanOrEqual(100);
+
+        // And the parent follows it down.
+        const update = scheduledTransactionsRepository.update.mock.calls[0];
+        expect(update).toBeDefined();
+        expect(Math.abs(update[1].amount)).toBeLessThan(500);
+      });
+    });
+
+    describe("clamps are not ratchets (review #1131)", () => {
+      it("grows the parent back to the configured payment after the balance is restored", async () => {
+        // A final payment shrank the template to 51. Then the posting that got
+        // the balance near zero was voided (or history was imported), so the
+        // loan owes 20,000 again -- but every recalculation used to read the
+        // configured payment from the shrunk template, so nothing could ever
+        // restore it: the schedule billed 51 a month against a 20,000 debt
+        // forever. The durable configuration is account.paymentAmount.
+        const loanAccount = makeLoanAccount({
+          currentBalance: -20000,
+          interestRate: 5.5,
+          paymentAmount: 500,
+        });
+        accountsRepository.findOne.mockResolvedValue(loanAccount);
+
+        scheduledTransactionsRepository.findOne.mockResolvedValue(
+          makeScheduledTransaction({
+            amount: -51,
+            splits: [
+              {
+                id: "split-principal",
+                transferAccountId: loanAccountId,
+                categoryId: null,
+                amount: -50,
+                memo: "Principal",
+              },
+              {
+                id: "split-interest",
+                transferAccountId: null,
+                categoryId: "cat-interest",
+                amount: -1,
+                memo: "Interest",
+              },
+            ],
+          } as never),
+        );
+
+        await service.recalculateLoanPaymentSplits(
+          scheduledTransactionId,
+          loanAccountId,
+        );
+
+        const update = scheduledTransactionsRepository.update.mock.calls.find(
+          (call: any) => call[1]?.amount !== undefined,
+        );
+        expect(update).toBeDefined();
+        expect(update![1].amount).toBe(-500);
+      });
+
+      it("restores the standing extra principal after a transient interest spike consumed it", async () => {
+        // One underpayment period wrote the extra split down to 0 so the
+        // installment could reconcile. That clamp was for that installment
+        // only, but the recalculation used to read the configured extra from
+        // the split it had just rewritten -- the user's standing instruction
+        // was gone for good. The durable copy is account.extraPaymentAmount.
+        const loanAccount = makeLoanAccount({
+          currentBalance: -50000,
+          interestRate: 2.4, // 0.2% monthly -> 100 interest on 50,000
+          paymentAmount: 1000,
+          extraPaymentAmount: 300,
+        });
+        accountsRepository.findOne.mockResolvedValue(loanAccount);
+
+        // Post-spike template: everything went to interest, extra clamped to 0.
+        // prevPrincipal = 0 sends the recalculation down the balance-based
+        // branch.
+        scheduledTransactionsRepository.findOne.mockResolvedValue(
+          makeScheduledTransaction({
+            amount: -1000,
+            splits: [
+              {
+                id: "split-principal",
+                transferAccountId: loanAccountId,
+                categoryId: null,
+                amount: 0,
+                memo: "Principal",
+              },
+              {
+                id: "split-interest",
+                transferAccountId: null,
+                categoryId: "cat-interest",
+                amount: -1000,
+                memo: "Interest",
+              },
+              {
+                id: "split-extra",
+                transferAccountId: loanAccountId,
+                categoryId: null,
+                amount: 0,
+                memo: "Extra Principal",
+              },
+            ],
+          } as never),
+        );
+
+        await service.recalculateLoanPaymentSplits(
+          scheduledTransactionId,
+          loanAccountId,
+        );
+
+        const extraSave = splitsRepository.save.mock.calls.find(
+          (call: any) => call[0].id === "split-extra",
+        );
+        expect(extraSave).toBeDefined();
+        expect(extraSave![0].amount).toBe(-300);
+
+        // 100 interest + 600 regular principal + 300 extra = the configured
+        // 1,000, so the parent needs no rewrite.
+        const principalSave = splitsRepository.save.mock.calls.find(
+          (call: any) => call[0].id === "split-principal",
+        );
+        expect(principalSave![0].amount).toBe(-600);
+      });
+    });
+
     it("should deactivate scheduled transaction when balance is near zero", async () => {
       const loanAccount = makeLoanAccount({ currentBalance: -0.005 });
       accountsRepository.findOne.mockResolvedValue(loanAccount);

--- a/backend/src/scheduled-transactions/scheduled-transaction-loan.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-loan.service.ts
@@ -11,6 +11,7 @@ import {
 } from "../accounts/mortgage-amortization.util";
 import { getPeriodsPerYear } from "../accounts/loan-amortization.util";
 import { roundMoney } from "../common/round.util";
+import { allocateLoanPayment } from "../accounts/loan-payment-waterfall.util";
 import { withScopedDb } from "../common/db/scoped-db";
 
 @Injectable()
@@ -52,7 +53,7 @@ export class ScheduledTransactionLoanService {
         return;
       }
 
-      const paymentAmount = Math.abs(Number(scheduledTransaction.amount));
+      const templateAmount = Math.abs(Number(scheduledTransaction.amount));
       const interestRate = Number(loanAccount.interestRate) || 0;
       const frequency = (loanAccount.paymentFrequency ||
         scheduledTransaction.frequency) as PaymentFrequency;
@@ -76,9 +77,29 @@ export class ScheduledTransactionLoanService {
         (s) => s.categoryId && !s.transferAccountId,
       );
 
-      // The base payment for amortization calculation excludes extra principal
-      const extraPrincipalAmount = extraPrincipalSplit
+      // What the template holds is what was just posted -- including any clamp
+      // a previous pass wrote for that one installment (a final payment, an
+      // interest spike consuming the extra). Deriving the *configured* payment
+      // from it therefore ratchets: the clamp becomes the configuration and
+      // nothing can grow back, even after the balance is restored by a void or
+      // an import (review #1131). The durable configuration lives on the
+      // account (payment_amount / extra_payment_amount, kept in sync when the
+      // user edits the schedule); the template only wins where it is larger,
+      // which can only mean a user edit the account columns have not seen.
+      const templateExtraAmount = extraPrincipalSplit
         ? Math.abs(Number(extraPrincipalSplit.amount))
+        : 0;
+      const paymentAmount = Math.max(
+        templateAmount,
+        Number(loanAccount.paymentAmount) || 0,
+      );
+      // The extra can only ride in an existing split row -- this recalculation
+      // never creates one -- so without the row the configured extra is 0.
+      const extraPrincipalAmount = extraPrincipalSplit
+        ? Math.max(
+            templateExtraAmount,
+            Number(loanAccount.extraPaymentAmount) || 0,
+          )
         : 0;
       const basePaymentAmount = paymentAmount - extraPrincipalAmount;
 
@@ -121,7 +142,10 @@ export class ScheduledTransactionLoanService {
               )
             : interestRate / 100 / periodsPerYear;
 
-        const totalPrevPrincipal = prevPrincipal + extraPrincipalAmount;
+        // The recurrence advances from what was actually posted, so the extra
+        // here is the template's (possibly clamped) figure, not the configured
+        // one.
+        const totalPrevPrincipal = prevPrincipal + templateExtraAmount;
         newInterest = prevInterest - totalPrevPrincipal * periodicRate;
         newInterest = Math.max(0, roundMoney(newInterest));
         newPrincipal = roundMoney(basePaymentAmount - newInterest);
@@ -149,13 +173,31 @@ export class ScheduledTransactionLoanService {
         newInterest = roundMoney(currentBalance * periodicRate);
         newPrincipal = roundMoney(basePaymentAmount - newInterest);
         if (newPrincipal < 0) newPrincipal = 0;
-        if (newPrincipal > currentBalance) newPrincipal = currentBalance;
       }
+
+      // The clamp sequence -- interest-first across the whole installment
+      // (recheck RR2-006, DR3-01), principal bounded by the debt with the
+      // discretionary extra absorbing the shortfall (audit P5-008, FR-009) --
+      // is `allocateLoanPayment`, shared with the first installment written by
+      // `LoanPaymentSetupService` because the two must agree about what any
+      // installment looks like.
+      const allocation = allocateLoanPayment({
+        paymentAmount,
+        extraPrincipal: extraPrincipalAmount,
+        interest: newInterest,
+        principal: newPrincipal,
+        currentBalance,
+      });
+      newInterest = allocation.interest;
+      newPrincipal = allocation.principal;
+      const finalExtraPrincipal = allocation.extraPrincipal;
+      const requiredParentAmount = allocation.total;
 
       this.logger.log(
         `Recalculate loan splits: prevPrincipal=${prevPrincipal}, prevInterest=${prevInterest}, ` +
           `rate=${interestRate}%, freq=${frequency}, basePayment=${basePaymentAmount}, ` +
-          `extra=${extraPrincipalAmount}, newPrincipal=${newPrincipal}, newInterest=${newInterest}, ` +
+          `extra=${extraPrincipalAmount} (final ${finalExtraPrincipal}), ` +
+          `newPrincipal=${newPrincipal}, newInterest=${newInterest}, ` +
           `isMortgage=${loanAccount.accountType === "MORTGAGE"}, ` +
           `isCanadian=${loanAccount.isCanadianMortgage}`,
       );
@@ -168,6 +210,41 @@ export class ScheduledTransactionLoanService {
       if (interestSplit) {
         interestSplit.amount = -newInterest;
         await m.getRepository(ScheduledTransactionSplit).save(interestSplit);
+      }
+
+      // The extra principal child was never written here, so a clamped total had
+      // nowhere to land: the parent would shrink while the children still summed
+      // to the unclamped figure, and the posting path's split validator requires
+      // exact 4dp equality between them (audit P5-008 again, on the child the
+      // first fix did not reach). Written whenever it differs from what the
+      // template holds -- in either direction, so one clamped installment does
+      // not become the standing instruction (review #1131).
+      if (extraPrincipalSplit && finalExtraPrincipal !== templateExtraAmount) {
+        extraPrincipalSplit.amount = -finalExtraPrincipal;
+        await m
+          .getRepository(ScheduledTransactionSplit)
+          .save(extraPrincipalSplit);
+      }
+
+      // Parent and children are written in the same transaction, so a posting
+      // can never see one without the other. The parent is written whenever the
+      // next installment differs from what the template holds: shrunk when the
+      // debt no longer needs the whole configured payment, and grown back
+      // toward the configured payment when a clamp written for one installment
+      // no longer binds -- a voided final payment or an imported balance must
+      // not leave the schedule billing the clamped figure forever (review
+      // #1131). `allocateLoanPayment` bounds the total by the configured
+      // payment, so this can never grow past what the user set.
+      if (
+        requiredParentAmount > 0 &&
+        requiredParentAmount !== roundMoney(templateAmount)
+      ) {
+        await m
+          .getRepository(ScheduledTransaction)
+          .update(scheduledTransactionId, { amount: -requiredParentAmount });
+        this.logger.log(
+          `Loan payment recalculated: scheduled amount changed from ${templateAmount} to ${requiredParentAmount} (configured payment ${paymentAmount}, outstanding balance ${currentBalance})`,
+        );
       }
     });
   }

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -146,6 +146,7 @@ describe("ScheduledTransactionsService", () => {
 
     accountsRepo = {
       findOne: jest.fn(),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
     };
 
     tagRepo = {
@@ -867,6 +868,63 @@ describe("ScheduledTransactionsService", () => {
           description: expect.stringContaining("Updated"),
         }),
       );
+    });
+
+    it("syncs the durable loan configuration when the user edits a loan payment schedule", async () => {
+      // The per-posting recalculation reads the configured payment and extra
+      // from the account, because the template also carries transient clamps.
+      // A user edit of the template is a reconfiguration, so it must land on
+      // the account too -- otherwise the recalculation would grow the edit
+      // back to the stale configured value (review #1131).
+      const scheduled = makeScheduled({ amount: -1000 });
+      stubFindOne(scheduled);
+      accountsRepo.findOne.mockResolvedValueOnce({
+        id: "acc-loan",
+        scheduledTransactionId: stId,
+      });
+
+      await service.update(userId, stId, {
+        amount: -800,
+        splits: [
+          { transferAccountId: "acc-loan", amount: -500, memo: "Principal" },
+          { categoryId: "cat-interest", amount: -100, memo: "Interest" },
+          {
+            transferAccountId: "acc-loan",
+            amount: -200,
+            memo: "Extra Principal",
+          },
+        ],
+      });
+
+      expect(accountsRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { scheduledTransactionId: stId, userId },
+        }),
+      );
+      expect(accountsRepo.update).toHaveBeenCalledWith("acc-loan", {
+        paymentAmount: 800,
+        extraPaymentAmount: 200,
+      });
+    });
+
+    it("does not touch any account when the schedule is not a loan payment", async () => {
+      const scheduled = makeScheduled();
+      stubFindOne(scheduled);
+      accountsRepo.findOne.mockResolvedValueOnce(null);
+
+      await service.update(userId, stId, { amount: -1200 });
+
+      expect(accountsRepo.update).not.toHaveBeenCalled();
+    });
+
+    it("does not look up a loan account for a presentation-only edit", async () => {
+      const scheduled = makeScheduled();
+      stubFindOne(scheduled);
+
+      await service.update(userId, stId, { name: "Renamed" });
+
+      expect(accountsRepo.findOne).not.toHaveBeenCalled();
+      expect(accountsRepo.update).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -29,7 +29,7 @@ import { AccountsService } from "../accounts/accounts.service";
 import { TransactionsService } from "../transactions/transactions.service";
 import { InvestmentTransactionsService } from "../securities/investment-transactions.service";
 import { InvestmentAction } from "../securities/entities/investment-transaction.entity";
-import { AccountSubType } from "../accounts/entities/account.entity";
+import { Account, AccountSubType } from "../accounts/entities/account.entity";
 import { ScheduledTransactionOverrideService } from "./scheduled-transaction-override.service";
 import { ScheduledTransactionLoanService } from "./scheduled-transaction-loan.service";
 import { todayInTimezone, todayYMD } from "../common/date-utils";
@@ -1301,6 +1301,46 @@ export class ScheduledTransactionsService {
 
       if (Object.keys(fieldsToUpdate).length > 0) {
         await m.update(ScheduledTransaction, id, fieldsToUpdate);
+      }
+
+      // A user edit of a loan payment schedule is a reconfiguration, so it has
+      // to reach the durable copy on the account: the per-posting
+      // recalculation grows the template back toward
+      // payment_amount / extra_payment_amount, because the template itself
+      // also carries transient clamps a previous pass wrote (a final payment,
+      // an interest spike) and cannot say which of the two it holds (review
+      // #1131).
+      if (
+        updateData.amount !== undefined ||
+        splits !== undefined ||
+        clearSplitsForModeSwitch
+      ) {
+        const loanAccount = await m.getRepository(Account).findOne({
+          where: { scheduledTransactionId: id, userId },
+        });
+        if (loanAccount) {
+          const accountUpdate: Partial<Account> = {};
+          if (updateData.amount !== undefined) {
+            accountUpdate.paymentAmount = Math.abs(Number(updateData.amount));
+          }
+          if (Array.isArray(splits)) {
+            const extraSplit = splits.find(
+              (s) =>
+                s.transferAccountId === loanAccount.id &&
+                s.memo?.toLowerCase().includes("extra"),
+            );
+            accountUpdate.extraPaymentAmount = extraSplit
+              ? Math.abs(Number(extraSplit.amount))
+              : 0;
+          } else if (clearSplitsForModeSwitch) {
+            accountUpdate.extraPaymentAmount = 0;
+          }
+          if (Object.keys(accountUpdate).length > 0) {
+            await m
+              .getRepository(Account)
+              .update(loanAccount.id, accountUpdate);
+          }
+        }
       }
     });
 

--- a/backend/test/integration/budget-split-transfer-spending.integration.spec.ts
+++ b/backend/test/integration/budget-split-transfer-spending.integration.spec.ts
@@ -1,0 +1,228 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+import { TransactionsModule } from "@/transactions/transactions.module";
+import {
+  Transaction,
+  TransactionStatus,
+} from "@/transactions/entities/transaction.entity";
+import { TransactionSplit } from "@/transactions/entities/transaction-split.entity";
+import { BudgetCategory } from "@/budgets/entities/budget-category.entity";
+import { queryCategorySpending } from "@/budgets/budget-spending.util";
+import { withScopedDb } from "@/common/db/scoped-db";
+import { withUserContext } from "@/common/db/with-context";
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import {
+  createTestAccount,
+  createTestCategory,
+} from "../helpers/test-factories";
+
+/**
+ * The split-transfer half of `queryCategorySpending` against a real
+ * PostgreSQL database. The unit suite mocks the QueryBuilder, so only this
+ * test exercises the actual SQL (review #1131): the two-shape union (a
+ * whole-row transfer joined through its linked counterpart, plus a split line
+ * carrying transfer_account_id directly), the no-double-count claim -- a
+ * counterpart row is not itself a split, and the incoming counterpart leg
+ * fails the outflow predicate -- and the void/direction exclusions.
+ */
+describe("queryCategorySpending split transfers (integration)", () => {
+  let module: TestingModule;
+  let dataSource: DataSource;
+  let userId: string;
+  let chequingId: string;
+  let savingsId: string;
+  let groceriesId: string;
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([TransactionsModule]);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "transaction_splits",
+      "transactions",
+      "accounts",
+      "categories",
+      "payees",
+      "users",
+    ]);
+    const user = await createTestUserDirect(dataSource);
+    userId = user.id;
+    chequingId = (
+      await createTestAccount(dataSource, userId, { name: "Chequing" })
+    ).id;
+    savingsId = (
+      await createTestAccount(dataSource, userId, { name: "Savings" })
+    ).id;
+    groceriesId = (
+      await createTestCategory(dataSource, userId, { name: "Groceries" })
+    ).id;
+  });
+
+  async function insertTransaction(
+    overrides: Partial<Transaction>,
+  ): Promise<Transaction> {
+    const tx = dataSource.manager.create(Transaction, {
+      userId,
+      accountId: chequingId,
+      transactionDate: "2026-07-10",
+      amount: -100,
+      currencyCode: "CAD",
+      status: TransactionStatus.UNRECONCILED,
+      isSplit: false,
+      isTransfer: false,
+      ...overrides,
+    } as Partial<Transaction>);
+    return dataSource.manager.save(tx);
+  }
+
+  /** A whole-row transfer: outgoing leg linked to its incoming counterpart. */
+  async function insertWholeRowTransfer(
+    amount: number,
+    overrides: Partial<Transaction> = {},
+  ): Promise<void> {
+    const inbound = await insertTransaction({
+      accountId: savingsId,
+      amount: -amount,
+      isTransfer: true,
+      ...overrides,
+    });
+    const outbound = await insertTransaction({
+      amount,
+      isTransfer: true,
+      linkedTransactionId: inbound.id,
+      ...overrides,
+    });
+    inbound.linkedTransactionId = outbound.id;
+    await dataSource.manager.save(inbound);
+  }
+
+  /**
+   * A split parent carrying a category line and a transfer line, with the
+   * transfer line's incoming counterpart row -- the shape a paycheque with a
+   * savings component takes (audit P5-007).
+   */
+  async function insertSplitWithTransferLine(
+    categoryAmount: number,
+    transferAmount: number,
+    overrides: Partial<Transaction> = {},
+  ): Promise<void> {
+    const parent = await insertTransaction({
+      amount: categoryAmount + transferAmount,
+      isSplit: true,
+      ...overrides,
+    });
+    const counterpart = await insertTransaction({
+      accountId: savingsId,
+      amount: -transferAmount,
+      isTransfer: true,
+      ...overrides,
+    });
+    const categorySplit = dataSource.manager.create(TransactionSplit, {
+      transactionId: parent.id,
+      categoryId: groceriesId,
+      amount: categoryAmount,
+    } as Partial<TransactionSplit>);
+    const transferSplit = dataSource.manager.create(TransactionSplit, {
+      transactionId: parent.id,
+      transferAccountId: savingsId,
+      linkedTransactionId: counterpart.id,
+      amount: transferAmount,
+    } as Partial<TransactionSplit>);
+    await dataSource.manager.save([categorySplit, transferSplit]);
+  }
+
+  function runQuery(budgetCategories: Partial<BudgetCategory>[]) {
+    return withUserContext(userId, () =>
+      withScopedDb(dataSource, (m) =>
+        queryCategorySpending(
+          m.getRepository(Transaction),
+          m.getRepository(TransactionSplit),
+          userId,
+          budgetCategories as BudgetCategory[],
+          "2026-07-01",
+          "2026-07-31",
+        ),
+      ),
+    );
+  }
+
+  const savingsBudgetCategory: Partial<BudgetCategory> = {
+    id: "bc-transfer",
+    categoryId: null,
+    isTransfer: true,
+    transferAccountId: null as unknown as string,
+  };
+
+  it("counts whole-row transfers and split-line transfers together, without double-counting", async () => {
+    await insertWholeRowTransfer(-200);
+    await insertSplitWithTransferLine(-700, -300);
+
+    const { spendingMap, transferSpendingMap } = await runQuery([
+      { id: "bc-cat", categoryId: groceriesId, isTransfer: false },
+      { ...savingsBudgetCategory, transferAccountId: savingsId },
+    ]);
+
+    // 200 whole-row + 300 split-line. The split's counterpart row (+300 into
+    // savings) and the whole-row transfer's inbound leg are both incoming, so
+    // neither is counted a second time.
+    expect(transferSpendingMap.get(savingsId)).toBe(500);
+    // The category line of the split still lands on its category, untouched by
+    // the transfer read.
+    expect(spendingMap.get(groceriesId)).toBe(-700);
+  });
+
+  it("ignores transfers INTO the budgeted account and VOID rows", async () => {
+    // A withdrawal from savings back to chequing: budget progress for a
+    // savings budget must not move.
+    const inbound = await insertTransaction({
+      amount: 150,
+      isTransfer: true,
+    });
+    const outbound = await insertTransaction({
+      accountId: savingsId,
+      amount: -150,
+      isTransfer: true,
+      linkedTransactionId: inbound.id,
+    });
+    inbound.linkedTransactionId = outbound.id;
+    await dataSource.manager.save(inbound);
+
+    // A voided contribution does not count either, in both shapes.
+    await insertWholeRowTransfer(-75, {
+      status: TransactionStatus.VOID,
+    });
+    await insertSplitWithTransferLine(-10, -80, {
+      status: TransactionStatus.VOID,
+    });
+
+    const { transferSpendingMap } = await runQuery([
+      { ...savingsBudgetCategory, transferAccountId: savingsId },
+    ]);
+
+    expect(transferSpendingMap.get(savingsId)).toBeUndefined();
+  });
+
+  it("scopes the split-line read to the requested destination accounts", async () => {
+    const otherAccountId = (
+      await createTestAccount(dataSource, userId, { name: "Vacation Fund" })
+    ).id;
+    await insertSplitWithTransferLine(-50, -60);
+
+    const { transferSpendingMap } = await runQuery([
+      { ...savingsBudgetCategory, transferAccountId: otherAccountId },
+    ]);
+
+    expect(transferSpendingMap.get(savingsId)).toBeUndefined();
+    expect(transferSpendingMap.get(otherAccountId)).toBeUndefined();
+  });
+});

--- a/database/migrations/154_account_extra_payment_amount.sql
+++ b/database/migrations/154_account_extra_payment_amount.sql
@@ -1,0 +1,14 @@
+-- 154: Record a loan's standing extra-principal instruction on the account
+--
+-- The scheduled-payment recalculation that runs after each posting derives the
+-- next installment from the template's own splits, so any clamp it wrote --
+-- an interest spike consuming the extra for one period, a final payment
+-- shrinking everything -- became the configured value on the next pass: a
+-- one-way ratchet with nothing durable to grow back from (review #1131).
+-- payment_amount already gives the parent that durable source; this gives the
+-- extra-principal child its own. Set at payment setup, synced when the user
+-- edits the loan's scheduled transaction, read (with the template split as a
+-- fallback for rows that predate the column) by the recalculation.
+
+ALTER TABLE accounts
+  ADD COLUMN IF NOT EXISTS extra_payment_amount NUMERIC(20, 4);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -132,6 +132,7 @@ CREATE TABLE accounts (
     exclude_from_net_worth BOOLEAN DEFAULT false,
     -- Loan-specific fields
     payment_amount NUMERIC(20, 4), -- payment amount per period for loans
+    extra_payment_amount NUMERIC(20, 4), -- standing extra-principal instruction inside that payment
     payment_frequency VARCHAR(20), -- 'WEEKLY', 'BIWEEKLY', 'MONTHLY', 'QUARTERLY', 'YEARLY'
     payment_start_date DATE, -- when loan payments start
     source_account_id UUID REFERENCES accounts(id) ON DELETE SET NULL, -- account payments come from

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -299,6 +299,8 @@ export interface SetupLoanPaymentsResponse {
   scheduledTransactionId: string;
   accountId: string;
   paymentAmount: number;
+  /** First installment after clamping against the outstanding balance. */
+  firstInstallmentAmount: number;
   paymentFrequency: string;
   nextDueDate: string;
 }


### PR DESCRIPTION

## Linked discussion / issue

Closes # TODO
Approved in: TODO - add the approved discussion or issue before requesting review.

## Summary

This PR gives scheduled loan posting and loan payment setup one shared payment waterfall, clamps the final payment to the actual outstanding balance, and makes transfer budgets count transfer legs embedded inside split transactions.

## Why

Two loan services previously computed principal, interest, and extra principal using different rules. That can produce children that do not sum to the parent payment, overpay the remaining loan balance, or double-count principal in edge cases.

Transfer budgets also ignored transfer children inside split transactions. A -100 transaction with a -60 category child and a -40 transfer child should contribute 40 to the destination transfer budget; previously that split-transfer contribution could be missed entirely.

## What changes

- Shares one loan payment waterfall between `ScheduledTransactionLoanService` and `LoanPaymentSetupService`.
- Applies payment to accrued interest first, then amortized principal, then extra principal.
- Clamps regular principal plus extra principal together against the remaining outstanding balance.
- Shrinks the final parent payment to exactly what the loan still owes while keeping child splits equal to the parent.
- Handles interest underpayment entirely as interest so child amounts continue to sum correctly.
- Corrects the zero-rate setup path so the regular payment is not simultaneously treated as full principal plus extra principal.
- Applies the same cap to the amortization-recurrence path that previously had no final-payment clamp.
- Makes transfer-budget queries read `transfer_account_id` from split rows and accumulate plain transfers plus split transfers into the same destination-account total.

## Financial correctness examples

- Outstanding principal 500, computed regular principal 400, extra principal instruction 300 -> total principal applied must be clamped to 500, not 700.
- Parent transaction -100 with children -60 category and -40 transfer -> destination transfer budget contribution is 40.

## Policy decision

The shared waterfall uses an interest-first policy: accrued interest is satisfied from the installment before principal. This is an explicit design decision recorded by the Phase 5 review. If product policy changes, the shared waterfall and its tests provide one place to change the rule.

## Tests and validation

Expanded coverage includes:

- loan setup waterfall behavior;
- scheduled-loan final-payment clamping;
- extra-principal interaction;
- zero-rate behavior;
- underpayment behavior;
- transfer budgets with split-transfer children and mixed plain/split transfers.

Read-only review confirmed this branch is exactly one commit above `pr/05d-investment-replay`. The full suite was not independently executed during this packaging pass, and GitHub exposed no commit status contexts for the reviewed head.

## Stack position

- Head branch: `pr/05e-loan-waterfall-budgets`
- Reviewed head SHA: `b5e1e6424b911b8587e6880a2d437161d32e879d`
- PR base: `pr/05d-investment-replay`
- Reviewed base SHA: `3bbef5f25229c02170db01706e7490391ad47dd7`

This is PR 5 of 7. The entire stack was 116 commits behind reviewed `main` at packaging time.

## Scope boundaries

- Monte Carlo valuation and historical-return weighting are intentionally separated into `pr/05f-monte-carlo-valuation`.
- This PR does not change the interest-first product policy; it centralizes and tests it.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a single concern in the Phase 05 stack.
- [ ] New behavior has tests, and the existing suite passes. Tests are present; the full suite was not independently run in this review.
- [x] This PR introduces no new user-facing catalog copy requiring localization.
- [ ] Shared financial calculation paths were changed; confirm the approving discussion explicitly covers this scope.
- [ ] The branch is rebased on the latest `main`. The stack was 116 commits behind at packaging time.
- [ ] AI assistance is disclosed below, and the maintainer has reviewed and owns the result.

## AI assistance disclosure

AI assistance was used in the implementation of this change and is disclosed in the commit metadata. The maintainer should complete human review and take ownership of correctness, conventions, and test results before marking this PR ready for merge.
