### PR TITLE
06: Invalidate transaction-derived balance caches (v1.15.0)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -42,10 +42,10 @@ Feature API modules (one per feature, typed axios wrappers) live alongside `api.
 
 ### A write that moves money calls `invalidateBalanceCaches()`
 
-`accountsApi.getAll` and `investmentsApi.getPortfolioSummary` are cached in
-`apiCache.ts` for two minutes, and the backend computes balances live from
-transactions -- so a write that does not drop those entries leaves the Accounts
-page showing the pre-write number. Navigating away and back does not fix it:
+`accountsApi.getAll`, `investmentsApi.getPortfolioSummary` and the budget
+progress views are cached in `apiCache.ts`, and the backend computes all three
+live from transaction rows -- so a write that does not drop those entries leaves
+the Accounts page showing the pre-write number. Navigating away and back does not fix it:
 the page refetches on mount and the refetch is served from the same cache, so
 only a browser reload clears it. Call `invalidateBalanceCaches()` (both
 prefixes at once) after any write that adds, removes, re-dates, re-prices or
@@ -56,6 +56,15 @@ named), an investment trade hitting its INVESTMENT_CASH account, and a QIF/OFX/
 CSV/MNY import all write transaction rows from their own modules. That omission
 on `scheduledTransactionsApi.post` is the bug this rule came from;
 `src/lib/balance-cache.guard.test.ts` now scans for it.
+
+**The prefix list inside the helper is the other half of the rule.** It covers
+`accounts:`, `investments:` and `budgets:` -- three views of the same rows. A
+categorised expense moves a budget's progress exactly as it moves the account's
+balance, and `budgets:dashboard` (30s) and `budgets:cat-status:*` (60s) used to
+survive the write, so the toast said saved while the remaining-funds figure
+beside it was pre-write. Adding a cached family that reads transaction rows means
+adding its prefix in `invalidateBalanceCaches` in the same change;
+`apiCache.test.ts` pins the set, both what it drops and what it leaves alone.
 
 Where the write can touch anything -- undo/redo, an AI assistant action, a
 backup restore -- use `clearAllCache()` instead; no prefix is narrow enough to

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -66,6 +66,15 @@ beside it was pre-write. Adding a cached family that reads transaction rows mean
 adding its prefix in `invalidateBalanceCaches` in the same change;
 `apiCache.test.ts` pins the set, both what it drops and what it leaves alone.
 
+Pinning the set is not enough on its own, because that is what was green while
+`budgets:` was missing from it: the pinned set matched the helper, and neither
+knew about the new family. So `cache-prefix-classification.guard.test.ts` scans
+`src/` for every prefix any cache call uses and requires each one to be listed as
+transaction-derived (and therefore dropped) or as reference data (and therefore
+kept). A prefix in neither list fails, which forces the decision at the moment it
+is cheap to make. The list also fails when it names a prefix nothing uses any
+more, so it cannot drift into fiction.
+
 Where the write can touch anything -- undo/redo, an AI assistant action, a
 backup restore -- use `clearAllCache()` instead; no prefix is narrow enough to
 be correct. This matters most for `notifyUndoRedo`/`notifyAiAction`: they exist

--- a/frontend/src/lib/apiCache.test.ts
+++ b/frontend/src/lib/apiCache.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { getCached, setCache, invalidateCache, clearAllCache, dedupe } from './apiCache';
+import {
+  getCached,
+  setCache,
+  invalidateCache,
+  clearAllCache,
+  dedupe,
+  invalidateBalanceCaches,
+} from './apiCache';
 
 describe('apiCache', () => {
   beforeEach(() => {
@@ -44,6 +51,42 @@ describe('apiCache', () => {
   it('uses default 30 second TTL when no ttl arg', () => {
     setCache('default-ttl', 'val');
     expect(getCached('default-ttl')).toBe('val');
+  });
+});
+
+describe('invalidateBalanceCaches', () => {
+  beforeEach(() => {
+    clearAllCache();
+  });
+
+  // Every family below is derived from transaction rows, so a money-moving
+  // write leaves all of them wrong. Budgets were the omission: a successful
+  // expense used to leave `budgets:dashboard` claiming the pre-write remaining
+  // amount for up to 30 seconds, and `budgets:cat-status:*` for up to 60.
+  it.each([
+    'accounts:all:true',
+    'accounts:daily-balances:::',
+    'investments:portfolioSummary',
+    'investments:summary:all',
+    'budgets:dashboard',
+    'budgets:cat-status:cat-1,cat-2',
+    'budgets:all',
+  ])('drops %s', (key) => {
+    setCache(key, 'stale', 120_000);
+    invalidateBalanceCaches();
+    expect(getCached(key)).toBeUndefined();
+  });
+
+  it('leaves families a transaction cannot change', () => {
+    // Renaming a payee or a category is not a money movement, and dropping
+    // those lists on every write would turn one mutation into four refetches.
+    setCache('payees:all', 'kept', 120_000);
+    setCache('categories:all', 'kept', 120_000);
+    setCache('institutions:all', 'kept', 120_000);
+    invalidateBalanceCaches();
+    expect(getCached('payees:all')).toBe('kept');
+    expect(getCached('categories:all')).toBe('kept');
+    expect(getCached('institutions:all')).toBe('kept');
   });
 });
 

--- a/frontend/src/lib/apiCache.ts
+++ b/frontend/src/lib/apiCache.ts
@@ -46,13 +46,24 @@ export function clearAllCache(): void {
  * browser reloads. Navigating back to the page does not help: the page
  * refetches on mount and the refetch is served from this cache.
  *
- * Both prefixes go together because an account balance and a portfolio value
- * are two views of the same rows: a trade moves the INVESTMENT_CASH balance,
- * and a split transfer moves an account the parent transaction never named.
+ * The prefixes go together because an account balance, a portfolio value and a
+ * budget's progress are three views of the same rows: a trade moves the
+ * INVESTMENT_CASH balance, a split transfer moves an account the parent
+ * transaction never named, and any categorised amount moves the budget it falls
+ * in. `budgets:dashboard` caches for 30 seconds and `budgets:cat-status:*` for
+ * 60, so leaving them behind means the write succeeds and the progress bar
+ * beside it still shows the pre-write remaining amount -- which is the number a
+ * user makes the next spending decision from.
+ *
+ * Anything derived from transaction rows belongs on this list. Adding a new
+ * cached family that reads them means adding its prefix here in the same
+ * change; `balance-cache.guard.test.ts` holds the call sites, and
+ * `apiCache.test.ts` holds the prefix set.
  */
 export function invalidateBalanceCaches(): void {
   invalidateCache('accounts:');
   invalidateCache('investments:');
+  invalidateCache('budgets:');
 }
 
 // Cache + in-flight deduplication. When several callers request the same key

--- a/frontend/src/lib/cache-prefix-classification.guard.test.ts
+++ b/frontend/src/lib/cache-prefix-classification.guard.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Every cache family is classified as transaction-derived or not.
+ *
+ * `balance-cache.guard.test.ts` polices one half of the rule: a write that moves
+ * money must call `invalidateBalanceCaches()`. This is the other half, and it is
+ * the half that failed. `budgets:` was added to the cache without being added to
+ * the invalidator, so every money-moving write correctly called a function that
+ * did not drop the budget progress bar sitting next to it -- the number a user
+ * makes the next spending decision from. Both guards were green.
+ *
+ * A prefix is transaction-derived when its cached value is computed from
+ * transaction rows: an account balance, a portfolio valuation, a budget's
+ * progress. It is reference data when a transaction write cannot change it: the
+ * payee list, the category tree, a report *definition* (as opposed to a report
+ * result), an institution, a tag.
+ *
+ * A new prefix in neither list fails this test, which is the point: the decision
+ * is cheap to make while writing the cache call and invisible afterwards.
+ */
+
+const sources = import.meta.glob('/src/**/*.{ts,tsx}', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+/** Dropped by `invalidateBalanceCaches()` -- derived from transaction rows. */
+const TRANSACTION_DERIVED: ReadonlyArray<[string, string]> = [
+  ['accounts:', 'balances are summed live from transactions'],
+  [
+    'investments:',
+    'holdings and portfolio value follow investment transactions, and a trade moves the INVESTMENT_CASH balance',
+  ],
+  [
+    'budgets:',
+    'dashboard progress and per-category status are sums of categorised transactions',
+  ],
+];
+
+/** Kept -- a transaction write cannot change these. */
+const REFERENCE_DATA: ReadonlyArray<[string, string]> = [
+  ['payees:', 'payee records; a transaction referencing one does not change it'],
+  ['categories:', 'category tree'],
+  ['institutions:', 'institution records'],
+  ['tags:', 'tag records'],
+  [
+    'scheduled:',
+    'schedule definitions. Posting one changes its nextDueDate and invalidates this prefix itself; an ordinary transaction write does not touch it',
+  ],
+  [
+    'reports:',
+    'custom report DEFINITIONS, not their results -- the list of saved reports',
+  ],
+  [
+    'investment-reports:',
+    'investment report definitions, same as above',
+  ],
+  ['attachments:', 'attachment metadata; carries no amount'],
+  [
+    'exchange-rates:',
+    'rate snapshots from the provider; a user transaction does not move a rate',
+  ],
+];
+
+/** Prefix literals passed to any cache call, e.g. `'accounts:all'` -> `accounts:`. */
+function prefixesIn(source: string): Set<string> {
+  const found = new Set<string>();
+  const call =
+    /(?:dedupe|setCache|getCached|invalidateCache)\s*(?:<[^>]*>)?\s*\(\s*['"`]([a-zA-Z][a-zA-Z0-9_-]*):/g;
+  for (const match of source.matchAll(call)) found.add(`${match[1]}:`);
+  return found;
+}
+
+const allPrefixes = new Set<string>();
+for (const [path, source] of Object.entries(sources)) {
+  if (/\.test\.tsx?$/.test(path)) continue;
+  if (path.endsWith('/src/lib/apiCache.ts')) continue;
+  for (const prefix of prefixesIn(source)) allPrefixes.add(prefix);
+}
+
+const apiCacheSource = sources['/src/lib/apiCache.ts'];
+const invalidatorBody = apiCacheSource.slice(
+  apiCacheSource.indexOf('export function invalidateBalanceCaches'),
+);
+
+describe('cache prefix classification', () => {
+  it('finds the prefixes it is meant to police', () => {
+    // A renamed helper or a changed call style would leave the checks below
+    // passing over an empty set. This fails first and says so.
+    expect(allPrefixes.size).toBeGreaterThanOrEqual(9);
+    expect(allPrefixes).toContain('accounts:');
+    expect(allPrefixes).toContain('budgets:');
+  });
+
+  it('classifies every cache prefix as transaction-derived or reference data', () => {
+    const classified = new Set([
+      ...TRANSACTION_DERIVED.map(([prefix]) => prefix),
+      ...REFERENCE_DATA.map(([prefix]) => prefix),
+    ]);
+    const unclassified = [...allPrefixes].filter(
+      (prefix) => !classified.has(prefix),
+    );
+
+    // Decide which it is and add it to the matching list above. If it is
+    // transaction-derived, also add it to `invalidateBalanceCaches()`.
+    expect(unclassified).toEqual([]);
+  });
+
+  it('drops every transaction-derived prefix in invalidateBalanceCaches', () => {
+    const missing = TRANSACTION_DERIVED.filter(
+      ([prefix]) => !invalidatorBody.includes(`invalidateCache('${prefix}')`),
+    ).map(([prefix, why]) => `${prefix} (${why})`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('leaves reference data alone in invalidateBalanceCaches', () => {
+    const wronglyDropped = REFERENCE_DATA.filter(([prefix]) =>
+      invalidatorBody.includes(`invalidateCache('${prefix}')`),
+    ).map(([prefix]) => prefix);
+
+    // Dropping reference data on every write is not a correctness bug, but it
+    // refetches the payee and category lists on every save. If a prefix really
+    // is transaction-derived, move it to the other list with a reason.
+    expect(wronglyDropped).toEqual([]);
+  });
+
+  it('has no classification entry for a prefix nothing uses', () => {
+    const stale = [...TRANSACTION_DERIVED, ...REFERENCE_DATA]
+      .map(([prefix]) => prefix)
+      .filter((prefix) => !allPrefixes.has(prefix));
+
+    expect(stale).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Invalidate every frontend cache family whose values are derived from transaction rows after a money-moving write.

`invalidateBalanceCaches()` previously cleared account and investment caches but left budget progress cached. A successful transaction could therefore be followed immediately by stale budget actuals and remaining amounts, including `budgets:dashboard` and category-status views.

## What changes

- Add the `budgets:` cache family to `invalidateBalanceCaches()`.
- Keep reference-data caches such as payees, categories, and institutions intact when a transaction write cannot change them.
- Add regression tests that pin the transaction-derived prefix set in both directions.
- Add a source guard that discovers cache prefixes used in `src/` and requires each family to be explicitly classified as either transaction-derived and invalidated after money-moving writes, or reference data that must not be dropped by those writes.
- Fail the guard for new unclassified cache families and for stale classifications that no longer exist.
- Document the cache invalidation invariant in the frontend repository instructions.

## User impact

Budget progress no longer remains at its pre-write value after a transaction succeeds. The classification guard also makes the same omission harder to reintroduce when new cache families are added.

## Validation

The branch adds/updates coverage for:

- invalidating account, investment, and budget cache families;
- preserving unrelated reference-data caches;
- rejecting a newly introduced unclassified cache family;
- rejecting stale cache-family classifications.

## Audit context

Addresses Phase 6 finding **P6-015**.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->