### PR TITLE
06: Make transfer VOID transitions pair-wide (v1.15.0)

### DIFF
--- a/backend/src/transactions/transaction-transfer.service.spec.ts
+++ b/backend/src/transactions/transaction-transfer.service.spec.ts
@@ -1788,6 +1788,213 @@ describe("TransactionTransferService", () => {
       });
     });
 
+    describe("per-leg reconciliation on same-owner edit (P6-RECHECK-004)", () => {
+      // CLEARED / RECONCILED record whether THIS account's statement has
+      // recognised THIS leg, and the two statements arrive separately. The edit
+      // form shows one status control for the transfer and used to write it onto
+      // both rows, so opening the form on one leg and saving rewrote the other
+      // account's reconciliation state. A non-VOID status change now stays on
+      // the leg the user opened; VOID still pairs because it moves both balances.
+      it("writes a reconciliation status only to the edited leg, leaving the counterpart untouched", async () => {
+        const activeFrom = {
+          ...fromTransaction,
+          status: TransactionStatus.UNRECONCILED,
+        } as unknown as Transaction;
+        const reconciledTo = {
+          ...toTransaction,
+          status: TransactionStatus.RECONCILED,
+        } as unknown as Transaction;
+
+        mockFindOne
+          .mockResolvedValueOnce(activeFrom)
+          .mockResolvedValueOnce(reconciledTo)
+          .mockResolvedValueOnce({
+            ...activeFrom,
+            status: TransactionStatus.CLEARED,
+          })
+          .mockResolvedValueOnce(reconciledTo);
+
+        // A description rides along so the counterpart IS updated (description
+        // mirrors to both legs) -- this distinguishes "status stripped from the
+        // counterpart update" from "counterpart never updated".
+        await service.updateTransfer(
+          "user-1",
+          "from-tx",
+          { status: TransactionStatus.CLEARED, description: "groceries" },
+          mockFindOne,
+        );
+
+        const updateCalls = transactionsRepository.update.mock.calls;
+        const fromUpdate = updateCalls.find((c) => c[0] === "from-tx")?.[1];
+        const toUpdate = updateCalls.find((c) => c[0] === "to-tx")?.[1];
+
+        // The edited leg takes the new status...
+        expect(fromUpdate).toMatchObject({ status: TransactionStatus.CLEARED });
+        // ...and the counterpart is written (its description mirrors) but its
+        // RECONCILED state is never rewritten. On the old behaviour toUpdate
+        // carried status: CLEARED and clobbered it.
+        expect(toUpdate).toMatchObject({ description: "groceries" });
+        expect(toUpdate.status).toBeUndefined();
+        // A non-VOID status change moves no balance.
+        expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      });
+
+      it("issues no counterpart update at all for a status-only edit", async () => {
+        const activeFrom = {
+          ...fromTransaction,
+          status: TransactionStatus.UNRECONCILED,
+        } as unknown as Transaction;
+        const reconciledTo = {
+          ...toTransaction,
+          status: TransactionStatus.RECONCILED,
+        } as unknown as Transaction;
+
+        mockFindOne
+          .mockResolvedValueOnce(activeFrom)
+          .mockResolvedValueOnce(reconciledTo)
+          .mockResolvedValueOnce({
+            ...activeFrom,
+            status: TransactionStatus.CLEARED,
+          })
+          .mockResolvedValueOnce(reconciledTo);
+
+        await service.updateTransfer(
+          "user-1",
+          "from-tx",
+          { status: TransactionStatus.CLEARED },
+          mockFindOne,
+        );
+
+        // With status the only changed field, stripping it leaves the
+        // counterpart's update data empty, so `Object.keys(...).length > 0` is
+        // false and no write is issued for the counterpart at all.
+        const updateCalls = transactionsRepository.update.mock.calls;
+        expect(updateCalls.some((c) => c[0] === "to-tx")).toBe(false);
+        expect(updateCalls.find((c) => c[0] === "from-tx")?.[1]).toMatchObject({
+          status: TransactionStatus.CLEARED,
+        });
+      });
+
+      it("strips the status from the from-leg when the user opened the to-leg", async () => {
+        const reconciledFrom = {
+          ...fromTransaction,
+          status: TransactionStatus.RECONCILED,
+        } as unknown as Transaction;
+        const activeTo = {
+          ...toTransaction,
+          status: TransactionStatus.UNRECONCILED,
+        } as unknown as Transaction;
+
+        // The user opened the TO leg, so findOne returns it first and its
+        // counterpart second.
+        mockFindOne
+          .mockResolvedValueOnce(activeTo)
+          .mockResolvedValueOnce(reconciledFrom)
+          .mockResolvedValueOnce(reconciledFrom)
+          .mockResolvedValueOnce({
+            ...activeTo,
+            status: TransactionStatus.CLEARED,
+          });
+
+        await service.updateTransfer(
+          "user-1",
+          "to-tx",
+          { status: TransactionStatus.CLEARED },
+          mockFindOne,
+        );
+
+        const updateCalls = transactionsRepository.update.mock.calls;
+        const fromUpdate = updateCalls.find((c) => c[0] === "from-tx")?.[1];
+        const toUpdate = updateCalls.find((c) => c[0] === "to-tx")?.[1];
+
+        expect(toUpdate).toMatchObject({ status: TransactionStatus.CLEARED });
+        expect(fromUpdate?.status).toBeUndefined();
+      });
+
+      it("still pairs the status across both legs when the transition crosses VOID", async () => {
+        const activeFrom = {
+          ...fromTransaction,
+          status: TransactionStatus.UNRECONCILED,
+        } as unknown as Transaction;
+        const activeTo = {
+          ...toTransaction,
+          status: TransactionStatus.UNRECONCILED,
+        } as unknown as Transaction;
+
+        mockFindOne
+          .mockResolvedValueOnce(activeFrom)
+          .mockResolvedValueOnce(activeTo)
+          .mockResolvedValueOnce({
+            ...activeFrom,
+            status: TransactionStatus.VOID,
+          })
+          .mockResolvedValueOnce({
+            ...activeTo,
+            status: TransactionStatus.VOID,
+          });
+
+        await service.updateTransfer(
+          "user-1",
+          "from-tx",
+          { status: TransactionStatus.VOID },
+          mockFindOne,
+        );
+
+        const updateCalls = transactionsRepository.update.mock.calls;
+        const fromUpdate = updateCalls.find((c) => c[0] === "from-tx")?.[1];
+        const toUpdate = updateCalls.find((c) => c[0] === "to-tx")?.[1];
+
+        // VOID moves both balances, so the status belongs to both legs.
+        expect(fromUpdate).toMatchObject({ status: TransactionStatus.VOID });
+        expect(toUpdate).toMatchObject({ status: TransactionStatus.VOID });
+      });
+
+      it("pairs the submitted status onto both legs when un-voiding directly to CLEARED, matching the bulk path", async () => {
+        const voidFrom = {
+          ...fromTransaction,
+          status: TransactionStatus.VOID,
+        } as unknown as Transaction;
+        const voidTo = {
+          ...toTransaction,
+          status: TransactionStatus.VOID,
+        } as unknown as Transaction;
+
+        // Un-void the FROM leg straight to CLEARED (VOID -> CLEARED). Leaving
+        // VOID crosses the boundary, so the status is NOT stripped and both legs
+        // reactivate carrying the submitted CLEARED -- identical to a bulk
+        // un-void through `expandTransferCounterparts`. A non-UNRECONCILED
+        // target is the case that distinguishes "pair the submitted status" from
+        // "reset the counterpart to UNRECONCILED"; this pins the former.
+        mockFindOne
+          .mockResolvedValueOnce(voidFrom)
+          .mockResolvedValueOnce(voidTo)
+          .mockResolvedValueOnce({
+            ...voidFrom,
+            status: TransactionStatus.CLEARED,
+          })
+          .mockResolvedValueOnce({
+            ...voidTo,
+            status: TransactionStatus.CLEARED,
+          });
+
+        await service.updateTransfer(
+          "user-1",
+          "from-tx",
+          { status: TransactionStatus.CLEARED },
+          mockFindOne,
+        );
+
+        const updateCalls = transactionsRepository.update.mock.calls;
+        const fromUpdate = updateCalls.find((c) => c[0] === "from-tx")?.[1];
+        const toUpdate = updateCalls.find((c) => c[0] === "to-tx")?.[1];
+
+        // Both legs leave VOID together and both carry CLEARED -- the counterpart
+        // is neither stripped nor reset to UNRECONCILED.
+        expect(fromUpdate).toMatchObject({ status: TransactionStatus.CLEARED });
+        expect(toUpdate).toMatchObject({ status: TransactionStatus.CLEARED });
+      });
+    });
+
     it("updates amount for both sides of the transfer", async () => {
       mockFindOne
         .mockResolvedValueOnce(fromTransaction)

--- a/backend/src/transactions/transaction-transfer.service.ts
+++ b/backend/src/transactions/transaction-transfer.service.ts
@@ -1696,6 +1696,37 @@ export class TransactionTransferService {
         await this.accountsService.updateBalance(oldToAccountId, -oldToAmount);
       }
 
+      // The reconciliation status is per-leg unless the transition crosses
+      // VOID. The edit form shows one status control for "the transfer" and used
+      // to write it onto both rows, but CLEARED and RECONCILED record whether
+      // *this* account's statement has recognised *this* leg, and the two
+      // statements arrive separately -- copying RECONCILED onto the counterpart
+      // removes the transfer from the other account's reconciliation candidates
+      // before its own statement contains it, and copying UNRECONCILED over the
+      // counterpart discards a reconciliation the user had already completed
+      // there (audit P6-RECHECK-004). So for a non-VOID edit the status stays on
+      // the leg the user opened and is stripped from the counterpart.
+      //
+      // A VOID crossing is the exception, and it PAIRS the status onto both
+      // legs: VOID decides balance inclusion, and a same-owner pair must be VOID
+      // on both legs or neither or its balances diverge. This matches the bulk
+      // path exactly -- `expandTransferCounterparts` drags the counterpart in on
+      // a VOID crossing only, and the same UPDATE stamps the submitted status
+      // onto it -- so the same action reads the same way whether done in the
+      // register or in bulk. Keeping the two surfaces in step is deliberate; the
+      // un-void sub-status question (a reactivated counterpart inheriting the
+      // opened leg's CLEARED/RECONCILED) is a platform-wide decision that must
+      // move both surfaces together, not something for one edit path to answer
+      // alone. `voidChanged` is read from the locked row above, so the
+      // strip-versus-pair choice here is made on the committed status rather
+      // than a stale snapshot -- this scopes only that choice, not the wider
+      // concurrency guard, which compares amount/account/date.
+      if (!voidChanged) {
+        // `isFromTransaction` already names which leg the user opened, so the
+        // counterpart is the other one.
+        delete (isFromTransaction ? toUpdateData : fromUpdateData).status;
+      }
+
       if (Object.keys(fromUpdateData).length > 0) {
         await m.update(Transaction, fromTransaction.id, fromUpdateData);
       }


### PR DESCRIPTION
## Summary

Make `VOID` an atomic, pair-wide economic state for linked transfers while keeping reconciliation state account-specific.

A transfer is one economic event represented by two transaction rows. Voiding only one leg can create or destroy the transfer amount in aggregate balances. The first remediation also showed the opposite risk: pairing every status is wrong because `CLEARED`, `RECONCILED`, and `reconciledDate` belong to each account's own statement lifecycle.

## What changes

### Pair-wide `VOID`

- Expand both legs only when a status transition enters or leaves `VOID`.
- Apply both status writes and both balance adjustments in the same database transaction.
- Use the same transition rule for the single-status endpoint, bulk updates, and transfer editing.
- Keep future-dated transfer recalculation consistent with pair-wide status changes.

### Per-account reconciliation state

- Keep `UNRECONCILED`, `CLEARED`, and `RECONCILED` on the leg the caller is actually changing.
- Keep `reconciledDate` on that leg only.
- Do not pair or reject split-owned/cross-owner legs for statement-only status changes.

### Cross-owner transfers

- For a connected cross-owner transfer, write a `VOID` transition to both legs and move both balances atomically.
- Keep non-`VOID` reconciliation status on the effective user's leg.
- For a frozen relationship where the counterpart can no longer be written, reject entering or leaving `VOID` before any write.
- Fail closed when two stored legs already disagree about `VOID` state instead of compounding historical corruption.

### Split-transfer safety

- Refuse a pair-wide `VOID` operation when a split-transfer leg cannot be mapped to a safe writable counterpart rather than accidentally voiding a split parent or applying only half of the economic event.

### Localization

- Localize the new error/confirmation copy across supported locales.

## Financial impact

For a 100.00 transfer, entering or leaving `VOID` now changes both transaction rows and both account balances together. Reconciliation of one account no longer marks the counterpart as reconciled before its own statement contains the transfer.

## Validation

The branch adds/updates regression coverage for:

- pair-wide `ACTIVE -> VOID` and `VOID -> ACTIVE`;
- single-status and bulk paths;
- `CLEARED` / `RECONCILED` remaining per-account;
- reconciled dates not being copied;
- same-owner and cross-owner transfers;
- source-leg and destination-leg edits;
- frozen cross-owner refusal with zero writes;
- pre-existing mismatched pair state failing closed;
- split-transfer refusal cases.

## Audit context

Addresses **P6-001**, **P6-RECHECK-004**, and **P6-RECHECK-006**.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->