### PR TITLE
fix(securities): persist website and IR website on edit (issue #1122)

### DIFF
--- a/backend/src/securities/securities.service.spec.ts
+++ b/backend/src/securities/securities.service.spec.ts
@@ -715,6 +715,37 @@ describe("SecuritiesService", () => {
       expect(saved.isFavourite).toBe(true);
     });
 
+    // Regression for issue #1122: the explicit property-mapping block omitted
+    // both address fields, so an edit normalised them and then dropped them --
+    // the save persisted the unchanged security and the link never stuck.
+    it("persists and normalizes website and irWebsite updates (issue #1122)", async () => {
+      securitiesRepository.findOne.mockResolvedValue({ ...mockSecurity });
+
+      await service.update("user-1", "sec-1", {
+        // A bare domain from the form -- the service normalises it to https.
+        website: "apple.com",
+        irWebsite: "https://investor.apple.com",
+      });
+
+      const saved = queryRunnerManager.save.mock.calls[0][1];
+      expect(saved.website).toBe("https://apple.com");
+      expect(saved.irWebsite).toBe("https://investor.apple.com");
+    });
+
+    it("clears website and irWebsite when the form submits them blank", async () => {
+      securitiesRepository.findOne.mockResolvedValue({
+        ...mockSecurity,
+        website: "https://apple.com",
+        irWebsite: "https://investor.apple.com",
+      });
+
+      await service.update("user-1", "sec-1", { website: "", irWebsite: "" });
+
+      const saved = queryRunnerManager.save.mock.calls[0][1];
+      expect(saved.website).toBeNull();
+      expect(saved.irWebsite).toBeNull();
+    });
+
     it("records action history on update", async () => {
       securitiesRepository.findOne.mockResolvedValue({ ...mockSecurity });
 

--- a/backend/src/securities/securities.service.ts
+++ b/backend/src/securities/securities.service.ts
@@ -595,6 +595,14 @@ export class SecuritiesService {
       security.currencyCode = updateSecurityDto.currencyCode;
     if (updateSecurityDto.description !== undefined)
       security.description = updateSecurityDto.description ?? null;
+    // Both addresses were normalised above ("" -> null, bare domain -> https).
+    // They must be copied onto the entity here like every other scalar: this
+    // block replaces Object.assign, so a field it omits is silently dropped and
+    // the edit never persists -- which is exactly what happened to these two.
+    if (updateSecurityDto.website !== undefined)
+      security.website = updateSecurityDto.website ?? null;
+    if (updateSecurityDto.irWebsite !== undefined)
+      security.irWebsite = updateSecurityDto.irWebsite ?? null;
     if (updateSecurityDto.isActive !== undefined)
       security.isActive = updateSecurityDto.isActive;
     if (updateSecurityDto.isFavourite !== undefined)


### PR DESCRIPTION
## Linked discussion / issue

Closes #1122
Approved in: #1122

## Summary

The `SecuritiesService.update()` method was omitting `website` and `irWebsite` fields from its explicit property-mapping block. Because the service normalizes these fields (converting bare domains to HTTPS URLs and empty strings to null), the normalized values were computed but never copied onto the entity before save. This caused edits to these fields to silently fail to persist.

The fix adds explicit assignments for both fields in the update method, matching the pattern used for all other scalar properties. Two regression tests verify that:
1. Website and IR website URLs are normalized and persisted correctly
2. Empty submissions clear these fields (set to null)

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (field persistence bug).
- [x] New behavior has tests, and the existing suite passes.
- [x] No user-facing strings added (bug fix only).
- [x] No shared/core areas refactored.
- [x] The branch is rebased on the latest `main`.
- [ ] AI assistance disclosure: N/A

https://claude.ai/code/session_011bVQLCsojE4rtguxA9sGeX