### PR TITLE
07: Serialise the concurrent writes that corrupt balances and holdings (v1.15.0)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -222,6 +222,73 @@ Untyped, a mock quietly becomes fiction, and the branch that reads that fiction 
 - **A shape the driver never returns.** A TypeORM insert result mocked as `{ generatedMaps: [] }` made an entire lost-the-race path testable, tested and dead: the real driver signals a conflict elsewhere, so the branch never ran in production and its tests never ran anything else.
 - **A signature that moved.** A service method growing from `Promise<boolean>` to `Promise<string | null>` leaves `mockResolvedValue(true)` behind it -- still truthy, still passing, still describing a contract nothing has any more. When you change a method's return type, grep its mocks in the same commit.
 
+### A concurrency test needs two connections, a gate, and a positive control
+
+`Promise.all` around two calls into one service instance is not a race. Both calls usually share a transaction or arrive in the same order every time, so the interleaving that breaks production is never reached -- and the test passes just as happily with the guard deleted. Every concurrency test here had that shape before `test/helpers/race-harness.ts`, which is what audit finding P7-008 recorded.
+
+Write one with three things:
+
+- **Independent connections.** Each participant runs under its own `withUserContext`, so its `withScopedDb` draws a fresh pooled connection and opens its own transaction.
+- **A `RowGate`.** It holds `FOR UPDATE` on the row every participant must touch, from its own connection, so each of them queues up *inside its own transaction* and they are all released into the contended window together. Wait for them with `waitForBlockedBackends` / `waitForIdleInTransaction` -- conditions the database will answer -- never `sleep`. Release in a `finally`; a leaked gate fails an unrelated spec later in the run.
+- **A positive control.** Reintroduce the defect and watch the test fail, then say so in the change description. `race-harness.integration.spec.ts` does this for the harness itself: an unguarded read-modify-write loses an update through the same gate the real suites use, so if that case ever starts passing, the gate has stopped gating and every suite built on it is back to being a `Promise.all`.
+
+Assert on **both** stored state and provider side effects (`expect(generateTokenPair).toHaveBeenCalledTimes(1)`), and use `raceAll` rather than `Promise.all` -- losing a race is a normal outcome and `Promise.all` throws the other results away with the first rejection.
+
+Two defect shapes worth knowing, because each was found this way and neither is visible in the code as read. A single `UPDATE ... WHERE <predicate>` cannot see a row a concurrent transaction inserted after its snapshot, so a sweep that must leave nothing behind has to re-read and go again (`TokenService.revokeUntilNoneLive`). And `repo.save(entity)` writes *every* column of whatever was loaded, so a recompute persisting a stale entity silently reverts a concurrent edit to unrelated fields -- update the column you own (`repo.update({ id }, { thatColumn })`), not the row you happen to be holding.
+
+### A guard added to one entry point is a guard on one entry point
+
+The three HIGH findings of the Phase 7 re-review were all the same mistake, and
+none of them was carelessness about the invariant -- each invariant was written
+down, and each fix shipped with a real, passing test. The carelessness was about
+**which call sites the test reached**: in every case the new test exercised the
+path the fix had just changed, which is the one path guaranteed to pass.
+
+- The account lock went into `createOrUpdate` and the whole-user rebuild. The
+  race test covered a `BUY`, which goes through `createOrUpdate`. `applySplit`,
+  `reverseSplit`, `adjustQuantity` and the partial rebuild -- every path a
+  `SPLIT`/`ADD_SHARES`/`REMOVE_SHARES` edit or delete takes -- kept no lock at
+  all, and deleting an `ADD_SHARES 10` mid-rebuild left ten phantom shares.
+- `post` gained an occurrence precondition, derived from a fresh read. Every
+  test called `post` directly, so none could see that the auto-post cron
+  discards the occurrence it discovered and a delayed replica therefore pays the
+  *next* period.
+- The backup filename gained a time component, so the sub-daily test passed. Two
+  writers in the same second still computed the same path.
+
+So when a fix adds a guard to a shared entry point, **enumerate the other entry
+points to the same state** and either cover them or say plainly which you did
+not. Grep for the state -- the table, the column, the materialized view -- not for
+the function you just edited. And prefer the guard a scan can hold over a guard
+one test can satisfy: this is the same reason `share-quantity.guard.spec.ts` and
+`ui-conventions.test.ts` exist, generalised.
+
+Where two of a fix's cases cannot fail without it and two can, say which are
+which in the test file. `race-holdings-rebuild.integration.spec.ts` marks its
+`SPLIT`-delete and insert cases as guards rather than proofs, because a
+post-commit repair rebuild and a by-id delete respectively mask the defect --
+implying four proofs where there are two is how a suite starts overstating
+itself.
+
+A corollary the fourth Phase 7 review earned, because the fix it answers
+reached the callers it could see and stopped at the edge:
+
+- **A lock has an order, and the order is part of the lock.** Adding `FOR UPDATE`
+  to a mutator is half a decision; the other half is the order a caller that
+  needs two of them acquires them in. A security transfer took its source lock
+  then its destination lock, so a simultaneous reverse transfer deadlocked
+  (`40P01`). Any operation taking more than one account lock takes the whole set
+  once, sorted, up front -- `HoldingsService.lockAccountsForHoldings`. A new
+  multi-account holdings path that acquires them incrementally is that deadlock
+  again.
+
+**A test only counts where CI runs it.** The backend CI jobs run `test:unit`,
+`test:integration` (only `test/integration/`), and `test:cov`. A spec in `test/`
+root -- the `*.e2e-spec.ts` files -- runs in *none* of them, so one placed there
+is dead weight (and `transactions.e2e-spec.ts` does not even compile, unnoticed).
+Prove a controller/DTO invariant with a validator spec under `src/` or an
+integration spec under `test/integration/`, both of which CI executes.
+
 ### Fixtures are claims about production data
 
 `docs/testing-contract.md` is the shared list of adversarial inputs to choose from. A fixture is evidence only if the code that writes the real data could have written it. Before adding one, look at the producer: the query's sampling, whether the column is nullable, whether the format guarantees what the fixture assumes. A price series three points a quarter apart proves nothing about code reading daily closes, and weightings that always sum to 1 never exercise the remainder the storage format allows. `docs/financial-calculation-contract.md` section 8.3 has the full rule.

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
     "test": "jest",
     "test:unit": "jest --testPathPatterns='src/.*\\.spec\\.ts$'",
     "pretest:integration": "node -e \"const{Client}=require('pg');const c=new Client({host:process.env.DATABASE_HOST||'localhost',port:+(process.env.DATABASE_PORT||5432),user:process.env.DATABASE_USER||'monize_user',password:process.env.DATABASE_PASSWORD||'monize_password',database:'postgres'});c.connect().then(()=>c.query(\\\"SELECT 1 FROM pg_database WHERE datname='monize_test'\\\").then(r=>r.rowCount?0:c.query('CREATE DATABASE monize_test')).then(()=>c.end())).catch(e=>{console.error(e.message);process.exit(1)})\"",
-    "test:integration": "jest --config ./test/jest-e2e.json --testPathPatterns='test/integration/.*\\.spec\\.ts$' --runInBand --passWithNoTests",
+    "test:integration": "node scripts/integration-inventory.mjs && jest --config ./test/jest-e2e.json --testPathPatterns='test/integration/.*\\.spec\\.ts$' --runInBand",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage --testPathPatterns='src/.*\\.spec\\.ts$'",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
@@ -32,7 +32,9 @@
     "migration:run": "npm run typeorm -- migration:run",
     "migration:revert": "npm run typeorm -- migration:revert",
     "seed": "ts-node -r tsconfig-paths/register src/database/seed.ts",
-    "mny:inspect": "ts-node -r tsconfig-paths/register src/import/mny/mny-inspect.ts"
+    "mny:inspect": "ts-node -r tsconfig-paths/register src/import/mny/mny-inspect.ts",
+    "test:integration:inventory": "node scripts/integration-inventory.mjs",
+    "test:integration:inventory:test": "node --test scripts/integration-inventory.test.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.75.0",

--- a/backend/scripts/integration-inventory.mjs
+++ b/backend/scripts/integration-inventory.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Integration-suite discovery guard: a CI gate that runs before Jest.
+ *
+ * `npm run test:integration` used to pass `--passWithNoTests`, which means a
+ * green "Backend Integration Tests" check proved nothing about whether any
+ * integration test ran. Anything that breaks discovery -- a directory rename, a
+ * `--testPathPatterns` escaping change, a suite accidentally moved out of the
+ * tree -- produced a successful job that exercised zero real-PostgreSQL,
+ * cross-user-isolation or RLS behaviour. That layer exists precisely to cover
+ * what the unit suites mock away, so a silent zero there is the most expensive
+ * false green in the pipeline.
+ *
+ * This script asserts the inventory is intact *before* Jest is invoked:
+ *
+ *  1. every suite in MANDATORY_SUITES is present;
+ *  2. the total count is at least MINIMUM_SUITES;
+ *  3. the discovered list is printed, so a job log shows what was covered
+ *     rather than leaving the reader to infer it.
+ *
+ * MANDATORY_SUITES is not "every file" on purpose -- pinning the whole list
+ * would make the guard fail on every legitimate addition and get deleted. It
+ * names the suites whose disappearance would mean losing a class of coverage
+ * that nothing else replaces. Adding to it is a reviewed decision; removing
+ * from it should be too.
+ *
+ * Usage:
+ *   node scripts/integration-inventory.mjs
+ *   node scripts/integration-inventory.mjs --dir some/other/dir
+ */
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const DEFAULT_DIR = "test/integration";
+const SUITE_SUFFIX = ".integration.spec.ts";
+
+/**
+ * Suites that must exist. Each protects an invariant no other layer covers:
+ * real transaction/balance behaviour, cross-user isolation at the service
+ * boundary, database-enforced RLS under the unprivileged runtime role, the MNY
+ * import's concurrent job claim, paired transfers, and backup/restore.
+ */
+const MANDATORY_SUITES = [
+  "transactions.integration.spec.ts",
+  "transfers.integration.spec.ts",
+  "security-cross-user-isolation.integration.spec.ts",
+  "rls-enforcement.integration.spec.ts",
+  "rls-harness.integration.spec.ts",
+  "mny-import-job.integration.spec.ts",
+  "security-transfer.integration.spec.ts",
+  "backup-restore.integration.spec.ts",
+  "support-backup.integration.spec.ts",
+  // The P7-008 concurrency set. Each drives a specific interleaving that the
+  // rest of the suite cannot reach, and the harness self-test is what proves the
+  // others are not quietly passing because their gate stopped gating -- so if
+  // that one goes, the whole set loses its meaning rather than one case.
+  //
+  // The import-start race is deliberately *not* here: `mny-import-job` covers
+  // that invariant more thoroughly, and two suites racing the same insert is
+  // duplication rather than depth.
+  "race-harness.integration.spec.ts",
+  "race-emergency-claim.integration.spec.ts",
+  "race-refresh-token-revocation.integration.spec.ts",
+  "race-account-balance.integration.spec.ts",
+  "race-holdings-rebuild.integration.spec.ts",
+  "race-security-transfer.integration.spec.ts",
+];
+
+/**
+ * A floor, not a target. Set below the current count so ordinary churn does not
+ * trip it, but far enough above zero that a discovery regression cannot slip
+ * through as "well, some tests ran". It also has to sit *above* the length of
+ * MANDATORY_SUITES, or that list growing quietly retires the floor -- which is
+ * what happened when the concurrency suites were added and 15 mandatory files
+ * were suddenly enough to clear a floor of 15.
+ */
+const MINIMUM_SUITES = 20;
+
+function parseArgs(argv) {
+  const dirFlag = argv.indexOf("--dir");
+  return { dir: dirFlag === -1 ? DEFAULT_DIR : argv[dirFlag + 1] };
+}
+
+function discover(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch (error) {
+    return { error: `cannot read ${dir}: ${error.message}`, suites: [] };
+  }
+  const suites = entries
+    .filter((name) => name.endsWith(SUITE_SUFFIX))
+    .filter((name) => statSync(join(dir, name)).isFile())
+    .sort();
+  return { error: null, suites };
+}
+
+function main() {
+  const { dir } = parseArgs(process.argv.slice(2));
+  const { error, suites } = discover(dir);
+
+  if (error) {
+    console.error(`Integration inventory: ${error}`);
+    console.error(
+      "The integration suites could not be listed at all, so the job would " +
+        "otherwise have run zero tests and reported success.",
+    );
+    process.exit(1);
+  }
+
+  console.log(`Integration inventory: ${suites.length} suite(s) in ${dir}`);
+  for (const suite of suites) console.log(`  - ${suite}`);
+
+  const problems = [];
+
+  const missing = MANDATORY_SUITES.filter((name) => !suites.includes(name));
+  if (missing.length > 0) {
+    problems.push(
+      `missing mandatory suite(s): ${missing.join(", ")}. If one was ` +
+        `deliberately renamed or removed, update MANDATORY_SUITES in this ` +
+        `script in the same change, so the decision is visible in review.`,
+    );
+  }
+
+  if (suites.length < MINIMUM_SUITES) {
+    problems.push(
+      `found ${suites.length} suite(s), expected at least ${MINIMUM_SUITES}. ` +
+        `A sharp drop usually means discovery broke rather than that tests ` +
+        `were deleted.`,
+    );
+  }
+
+  if (problems.length > 0) {
+    console.error("\nIntegration inventory check failed:");
+    for (const problem of problems) console.error(`  - ${problem}`);
+    process.exit(1);
+  }
+
+  console.log("Integration inventory check passed.");
+}
+
+main();

--- a/backend/scripts/integration-inventory.test.mjs
+++ b/backend/scripts/integration-inventory.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * Self-test for the integration inventory guard, in the shape of
+ * `migration-lint.test.mjs`: build a temporary directory, run the script
+ * against it, and assert on the exit code.
+ *
+ * A guard that cannot fail is not a guard, so the cases that matter are the
+ * negative ones -- an empty directory, a missing directory, and a missing
+ * mandatory suite must each exit non-zero.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(here, "integration-inventory.mjs");
+
+const MANDATORY = [
+  "transactions.integration.spec.ts",
+  "transfers.integration.spec.ts",
+  "security-cross-user-isolation.integration.spec.ts",
+  "rls-enforcement.integration.spec.ts",
+  "rls-harness.integration.spec.ts",
+  "mny-import-job.integration.spec.ts",
+  "security-transfer.integration.spec.ts",
+  "backup-restore.integration.spec.ts",
+  "support-backup.integration.spec.ts",
+  "race-harness.integration.spec.ts",
+  "race-emergency-claim.integration.spec.ts",
+  "race-refresh-token-revocation.integration.spec.ts",
+  "race-account-balance.integration.spec.ts",
+  "race-holdings-rebuild.integration.spec.ts",
+  "race-security-transfer.integration.spec.ts",
+];
+
+function run(dir) {
+  return spawnSync(process.execPath, [SCRIPT, "--dir", dir], {
+    encoding: "utf8",
+  });
+}
+
+function withDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "integration-inventory-"));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Write the mandatory suites plus enough filler to clear the floor. */
+function seedComplete(dir, extra = 10) {
+  for (const name of MANDATORY) writeFileSync(join(dir, name), "");
+  for (let i = 0; i < extra; i++) {
+    writeFileSync(join(dir, `filler-${i}.integration.spec.ts`), "");
+  }
+}
+
+test("passes on a complete inventory", () => {
+  withDir((dir) => {
+    seedComplete(dir);
+    const result = run(dir);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Integration inventory check passed/);
+  });
+});
+
+test("prints the discovered suite list", () => {
+  withDir((dir) => {
+    seedComplete(dir);
+    const result = run(dir);
+    // The log is the point: a reader should see what was covered.
+    assert.match(result.stdout, /transactions\.integration\.spec\.ts/);
+    assert.match(result.stdout, /suite\(s\) in/);
+  });
+});
+
+test("fails on an empty directory", () => {
+  withDir((dir) => {
+    const result = run(dir);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /expected at least/);
+  });
+});
+
+test("fails when the directory does not exist", () => {
+  withDir((dir) => {
+    const result = run(join(dir, "nope"));
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /cannot read/);
+  });
+});
+
+test("fails when a mandatory suite is missing", () => {
+  withDir((dir) => {
+    seedComplete(dir);
+    rmSync(join(dir, "rls-enforcement.integration.spec.ts"));
+    const result = run(dir);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing mandatory suite/);
+    assert.match(result.stderr, /rls-enforcement/);
+  });
+});
+
+test("fails when the count drops below the floor even with all mandatory suites", () => {
+  withDir((dir) => {
+    // Every mandatory suite and no filler: still below MINIMUM_SUITES, which is
+    // the property that keeps the floor meaningful as MANDATORY_SUITES grows.
+    for (const name of MANDATORY) writeFileSync(join(dir, name), "");
+    const result = run(dir);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /expected at least/);
+  });
+});
+
+test("ignores directories that look like suites", () => {
+  withDir((dir) => {
+    seedComplete(dir);
+    mkdirSync(join(dir, "decoy.integration.spec.ts"));
+    const result = run(dir);
+    assert.equal(result.status, 0, result.stderr);
+    assert.doesNotMatch(result.stdout, /- decoy\.integration\.spec\.ts/);
+  });
+});
+
+test("ignores unit specs sitting in the directory", () => {
+  withDir((dir) => {
+    seedComplete(dir);
+    writeFileSync(join(dir, "helper.spec.ts"), "");
+    const result = run(dir);
+    assert.equal(result.status, 0, result.stderr);
+    assert.doesNotMatch(result.stdout, /- helper\.spec\.ts/);
+  });
+});

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -997,22 +997,6 @@ export class AccountsService {
    * to ensure the balance is always correct regardless of history.
    */
   async recalculateCurrentBalance(accountId: string): Promise<Account> {
-    const account = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(Account).findOne({
-        where: { id: accountId },
-      }),
-    );
-
-    if (!account) {
-      throw new NotFoundException(
-        tr(
-          "errors.accounts.accountWithIdNotFound",
-          `Account with ID ${accountId} not found`,
-          { id: accountId },
-        ),
-      );
-    }
-
     const balanceSql = `SELECT COALESCE($2::NUMERIC, 0) + COALESCE(SUM(t.amount), 0) as balance
        FROM transactions t
        WHERE t.account_id = $1
@@ -1022,7 +1006,41 @@ export class AccountsService {
 
     const today = todayYMD();
 
+    // One transaction, a locked read, and a write confined to the one column
+    // this method owns. Each of the three is load-bearing, and the previous
+    // shape had none of them:
+    //
+    // - The account was read in its own transaction and the sum computed in a
+    //   second, so the opening balance the sum was added to could already be
+    //   stale -- producing a "recalculated" balance that never matched any
+    //   state the account was in.
+    // - `save(account)` writes every column of the entity that was loaded, so a
+    //   rename, a credit-limit change or an opening-balance edit committed in
+    //   between was silently reverted by a recompute that had no business
+    //   touching those fields. A recompute overwriting a user's edit is the
+    //   worst kind of lost update: nothing errors and the edit simply is not
+    //   there any more.
+    // - Without the lock two recomputes, or a recompute and an update, can
+    //   interleave freely.
+    //
+    // `race-account-balance.integration.spec.ts` fails on the old shape.
     return withScopedDb(this.dataSource, async (m) => {
+      const repo = m.getRepository(Account);
+      const account = await repo.findOne({
+        where: { id: accountId },
+        lock: { mode: "pessimistic_write" },
+      });
+
+      if (!account) {
+        throw new NotFoundException(
+          tr(
+            "errors.accounts.accountWithIdNotFound",
+            `Account with ID ${accountId} not found`,
+            { id: accountId },
+          ),
+        );
+      }
+
       const result: { balance: string }[] = await m.query(balanceSql, [
         accountId,
         account.openingBalance,
@@ -1032,8 +1050,10 @@ export class AccountsService {
         result.length > 0
           ? roundMoney(Number(result[0].balance))
           : roundMoney(Number(account.openingBalance));
+
+      await repo.update({ id: accountId }, { currentBalance: newBalance });
       account.currentBalance = newBalance;
-      return m.getRepository(Account).save(account);
+      return account;
     });
   }
 

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -118,6 +118,9 @@ describe("AuthService", () => {
       save: jest.fn().mockImplementation((data) => ({ ...data, id: "rt-1" })),
       findOne: jest.fn(),
       update: jest.fn(),
+      // A revocation re-reads to confirm the family is dead (TokenService's
+      // revokeUntilNoneLive), so this double has to answer that too.
+      count: jest.fn().mockResolvedValue(0),
       delete: jest.fn(),
     };
 
@@ -1153,7 +1156,7 @@ describe("AuthService", () => {
       await service.revokeRefreshToken("some-token");
 
       expect(refreshTokensRepository.update).toHaveBeenCalledWith(
-        { familyId: "family-1" },
+        { familyId: "family-1", isRevoked: false },
         { isRevoked: true },
       );
     });
@@ -2204,9 +2207,8 @@ describe("AuthService", () => {
         service.refreshTokens("reused-refresh-token"),
       ).rejects.toThrow("Refresh token reuse detected");
 
-      expect(manager.update).toHaveBeenCalledWith(
-        RefreshToken,
-        { familyId: "family-replay" },
+      expect(refreshTokensRepository.update).toHaveBeenCalledWith(
+        { familyId: "family-replay", isRevoked: false },
         { isRevoked: true },
       );
     });
@@ -2250,9 +2252,8 @@ describe("AuthService", () => {
         service.refreshTokens("valid-token-inactive-user"),
       ).rejects.toThrow("User not found or inactive");
 
-      expect(manager.update).toHaveBeenCalledWith(
-        RefreshToken,
-        { familyId: "family-inactive" },
+      expect(refreshTokensRepository.update).toHaveBeenCalledWith(
+        { familyId: "family-inactive", isRevoked: false },
         { isRevoked: true },
       );
     });
@@ -2284,9 +2285,8 @@ describe("AuthService", () => {
         "User not found or inactive",
       );
 
-      expect(manager.update).toHaveBeenCalledWith(
-        RefreshToken,
-        { familyId: "family-gone" },
+      expect(refreshTokensRepository.update).toHaveBeenCalledWith(
+        { familyId: "family-gone", isRevoked: false },
         { isRevoked: true },
       );
     });

--- a/backend/src/auth/token.service.spec.ts
+++ b/backend/src/auth/token.service.spec.ts
@@ -59,6 +59,9 @@ describe("TokenService", () => {
       save: jest.fn().mockResolvedValue(mockRefreshToken),
       findOne: jest.fn(),
       update: jest.fn().mockResolvedValue({ affected: 1 }),
+      // A revocation re-reads to confirm nothing is still live, so the double
+      // has to answer that question -- see revokeUntilNoneLive.
+      count: jest.fn().mockResolvedValue(0),
       delete: jest.fn().mockResolvedValue({ affected: 0 }),
     };
 
@@ -196,13 +199,24 @@ describe("TokenService", () => {
 
   describe("refreshTokens", () => {
     let mockManager: Record<string, jest.Mock>;
+    let familyRepo: Record<string, jest.Mock>;
 
     beforeEach(() => {
+      // The in-transaction family revocations go through
+      // `manager.getRepository(RefreshToken)` rather than `manager.update`, so
+      // the double routes there and the spec asserts on it. Typed as the
+      // repository surface the service actually uses, so a signature change
+      // shows up here rather than as a passing test of a method that moved.
+      familyRepo = {
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+        count: jest.fn().mockResolvedValue(0),
+      };
       mockManager = {
         findOne: jest.fn(),
         update: jest.fn().mockResolvedValue({ affected: 1 }),
         save: jest.fn().mockImplementation((entity) => Promise.resolve(entity)),
         create: jest.fn().mockImplementation((_Entity, data) => data),
+        getRepository: jest.fn(() => familyRepo),
       };
 
       dataSource.transaction.mockImplementation(async (callback) => {
@@ -311,11 +325,15 @@ describe("TokenService", () => {
         UnauthorizedException,
       );
 
-      expect(mockManager.update).toHaveBeenCalledWith(
-        RefreshToken,
-        { familyId: "family-1" },
+      expect(familyRepo.update).toHaveBeenCalledWith(
+        { familyId: "family-1", isRevoked: false },
         { isRevoked: true },
       );
+      // And it confirmed the family is actually dead rather than assuming one
+      // statement was enough.
+      expect(familyRepo.count).toHaveBeenCalledWith({
+        where: { familyId: "family-1", isRevoked: false },
+      });
     });
 
     it("should throw with correct message on replay detection", async () => {
@@ -378,11 +396,15 @@ describe("TokenService", () => {
         UnauthorizedException,
       );
 
-      expect(mockManager.update).toHaveBeenCalledWith(
-        RefreshToken,
-        { familyId: "family-1" },
+      expect(familyRepo.update).toHaveBeenCalledWith(
+        { familyId: "family-1", isRevoked: false },
         { isRevoked: true },
       );
+      // And it confirmed the family is actually dead rather than assuming one
+      // statement was enough.
+      expect(familyRepo.count).toHaveBeenCalledWith({
+        where: { familyId: "family-1", isRevoked: false },
+      });
     });
 
     it("should revoke family and throw when user is inactive", async () => {
@@ -403,11 +425,15 @@ describe("TokenService", () => {
         "User not found or inactive",
       );
 
-      expect(mockManager.update).toHaveBeenCalledWith(
-        RefreshToken,
-        { familyId: "family-1" },
+      expect(familyRepo.update).toHaveBeenCalledWith(
+        { familyId: "family-1", isRevoked: false },
         { isRevoked: true },
       );
+      // And it confirmed the family is actually dead rather than assuming one
+      // statement was enough.
+      expect(familyRepo.count).toHaveBeenCalledWith({
+        where: { familyId: "family-1", isRevoked: false },
+      });
     });
   });
 
@@ -416,8 +442,36 @@ describe("TokenService", () => {
       await service.revokeTokenFamily("family-1");
 
       expect(refreshTokensRepository.update).toHaveBeenCalledWith(
-        { familyId: "family-1" },
+        { familyId: "family-1", isRevoked: false },
         { isRevoked: true },
+      );
+    });
+
+    it("looks again, and revokes again, when a token is still live", async () => {
+      // The shape of the real race: a rotation committed its replacement after
+      // the first statement's snapshot, so the first pass could not see it and
+      // the second must. A single-pass revocation returns here having left a
+      // usable session behind a confirmed logout --
+      // `test/integration/race-refresh-token-revocation.integration.spec.ts`
+      // drives that against a real database; this asserts the loop exists.
+      refreshTokensRepository.count
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(0);
+
+      await service.revokeTokenFamily("family-1");
+
+      expect(refreshTokensRepository.update).toHaveBeenCalledTimes(2);
+      expect(refreshTokensRepository.count).toHaveBeenCalledTimes(2);
+    });
+
+    it("fails loudly rather than reporting a partial revocation", async () => {
+      // A revocation that cannot converge must not return: the caller is a
+      // logout, and "mostly logged out" is the failure this method exists to
+      // prevent.
+      refreshTokensRepository.count.mockResolvedValue(1);
+
+      await expect(service.revokeTokenFamily("family-1")).rejects.toThrow(
+        /did not converge/,
       );
     });
   });
@@ -435,7 +489,7 @@ describe("TokenService", () => {
         where: { tokenHash: "hashed-token" },
       });
       expect(refreshTokensRepository.update).toHaveBeenCalledWith(
-        { familyId: "family-1" },
+        { familyId: "family-1", isRevoked: false },
         { isRevoked: true },
       );
     });

--- a/backend/src/auth/token.service.ts
+++ b/backend/src/auth/token.service.ts
@@ -133,10 +133,14 @@ export class TokenService {
 
       // Replay detection: if token is revoked, a previously-rotated token was reused
       if (existingToken.isRevoked) {
-        await manager.update(
-          RefreshToken,
+        // Convergent, for the reason revokeUntilNoneLive documents: a legitimate
+        // rotation of another live row of this family can commit its replacement
+        // after this statement's snapshot, and the family must be dead when the
+        // attacker's request is refused, not nearly dead.
+        await this.revokeUntilNoneLive(
+          manager.getRepository(RefreshToken),
           { familyId: existingToken.familyId },
-          { isRevoked: true },
+          `family ${existingToken.familyId}`,
         );
         throw new UnauthorizedException(
           tr(
@@ -159,10 +163,10 @@ export class TokenService {
       });
 
       if (!user || !user.isActive) {
-        await manager.update(
-          RefreshToken,
+        await this.revokeUntilNoneLive(
+          manager.getRepository(RefreshToken),
           { familyId: existingToken.familyId },
-          { isRevoked: true },
+          `family ${existingToken.familyId}`,
         );
         throw new UnauthorizedException(
           tr(
@@ -219,9 +223,73 @@ export class TokenService {
   }
 
   async revokeTokenFamily(familyId: string): Promise<void> {
-    await this.scoped(RefreshToken, (repo) =>
-      repo.update({ familyId }, { isRevoked: true }),
+    await withScopedDb(this.dataSource, (manager) =>
+      this.revokeUntilNoneLive(
+        manager.getRepository(RefreshToken),
+        { familyId },
+        `family ${familyId}`,
+      ),
     );
+  }
+
+  /**
+   * How many times a revocation will re-look for a descendant a concurrent
+   * rotation committed underneath it. Two passes settle the ordinary race; the
+   * rest of the budget exists so a pathological one fails loudly instead of
+   * spinning.
+   */
+  private static readonly REVOKE_CONVERGENCE_PASSES = 8;
+
+  /**
+   * Revokes every token matching `criteria`, then looks again, until none is
+   * live.
+   *
+   * The second look is the whole point. A single
+   * `UPDATE ... WHERE family_id = $1` cannot revoke a rotation's replacement
+   * token, because of how the two transactions have to interleave: the rotation
+   * holds `FOR UPDATE` on the token it is replacing for its whole transaction,
+   * so the revocation's statement blocks on that row and the rotation always
+   * commits first -- meaning the replacement row was inserted *after* the
+   * revocation statement took its snapshot, and is invisible to it. The
+   * revocation then reports success, and the descendant of the token the user
+   * just logged out stays valid for its full lifetime. Reuse detection does not
+   * catch it either: nothing was reused.
+   *
+   * A second statement takes a fresh snapshot under READ COMMITTED, which is
+   * where the descendant finally becomes visible. Looping on a *read* rather
+   * than on `affected` matters: the parent row the rotation already revoked
+   * itself no longer counts as changed, so an `affected === 0` exit would stop
+   * one row short of the token that matters.
+   *
+   * `race-refresh-token-revocation.integration.spec.ts` drives exactly that
+   * interleaving, and fails on a single-pass revocation.
+   */
+  private async revokeUntilNoneLive(
+    repo: Repository<RefreshToken>,
+    criteria: { familyId: string } | { userId: string },
+    describe: string,
+  ): Promise<void> {
+    for (let pass = 1; ; pass++) {
+      // Narrowed to the live rows so a repeat pass does not restamp
+      // `updated_at` on tokens that were already revoked. That narrowing is
+      // safe here and would not be safe as an exit condition: each statement
+      // takes its own snapshot, so pass two still sees the descendant even
+      // though pass one reported no rows changed.
+      await repo.update({ ...criteria, isRevoked: false }, { isRevoked: true });
+      const live = await repo.count({
+        where: { ...criteria, isRevoked: false },
+      });
+      if (live === 0) return;
+      if (pass >= TokenService.REVOKE_CONVERGENCE_PASSES) {
+        // Never return quietly here: the caller is a logout or a reuse
+        // response, and a silent partial revocation is the security failure
+        // this method exists to prevent.
+        throw new Error(
+          `Refresh-token revocation for ${describe} did not converge: ` +
+            `${live} token(s) still live after ${pass} passes`,
+        );
+      }
+    }
   }
 
   async revokeRefreshToken(rawRefreshToken: string): Promise<void> {
@@ -238,8 +306,15 @@ export class TokenService {
   }
 
   async revokeAllUserRefreshTokens(userId: string): Promise<void> {
-    await this.scoped(RefreshToken, (repo) =>
-      repo.update({ userId, isRevoked: false }, { isRevoked: true }),
+    // Same convergence requirement as a family revocation, and reached the same
+    // way -- a rotation in flight on any of this user's families commits its
+    // replacement after this statement's snapshot.
+    await withScopedDb(this.dataSource, (manager) =>
+      this.revokeUntilNoneLive(
+        manager.getRepository(RefreshToken),
+        { userId },
+        `user ${userId}`,
+      ),
     );
   }
 

--- a/backend/src/emergency-access/emergency-access-claim.controller.ts
+++ b/backend/src/emergency-access/emergency-access-claim.controller.ts
@@ -190,8 +190,18 @@ export class EmergencyAccessClaimController {
     const tokenHash = hashToken(dto.token);
     const passwordHash = await bcrypt.hash(dto.newPassword, 12);
     const ownerId = await withScopedDb(this.dataSource, async (manager) => {
+      // `FOR UPDATE`, and not merely for tidiness: this is the single-use check,
+      // and without the lock two claims arriving together both read
+      // `claim_token_used_at IS NULL`, both rewrite the owner's password, and
+      // both are told they succeeded -- while only the last write survives, so
+      // one contact holds a password that does not work and the account has been
+      // handed to someone who was told they lost. With the lock the second
+      // claim's SELECT re-evaluates after the first commits, finds the hash
+      // cleared, matches nothing, and returns the not-found this endpoint
+      // already has for a spent link.
       const contact = await manager.findOne(EmergencyAccessContact, {
         where: { claimTokenHash: tokenHash },
+        lock: { mode: "pessimistic_write" },
       });
       if (
         !contact ||

--- a/backend/src/securities/holdings.service.ts
+++ b/backend/src/securities/holdings.service.ts
@@ -54,6 +54,67 @@ export class HoldingsService {
     return manager ? fn(manager) : withScopedDb(this.dataSource, fn);
   }
 
+  /**
+   * Serializes holdings work for these accounts by locking their `accounts` rows
+   * for the rest of the caller's transaction.
+   *
+   * Holdings cannot serialize on themselves. A rebuild deletes every holding for
+   * an account and re-inserts from a replay, while a trade upserts one -- and the
+   * row a concurrent trade is about to create does not exist yet, so there is
+   * nothing to lock. Without a common parent to contend on, a trade committing
+   * between the rebuild's read of the transactions and its delete/insert was
+   * simply erased from holdings: the `investment_transactions` row survived, so
+   * the shares reappeared at the next rebuild and vanished again in between,
+   * which is an unusually confusing way to lose a position.
+   *
+   * The account row is that common parent. Locked in id order, because a rebuild
+   * takes several at once and two of them arriving in opposite orders would
+   * deadlock. Nothing else in the trade path locks an account before its cash
+   * balance update, so there is no cycle with that either.
+   *
+   * **Every** entry point that reads or writes an account's holdings takes it:
+   * `createOrUpdate`, `applySplit` (and so `reverseSplit`), `adjustQuantity`,
+   * and both rebuilds. A lock only half the mutators take serializes nothing --
+   * the first round of this fix put it on `createOrUpdate` and the whole-user
+   * rebuild only, which left the `SPLIT` / `ADD_SHARES` / `REMOVE_SHARES`
+   * edit and delete paths free to interleave with a rebuild and leave holdings
+   * disagreeing with the transaction history. `race-holdings-rebuild` covers
+   * those paths specifically, because the `BUY` it originally covered went
+   * through the one mutator that did lock.
+   */
+  private async lockHoldingAccounts(
+    m: EntityManager,
+    accountIds: string[],
+  ): Promise<void> {
+    if (accountIds.length === 0) return;
+    await m.query(
+      `SELECT id FROM accounts WHERE id = ANY($1::uuid[]) ORDER BY id FOR UPDATE`,
+      [[...accountIds].sort()],
+    );
+  }
+
+  /**
+   * Public entry to {@link lockHoldingAccounts}, for an operation that mutates
+   * holdings across **more than one** account in the same transaction.
+   *
+   * The single-account mutators lock their one account themselves, and that is
+   * enough on its own -- but not when two of them run back to back on different
+   * accounts. A security transfer creates a `TRANSFER_OUT` (locking the source)
+   * and then a `TRANSFER_IN` (locking the destination), so it acquires the pair
+   * source-then-destination; a simultaneous reverse transfer acquires the same
+   * pair destination-then-source, and the two deadlock (review R4-002). The
+   * caller must take the whole set here first, in the sorted order this uses, so
+   * every multi-account holdings operation acquires them the same way. The
+   * per-leg locks that follow re-take rows already held -- a no-op -- so the
+   * order this establishes is the one that counts.
+   */
+  async lockAccountsForHoldings(
+    m: EntityManager,
+    accountIds: string[],
+  ): Promise<void> {
+    await this.lockHoldingAccounts(m, accountIds);
+  }
+
   async findAll(userId: string, accountId?: string): Promise<Holding[]> {
     return withScopedDb(this.dataSource, (m) => {
       const query = m
@@ -211,6 +272,7 @@ export class HoldingsService {
     await this.securitiesService.findOne(userId, securityId);
 
     return this.inScope(manager, async (m) => {
+      await this.lockHoldingAccounts(m, [accountId]);
       const repo = m.getRepository(Holding);
 
       // Find existing holding
@@ -320,6 +382,7 @@ export class HoldingsService {
     }
 
     return this.inScope(manager, async (m) => {
+      await this.lockHoldingAccounts(m, [accountId]);
       const holding = await this.findByAccountAndSecurity(
         accountId,
         securityId,
@@ -373,6 +436,7 @@ export class HoldingsService {
     await this.securitiesService.findOne(userId, securityId);
 
     return this.inScope(manager, async (m) => {
+      await this.lockHoldingAccounts(m, [accountId]);
       const repo = m.getRepository(Holding);
 
       let holding = await this.findByAccountAndSecurity(
@@ -686,6 +750,11 @@ export class HoldingsService {
   ): Promise<void> {
     if (accountIds.length === 0) return;
 
+    // Same lock as the whole-user rebuild, for the same reason: this runs inside
+    // the caller's transaction, so taking it here serializes this partial
+    // rebuild against every other holdings mutation on those accounts.
+    await this.lockHoldingAccounts(manager, accountIds);
+
     // Only brokerage / standalone investment accounts track holdings; the cash
     // sleeve of an investment account is excluded everywhere else, so it must be
     // excluded here too or its rows would be deleted but never rebuilt.
@@ -765,37 +834,51 @@ export class HoldingsService {
     holdingsUpdated: number;
     holdingsDeleted: number;
   }> {
-    // M14: Get all investment accounts (brokerage + standalone) for the user
-    const investmentAccounts = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(Account).find({
+    const cutoff = asOfDate ?? this.serverToday();
+
+    // Rebuild holdings from transactions
+    let holdingsDeleted = 0;
+    let holdingsCreated = 0;
+
+    // One transaction for the whole rebuild, with the accounts locked before
+    // anything is read. Reading the accounts and the transactions in earlier,
+    // separate transactions and then deleting and re-inserting from that
+    // snapshot meant a trade committing in between was replaced by a replay that
+    // predated it -- the position disappeared until the next rebuild put it back.
+    // Both halves matter: the single transaction makes the read and the write
+    // agree, and the lock is what makes a concurrent trade wait rather than land
+    // in the gap. `test/integration/race-holdings-rebuild.integration.spec.ts`
+    // fails on either half alone.
+    const result = await withScopedDb(this.dataSource, async (m) => {
+      // M14: Get all investment accounts (brokerage + standalone) for the user
+      const investmentAccounts = await m.getRepository(Account).find({
         where: {
           userId,
           accountType: AccountType.INVESTMENT,
         },
-      }),
-    );
+      });
 
-    // Include brokerage accounts and standalone investment accounts (null subType)
-    const eligibleAccounts = investmentAccounts.filter(
-      (a) =>
-        a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
-        !a.accountSubType,
-    );
+      // Include brokerage accounts and standalone investment accounts (null subType)
+      const eligibleAccounts = investmentAccounts.filter(
+        (a) =>
+          a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
+          !a.accountSubType,
+      );
 
-    if (eligibleAccounts.length === 0) {
-      return { holdingsCreated: 0, holdingsUpdated: 0, holdingsDeleted: 0 };
-    }
+      if (eligibleAccounts.length === 0) {
+        return { holdingsCreated: 0, holdingsUpdated: 0, holdingsDeleted: 0 };
+      }
 
-    const brokerageAccountIds = eligibleAccounts.map((a) => a.id);
+      const brokerageAccountIds = eligibleAccounts.map((a) => a.id);
+      await this.lockHoldingAccounts(m, brokerageAccountIds);
 
-    // Get all investment transactions for these accounts up to the cutoff date,
-    // ordered by date. Future-dated transactions are excluded so they don't
-    // affect current holdings. Callers materializing matured transactions (the
-    // hourly cron) pass the user's timezone-correct "today" so a transfer dated
-    // today in a timezone ahead of the server isn't wrongly treated as future.
-    const cutoff = asOfDate ?? this.serverToday();
-    const transactions = await withScopedDb(this.dataSource, (m) =>
-      m.getRepository(InvestmentTransaction).find({
+      // Get all investment transactions for these accounts up to the cutoff
+      // date, ordered by date. Future-dated transactions are excluded so they
+      // don't affect current holdings. Callers materializing matured
+      // transactions (the hourly cron) pass the user's timezone-correct "today"
+      // so a transfer dated today in a timezone ahead of the server isn't
+      // wrongly treated as future.
+      const transactions = await m.getRepository(InvestmentTransaction).find({
         where: {
           userId,
           accountId: In(brokerageAccountIds),
@@ -805,18 +888,11 @@ export class HoldingsService {
           transactionDate: "ASC",
           createdAt: "ASC",
         },
-      }),
-    );
+      });
 
-    // Rebuild holdings from transactions
-    // Map: accountId -> securityId -> { quantity, totalCost }
-    const holdingsMap = this.computeHoldingsMap(transactions);
+      // Map: accountId -> securityId -> { quantity, totalCost }
+      const holdingsMap = this.computeHoldingsMap(transactions);
 
-    // Wrap delete-all + rebuild in a transaction for atomicity
-    let holdingsDeleted = 0;
-    let holdingsCreated = 0;
-
-    await withScopedDb(this.dataSource, async (m) => {
       // Delete all existing holdings for these accounts
       const existingHoldings = await m.find(Holding, {
         where: { accountId: In(brokerageAccountIds) },
@@ -850,13 +926,15 @@ export class HoldingsService {
         await holdingsRepo.save(holdingsToCreate);
       }
       holdingsCreated = holdingsToCreate.length;
+
+      return {
+        holdingsCreated,
+        holdingsUpdated: 0, // We deleted and recreated, so no updates
+        holdingsDeleted,
+      };
     });
 
-    return {
-      holdingsCreated,
-      holdingsUpdated: 0, // We deleted and recreated, so no updates
-      holdingsDeleted,
-    };
+    return result;
   }
 
   /**

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -238,6 +238,7 @@ describe("InvestmentTransactionsService", () => {
     transactionsService = {};
 
     holdingsService = {
+      lockAccountsForHoldings: jest.fn().mockResolvedValue(undefined),
       updateHolding: jest.fn().mockResolvedValue(undefined),
       adjustQuantity: jest.fn().mockResolvedValue(undefined),
       applySplit: jest.fn().mockResolvedValue(undefined),

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -1529,6 +1529,18 @@ export class InvestmentTransactionsService {
     const { outId, inId } = await withScopedDb(
       this.dataSource,
       async (manager) => {
+        // Lock both accounts before touching either leg, in one deterministic
+        // order (review R4-002). The legs below each lock their own account --
+        // TRANSFER_OUT the source, TRANSFER_IN the destination -- so without this
+        // the pair is acquired source-then-destination, and a simultaneous
+        // reverse transfer acquiring destination-then-source deadlocks. Taking
+        // the whole set up front, sorted, makes every transfer acquire them the
+        // same way; the per-leg locks that follow are then no-op re-locks.
+        await this.holdingsService.lockAccountsForHoldings(manager, [
+          dto.fromAccountId,
+          dto.toAccountId,
+        ]);
+
         const transferOut = manager.create(InvestmentTransaction, {
           userId,
           accountId: dto.fromAccountId,
@@ -2610,6 +2622,20 @@ export class InvestmentTransactionsService {
     }
 
     await withScopedDb(this.dataSource, async (manager) => {
+      // Lock every account this edit could touch -- both legs' current accounts
+      // and any they are being rerouted to -- before reversing or reapplying
+      // either leg (review R4-002). Same reason as the create path: without a
+      // single up-front acquisition, two edits touching the same account pair in
+      // opposite orders deadlock.
+      await this.holdingsService.lockAccountsForHoldings(manager, [
+        editedLeg.accountId,
+        linkedLeg.accountId,
+        ...(updateDto.accountId ? [updateDto.accountId] : []),
+        ...(updateDto.destinationAccountId
+          ? [updateDto.destinationAccountId]
+          : []),
+      ]);
+
       // Reverse both legs at their original values before reapplying.
       await this.reverseTransactionEffectsInTransaction(
         manager,
@@ -3359,6 +3385,15 @@ export class InvestmentTransactionsService {
     );
 
     await withScopedDb(this.dataSource, async (manager) => {
+      // Lock both legs' accounts before reversing either (review R4-002). The
+      // reverses lock each account incrementally, so deleting A->B and deleting
+      // B->A at the same time would otherwise acquire the pair in opposite
+      // orders and deadlock. `affectedAccountIds` is exactly that set.
+      await this.holdingsService.lockAccountsForHoldings(
+        manager,
+        affectedAccountIds,
+      );
+
       // Break the mutual link before deleting so neither row's FK points at a
       // row that is about to disappear.
       for (const leg of legsToRemove) {

--- a/backend/test/helpers/race-harness.ts
+++ b/backend/test/helpers/race-harness.ts
@@ -1,0 +1,312 @@
+import { DataSource, QueryRunner } from "typeorm";
+
+/**
+ * Primitives for racing two or more requests at the **production conflict
+ * boundary**: independent connections, independent transactions, and
+ * synchronisation on observable conditions rather than on elapsed time.
+ *
+ * Why this file exists. A `Promise.all` around two calls into one service
+ * instance looks like a race and mostly is not: whichever call reaches the
+ * database first usually also finishes first, so the interleaving that breaks
+ * production is never reached and the test passes for the wrong reason. Worse,
+ * the same `Promise.all` passes just as happily when the guard it is supposed to
+ * exercise is deleted. Every concurrency test in this repository before this
+ * harness had one of those two shapes, which is what audit finding P7-008
+ * recorded.
+ *
+ * Three rules follow, and the helpers here exist to make them cheap:
+ *
+ * 1. **Independent connections.** Each participant runs under its own
+ *    `withUserContext`, so its `withScopedDb` draws a fresh pooled connection
+ *    and opens its own transaction. Two calls sharing one ambient transaction
+ *    cannot conflict with each other at all -- they are the same transaction.
+ * 2. **No sleeps.** `sleep(50)` is a guess about scheduling that is wrong under
+ *    load, which is where a flaky concurrency test comes from. Wait on a
+ *    condition the database can be asked about: a backend blocked on a lock, a
+ *    transaction sitting open. {@link waitForBlockedBackends} and
+ *    {@link waitForIdleInTransaction} are those questions.
+ * 3. **A positive control per race.** A race test that passes must be shown to
+ *    fail when the guard is removed, or it is only asserting that nothing
+ *    happened. `race-harness.spec.ts` does that for the harness itself, with an
+ *    intentionally unguarded read-modify-write that loses an update through the
+ *    same gate the real tests use.
+ */
+
+/** How long any wait-for-condition helper will keep asking before giving up. */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** Gap between polls of a database condition. Not a synchronisation device. */
+const POLL_INTERVAL_MS = 10;
+
+/**
+ * A one-shot signal. `wait()` resolves once `open()` has been called, whichever
+ * happens first, so there is no window in which a participant misses it.
+ */
+export class Latch {
+  private opened = false;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(readonly name: string) {}
+
+  open(): void {
+    if (this.opened) return;
+    this.opened = true;
+    for (const resolve of this.waiters.splice(0)) resolve();
+  }
+
+  get isOpen(): boolean {
+    return this.opened;
+  }
+
+  async wait(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<void> {
+    if (this.opened) return;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error(`Latch "${this.name}" was never opened`));
+      }, timeoutMs);
+      this.waiters.push(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+}
+
+/**
+ * A rendezvous for a known number of participants: every `arrive()` blocks
+ * until the last one arrives, then all resume.
+ *
+ * Use this to line participants up so each is provably inside its own
+ * transaction before any of them is allowed to reach the contended write.
+ */
+export class Barrier {
+  private arrived = 0;
+  private readonly latch: Latch;
+
+  constructor(
+    readonly name: string,
+    private readonly parties: number,
+  ) {
+    this.latch = new Latch(`barrier:${name}`);
+  }
+
+  async arrive(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<void> {
+    this.arrived += 1;
+    if (this.arrived >= this.parties) {
+      this.latch.open();
+      return;
+    }
+    await this.latch.wait(timeoutMs);
+  }
+}
+
+/**
+ * Waits for an arbitrary condition, polled, with a timeout that names what it was
+ * waiting for.
+ *
+ * Exported because some races have to wait on a disjunction the harness cannot
+ * know about -- "the other participant has either committed or is blocked",
+ * which is the shape needed when the *presence* of the fix changes which of the
+ * two happens. The condition still has to be observable; this is not a licence
+ * to poll a wall clock.
+ */
+export async function waitUntil(
+  describe: string,
+  condition: () => Promise<boolean>,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<void> {
+  await waitFor(describe, condition, timeoutMs);
+}
+
+/** Backends of this database currently blocked waiting for a lock. */
+export async function blockedBackendCount(
+  dataSource: DataSource,
+): Promise<number> {
+  const rows: Array<{ blocked: string }> = await dataSource.query(
+    `SELECT COUNT(*)::text AS blocked
+       FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND pid <> pg_backend_pid()
+        AND wait_event_type = 'Lock'`,
+  );
+  return Number(rows[0].blocked);
+}
+
+async function waitFor(
+  describe: string,
+  condition: () => Promise<boolean>,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await condition()) return;
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for ${describe}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+}
+
+/**
+ * Resolves once at least `count` backends of this database are blocked waiting
+ * for a lock.
+ *
+ * This is the harness's substitute for "give the other request a moment to get
+ * going". A participant blocked on a row lock is a fact PostgreSQL will report,
+ * so the test can proceed the instant it is true and cannot proceed while it is
+ * false.
+ */
+export async function waitForBlockedBackends(
+  dataSource: DataSource,
+  count: number,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<void> {
+  await waitFor(
+    `${count} backend(s) blocked on a lock`,
+    async () => {
+      const rows: Array<{ blocked: string }> = await dataSource.query(
+        `SELECT COUNT(*)::text AS blocked
+           FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND pid <> pg_backend_pid()
+            AND wait_event_type = 'Lock'`,
+      );
+      return Number(rows[0].blocked) >= count;
+    },
+    timeoutMs,
+  );
+}
+
+/**
+ * Resolves once at least `count` backends are sitting in an open transaction
+ * with no statement running.
+ *
+ * That is the observable form of "the participant has begun its transaction and
+ * taken its snapshot", which is the starting gun for every stale-snapshot race.
+ */
+export async function waitForIdleInTransaction(
+  dataSource: DataSource,
+  count: number,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<void> {
+  await waitFor(
+    `${count} backend(s) idle in transaction`,
+    async () => {
+      const rows: Array<{ open: string }> = await dataSource.query(
+        `SELECT COUNT(*)::text AS open
+           FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND pid <> pg_backend_pid()
+            AND state = 'idle in transaction'`,
+      );
+      return Number(rows[0].open) >= count;
+    },
+    timeoutMs,
+  );
+}
+
+/**
+ * An independent transaction that holds row locks until the test releases them.
+ *
+ * The gate is how a race becomes deterministic without reaching inside the code
+ * under test. It opens its own connection, locks the rows every participant must
+ * touch, and holds them; each participant then starts, runs as far as that row
+ * and stops there, inside its own transaction. When {@link release} commits, all
+ * of them are freed into the contended window at once -- so whatever guard the
+ * application has (a conditional UPDATE, a `FOR UPDATE`, a unique index) is what
+ * decides the outcome, exactly as in production.
+ *
+ * A gate must be released in a `finally`. A leaked gate holds locks for the rest
+ * of the suite, and the failure shows up as an unrelated spec timing out.
+ */
+export class RowGate {
+  private constructor(private readonly runner: QueryRunner) {}
+
+  /**
+   * Opens a transaction on its own connection and locks whatever `sql` selects.
+   * `sql` must end in `FOR UPDATE` (or another locking clause) -- a plain SELECT
+   * gates nothing, and a gate that gates nothing turns every race built on it
+   * into a `Promise.all` again.
+   */
+  static async hold(
+    dataSource: DataSource,
+    sql: string,
+    params: unknown[] = [],
+  ): Promise<RowGate> {
+    if (!/\bfor\s+(update|no\s+key\s+update|share|key\s+share)\b/i.test(sql)) {
+      throw new Error(
+        `RowGate.hold needs a locking SELECT; "${sql}" would hold nothing`,
+      );
+    }
+    const runner = dataSource.createQueryRunner();
+    await runner.connect();
+    await runner.startTransaction();
+    try {
+      await runner.query(sql, params);
+    } catch (error) {
+      await runner.rollbackTransaction().catch(() => undefined);
+      await runner.release();
+      throw error;
+    }
+    return new RowGate(runner);
+  }
+
+  /** Commits, freeing every participant waiting on the locked rows. */
+  async release(): Promise<void> {
+    if (this.runner.isReleased) return;
+    if (this.runner.isTransactionActive) await this.runner.commitTransaction();
+    await this.runner.release();
+  }
+}
+
+/** What one racing participant did. */
+export type Outcome<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: unknown };
+
+/**
+ * Runs every participant concurrently and reports what each one did, including
+ * the ones that threw.
+ *
+ * `Promise.all` is the wrong tool for a race: the first rejection discards the
+ * other outcomes, and "one of them was rejected" is usually the assertion the
+ * test most needs to make. Losing a race is a normal, expected result here.
+ */
+export async function raceAll<T>(
+  participants: Array<() => Promise<T>>,
+): Promise<Array<Outcome<T>>> {
+  const settled = await Promise.allSettled(participants.map((run) => run()));
+  return settled.map((result) =>
+    result.status === "fulfilled"
+      ? { ok: true, value: result.value }
+      : { ok: false, error: result.reason },
+  );
+}
+
+/** The outcomes that succeeded. */
+export const winners = <T>(outcomes: Array<Outcome<T>>): T[] =>
+  outcomes.filter((o): o is { ok: true; value: T } => o.ok).map((o) => o.value);
+
+/** The outcomes that threw. */
+export const losers = <T>(outcomes: Array<Outcome<T>>): unknown[] =>
+  outcomes
+    .filter((o): o is { ok: false; error: unknown } => !o.ok)
+    .map((o) => o.error);
+
+/**
+ * A readable summary of a race, for a failure message. Without it, a broken
+ * single-winner assertion reports `2` versus `1` and nothing about why.
+ */
+export function describeOutcomes<T>(outcomes: Array<Outcome<T>>): string {
+  return outcomes
+    .map((outcome, index) =>
+      outcome.ok
+        ? `#${index}: ok ${JSON.stringify(outcome.value)}`
+        : `#${index}: threw ${
+            outcome.error instanceof Error
+              ? `${outcome.error.constructor.name}: ${outcome.error.message}`
+              : String(outcome.error)
+          }`,
+    )
+    .join("\n");
+}

--- a/backend/test/integration/race-account-balance.integration.spec.ts
+++ b/backend/test/integration/race-account-balance.integration.spec.ts
@@ -1,0 +1,189 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+
+import { AccountsService } from "@/accounts/accounts.service";
+import { AccountsModule } from "@/accounts/accounts.module";
+import { Account } from "@/accounts/entities/account.entity";
+import { withUserContext } from "@/common/db/with-context";
+
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { createTestAccount } from "../helpers/test-factories";
+import {
+  RowGate,
+  raceAll,
+  waitForBlockedBackends,
+  winners,
+} from "../helpers/race-harness";
+
+/**
+ * P4-003 and P4-005 / audit races 2 and 4: a balance recompute against a
+ * concurrent write to the same account.
+ *
+ * A recompute is triggered from a dozen places -- creating a future-dated
+ * transaction, voiding one, an import, a timezone change, the hourly cron -- so
+ * "a recompute is running while the user edits the account" is an ordinary
+ * Tuesday, not an adversarial scenario. Two things could go wrong, and both did:
+ *
+ * - The recompute read the account in one transaction and summed the
+ *   transactions in another, so the opening balance it added the sum to could
+ *   already be superseded.
+ * - It then persisted the *whole entity* it had loaded, which reverted every
+ *   other column a concurrent edit had committed. That failure is silent: no
+ *   error, no conflict, the user's rename or credit-limit change is simply gone
+ *   the next time the page loads.
+ *
+ * The second is the interesting one to test, because it is invisible to any
+ * assertion about balances -- which is presumably why it survived a suite that
+ * checked balances thoroughly.
+ */
+describe("Account balance recompute under contention (integration)", () => {
+  let module: TestingModule;
+  let accounts: AccountsService;
+  let dataSource: DataSource;
+  let userId: string;
+  let accountId: string;
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([AccountsModule]);
+    accounts = module.get(AccountsService);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "transaction_splits",
+      "transactions",
+      "accounts",
+      "categories",
+      "payees",
+      "scheduled_transaction_splits",
+      "scheduled_transaction_overrides",
+      "scheduled_transactions",
+      "investment_transactions",
+      "monthly_account_balances",
+      "users",
+    ]);
+    userId = (await createTestUserDirect(dataSource)).id;
+    const account = await createTestAccount(dataSource, userId, {
+      name: "Chequing",
+      openingBalance: 1000,
+      currentBalance: 1000,
+    });
+    accountId = account.id;
+  });
+
+  const stored = (): Promise<Account> =>
+    dataSource.getRepository(Account).findOneByOrFail({ id: accountId });
+
+  it("does not revert a concurrent rename", async () => {
+    // Both participants must go through the account row, so the gate holds it and
+    // lets each of them queue up inside its own transaction first.
+    const gate = await RowGate.hold(
+      dataSource,
+      `SELECT id FROM accounts WHERE id = $1 FOR UPDATE`,
+      [accountId],
+    );
+
+    let outcomes;
+    try {
+      const running = raceAll([
+        () =>
+          withUserContext(userId, () =>
+            accounts.recalculateCurrentBalance(accountId),
+          ),
+        () =>
+          withUserContext(userId, () =>
+            accounts.update(userId, accountId, { name: "Chequing (joint)" }),
+          ),
+      ]);
+      await waitForBlockedBackends(dataSource, 2);
+      await gate.release();
+      outcomes = await running;
+    } finally {
+      await gate.release();
+    }
+
+    expect(winners(outcomes)).toHaveLength(2);
+    // Whichever order the two ran in, the rename is a committed user edit and a
+    // recompute has no mandate to undo it.
+    expect((await stored()).name).toBe("Chequing (joint)");
+  });
+
+  it("does not revert a concurrent opening-balance change, and agrees with it", async () => {
+    // The sharper version: the edit changes an input the recompute *reads*, so a
+    // stale snapshot shows up in the balance as well as in the reverted column.
+    await dataSource.query(
+      `INSERT INTO transactions (user_id, account_id, transaction_date, amount, currency_code, description)
+         VALUES ($1, $2, CURRENT_DATE, 250, 'CAD', 'deposit')`,
+      [userId, accountId],
+    );
+
+    const gate = await RowGate.hold(
+      dataSource,
+      `SELECT id FROM accounts WHERE id = $1 FOR UPDATE`,
+      [accountId],
+    );
+
+    try {
+      const running = raceAll([
+        () =>
+          withUserContext(userId, () =>
+            accounts.recalculateCurrentBalance(accountId),
+          ),
+        () =>
+          withUserContext(userId, () =>
+            accounts.update(userId, accountId, { openingBalance: 2000 }),
+          ),
+      ]);
+      await waitForBlockedBackends(dataSource, 2);
+      await gate.release();
+      await running;
+    } finally {
+      await gate.release();
+    }
+
+    const account = await stored();
+    expect(Number(account.openingBalance)).toBe(2000);
+    // The stored balance has to be reachable from the stored opening balance:
+    // 2000 + 250. A recompute that used the pre-edit opening balance would leave
+    // 1250 sitting against an opening balance of 2000 -- a row that describes no
+    // state the account was ever in.
+    expect(Number(account.currentBalance)).toBe(2250);
+  });
+
+  it("still recomputes correctly with no contention", async () => {
+    await dataSource.query(
+      `INSERT INTO transactions (user_id, account_id, transaction_date, amount, currency_code, description)
+         VALUES ($1, $2, CURRENT_DATE, -125.5, 'CAD', 'groceries')`,
+      [userId, accountId],
+    );
+
+    const result = await withUserContext(userId, () =>
+      accounts.recalculateCurrentBalance(accountId),
+    );
+
+    expect(Number(result.currentBalance)).toBe(874.5);
+    expect(Number((await stored()).currentBalance)).toBe(874.5);
+    // The returned entity must not have lost the rest of its fields either.
+    expect(result.name).toBe("Chequing");
+  });
+
+  it("refuses an account that does not exist", async () => {
+    await expect(
+      withUserContext(userId, () =>
+        accounts.recalculateCurrentBalance(
+          "00000000-0000-0000-0000-000000000000",
+        ),
+      ),
+    ).rejects.toThrow(/not found/i);
+  });
+});

--- a/backend/test/integration/race-emergency-claim.integration.spec.ts
+++ b/backend/test/integration/race-emergency-claim.integration.spec.ts
@@ -1,0 +1,270 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { DataSource } from "typeorm";
+import * as bcrypt from "bcryptjs";
+
+import { EmergencyAccessClaimController } from "@/emergency-access/emergency-access-claim.controller";
+import { EmergencyAccessContact } from "@/emergency-access/entities/emergency-access-contact.entity";
+import { EmergencyAccessSettings } from "@/emergency-access/entities/emergency-access-settings.entity";
+import { User } from "@/users/entities/user.entity";
+import { UserPreference } from "@/users/entities/user-preference.entity";
+import { TrustedDevice } from "@/users/entities/trusted-device.entity";
+import { TokenService } from "@/auth/token.service";
+import { AuthService } from "@/auth/auth.service";
+import { PasswordBreachService } from "@/auth/password-breach.service";
+import { AiEncryptionService } from "@/ai/ai-encryption.service";
+import { hashToken } from "@/auth/crypto.util";
+
+import {
+  INTEGRATION_TYPEORM_OPTIONS,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import {
+  RowGate,
+  describeOutcomes,
+  losers,
+  raceAll,
+  waitForBlockedBackends,
+  winners,
+} from "../helpers/race-harness";
+
+/**
+ * P4-007 / audit race 6: two emergency-access claims completing at once.
+ *
+ * An emergency claim hands an account over: it replaces the owner's password,
+ * clears their 2FA, drops their trusted devices, and signs the claimant in. It is
+ * single-use by construction -- the link's hash is consumed -- and the whole of
+ * that construction is a read of `claim_token_used_at` followed by a write.
+ *
+ * Without a lock on the read, two contacts completing together both pass the
+ * check, both rewrite the credentials, and both are told they now hold the
+ * account, while only the last password written actually works. The contact who
+ * is locked out was told they succeeded, and the owner's account went to whoever
+ * committed second. The code carried a comment claiming the transaction
+ * "re-validates under lock"; it did not, which is the kind of claim only a race
+ * against a real database can settle.
+ */
+describe("Emergency access claim single-use (integration)", () => {
+  let module: TestingModule;
+  let dataSource: DataSource;
+  let controller: EmergencyAccessClaimController;
+  let ownerId: string;
+  let generateTokenPair: jest.Mock;
+  let revokeAllUserRefreshTokens: jest.Mock;
+
+  const TOKEN_A = "claim-token-alpha";
+  const TOKEN_B = "claim-token-beta";
+
+  /** Enough of an express Response to satisfy the handler. */
+  const fakeResponse = () => {
+    const body: unknown[] = [];
+    return {
+      cookie: jest.fn(),
+      json: (payload: unknown) => {
+        body.push(payload);
+      },
+      body,
+    };
+  };
+
+  beforeAll(async () => {
+    generateTokenPair = jest
+      .fn()
+      .mockResolvedValue({ accessToken: "a", refreshToken: "r" });
+    revokeAllUserRefreshTokens = jest.fn().mockResolvedValue(undefined);
+
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        TypeOrmModule.forRoot(INTEGRATION_TYPEORM_OPTIONS),
+        TypeOrmModule.forFeature([
+          EmergencyAccessContact,
+          EmergencyAccessSettings,
+          User,
+          UserPreference,
+          TrustedDevice,
+        ]),
+      ],
+      controllers: [EmergencyAccessClaimController],
+      providers: [
+        // Typed doubles: the grant's side effects are what this race counts, so
+        // they have to be observable, and `jest.Mocked<T>` keeps their shapes
+        // honest against the real services.
+        {
+          provide: TokenService,
+          useValue: {
+            generateTokenPair,
+            revokeAllUserRefreshTokens,
+            getRefreshExpiryMs: () => 1000,
+          } as unknown as jest.Mocked<TokenService>,
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            getCsrfKey: () => "csrf-key",
+          } as unknown as jest.Mocked<AuthService>,
+        },
+        {
+          provide: PasswordBreachService,
+          useValue: {
+            isBreached: async () => false,
+          } as unknown as jest.Mocked<PasswordBreachService>,
+        },
+        {
+          provide: AiEncryptionService,
+          useValue: {
+            isConfigured: () => false,
+          } as unknown as jest.Mocked<AiEncryptionService>,
+        },
+      ],
+    }).compile();
+
+    dataSource = module.get(DataSource);
+    controller = module.get(EmergencyAccessClaimController);
+    module.get(ConfigService);
+  });
+
+  afterAll(async () => {
+    await module?.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "emergency_access_contacts",
+      "emergency_access_settings",
+      "trusted_devices",
+      "user_preferences",
+      "users",
+    ]);
+    generateTokenPair.mockClear();
+    revokeAllUserRefreshTokens.mockClear();
+
+    ownerId = (await createTestUserDirect(dataSource)).id;
+    const contacts = dataSource.getRepository(EmergencyAccessContact);
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    for (const [name, token] of [
+      ["Alpha", TOKEN_A],
+      ["Beta", TOKEN_B],
+    ] as const) {
+      await contacts.save(
+        contacts.create({
+          ownerUserId: ownerId,
+          firstName: name,
+          email: `${name.toLowerCase()}@example.com`,
+          claimTokenHash: hashToken(token),
+          claimTokenExpiresAt: expiresAt,
+          claimTokenUsedAt: null,
+          claimVoidedReason: null,
+        }),
+      );
+    }
+    await dataSource.query(
+      `INSERT INTO emergency_access_settings (owner_user_id, enabled) VALUES ($1, true)
+         ON CONFLICT (owner_user_id) DO UPDATE SET enabled = true`,
+      [ownerId],
+    );
+  });
+
+  const ownerPasswordHash = async (): Promise<string> => {
+    const owner = await dataSource
+      .getRepository(User)
+      .findOneByOrFail({ id: ownerId });
+    return owner.passwordHash!;
+  };
+
+  it("lets exactly one of two simultaneous completions take the account", async () => {
+    // Both claims are parked on the row the first one will consume, each inside
+    // its own transaction, so both are past their pre-checks and inside the
+    // window when they are released. Two distinct contacts, because the
+    // dangerous case is not a double-click -- it is two different people holding
+    // two valid links for the same owner.
+    const gate = await RowGate.hold(
+      dataSource,
+      `SELECT id FROM emergency_access_contacts WHERE owner_user_id = $1 FOR UPDATE`,
+      [ownerId],
+    );
+
+    let outcomes;
+    try {
+      const running = raceAll([
+        () =>
+          controller.complete(
+            { token: TOKEN_A, newPassword: "AlphaPassword123!" },
+            fakeResponse() as never,
+          ),
+        () =>
+          controller.complete(
+            { token: TOKEN_B, newPassword: "BetaPassword123!" },
+            fakeResponse() as never,
+          ),
+      ]);
+      await waitForBlockedBackends(dataSource, 2);
+      await gate.release();
+      outcomes = await running;
+    } finally {
+      await gate.release();
+    }
+
+    expect(winners(outcomes)).toHaveLength(1);
+    expect(losers(outcomes)).toHaveLength(1);
+
+    // One grant side effect, not two: the losing claimant must not have been
+    // issued a session for an account they do not hold.
+    expect(generateTokenPair).toHaveBeenCalledTimes(1);
+    expect(revokeAllUserRefreshTokens).toHaveBeenCalledTimes(1);
+
+    // And the surviving password must be the winner's. Before the lock both
+    // completions wrote, so the winner's password could be overwritten by the
+    // loser's -- leaving the person who was told they succeeded unable to sign in
+    // and the person who was told they failed holding the account.
+    const stored = await ownerPasswordHash();
+    const matches = await Promise.all([
+      bcrypt.compare("AlphaPassword123!", stored),
+      bcrypt.compare("BetaPassword123!", stored),
+    ]);
+    expect(matches.filter(Boolean)).toHaveLength(1);
+
+    const consumed = await dataSource
+      .getRepository(EmergencyAccessContact)
+      .count({ where: { claimTokenUsedAt: undefined } });
+    expect(consumed).toBeGreaterThanOrEqual(0);
+    expect(describeOutcomes(outcomes)).toContain("threw");
+  });
+
+  it("voids the sibling link rather than leaving it claimable", async () => {
+    await controller.complete(
+      { token: TOKEN_A, newPassword: "AlphaPassword123!" },
+      fakeResponse() as never,
+    );
+
+    await expect(
+      controller.complete(
+        { token: TOKEN_B, newPassword: "BetaPassword123!" },
+        fakeResponse() as never,
+      ),
+    ).rejects.toThrow();
+
+    const rows = await dataSource
+      .getRepository(EmergencyAccessContact)
+      .find({ order: { firstName: "ASC" } });
+    expect(rows.map((r) => r.claimTokenHash)).toEqual([null, null]);
+    expect(rows.every((r) => r.claimTokenUsedAt !== null)).toBe(true);
+    expect(rows.find((r) => r.firstName === "Beta")!.claimVoidedReason).toBe(
+      "claimed_by_other",
+    );
+  });
+
+  it("still completes a single uncontended claim", async () => {
+    await controller.complete(
+      { token: TOKEN_A, newPassword: "AlphaPassword123!" },
+      fakeResponse() as never,
+    );
+
+    expect(generateTokenPair).toHaveBeenCalledTimes(1);
+    expect(
+      await bcrypt.compare("AlphaPassword123!", await ownerPasswordHash()),
+    ).toBe(true);
+  });
+});

--- a/backend/test/integration/race-harness.integration.spec.ts
+++ b/backend/test/integration/race-harness.integration.spec.ts
@@ -1,0 +1,243 @@
+import { DataSource } from "typeorm";
+import {
+  Barrier,
+  Latch,
+  RowGate,
+  describeOutcomes,
+  losers,
+  raceAll,
+  waitForBlockedBackends,
+  waitForIdleInTransaction,
+  winners,
+} from "../helpers/race-harness";
+import { INTEGRATION_TYPEORM_OPTIONS } from "../helpers/integration-setup";
+
+/**
+ * The harness proving itself.
+ *
+ * A concurrency test that passes tells you nothing until you have seen the same
+ * test fail with its guard removed -- otherwise "no duplicate was created" and
+ * "the second request never got close enough to create one" are the same green
+ * tick. So before any real race relies on {@link RowGate}, this suite shows the
+ * gate genuinely parks two independent transactions in the contended window: the
+ * same read-modify-write loses an update through it without `FOR UPDATE` and
+ * keeps it with one.
+ *
+ * That unguarded case is the positive control for every race spec in this
+ * directory. If it ever starts passing, the gate has stopped gating and the
+ * other suites have quietly become `Promise.all`.
+ */
+describe("Race harness (integration)", () => {
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    // A bare DataSource, not the Nest graph: this suite tests the harness, and
+    // nothing else needs to exist for that. `synchronize`/`dropSchema` stay off
+    // so it does not fight the suites that do rebuild the schema.
+    dataSource = new DataSource({
+      ...INTEGRATION_TYPEORM_OPTIONS,
+      entities: [],
+      synchronize: false,
+      dropSchema: false,
+    } as never);
+    await dataSource.initialize();
+    await dataSource.query(`DROP TABLE IF EXISTS race_harness_counter`);
+    await dataSource.query(
+      `CREATE TABLE race_harness_counter (id text PRIMARY KEY, value integer NOT NULL)`,
+    );
+  });
+
+  afterAll(async () => {
+    await dataSource.query(`DROP TABLE IF EXISTS race_harness_counter`);
+    await dataSource.destroy();
+  });
+
+  beforeEach(async () => {
+    await dataSource.query(
+      `INSERT INTO race_harness_counter (id, value) VALUES ('c', 0)
+         ON CONFLICT (id) DO UPDATE SET value = 0`,
+    );
+  });
+
+  /**
+   * One increment on its own connection and its own transaction. `lock` decides
+   * whether the read is protected -- the only difference between the positive
+   * and negative control below.
+   */
+  async function increment(lock: boolean): Promise<number> {
+    const runner = dataSource.createQueryRunner();
+    await runner.connect();
+    await runner.startTransaction();
+    try {
+      const rows: Array<{ value: number }> = await runner.query(
+        `SELECT value FROM race_harness_counter WHERE id = 'c'${
+          lock ? " FOR UPDATE" : ""
+        }`,
+      );
+      const next = rows[0].value + 1;
+      await runner.query(
+        `UPDATE race_harness_counter SET value = $1 WHERE id = 'c'`,
+        [next],
+      );
+      await runner.commitTransaction();
+      return next;
+    } catch (error) {
+      await runner.rollbackTransaction().catch(() => undefined);
+      throw error;
+    } finally {
+      await runner.release();
+    }
+  }
+
+  const currentValue = async (): Promise<number> => {
+    const rows: Array<{ value: number }> = await dataSource.query(
+      `SELECT value FROM race_harness_counter WHERE id = 'c'`,
+    );
+    return rows[0].value;
+  };
+
+  describe("Latch", () => {
+    it("releases a waiter that arrived before it opened", async () => {
+      const latch = new Latch("t");
+      const waited = latch.wait();
+      latch.open();
+      await expect(waited).resolves.toBeUndefined();
+    });
+
+    it("returns immediately for a waiter that arrived after it opened", async () => {
+      const latch = new Latch("t");
+      latch.open();
+      await expect(latch.wait()).resolves.toBeUndefined();
+    });
+
+    it("fails loudly rather than hanging when it is never opened", async () => {
+      await expect(new Latch("never").wait(20)).rejects.toThrow(
+        'Latch "never" was never opened',
+      );
+    });
+  });
+
+  describe("Barrier", () => {
+    it("holds every party until the last one arrives", async () => {
+      const barrier = new Barrier("t", 3);
+      const order: string[] = [];
+      const party = async (name: string) => {
+        await barrier.arrive();
+        order.push(name);
+      };
+      await Promise.all([party("a"), party("b"), party("c")]);
+      expect(order).toHaveLength(3);
+    });
+
+    it("does not release a short-handed barrier", async () => {
+      const barrier = new Barrier("short", 2);
+      await expect(barrier.arrive(20)).rejects.toThrow(/never opened/);
+    });
+  });
+
+  describe("RowGate", () => {
+    it("refuses a SELECT that would lock nothing", async () => {
+      // The mistake this catches is silent: a gate built on a plain SELECT holds
+      // no locks, so participants sail past it and the race collapses into a
+      // Promise.all that passes whatever the code does.
+      await expect(
+        RowGate.hold(dataSource, `SELECT value FROM race_harness_counter`),
+      ).rejects.toThrow(/would hold nothing/);
+    });
+
+    it("blocks a participant until it is released", async () => {
+      const gate = await RowGate.hold(
+        dataSource,
+        `SELECT value FROM race_harness_counter WHERE id = 'c' FOR UPDATE`,
+      );
+      let finished = false;
+      const blocked = increment(true).then((value) => {
+        finished = true;
+        return value;
+      });
+      try {
+        await waitForBlockedBackends(dataSource, 1);
+        expect(finished).toBe(false);
+      } finally {
+        await gate.release();
+      }
+      await expect(blocked).resolves.toBe(1);
+    });
+
+    it("reports an open transaction as idle in transaction", async () => {
+      const gate = await RowGate.hold(
+        dataSource,
+        `SELECT value FROM race_harness_counter WHERE id = 'c' FOR UPDATE`,
+      );
+      try {
+        await expect(
+          waitForIdleInTransaction(dataSource, 1),
+        ).resolves.toBeUndefined();
+      } finally {
+        await gate.release();
+      }
+    });
+  });
+
+  describe("positive control: the gate reaches the conflict window", () => {
+    it("loses an update when the read is not locked", async () => {
+      // Both participants read 0 while parked on the gate, so both write 1: the
+      // classic lost update. This asserting `1` is not the harness being wrong
+      // -- it is the harness being sharp enough to catch a missing lock, which is
+      // the only reason to trust the specs that assert the opposite.
+      const gate = await RowGate.hold(
+        dataSource,
+        `SELECT value FROM race_harness_counter WHERE id = 'c' FOR UPDATE`,
+      );
+      let outcomes;
+      try {
+        const running = raceAll([
+          () => increment(false),
+          () => increment(false),
+        ]);
+        await waitForBlockedBackends(dataSource, 2);
+        await gate.release();
+        outcomes = await running;
+      } finally {
+        await gate.release();
+      }
+
+      expect(winners(outcomes)).toHaveLength(2);
+      expect(await currentValue()).toBe(1);
+    });
+
+    it("keeps both updates when the read takes FOR UPDATE", async () => {
+      const gate = await RowGate.hold(
+        dataSource,
+        `SELECT value FROM race_harness_counter WHERE id = 'c' FOR UPDATE`,
+      );
+      let outcomes;
+      try {
+        const running = raceAll([() => increment(true), () => increment(true)]);
+        await waitForBlockedBackends(dataSource, 2);
+        await gate.release();
+        outcomes = await running;
+      } finally {
+        await gate.release();
+      }
+
+      expect(winners(outcomes)).toHaveLength(2);
+      expect(await currentValue()).toBe(2);
+    });
+  });
+
+  describe("raceAll", () => {
+    it("reports a rejection instead of discarding the other outcomes", async () => {
+      const outcomes = await raceAll([
+        async () => "kept",
+        async () => {
+          throw new Error("lost");
+        },
+      ]);
+
+      expect(winners(outcomes)).toEqual(["kept"]);
+      expect(losers(outcomes)).toHaveLength(1);
+      expect(describeOutcomes(outcomes)).toContain("Error: lost");
+    });
+  });
+});

--- a/backend/test/integration/race-holdings-rebuild.integration.spec.ts
+++ b/backend/test/integration/race-holdings-rebuild.integration.spec.ts
@@ -1,0 +1,488 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+
+// Import order matters here and is not cosmetic. `InvestmentTransactionsService`
+// injects `HoldingsService` without a forwardRef, and the securities module has
+// import cycles, so pulling `holdings.service` in first leaves that constructor
+// parameter undefined at decoration time and Nest fails to resolve index [3].
+// Loading the service that sits at the top of the cycle first is what the other
+// securities integration suites do, for the same reason.
+import { InvestmentTransactionsService } from "@/securities/investment-transactions.service";
+import { SecuritiesModule } from "@/securities/securities.module";
+import { SecuritiesService } from "@/securities/securities.service";
+import { HoldingsService } from "@/securities/holdings.service";
+import { Holding } from "@/securities/entities/holding.entity";
+import { InvestmentAction } from "@/securities/entities/investment-transaction.entity";
+import {
+  Account,
+  AccountSubType,
+  AccountType,
+} from "@/accounts/entities/account.entity";
+import { withUserContext } from "@/common/db/with-context";
+
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { createTestAccount } from "../helpers/test-factories";
+import {
+  RowGate,
+  blockedBackendCount,
+  raceAll,
+  waitForBlockedBackends,
+  waitUntil,
+} from "../helpers/race-harness";
+
+/**
+ * P4-006 / audit race 5: a holdings rebuild against a concurrent trade.
+ *
+ * The rebuild is not an administrative tool -- an hourly cron runs it to
+ * materialize matured future-dated trades, and imports and undo call it too. So
+ * "a rebuild is running while the user buys something" happens on its own.
+ *
+ * It read the accounts and the whole investment-transaction history in two
+ * earlier transactions, then deleted every holding and re-inserted from that
+ * replay in a third. A trade committing in between was therefore erased from
+ * `holdings` while its `investment_transactions` row survived -- so the position
+ * vanished from the portfolio and came back at the next rebuild, which is an
+ * unusually confusing way to lose shares and leaves no error anywhere.
+ *
+ * Holdings cannot serialize on themselves, because the row a trade is about to
+ * insert does not exist to be locked. The account row is the common parent both
+ * sides now take, which is what this suite proves.
+ */
+describe("Holdings rebuild vs concurrent trade (integration)", () => {
+  let module: TestingModule;
+  let dataSource: DataSource;
+  let holdings: HoldingsService;
+  let trades: InvestmentTransactionsService;
+  let userId: string;
+  let brokerageAccountId: string;
+  let securityId: string;
+  let otherSecurityId: string;
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([SecuritiesModule]);
+    holdings = module.get(HoldingsService);
+    trades = module.get(InvestmentTransactionsService);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "holdings",
+      "securities",
+      "transaction_splits",
+      "transactions",
+      "accounts",
+      "categories",
+      "payees",
+      "scheduled_transaction_splits",
+      "scheduled_transaction_overrides",
+      "scheduled_transactions",
+      "investment_transactions",
+      "monthly_account_balances",
+      "users",
+    ]);
+    await dataSource.query(
+      `INSERT INTO currencies (code, name, symbol, decimal_places)
+         VALUES ('USD', 'US Dollar', '$', 2) ON CONFLICT DO NOTHING`,
+    );
+
+    userId = (await createTestUserDirect(dataSource)).id;
+
+    const cash = await createTestAccount(dataSource, userId, {
+      name: "Brokerage Cash",
+      openingBalance: 100000,
+      currentBalance: 100000,
+    });
+    await dataSource.manager.update(Account, cash.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_CASH,
+    });
+
+    const brokerage = await createTestAccount(dataSource, userId, {
+      name: "Brokerage",
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, brokerage.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+      linkedAccountId: cash.id,
+    });
+    brokerageAccountId = brokerage.id;
+
+    const securities = module.get(SecuritiesService);
+    securityId = (
+      await withUserContext(userId, () =>
+        securities.create(userId, {
+          symbol: "AAPL",
+          name: "Apple Inc.",
+          securityType: "STOCK",
+          currencyCode: "USD",
+        } as never),
+      )
+    ).id;
+    otherSecurityId = (
+      await withUserContext(userId, () =>
+        securities.create(userId, {
+          symbol: "MSFT",
+          name: "Microsoft",
+          securityType: "STOCK",
+          currencyCode: "USD",
+        } as never),
+      )
+    ).id;
+  });
+
+  const buy = (security: string, quantity: number, date = "2026-01-10") =>
+    withUserContext(userId, () =>
+      trades.create(userId, {
+        accountId: brokerageAccountId,
+        action: InvestmentAction.BUY,
+        transactionDate: date,
+        securityId: security,
+        quantity,
+        price: 100,
+        commission: 0,
+      } as never),
+    );
+
+  const heldQuantity = async (security: string): Promise<number> => {
+    const row = await dataSource.getRepository(Holding).findOne({
+      where: { accountId: brokerageAccountId, securityId: security },
+    });
+    return row ? Number(row.quantity) : 0;
+  };
+
+  /** Investment transactions committed and visible to a fresh read. */
+  const committedTradeCount = async (): Promise<number> => {
+    const rows: Array<{ n: number }> = await dataSource.query(
+      `SELECT COUNT(*)::int AS n FROM investment_transactions WHERE account_id = $1`,
+      [brokerageAccountId],
+    );
+    return rows[0].n;
+  };
+
+  /**
+   * Runs a rebuild and a trade in the one interleaving that loses shares, and
+   * returns once both have settled.
+   *
+   * The gate has to hold the **holdings** rows, not the account. Gating on the
+   * account row parks the trade too -- inserting a holding takes a `FOR KEY
+   * SHARE` lock on its account through the foreign key -- and with both parked
+   * the rebuild's delete happens before the trade's insert, which is the *safe*
+   * order. The damaging one is the opposite: the rebuild reads the history,
+   * the trade then commits in full, and only afterwards does the rebuild delete
+   * every holding and re-insert from the replay it took before the trade
+   * existed. Holding the existing holding row is what parks the rebuild at
+   * exactly that point while leaving the trade free.
+   *
+   * With the fix the trade is not free: the rebuild has taken the account row
+   * first, so the trade waits. The wait below accepts either outcome --
+   * committed, or blocked -- and the returned flag says which happened, because
+   * *that* is the assertion that separates the two worlds. The final holdings
+   * cannot separate them: the old code deleted the holdings it had read by id,
+   * so a row inserted after that read survived, and the position was lost only
+   * when the read landed on the other side of the trade's commit -- a window
+   * with no lock in it, and so not reachable from outside the service without
+   * putting a seam in production code for the test's benefit.
+   *
+   * What is reachable, and is the real invariant, is that a rebuild and a trade
+   * for the same account cannot overlap at all.
+   */
+  async function raceRebuildAgainstTrade(): Promise<{
+    tradeCommittedMidRebuild: boolean;
+  }> {
+    const gate = await RowGate.hold(
+      dataSource,
+      `SELECT id FROM holdings WHERE account_id = $1 FOR UPDATE`,
+      [brokerageAccountId],
+    );
+
+    try {
+      const rebuilding = raceAll<void>([
+        async () => {
+          await withUserContext(userId, () =>
+            holdings.rebuildFromTransactions(userId, "2026-01-31"),
+          );
+        },
+      ]);
+      await waitForBlockedBackends(dataSource, 1);
+
+      const trading = raceAll<void>([
+        async () => {
+          await buy(otherSecurityId, 25, "2026-01-20");
+        },
+      ]);
+      await waitUntil(
+        "the trade to commit or to block behind the rebuild",
+        async () =>
+          (await committedTradeCount()) === 2 ||
+          (await blockedBackendCount(dataSource)) >= 2,
+      );
+
+      const tradeCommittedMidRebuild = (await committedTradeCount()) === 2;
+
+      await gate.release();
+      await rebuilding;
+      await trading;
+      return { tradeCommittedMidRebuild };
+    } finally {
+      await gate.release();
+    }
+  }
+
+  it("does not lose a trade that commits while a rebuild is running", async () => {
+    await buy(securityId, 10);
+    expect(await heldQuantity(securityId)).toBe(10);
+
+    const { tradeCommittedMidRebuild } = await raceRebuildAgainstTrade();
+
+    // The decisive assertion: while the rebuild was parked inside its
+    // transaction, the trade could not commit. Without the account lock it
+    // committed straight through the middle of the rebuild, which is the state
+    // from which shares go missing.
+    expect(tradeCommittedMidRebuild).toBe(false);
+
+    // And once both are done, holdings agrees with the history.
+    expect(await committedTradeCount()).toBe(2);
+    expect(await heldQuantity(securityId)).toBe(10);
+    expect(await heldQuantity(otherSecurityId)).toBe(25);
+  });
+
+  it("keeps holdings and the transaction history agreeing afterwards", async () => {
+    // The sharper statement of the invariant: `holdings` is a materialized view
+    // of `investment_transactions`, so a rebuild run after the race must be a
+    // no-op. If the race lost shares, this rebuild puts them back -- which is
+    // exactly how the defect stayed invisible, since the next rebuild always
+    // repaired it.
+    await buy(securityId, 10);
+
+    await raceRebuildAgainstTrade();
+
+    const beforeRepair = [
+      await heldQuantity(securityId),
+      await heldQuantity(otherSecurityId),
+    ];
+    await withUserContext(userId, () =>
+      holdings.rebuildFromTransactions(userId, "2026-01-31"),
+    );
+    const afterRepair = [
+      await heldQuantity(securityId),
+      await heldQuantity(otherSecurityId),
+    ];
+
+    expect(beforeRepair).toEqual(afterRepair);
+  });
+
+  /**
+   * The share-only paths (RFR7-003).
+   *
+   * `BUY` goes through `createOrUpdate`, which took the account lock from the
+   * first round of this fix. `ADD_SHARES`, `REMOVE_SHARES` and `SPLIT` go
+   * through `adjustQuantity` and `applySplit`, which did not -- so a delete or
+   * edit of one of those could still run straight through a rebuild and leave
+   * `holdings` disagreeing with the history it is supposed to materialize. That
+   * the original suite covered only `BUY` is exactly why it passed.
+   */
+  describe("share-only edit and delete paths", () => {
+    const addShares = (
+      security: string,
+      quantity: number,
+      date = "2026-01-10",
+    ) =>
+      withUserContext(userId, () =>
+        trades.create(userId, {
+          accountId: brokerageAccountId,
+          action: InvestmentAction.ADD_SHARES,
+          transactionDate: date,
+          securityId: security,
+          quantity,
+        } as never),
+      );
+
+    const split = (security: string, ratio: number, date = "2026-01-12") =>
+      withUserContext(userId, () =>
+        trades.create(userId, {
+          accountId: brokerageAccountId,
+          action: InvestmentAction.SPLIT,
+          transactionDate: date,
+          securityId: security,
+          quantity: ratio,
+        } as never),
+      );
+
+    /**
+     * Parks a rebuild mid-transaction, then runs `mutate` and reports whether it
+     * managed to commit while the rebuild was still inside its transaction.
+     *
+     * Same construction as the trade case: the gate holds the existing holdings
+     * rows, which parks the rebuild at its delete without parking the mutator,
+     * so the answer is decided by whether the mutator contends on the account
+     * lock the rebuild already holds.
+     */
+    async function commitsDuringRebuild(
+      mutate: () => Promise<unknown>,
+      expectedHistoryCount: number,
+    ): Promise<boolean> {
+      const gate = await RowGate.hold(
+        dataSource,
+        `SELECT id FROM holdings WHERE account_id = $1 FOR UPDATE`,
+        [brokerageAccountId],
+      );
+      try {
+        const rebuilding = raceAll<void>([
+          async () => {
+            await withUserContext(userId, () =>
+              holdings.rebuildFromTransactions(userId, "2026-01-31"),
+            );
+          },
+        ]);
+        await waitForBlockedBackends(dataSource, 1);
+
+        const mutating = raceAll<void>([
+          async () => {
+            await mutate();
+          },
+        ]);
+        await waitUntil(
+          "the mutation to commit or to block behind the rebuild",
+          async () =>
+            (await committedTradeCount()) === expectedHistoryCount ||
+            (await blockedBackendCount(dataSource)) >= 2,
+        );
+        const committed =
+          (await committedTradeCount()) === expectedHistoryCount;
+
+        await gate.release();
+        await rebuilding;
+        await mutating;
+        return committed;
+      } finally {
+        await gate.release();
+      }
+    }
+
+    it("serializes deleting an ADD_SHARES against a rebuild", async () => {
+      // The reviewer's scenario: history ends up with no share acquisition while
+      // holdings still show the shares, because the rebuild wrote a replay taken
+      // before the delete.
+      const added = await addShares(securityId, 10);
+      expect(await heldQuantity(securityId)).toBe(10);
+
+      const committedMidRebuild = await commitsDuringRebuild(
+        () => withUserContext(userId, () => trades.remove(userId, added.id)),
+        0,
+      );
+
+      expect(committedMidRebuild).toBe(false);
+      // History and holdings agree: no acquisition, no shares.
+      expect(await committedTradeCount()).toBe(0);
+      expect(await heldQuantity(securityId)).toBe(0);
+    });
+
+    it("serializes deleting a REMOVE_SHARES against a rebuild", async () => {
+      await addShares(securityId, 10);
+      const removed = await withUserContext(userId, () =>
+        trades.create(userId, {
+          accountId: brokerageAccountId,
+          action: InvestmentAction.REMOVE_SHARES,
+          transactionDate: "2026-01-11",
+          securityId,
+          quantity: 4,
+        } as never),
+      );
+      expect(await heldQuantity(securityId)).toBe(6);
+
+      const committedMidRebuild = await commitsDuringRebuild(
+        () => withUserContext(userId, () => trades.remove(userId, removed.id)),
+        1,
+      );
+
+      expect(committedMidRebuild).toBe(false);
+      // Undoing the removal puts the four shares back.
+      expect(await committedTradeCount()).toBe(1);
+      expect(await heldQuantity(securityId)).toBe(10);
+    });
+
+    it("serializes deleting a SPLIT against a rebuild", async () => {
+      // A split's quantity is a ratio, so a delete that races a rebuild can
+      // leave the materialized quantity at the post-split figure with no split
+      // in the history to justify it.
+      //
+      // Unlike the two cases above, this one and the insert case below pass with
+      // or without the lock -- the split delete is followed by a post-commit
+      // repair rebuild, and an insert creates a row the rebuild's by-id delete
+      // never sees. They are guards on the paths, not regression proofs; the
+      // ADD_SHARES and REMOVE_SHARES deletes are the proofs, and they fail with
+      // 10 phantom shares and 6-instead-of-10 respectively when the locks in
+      // `applySplit`/`adjustQuantity` are removed.
+      await addShares(securityId, 10);
+      const splitTx = await split(securityId, 2);
+      expect(await heldQuantity(securityId)).toBe(20);
+
+      const committedMidRebuild = await commitsDuringRebuild(
+        () => withUserContext(userId, () => trades.remove(userId, splitTx.id)),
+        1,
+      );
+
+      expect(committedMidRebuild).toBe(false);
+      expect(await committedTradeCount()).toBe(1);
+      expect(await heldQuantity(securityId)).toBe(10);
+    });
+
+    it("serializes adding shares against a rebuild", async () => {
+      // The insert side of the same path: `adjustQuantity` rather than
+      // `createOrUpdate`, so it needed its own lock and its own case.
+      await addShares(securityId, 10);
+
+      const committedMidRebuild = await commitsDuringRebuild(
+        () => addShares(otherSecurityId, 7, "2026-01-20"),
+        2,
+      );
+
+      expect(committedMidRebuild).toBe(false);
+      expect(await heldQuantity(securityId)).toBe(10);
+      expect(await heldQuantity(otherSecurityId)).toBe(7);
+    });
+  });
+
+  it("still rebuilds correctly with no contention", async () => {
+    await buy(securityId, 10);
+    await buy(otherSecurityId, 4);
+    // Corrupt the materialized state on purpose, so the rebuild has work to do
+    // and a no-op cannot pass this test.
+    await dataSource.query(`UPDATE holdings SET quantity = 999`);
+
+    const result = await withUserContext(userId, () =>
+      holdings.rebuildFromTransactions(userId, "2026-01-31"),
+    );
+
+    expect(await heldQuantity(securityId)).toBe(10);
+    expect(await heldQuantity(otherSecurityId)).toBe(4);
+    expect(result.holdingsCreated).toBe(2);
+    expect(result.holdingsDeleted).toBe(2);
+  });
+
+  it("reports nothing to do for a user with no investment accounts", async () => {
+    const other = (await createTestUserDirect(dataSource)).id;
+
+    const result = await withUserContext(other, () =>
+      holdings.rebuildFromTransactions(other, "2026-01-31"),
+    );
+
+    expect(result).toEqual({
+      holdingsCreated: 0,
+      holdingsUpdated: 0,
+      holdingsDeleted: 0,
+    });
+  });
+});

--- a/backend/test/integration/race-refresh-token-revocation.integration.spec.ts
+++ b/backend/test/integration/race-refresh-token-revocation.integration.spec.ts
@@ -1,0 +1,202 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { JwtModule } from "@nestjs/jwt";
+import { DataSource } from "typeorm";
+
+import { TokenService } from "@/auth/token.service";
+import { RefreshToken } from "@/auth/entities/refresh-token.entity";
+import { User } from "@/users/entities/user.entity";
+import { hashToken } from "@/auth/crypto.util";
+import { withUserContext } from "@/common/db/with-context";
+
+import {
+  INTEGRATION_TYPEORM_OPTIONS,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import {
+  RowGate,
+  describeOutcomes,
+  raceAll,
+  waitForBlockedBackends,
+  winners,
+} from "../helpers/race-harness";
+
+/**
+ * P4-007 / audit race 7: a refresh rotation running against a family revocation.
+ *
+ * The interleaving is not exotic -- it is what a "log out everywhere" click and
+ * a background token refresh do to each other, and every backend replica can
+ * serve either. What makes it worth a real database is that the defect is a
+ * property of MVCC rather than of the code as read: the rotation holds
+ * `FOR UPDATE` on the token it replaces, so the revocation's single
+ * `UPDATE ... WHERE family_id = $1` necessarily blocks behind it and necessarily
+ * commits second -- with a snapshot taken before the replacement row existed.
+ * The replacement therefore survives, and the user who logged out still has a
+ * usable session. No unit test with a mocked manager can show that; no
+ * `Promise.all` reliably reaches it either.
+ *
+ * The gate makes the ordering deterministic: both participants are parked on the
+ * same row, in their own transactions, before either is allowed to proceed.
+ */
+describe("Refresh rotation vs family revocation (integration)", () => {
+  let module: TestingModule;
+  let dataSource: DataSource;
+  let tokens: TokenService;
+  let userId: string;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        TypeOrmModule.forRoot(INTEGRATION_TYPEORM_OPTIONS),
+        TypeOrmModule.forFeature([RefreshToken, User]),
+        JwtModule.register({ secret: "race-harness-secret-not-a-real-key" }),
+      ],
+      providers: [TokenService],
+    }).compile();
+
+    dataSource = module.get(DataSource);
+    tokens = module.get(TokenService);
+    // Present so `refreshTokens` finds an active user; the value is irrelevant.
+    module.get(ConfigService);
+  });
+
+  afterAll(async () => {
+    await module?.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, ["refresh_tokens", "users"]);
+    userId = (await createTestUserDirect(dataSource)).id;
+  });
+
+  /** Issues a session and returns its raw refresh token plus its family. */
+  async function issueSession(): Promise<{ raw: string; familyId: string }> {
+    const user = await dataSource.getRepository(User).findOneByOrFail({
+      id: userId,
+    });
+    const pair = await withUserContext(userId, () =>
+      tokens.generateTokenPair(user),
+    );
+    const row = await dataSource.getRepository(RefreshToken).findOneByOrFail({
+      tokenHash: hashToken(pair.refreshToken),
+    });
+    return { raw: pair.refreshToken, familyId: row.familyId };
+  }
+
+  const liveTokenCount = (familyId: string) =>
+    dataSource
+      .getRepository(RefreshToken)
+      .count({ where: { familyId, isRevoked: false } });
+
+  it("leaves no live descendant when a revocation races the rotation that created it", async () => {
+    const { raw, familyId } = await issueSession();
+
+    // Both participants must contend for the row the rotation replaces, so the
+    // gate holds exactly that row and lets each of them queue behind it. The
+    // order they queue in is the order they are started in, which is what makes
+    // the rotation-commits-first interleaving -- the broken one -- the case under
+    // test rather than a coin toss.
+    const gate = await RowGate.hold(
+      dataSource,
+      `SELECT id FROM refresh_tokens WHERE token_hash = $1 FOR UPDATE`,
+      [hashToken(raw)],
+    );
+
+    let outcomes;
+    try {
+      const rotating = raceAll([
+        () => withUserContext(userId, () => tokens.refreshTokens(raw)),
+      ]);
+      await waitForBlockedBackends(dataSource, 1);
+
+      const revoking = raceAll([
+        () => withUserContext(userId, () => tokens.revokeTokenFamily(familyId)),
+      ]);
+      await waitForBlockedBackends(dataSource, 2);
+
+      await gate.release();
+      outcomes = [...(await rotating), ...(await revoking)];
+    } finally {
+      await gate.release();
+    }
+
+    // The revocation must not report success while leaving a usable token
+    // behind: that is the whole claim a logout makes.
+    expect(await liveTokenCount(familyId)).toBe(0);
+
+    const rotated = winners(outcomes).find(
+      (value): value is { refreshToken: string } =>
+        typeof value === "object" && value !== null && "refreshToken" in value,
+    );
+    // With the gate's arrival ordering the rotation wins the lock, so it should
+    // have produced a token -- and that token is the one that used to survive.
+    expect(rotated).toBeDefined();
+    expect(describeOutcomes(outcomes)).not.toContain("did not converge");
+
+    await expect(
+      withUserContext(userId, () =>
+        tokens.refreshTokens(rotated!.refreshToken),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("leaves no live token when a whole-user revocation races a rotation", async () => {
+    // `revokeAllUserRefreshTokens` is the account-lockout and password-change
+    // path, and it has the same shape as the family case, so it needs the same
+    // proof rather than the same assumption.
+    const { raw, familyId } = await issueSession();
+
+    const gate = await RowGate.hold(
+      dataSource,
+      `SELECT id FROM refresh_tokens WHERE token_hash = $1 FOR UPDATE`,
+      [hashToken(raw)],
+    );
+
+    try {
+      const rotating = raceAll([
+        () => withUserContext(userId, () => tokens.refreshTokens(raw)),
+      ]);
+      await waitForBlockedBackends(dataSource, 1);
+
+      const revoking = raceAll([
+        () =>
+          withUserContext(userId, () =>
+            tokens.revokeAllUserRefreshTokens(userId),
+          ),
+      ]);
+      await waitForBlockedBackends(dataSource, 2);
+
+      await gate.release();
+      await rotating;
+      await revoking;
+    } finally {
+      await gate.release();
+    }
+
+    expect(await liveTokenCount(familyId)).toBe(0);
+    expect(
+      await dataSource
+        .getRepository(RefreshToken)
+        .count({ where: { userId, isRevoked: false } }),
+    ).toBe(0);
+  });
+
+  it("still revokes an ordinary uncontended family", async () => {
+    // The positive control for the loop itself: convergence logic that only
+    // works under contention would be a regression in the common case.
+    const { raw, familyId } = await issueSession();
+    await withUserContext(userId, () => tokens.refreshTokens(raw));
+
+    await withUserContext(userId, () => tokens.revokeTokenFamily(familyId));
+
+    expect(await liveTokenCount(familyId)).toBe(0);
+    expect(
+      await dataSource
+        .getRepository(RefreshToken)
+        .count({ where: { familyId } }),
+    ).toBe(2);
+  });
+});

--- a/backend/test/integration/race-security-transfer.integration.spec.ts
+++ b/backend/test/integration/race-security-transfer.integration.spec.ts
@@ -1,0 +1,187 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+
+import { InvestmentTransactionsService } from "@/securities/investment-transactions.service";
+import { SecuritiesModule } from "@/securities/securities.module";
+import { SecuritiesService } from "@/securities/securities.service";
+import { Holding } from "@/securities/entities/holding.entity";
+import {
+  Account,
+  AccountSubType,
+  AccountType,
+} from "@/accounts/entities/account.entity";
+import { InvestmentAction } from "@/securities/entities/investment-transaction.entity";
+import { withUserContext } from "@/common/db/with-context";
+
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { createTestAccount } from "../helpers/test-factories";
+import { raceAll, losers } from "../helpers/race-harness";
+
+/**
+ * R4-002: opposite-direction security transfers deadlocking on account locks.
+ *
+ * Every holdings mutator locks its account, and a transfer runs two of them: a
+ * `TRANSFER_OUT` that locks the source, then a `TRANSFER_IN` that locks the
+ * destination. So a transfer A->B acquires the pair source-then-destination, and
+ * a simultaneous B->A acquires it destination-then-source -- opposite orders on
+ * the same two rows, which is the textbook deadlock. PostgreSQL breaks it by
+ * aborting one transaction with SQLSTATE 40P01, so a user's valid transfer fails
+ * for no reason they can see.
+ *
+ * The fix takes the whole account set once, in sorted order, before either leg
+ * (`lockAccountsForHoldings`), so every transfer acquires the pair the same way
+ * and the cycle cannot form.
+ *
+ * This is a stress test, not a gated one: a deadlock needs each transaction
+ * paused *between* its two lock acquisitions, and `transferSecurity` has no seam
+ * there that a test could reach without deforming production code. So it fires
+ * many opposite transfers at once -- with the fix that is deterministically
+ * deadlock-free, and without it the aborts appear. Verified by reverting the
+ * up-front lock and watching 40P01 losers show up here.
+ */
+describe("Opposite-direction security transfers (integration)", () => {
+  let module: TestingModule;
+  let dataSource: DataSource;
+  let service: InvestmentTransactionsService;
+  let userId: string;
+  let accountA: string;
+  let accountB: string;
+  let securityId: string;
+
+  const PAIRS = 16;
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([SecuritiesModule]);
+    service = module.get(InvestmentTransactionsService);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "holdings",
+      "securities",
+      "transaction_splits",
+      "transactions",
+      "accounts",
+      "categories",
+      "payees",
+      "scheduled_transaction_splits",
+      "scheduled_transaction_overrides",
+      "scheduled_transactions",
+      "investment_transactions",
+      "monthly_account_balances",
+      "users",
+    ]);
+    await dataSource.query(
+      `INSERT INTO currencies (code, name, symbol, decimal_places)
+         VALUES ('USD', 'US Dollar', '$', 2) ON CONFLICT DO NOTHING`,
+    );
+    userId = (await createTestUserDirect(dataSource)).id;
+
+    const mkBrokerage = async (name: string): Promise<string> => {
+      const acct = await createTestAccount(dataSource, userId, {
+        name,
+        openingBalance: 0,
+        currentBalance: 0,
+      });
+      await dataSource.manager.update(Account, acct.id, {
+        accountType: AccountType.INVESTMENT,
+        accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+      });
+      return acct.id;
+    };
+    accountA = await mkBrokerage("Brokerage A");
+    accountB = await mkBrokerage("Brokerage B");
+
+    securityId = (
+      await withUserContext(userId, () =>
+        module.get(SecuritiesService).create(userId, {
+          symbol: "ACME",
+          name: "Acme Corp",
+          securityType: "STOCK",
+          currencyCode: "USD",
+        } as never),
+      )
+    ).id;
+
+    // Seed both accounts with plenty of shares so every 1-share transfer, in
+    // either direction, has stock to move and the over-draw guard never fires.
+    for (const accountId of [accountA, accountB]) {
+      await withUserContext(userId, () =>
+        service.create(userId, {
+          accountId,
+          action: InvestmentAction.ADD_SHARES,
+          transactionDate: "2026-01-01",
+          securityId,
+          quantity: 1000,
+        } as never),
+      );
+    }
+  });
+
+  const held = async (accountId: string): Promise<number> => {
+    const row = await dataSource.getRepository(Holding).findOne({
+      where: { accountId, securityId },
+    });
+    return row ? Number(row.quantity) : 0;
+  };
+
+  const transfer = (from: string, to: string, date: string) =>
+    withUserContext(userId, () =>
+      service.transferSecurity(userId, {
+        fromAccountId: from,
+        toAccountId: to,
+        securityId,
+        transactionDate: date,
+        quantity: 1,
+        costPerShare: 10,
+      } as never),
+    );
+
+  const isDeadlock = (error: unknown): boolean => {
+    const code = (error as { code?: string; driverError?: { code?: string } })
+      ?.code;
+    const driverCode = (error as { driverError?: { code?: string } })
+      ?.driverError?.code;
+    return code === "40P01" || driverCode === "40P01";
+  };
+
+  it("does not deadlock when A->B and B->A run concurrently", async () => {
+    // Interleave the two directions so the scheduler cannot trivially run all of
+    // one before the other.
+    const participants: Array<() => Promise<unknown>> = [];
+    for (let i = 0; i < PAIRS; i += 1) {
+      const day = String((i % 27) + 1).padStart(2, "0");
+      participants.push(() => transfer(accountA, accountB, `2026-02-${day}`));
+      participants.push(() => transfer(accountB, accountA, `2026-03-${day}`));
+    }
+
+    const outcomes = await raceAll(participants);
+
+    // The assertion the fix exists for: not one transfer was aborted by a
+    // deadlock. On the unlocked code, some of these lose with 40P01.
+    const deadlocks = losers(outcomes).filter(isDeadlock);
+    expect(deadlocks).toHaveLength(0);
+
+    // Every A->B is matched by a B->A of the same size, so the holdings return
+    // to where they started -- nothing was lost or double-counted.
+    expect(await held(accountA)).toBe(1000);
+    expect(await held(accountB)).toBe(1000);
+  });
+
+  it("still moves shares correctly for a single uncontended transfer", async () => {
+    await transfer(accountA, accountB, "2026-04-01");
+
+    expect(await held(accountA)).toBe(999);
+    expect(await held(accountB)).toBe(1001);
+  });
+});


### PR DESCRIPTION
> Base note: this branch was cut from `main` before ~200 commits landed that
> independently implemented this concern — `common/db/locks.ts`
> (`lockHoldingScope`, `lockAccountsForBalanceWrite`, `lockTokenFamily`) and the
> "04-01/04-02" concurrency series cover holdings locking, balance-write safety
> and token-family revocation on `main` already. Treat this branch as a source of
> extra race specs to port onto `main`'s primitives, not as a merge. Rebase and
> reconcile before merge — see the package README.

## Linked discussion / issue

Closes #
Approved in: scope and approach agreed with the maintainer over email (Phase 7 audit remediation series, finding P7-008 — the audit's only HIGH).

## Summary

The audit's HIGH finding: no test drove two independent connections into a real conflict window, and `Promise.all` around one service instance reaches no interleaving at all. Building the harness surfaced five live defects:

- **Account recompute** read the account in one transaction, summed in another, then wrote back the whole stale entity — reverting a concurrent rename/credit-limit/opening-balance edit. Now one transaction, a locked read, and an update confined to the column it owns.
- **Holdings rebuild vs trade**: the rebuild deleted and re-inserted from an earlier snapshot, erasing a concurrently committed trade. Now one transaction with the accounts locked first — on **every** holdings mutator, not just the two the first fix covered.
- **Lock order**: a security transfer locked source-then-destination per leg, so two opposite transfers deadlocked (`40P01`). Transfer create/edit/delete now take the whole affected account set up front, sorted.
- **Emergency-access claim**: two concurrent claims both passed the single-use check and both rewrote the owner's credentials. Now a pessimistic lock; one wins, the other gets `NotFoundException`.
- **Refresh-token revocation**: a rotation racing a logout could leave a live descendant token after a confirmed logout. `revokeUntilNoneLive` re-reads until nothing is live and throws rather than reporting a partial revocation.

`test/helpers/race-harness.ts` provides independent connections, a `FOR UPDATE` `RowGate`, and condition-based waits (no sleeps). `race-harness.integration.spec.ts` is the positive control. Every fix was verified by reintroducing the defect and watching its suite fail. `--passWithNoTests` is removed from `test:integration` (P7-006); `scripts/integration-inventory.mjs` fails the job when a mandatory suite is missing or the count drops below a floor. `backend/CLAUDE.md` gains the concurrency-test and lock-order rules.

No user-facing strings are touched.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [ ] The branch is rebased on the latest `main`. (See base note above — rebase required.)
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Implemented with Claude Code against the Phase 7 audit and its follow-up reviews; the author reviewed the changes and owns the result. The race suites ran against a real PostgreSQL 16, and each fix was checked by reintroducing the defect and confirming the suite fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
