### PR TITLE
Fix .mny import turning yearly bills into bimonthly ones

### DIFF
--- a/backend/src/import/mny/README.md
+++ b/backend/src/import/mny/README.md
@@ -23,6 +23,17 @@ that turns up in a real file must become a warning in the verification report, n
 mapping: `mapAccountType`, `mapInvestmentAction` and `mapFrequency` all return null for codes they
 do not know, and `MNY_UNCONFIRMED_ACTIONS` names the ones whose meaning is inferred.
 
+### Where the file can answer for itself, do not ask the code table
+
+`BILL.frq` had eight entries carried from the format reference and no fixture to
+check them against. The one entry a bug report could check was wrong, and yearly
+bills imported recurring every two months for every user with one (issue #1150).
+`BILL` holds one row per occurrence, so the spacing between a series' `dt`
+values *is* its recurrence: `map/bill-cadence.ts` reads it and `map/map-bills.ts`
+prefers that to `frq`, which now maps only the codes there is evidence for (0, 1,
+2, 3, 5) and reports the rest. Before adding an unconfirmed constant, look for
+the column that already carries the same fact as data.
+
 ### A bit mask cannot warn you, so measure it before you trust it
 
 That null-and-warn rule protects lookups over a *value* -- an unknown `at` or `act` has no entry,

--- a/backend/src/import/mny/map/bill-cadence.spec.ts
+++ b/backend/src/import/mny/map/bill-cadence.spec.ts
@@ -1,0 +1,166 @@
+import { FrequencyType } from "../../../scheduled-transactions/dto/create-scheduled-transaction.dto";
+import {
+  CADENCE_DAYS,
+  cadenceForGap,
+  inferFrequencyFromDueDates,
+} from "./bill-cadence";
+
+/** `count` dates from `start`, stepped by whole days. */
+function everyDays(start: string, days: number, count: number): string[] {
+  const dates: string[] = [];
+  const cursor = new Date(`${start}T00:00:00Z`);
+  for (let i = 0; i < count; i += 1) {
+    dates.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + days);
+  }
+  return dates;
+}
+
+/** `count` dates from `start`, stepped by whole months (day clamped). */
+function everyMonths(start: string, months: number, count: number): string[] {
+  const [year, month, day] = start.split("-").map(Number);
+  return Array.from({ length: count }, (_, i) => {
+    const total = month - 1 + i * months;
+    const y = year + Math.floor(total / 12);
+    const m = (total % 12) + 1;
+    const last = new Date(Date.UTC(y, m, 0)).getUTCDate();
+    const d = Math.min(day, last);
+    return `${y}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+  });
+}
+
+describe("cadenceForGap", () => {
+  it.each([
+    [1, FrequencyType.DAILY],
+    [7, FrequencyType.WEEKLY],
+    [14, FrequencyType.BIWEEKLY],
+    [15, FrequencyType.SEMIMONTHLY],
+    [16, FrequencyType.SEMIMONTHLY],
+    [28, FrequencyType.EVERY4WEEKS],
+    [30, FrequencyType.MONTHLY],
+    [31, FrequencyType.MONTHLY],
+    [61, FrequencyType.EVERY2MONTHS],
+    [91, FrequencyType.QUARTERLY],
+    [92, FrequencyType.QUARTERLY],
+    [182, FrequencyType.SEMIANNUAL],
+    [365, FrequencyType.YEARLY],
+    [366, FrequencyType.YEARLY],
+  ])("reads a %p day gap as %s", (days, expected) => {
+    expect(cadenceForGap(days)).toBe(expected);
+  });
+
+  it("keeps four weeks and a calendar month apart", () => {
+    // 28 vs 30.44 is 8%, the closest pair in the table. A tolerance that
+    // matched both would make every four-weekly bill monthly.
+    expect(cadenceForGap(28)).toBe(FrequencyType.EVERY4WEEKS);
+    expect(cadenceForGap(31)).toBe(FrequencyType.MONTHLY);
+  });
+
+  it.each([[45], [120], [250]])(
+    "refuses a %p day gap that matches nothing",
+    (days) => {
+      expect(cadenceForGap(days)).toBeNull();
+    },
+  );
+
+  it.each([[0], [-30], [Number.NaN]])(
+    "refuses the nonsensical gap %p",
+    (days) => {
+      expect(cadenceForGap(days)).toBeNull();
+    },
+  );
+
+  it("never answers ONCE, which has no spacing", () => {
+    expect(CADENCE_DAYS.ONCE).toBe(0);
+    for (const days of [0.5, 1, 7, 400, 10_000]) {
+      expect(cadenceForGap(days)).not.toBe(FrequencyType.ONCE);
+    }
+  });
+});
+
+describe("inferFrequencyFromDueDates", () => {
+  it("reads a yearly series as YEARLY (issue #1150)", () => {
+    // The file says so in its own dates, whatever `BILL.frq` is taken to mean.
+    expect(inferFrequencyFromDueDates(everyMonths("2019-03-15", 12, 8))).toBe(
+      FrequencyType.YEARLY,
+    );
+  });
+
+  it.each([
+    [everyMonths("2024-01-31", 1, 14), FrequencyType.MONTHLY],
+    [everyMonths("2024-01-15", 2, 8), FrequencyType.EVERY2MONTHS],
+    [everyMonths("2024-01-15", 3, 8), FrequencyType.QUARTERLY],
+    [everyMonths("2024-01-15", 6, 6), FrequencyType.SEMIANNUAL],
+    [everyDays("2024-01-15", 7, 10), FrequencyType.WEEKLY],
+    [everyDays("2024-01-15", 14, 10), FrequencyType.BIWEEKLY],
+    [everyDays("2024-01-15", 28, 10), FrequencyType.EVERY4WEEKS],
+    [everyDays("2024-01-15", 1, 10), FrequencyType.DAILY],
+  ])("reads a regular series as %#: %s", (dates, expected) => {
+    expect(inferFrequencyFromDueDates(dates)).toBe(expected);
+  });
+
+  it("reads month-end and mid-month instances as SEMIMONTHLY", () => {
+    const dates = [
+      "2025-01-15",
+      "2025-01-31",
+      "2025-02-15",
+      "2025-02-28",
+      "2025-03-15",
+      "2025-03-31",
+      "2025-04-15",
+    ];
+    expect(inferFrequencyFromDueDates(dates)).toBe(FrequencyType.SEMIMONTHLY);
+  });
+
+  it("survives a skipped occurrence", () => {
+    const dates = everyMonths("2024-01-15", 1, 12).filter(
+      (date) => date !== "2024-06-15",
+    );
+    expect(inferFrequencyFromDueDates(dates)).toBe(FrequencyType.MONTHLY);
+  });
+
+  it("reads the newest instances, so a changed cadence imports as it is now", () => {
+    const dates = [
+      ...everyMonths("2018-01-15", 12, 5),
+      ...everyMonths("2024-01-15", 1, 12),
+    ];
+    expect(inferFrequencyFromDueDates(dates)).toBe(FrequencyType.MONTHLY);
+  });
+
+  it.each([[[]], [["2025-01-15"]], [["2025-01-15", "2025-02-15"]]])(
+    "refuses %p -- two instances is a coincidence",
+    (dates) => {
+      expect(inferFrequencyFromDueDates(dates)).toBeNull();
+    },
+  );
+
+  it("refuses a series whose repeated date carries no spacing", () => {
+    expect(
+      inferFrequencyFromDueDates(["2025-01-15", "2025-01-15", "2025-01-15"]),
+    ).toBeNull();
+  });
+
+  it("refuses an irregular series rather than averaging it", () => {
+    expect(
+      inferFrequencyFromDueDates([
+        "2025-01-02",
+        "2025-01-09",
+        "2025-03-30",
+        "2025-04-04",
+        "2025-09-17",
+      ]),
+    ).toBeNull();
+  });
+
+  it("ignores instances with no date", () => {
+    const dates = everyMonths("2024-01-15", 1, 6);
+    expect(inferFrequencyFromDueDates([...dates, null, null])).toBe(
+      FrequencyType.MONTHLY,
+    );
+  });
+
+  it("reads instances stored newest first", () => {
+    const dates = [...everyMonths("2024-01-15", 12, 5)].reverse();
+    expect(inferFrequencyFromDueDates(dates)).toBe(FrequencyType.YEARLY);
+  });
+});

--- a/backend/src/import/mny/map/bill-cadence.ts
+++ b/backend/src/import/mny/map/bill-cadence.ts
@@ -1,0 +1,131 @@
+import { FrequencyType } from "../../../scheduled-transactions/dto/create-scheduled-transaction.dto";
+
+/**
+ * A bill series' cadence read from its own instance dates.
+ *
+ * `BILL` is an accumulation of instances -- one row per occurrence -- so a
+ * series carries its own answer to "how often": the spacing between
+ * consecutive `dt` values. That is evidence from the file in front of us,
+ * where `BILL.frq` is a code this repository has never been able to observe
+ * (`MNY_FREQUENCY` explains what is known and how). Issue #1150 is what the
+ * difference costs: a table entry taken on trust turned yearly bills into
+ * bimonthly ones, and every one of those files said "365 days apart" in data
+ * nothing was reading.
+ *
+ * So the mapper asks the dates first and the code second. Where the two agree
+ * this changes nothing; where they disagree the dates win, because a code
+ * table is a claim about Money and the dates are the user's bill.
+ */
+
+/**
+ * Mean days in one cycle of each frequency. Means, not whole cycles: these are
+ * matched against observed spacing, so February and a 31-day month have to
+ * average out rather than round up. `map-bills.ts` derives its activity
+ * horizon from the same table -- one list of cycle lengths, not two.
+ */
+export const CADENCE_DAYS: Record<FrequencyType, number> = {
+  ONCE: 0,
+  DAILY: 1,
+  WEEKLY: 7,
+  BIWEEKLY: 14,
+  SEMIMONTHLY: 365.25 / 24,
+  EVERY4WEEKS: 28,
+  MONTHLY: 365.25 / 12,
+  EVERY2MONTHS: 365.25 / 6,
+  QUARTERLY: 365.25 / 4,
+  SEMIANNUAL: 365.25 / 2,
+  YEARLY: 365.25,
+};
+
+/**
+ * How far an observed gap may sit from a cadence and still be read as it.
+ *
+ * Matching is by ratio rather than by difference so the short periods are not
+ * swallowed by the long ones: 12% of a week is a day, 12% of a year is six
+ * weeks. The pairs this has to keep apart are the close ones -- 28 days versus
+ * a calendar month (9%), a fortnight versus twice a month (9%) -- so the
+ * nearest match wins and the tolerance only decides whether *anything*
+ * matches.
+ */
+const CADENCE_TOLERANCE = 1.12;
+
+/**
+ * Instances read back from the newest end of a series. A series can run for
+ * decades, and a bill whose frequency the user changed should be imported as
+ * what it is now, not as the average of its history.
+ */
+const MAX_SAMPLED_INSTANCES = 13;
+
+/** Minimum gaps -- two instances is a coincidence, three is a cadence. */
+const MIN_GAPS = 2;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Whole days between two `YYYY-MM-DD` dates, or null if either is unusable. */
+function daysBetween(from: string, to: string): number | null {
+  const start = Date.parse(`${from}T00:00:00Z`);
+  const end = Date.parse(`${to}T00:00:00Z`);
+  if (Number.isNaN(start) || Number.isNaN(end)) {
+    return null;
+  }
+  return Math.round((end - start) / MS_PER_DAY);
+}
+
+/** The frequency whose cycle is closest to `days`, by ratio, or null. */
+export function cadenceForGap(days: number): FrequencyType | null {
+  if (!Number.isFinite(days) || days <= 0) {
+    return null;
+  }
+
+  let best: FrequencyType | null = null;
+  let bestRatio = Number.POSITIVE_INFINITY;
+  for (const [frequency, cycle] of Object.entries(CADENCE_DAYS)) {
+    if (cycle <= 0) {
+      continue;
+    }
+    const ratio = days > cycle ? days / cycle : cycle / days;
+    if (ratio < bestRatio) {
+      best = frequency as FrequencyType;
+      bestRatio = ratio;
+    }
+  }
+  return bestRatio <= CADENCE_TOLERANCE ? best : null;
+}
+
+/**
+ * The cadence a series' instance dates agree on, or null when they do not.
+ *
+ * A strict majority of the sampled gaps has to read as the same frequency.
+ * That is what makes a skipped occurrence harmless -- it produces one doubled
+ * gap, which either matches a different frequency or matches nothing -- while
+ * still refusing to answer for a series whose dates are simply irregular.
+ * Refusing is not a failure here: the caller falls back to `BILL.frq`.
+ */
+export function inferFrequencyFromDueDates(
+  dates: readonly (string | null)[],
+): FrequencyType | null {
+  const sampled = [...new Set(dates.filter((date): date is string => !!date))]
+    .sort()
+    .slice(-MAX_SAMPLED_INSTANCES);
+
+  const gaps = sampled
+    .slice(1)
+    .map((date, index) => daysBetween(sampled[index], date))
+    .filter((days): days is number => days !== null);
+  if (gaps.length < MIN_GAPS) {
+    return null;
+  }
+
+  const votes = new Map<FrequencyType, number>();
+  for (const gap of gaps) {
+    const cadence = cadenceForGap(gap);
+    if (cadence !== null) {
+      votes.set(cadence, (votes.get(cadence) ?? 0) + 1);
+    }
+  }
+
+  const [winner, count] = [...votes.entries()].reduce<
+    [FrequencyType | null, number]
+  >((best, entry) => (entry[1] > best[1] ? entry : best), [null, 0]);
+  return count * 2 > gaps.length ? winner : null;
+}

--- a/backend/src/import/mny/map/map-bills.spec.ts
+++ b/backend/src/import/mny/map/map-bills.spec.ts
@@ -273,7 +273,7 @@ describe("mapBills", () => {
       const yearly = (handle: number, daysAgo: number) =>
         mnyBill({
           handle,
-          frequency: 6,
+          frequency: 5,
           nextDue: shiftIsoDate(AS_OF, -daysAgo),
           templateTransaction: 500 + handle,
         });
@@ -646,8 +646,120 @@ describe("mapBills", () => {
       expect(result.bills).toEqual([]);
       expect(result.skipped).toBe(1);
       expect(result.warnings).toEqual([
-        { code: "unusableBill", subject: "hbill=7", detail: "frq=99" },
+        { code: "unusableBill", subject: "hbill=7", detail: "frq=99 x1" },
       ]);
+    });
+
+    it("imports a yearly series as YEARLY, not every two months (issue #1150)", () => {
+      // The report: a Money Plus Sunset file's annual bills arrived recurring
+      // every two months, which is what `frq` 5 mapped to on PR #192's word.
+      const result = mapBills(
+        input({
+          bills: billData({
+            bills: [
+              mnyBill({
+                handle: 7,
+                frequency: 5,
+                nextDue: AS_OF,
+                templateTransaction: 500,
+              }),
+            ],
+          }),
+          transactions: transactionData({
+            transactions: [template({ handle: 500, account: 1 })],
+          }),
+        }),
+      );
+
+      expect(result.bills[0].frequency).toBe(FrequencyType.YEARLY);
+      expect(result.bills[0].approximate).toBe(false);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("takes the cadence from the series' own instances over its code", () => {
+      // Instances a year apart are the file saying "yearly" in data. Whatever
+      // `BILL.frq` 3 is taken to mean, it does not outrank that.
+      const result = mapBills(
+        input({
+          bills: billData({
+            bills: [2022, 2023, 2024, 2025, 2026].map((year, index) =>
+              mnyBill({
+                handle: 7 + index,
+                series: 7,
+                instance: index,
+                frequency: 3,
+                nextDue: `${year}-07-30`,
+                templateTransaction: 500,
+              }),
+            ),
+          }),
+          transactions: transactionData({
+            transactions: [template({ handle: 500, account: 1 })],
+          }),
+        }),
+      );
+
+      expect(result.bills).toHaveLength(1);
+      expect(result.bills[0].frequency).toBe(FrequencyType.YEARLY);
+      expect(result.bills[0].approximate).toBe(false);
+    });
+
+    it("keeps a series whose code is unknown but whose instances are regular", () => {
+      const result = mapBills(
+        input({
+          bills: billData({
+            bills: ["2026-05-30", "2026-06-30", "2026-07-30"].map(
+              (nextDue, index) =>
+                mnyBill({
+                  handle: 7 + index,
+                  series: 7,
+                  instance: index,
+                  frequency: 4,
+                  nextDue,
+                  templateTransaction: 500,
+                }),
+            ),
+          }),
+          transactions: transactionData({
+            transactions: [template({ handle: 500, account: 1 })],
+          }),
+        }),
+      );
+
+      expect(result.bills).toHaveLength(1);
+      expect(result.bills[0].frequency).toBe(FrequencyType.MONTHLY);
+      expect(result.skipped).toBe(0);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("keeps the approximation flag when the instances agree with the code", () => {
+      const result = mapBills(
+        input({
+          bills: billData({
+            bills: ["2026-06-18", "2026-07-09", "2026-07-30"].map(
+              (nextDue, index) =>
+                mnyBill({
+                  handle: 7 + index,
+                  series: 7,
+                  instance: index,
+                  frequency: 2,
+                  interval: 3,
+                  nextDue,
+                  templateTransaction: 500,
+                }),
+            ),
+          }),
+          transactions: transactionData({
+            transactions: [template({ handle: 500, account: 1 })],
+          }),
+          payees: [],
+        }),
+      );
+
+      // Three-weekly spacing matches no Monize type, so the inference declines
+      // and the code's downgrade -- WEEKLY, flagged -- stands.
+      expect(result.bills[0].frequency).toBe(FrequencyType.WEEKLY);
+      expect(result.bills[0].approximate).toBe(true);
     });
   });
 

--- a/backend/src/import/mny/map/map-bills.ts
+++ b/backend/src/import/mny/map/map-bills.ts
@@ -16,6 +16,7 @@ import {
   FrequencyType,
   calculateNextDueDate,
 } from "../../../common/recurrence";
+import { CADENCE_DAYS, inferFrequencyFromDueDates } from "./bill-cadence";
 import { MnyBill, MnyPayee, MnyTransaction } from "../model/mny-rows";
 import { MnyWarning } from "../model/mny-warnings";
 import { isDegeneratePayeeName } from "./map-reference";
@@ -51,20 +52,10 @@ import { MnyTransactionData } from "../tables/read-transactions";
  */
 export const BILL_PAST_HORIZON_DAYS = 92;
 
-/** One cycle of each frequency, in days, rounded up. */
-const CYCLE_DAYS: Record<FrequencyType, number> = {
-  ONCE: 0,
-  DAILY: 1,
-  WEEKLY: 7,
-  BIWEEKLY: 14,
-  EVERY4WEEKS: 28,
-  SEMIMONTHLY: 15,
-  MONTHLY: 31,
-  EVERY2MONTHS: 62,
-  QUARTERLY: 92,
-  SEMIANNUAL: 184,
-  YEARLY: 366,
-};
+/** One cycle of each frequency, in whole days, rounded up. */
+function cycleDays(frequency: keyof typeof CADENCE_DAYS): number {
+  return Math.ceil(CADENCE_DAYS[frequency]);
+}
 
 /**
  * The date a series' activity is judged against.
@@ -279,7 +270,7 @@ function isActive(
 
   const window = Math.max(
     BILL_FUTURE_HORIZON_DAYS,
-    CYCLE_DAYS[mapping.frequency] + BILL_PAST_HORIZON_DAYS,
+    cycleDays(mapping.frequency) + BILL_PAST_HORIZON_DAYS,
   );
   return nextDue >= shiftIsoDate(anchor, -window);
 }
@@ -409,11 +400,38 @@ function billName(
   return memo || `Bill ${handle}`;
 }
 
+/**
+ * The cadence a series recurs at: what its own instances do, falling back to
+ * what `BILL.frq` says they should do.
+ *
+ * The dates win a disagreement. `frq` is a code no fixture in this repository
+ * has ever contained, and the one value a bug report could check was wrong
+ * (issue #1150: yearly bills imported as every two months); the spacing
+ * between a series' instances is the file stating its own cadence. Where the
+ * two agree the code's mapping is kept as-is, so an approximated interval
+ * still reports itself as approximate.
+ */
+export function resolveSeriesFrequency(
+  representative: MnyBill,
+  instances: readonly MnyBill[],
+): MnyFrequencyMapping | null {
+  const coded = mapFrequency(representative.frequency, representative.interval);
+  const observed = inferFrequencyFromDueDates(
+    instances.map((instance) => instance.nextDue),
+  );
+
+  if (observed === null || coded?.frequency === observed) {
+    return coded;
+  }
+  return { frequency: observed, approximate: false };
+}
+
 /** A series the user's account selection left out, as opposed to a bad row. */
 const EXCLUDED = "excluded";
 
 function mapOne(
   representative: MnyBill,
+  mapping: MnyFrequencyMapping | null,
   context: Context,
 ): MappedBill | typeof EXCLUDED | null {
   const handle = representative.handle as number;
@@ -444,15 +462,14 @@ function mapOne(
     return EXCLUDED;
   }
 
-  const mapping = mapFrequency(
-    representative.frequency,
-    representative.interval,
-  );
   if (mapping === null) {
+    // The raw pair rides along: `BILL.frq` is still only partly known, and an
+    // unmapped code plus its interval is what a real file has to report for
+    // the rest of the table to ever be pinned down.
     context.warnings.push({
       code: "unusableBill",
       subject: `hbill=${handle}`,
-      detail: `frq=${representative.frequency}`,
+      detail: `frq=${representative.frequency} x${representative.interval}`,
     });
     return null;
   }
@@ -605,17 +622,14 @@ export function mapBills(input: MapBillsInput): MappedBills {
 
   for (const instances of bySeries.values()) {
     const representative = representativeOf(instances, anchor);
-    if (
-      representative === null ||
-      !isActive(
-        representative,
-        anchor,
-        mapFrequency(representative.frequency, representative.interval),
-      )
-    ) {
+    if (representative === null) {
       continue;
     }
-    const bill = mapOne(representative, context);
+    const mapping = resolveSeriesFrequency(representative, instances);
+    if (!isActive(representative, anchor, mapping)) {
+      continue;
+    }
+    const bill = mapOne(representative, mapping, context);
     if (bill === null) {
       skipped += 1;
       continue;

--- a/backend/src/import/mny/model/mny-model.spec.ts
+++ b/backend/src/import/mny/model/mny-model.spec.ts
@@ -397,9 +397,6 @@ describe("mapFrequency", () => {
     [MNY_FREQUENCY.WEEKLY, FrequencyType.WEEKLY],
     [MNY_FREQUENCY.MONTHLY, FrequencyType.MONTHLY],
     [MNY_FREQUENCY.YEARLY, FrequencyType.YEARLY],
-    [MNY_FREQUENCY.EVERY_2_MONTHS, FrequencyType.EVERY2MONTHS],
-    [MNY_FREQUENCY.QUARTERLY, FrequencyType.QUARTERLY],
-    [MNY_FREQUENCY.SEMIANNUAL, FrequencyType.SEMIANNUAL],
   ])("maps frq %p to %s exactly", (frequency, expected) => {
     expect(mapFrequency(frequency)).toEqual({
       frequency: expected,
@@ -435,27 +432,50 @@ describe("mapFrequency", () => {
     },
   );
 
-  it("maps every-two-months exactly, by code and by interval", () => {
-    // PR #192 mapped this to BIWEEKLY -- every two weeks, not every two
-    // months. Before task B3 Monize had no type for it and the mapper
-    // downgraded to MONTHLY with a warning.
-    const expected = {
-      frequency: FrequencyType.EVERY2MONTHS,
+  it("maps a yearly bill to YEARLY, not to every two months (issue #1150)", () => {
+    // The regression: `frq` 5 was mapped to EVERY2MONTHS on PR #192's word,
+    // and a Money Plus Sunset file's yearly bills imported six times a year.
+    expect(mapFrequency(5)).toEqual({
+      frequency: FrequencyType.YEARLY,
       approximate: false,
-    };
-    expect(mapFrequency(MNY_FREQUENCY.EVERY_2_MONTHS)).toEqual(expected);
-    expect(mapFrequency(MNY_FREQUENCY.MONTHLY, 2)).toEqual(expected);
+    });
   });
 
-  it("maps semiannual exactly, by code and by interval", () => {
-    // PR #192 stretched it to YEARLY, halving the reminders; before B3 the
-    // mapper downgraded to QUARTERLY with a warning.
-    const expected = {
+  it("maps every-two-months and semiannual by interval", () => {
+    // PR #192 mapped the first to BIWEEKLY -- every two weeks, not every two
+    // months -- and stretched the second to YEARLY, halving the reminders.
+    // Before task B3 Monize had no type for either. Money expresses both as a
+    // monthly code with a multiplier, which is the only spelling of them this
+    // repository has evidence for.
+    expect(mapFrequency(MNY_FREQUENCY.MONTHLY, 2)).toEqual({
+      frequency: FrequencyType.EVERY2MONTHS,
+      approximate: false,
+    });
+    expect(mapFrequency(MNY_FREQUENCY.MONTHLY, 6)).toEqual({
       frequency: FrequencyType.SEMIANNUAL,
       approximate: false,
-    };
-    expect(mapFrequency(MNY_FREQUENCY.SEMIANNUAL)).toEqual(expected);
-    expect(mapFrequency(MNY_FREQUENCY.MONTHLY, 6)).toEqual(expected);
+    });
+  });
+
+  it("approximates an unrepresentable yearly interval", () => {
+    expect(mapFrequency(MNY_FREQUENCY.YEARLY, 2)).toEqual({
+      frequency: FrequencyType.YEARLY,
+      approximate: true,
+    });
+  });
+
+  it("approximates an unrepresentable daily interval", () => {
+    expect(mapFrequency(MNY_FREQUENCY.DAILY, 3)).toEqual({
+      frequency: FrequencyType.DAILY,
+      approximate: true,
+    });
+  });
+
+  it("ignores an interval on a one-off", () => {
+    expect(mapFrequency(MNY_FREQUENCY.ONCE, 4)).toEqual({
+      frequency: FrequencyType.ONCE,
+      approximate: false,
+    });
   });
 
   it("approximates an unrepresentable weekly interval", () => {
@@ -482,7 +502,12 @@ describe("mapFrequency", () => {
     },
   );
 
-  it.each([[8], [-1], [99]])(
+  // 4, 6 and 7 are on this list rather than mapped: PR #192's table claimed
+  // them, and the one claim above 3 that a bug report could check (4 = yearly)
+  // was wrong -- so the rest of that table is a guess, and a guess about how
+  // often money leaves an account is reported, never made. The bill mapper
+  // reads the cadence off the series' own instance dates first.
+  it.each([[4], [6], [7], [8], [-1], [99]])(
     "returns null for the unknown frq %p",
     (frequency) => {
       expect(mapFrequency(frequency)).toBeNull();

--- a/backend/src/import/mny/model/mny-model.ts
+++ b/backend/src/import/mny/model/mny-model.ts
@@ -535,28 +535,44 @@ export function isIncomeCategoryType(categoryType: number): boolean | null {
 // ---------------------------------------------------------------------------
 
 /**
- * Money recurrence codes. **Unconfirmed** -- `BILL` is empty in every fixture.
- * From PR #192's format reference.
+ * Money recurrence codes.
+ *
+ * `BILL` is empty in every committed fixture, so none of these can be read out
+ * of a file this repository holds. The list PR #192 supplied claimed eight of
+ * them -- 4 yearly, 5 every two months, 6 quarterly, 7 semiannual -- and issue
+ * #1150 checked the only one a bug report can check: a Money Plus Sunset file
+ * whose **yearly** bills imported as "every 2 months", which is `EXACT[5]`
+ * under that list. So Money writes 5 for a yearly bill, and the same report
+ * confirms 3 for a monthly one, since the same file's monthly bills arrived
+ * monthly.
+ *
+ * That refutes the reference's 4, and leaves 6 and 7 as claims from a source
+ * now known to be wrong about the codes above 3. They are therefore **not**
+ * mapped: an unknown code is reported (`unusableBill`, with the raw `frq` and
+ * `cFrqInst`) rather than guessed, and `inferFrequencyFromDueDates` answers
+ * from the series' own instance dates first anyway -- a file's own spacing
+ * outranks any table in this file.
+ *
+ * The gap is smaller than the missing codes make it look, because `cFrqInst`
+ * is a real multiplier: every two months, quarterly and twice a year are all
+ * `frq` 3 with an interval of 2, 3 and 6.
  */
 export const MNY_FREQUENCY = {
   ONCE: 0,
   DAILY: 1,
   WEEKLY: 2,
   MONTHLY: 3,
-  YEARLY: 4,
-  EVERY_2_MONTHS: 5,
-  QUARTERLY: 6,
-  SEMIANNUAL: 7,
+  YEARLY: 5,
 } as const;
 
 export interface MnyFrequencyMapping {
   readonly frequency: FrequencyType;
   /**
    * True when Monize has no exact equivalent, so the mapping changes how often
-   * the bill falls due, and the mapper must warn per bill. Every Money
-   * recurrence *code* now maps exactly (Track B task B3 added `EVERY2MONTHS`
-   * and `SEMIANNUAL`); only an unrepresentable `cFrqInst` interval -- weekly
-   * every 3 weeks, monthly every 5 months -- still approximates.
+   * the bill falls due, and the mapper must warn per bill. Every *known* Money
+   * recurrence code maps exactly (Track B task B3 added `EVERY2MONTHS` and
+   * `SEMIANNUAL`); only an unrepresentable `cFrqInst` interval -- weekly every
+   * 3 weeks, monthly every 5 months, yearly every 2 years -- approximates.
    */
   readonly approximate: boolean;
 }
@@ -567,9 +583,6 @@ const EXACT: Record<number, FrequencyType> = {
   [MNY_FREQUENCY.WEEKLY]: FrequencyType.WEEKLY,
   [MNY_FREQUENCY.MONTHLY]: FrequencyType.MONTHLY,
   [MNY_FREQUENCY.YEARLY]: FrequencyType.YEARLY,
-  [MNY_FREQUENCY.EVERY_2_MONTHS]: FrequencyType.EVERY2MONTHS,
-  [MNY_FREQUENCY.QUARTERLY]: FrequencyType.QUARTERLY,
-  [MNY_FREQUENCY.SEMIANNUAL]: FrequencyType.SEMIANNUAL,
 };
 
 /** Weekly recurrences whose interval Monize expresses as its own type. */
@@ -586,45 +599,48 @@ const MONTHLY_BY_INTERVAL: Record<number, FrequencyType> = {
   12: FrequencyType.YEARLY,
 };
 
+/** Every code whose `cFrqInst` multiples land on a type of their own. */
+const BY_INTERVAL: Record<number, Record<number, FrequencyType>> = {
+  [MNY_FREQUENCY.WEEKLY]: WEEKLY_BY_INTERVAL,
+  [MNY_FREQUENCY.MONTHLY]: MONTHLY_BY_INTERVAL,
+};
+
 /**
  * Maps a Money recurrence onto a Monize frequency.
  *
  * `cFrqInst` is Money's interval multiplier: weekly with an interval of 2 is
- * exactly Monize's BIWEEKLY, monthly with 3 is QUARTERLY. Every Money
- * recurrence code has an exact Monize type since task B3 added `EVERY2MONTHS`
- * and `SEMIANNUAL`, so only an interval with no matching type (weekly every 3
- * weeks, monthly every 5 months) still falls to the next **shorter** period and
- * is flagged approximate. Shorter is the safer error: v1 imports bills with
+ * exactly Monize's BIWEEKLY, monthly with 3 is QUARTERLY. An interval with no
+ * matching type -- weekly every 3 weeks, monthly every 5 months, yearly every
+ * 2 years -- falls to the code's own **shorter** period and is flagged
+ * approximate. Shorter is the safer error: v1 imports bills with
  * `auto_post = false`, so an extra reminder is noise while a missed one is a
  * missed payment. (PR #192 erred in both directions, turning bimonthly bills
  * into biweekly ones and semiannual bills into yearly ones.)
  *
  * Returns null for an unknown code, which the mapper reports rather than
- * guesses.
+ * guesses -- see `MNY_FREQUENCY` for which codes are known and how. The bill
+ * mapper asks the series' instance dates before it asks this function, so an
+ * unmapped code only loses a series that has no spacing to read.
  */
 export function mapFrequency(
   frequency: number,
   interval = 1,
 ): MnyFrequencyMapping | null {
+  const base = EXACT[frequency];
+  if (base === undefined) {
+    return null;
+  }
+
   const steps =
     Number.isFinite(interval) && interval >= 1 ? Math.round(interval) : 1;
-
-  if (frequency === MNY_FREQUENCY.WEEKLY && steps > 1) {
-    const exact = WEEKLY_BY_INTERVAL[steps];
-    return exact
-      ? { frequency: exact, approximate: false }
-      : { frequency: FrequencyType.WEEKLY, approximate: true };
+  if (steps <= 1 || base === FrequencyType.ONCE) {
+    return { frequency: base, approximate: false };
   }
 
-  if (frequency === MNY_FREQUENCY.MONTHLY && steps > 1) {
-    const exact = MONTHLY_BY_INTERVAL[steps];
-    return exact
-      ? { frequency: exact, approximate: false }
-      : { frequency: FrequencyType.MONTHLY, approximate: true };
-  }
-
-  const exact = EXACT[frequency];
-  return exact ? { frequency: exact, approximate: false } : null;
+  const exact = BY_INTERVAL[frequency]?.[steps];
+  return exact
+    ? { frequency: exact, approximate: false }
+    : { frequency: base, approximate: true };
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/import/mny/model/mny-rows.ts
+++ b/backend/src/import/mny/model/mny-rows.ts
@@ -250,7 +250,7 @@ export interface MnyBill {
   readonly handle: number | null;
   /** `st`: series status. Active semantics pinned by task M0.6. */
   readonly status: number;
-  /** `frq`: 0 once, 1 daily, 2 weekly, 3 monthly, 4 yearly, 6 quarterly. */
+  /** `frq`: 0 once, 1 daily, 2 weekly, 3 monthly, 5 yearly (`MNY_FREQUENCY`). */
   readonly frequency: number;
   /** `cFrqInst`: interval multiplier for `frequency`. */
   readonly interval: number;

--- a/docs/future-plans/mny-import.md
+++ b/docs/future-plans/mny-import.md
@@ -388,8 +388,17 @@ is BIWEEKLY, weekly × 4 is EVERY4WEEKS (likewise monthly × 2 → EVERY2MONTHS,
 **shorter** period and returns `approximate: true`. Shorter is the safer error while v1 imports
 bills with `auto_post = false`: an extra reminder is noise, a missed one is a missed payment.
 PR #192 erred in both directions (bimonthly → BIWEEKLY, semiannual → YEARLY). Track B task B3
-has since added `EVERY2MONTHS` and `SEMIANNUAL`, so every recurrence *code* is now exact and only
-an unrepresentable interval (weekly × 3, monthly × 5) still approximates.
+has since added `EVERY2MONTHS` and `SEMIANNUAL`, so an unrepresentable interval (weekly × 3,
+monthly × 5, yearly × 2) is all that still approximates.
+
+**But the code table itself was a guess, and issue #1150 caught it.** A Money Plus Sunset file's
+yearly bills imported recurring every two months — `frq` 5 under PR #192's table — while its
+monthly bills were right, so 5 is yearly, 3 is monthly, and 4/6/7 are claims from a source now
+known to be wrong. They map to nothing and are reported with their raw `frq`/`cFrqInst`. The
+durable half of the fix is that `BILL` answers the question itself: it holds one row per
+occurrence, so `inferFrequencyFromDueDates` reads the cadence off the spacing of a series'
+instances and `map-bills.ts` prefers it to the code. A table nobody can check loses to the file
+in front of us.
 
 **Still unanswerable from the fixtures.** `BILL` is empty in all five files and the transactions
 exercise only `act` 0, 1 and 15, so `BILL.st` (question 12.3) and the `act` 5 / 14 semantics
@@ -580,10 +589,10 @@ real mappers and, in the integration spec, the real INSERT path.
 `BILL` + template `TRN` (`lHtrn`) -> `scheduled_transactions` with splits/transfer/investment
 template support. Active-series detection: `st` in the spike-confirmed active set, next-due date
 within a sanity horizon, deduped per series. Wizard selection is authoritative; selected bills
-import with `is_active = true`, `auto_post = false`. Frequency map: 0 ONCE, 1 DAILY, 2 WEEKLY,
-3 MONTHLY, 4 YEARLY, 5 EVERY2MONTHS, 6 QUARTERLY, 7 SEMIANNUAL;
-`cFrqInst` interval honored where representable, else downgrade + warning. (B3 has landed, so
-only intervals with no Monize type downgrade.)
+import with `is_active = true`, `auto_post = false`. Cadence comes from the series' own instance
+dates where they are regular enough to read (`map/bill-cadence.ts`), and from `frq` otherwise:
+0 ONCE, 1 DAILY, 2 WEEKLY, 3 MONTHLY, 5 YEARLY, with 4/6/7 unknown since issue #1150 refuted the
+reference above 3; `cFrqInst` interval honored where representable, else downgrade + warning.
 
 ### 8.4 Investments
 

--- a/docs/ms-money-data-model.md
+++ b/docs/ms-money-data-model.md
@@ -582,16 +582,14 @@ reduce each series to one representative before doing anything else.
 
 ### Frequency codes (`frq`)
 
-| frq | Meaning |
-|-----|---------|
-| 0 | Once |
-| 1 | Daily |
-| 2 | Weekly |
-| 3 | Monthly |
-| 4 | Yearly |
-| 5 | Every two months |
-| 6 | Quarterly |
-| 7 | Semiannually |
+| frq | Meaning | Evidence |
+|-----|---------|----------|
+| 0 | Once | Format reference only |
+| 1 | Daily | Format reference only |
+| 2 | Weekly | Format reference only |
+| 3 | Monthly | Issue #1150: the same file's monthly bills imported monthly |
+| 5 | Yearly | Issue #1150: yearly bills imported as `EXACT[5]`, then "every 2 months" |
+| 4, 6, 7 | **Unknown** | Claimed yearly / quarterly / semiannual by the original reference, which 5 refutes |
 
 The code alone is not the whole answer: `cFrqInst` multiplies it, and several
 combinations land exactly on a distinct recurrence (weekly x 2 is fortnightly,
@@ -602,6 +600,25 @@ missed payment.
 
 > **Correction.** The proof of concept mapped bimonthly (every two months) to
 > fortnightly and semiannual to yearly -- errors in both directions at once.
+
+> **Correction.** The original recorded 4 as yearly, 5 as every two months, 6 as
+> quarterly and 7 as semiannual. Issue #1150 reported a Money Plus Sunset file
+> whose **yearly** bills imported recurring every two months -- which is code 5
+> under that table -- while the same file's monthly bills were right. So 5 is
+> yearly, 3 is monthly, and the reference is wrong above 3; 4, 6 and 7 now map
+> to nothing and are reported (`unusableBill`, carrying `frq` and `cFrqInst`)
+> rather than guessed. The gap is narrower than it looks, because `cFrqInst` is
+> a real multiplier: every two months, quarterly and twice a year are `frq` 3
+> with an interval of 2, 3 and 6.
+
+**A series' own instance dates outrank its code.** `BILL` holds one row per
+occurrence, so the spacing between a series' `dt` values *is* its recurrence --
+measured on the file in hand, where `frq` is a table nobody has been able to
+check. `map/bill-cadence.ts` reads it (a strict majority of the recent gaps
+matching one cadence within 12%), and `map-bills.ts` prefers that answer to
+`frq`, falling back to the code only for a series too short to measure. Issue
+#1150 is the cost of the other order: every affected file stated "365 days
+apart" in data nothing was reading.
 
 ## Limitations of this reference
 


### PR DESCRIPTION
Annual Money bills imported as recurring every two months (issue #1150).
`BILL.frq` was mapped from PR #192's format reference, which no fixture in
this repository can check -- `BILL` is empty in all five. The one entry a
bug report could check was wrong: yearly is code 5, which that table read
as "every two months", while the same file's monthly bills (code 3) were
right.

So `mapFrequency` now maps only the codes there is evidence for -- 0 once,
1 daily, 2 weekly, 3 monthly, 5 yearly -- and reports 4, 6 and 7 as unknown
(`unusableBill`, carrying `frq` and `cFrqInst`) rather than guessing how
often money leaves an account. Little is lost by dropping them: `cFrqInst`
is a real multiplier, so every two months, quarterly and twice a year are
code 3 with an interval of 2, 3 and 6.

The durable half is that the file answers the question itself. `BILL` holds
one row per occurrence, so the spacing between a series' instances *is* its
recurrence: `inferFrequencyFromDueDates` reads it (a strict majority of the
recent gaps matching one cadence within 12%) and the mapper prefers it to
the code, falling back to `frq` only for a series too short to measure. Every
file affected by this bug said "365 days apart" in data nothing was reading.

Also folds the bill horizon's cycle-length table into the same list of
cadences, and approximates an unrepresentable interval on any code (yearly
every 2 years, daily every 3 days) rather than only on weekly and monthly.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011hN4mgmnDxxXp9iYZXZufb