### PR TITLE
Fix scheduled-investment state cleanup, posting consistency, and concurrency (#1154)

### DIFF
--- a/backend/src/i18n/locales/de/errors.json
+++ b/backend/src/i18n/locales/de/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Terminierte Investmentbuchungen erfordern ein Maklerkonto",
     "notFound": "Terminierte Buchung mit ID {{ id }} nicht gefunden",
     "occurrenceAlreadyPosted": "Dieser Vorgang wurde bereits gebucht.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Eine abweichende Währung ist nur bei einer einfachen terminierten Buchung möglich, nicht bei einer Aufteilung, Überweisung oder Investition",
     "fxRateUnavailable": "Für {{ from }} zu {{ to }} ist am {{ date }} kein Wechselkurs verfügbar. Geben Sie den Betrag in {{ to }} ein, um ihn zu buchen.",
     "investmentActionRequired": "Investmentaktion ist für terminierte Investmentbuchungen erforderlich",

--- a/backend/src/i18n/locales/en/errors.json
+++ b/backend/src/i18n/locales/en/errors.json
@@ -372,6 +372,7 @@
     "requiresBrokerageAccount": "Scheduled investment transactions require a brokerage account",
     "notFound": "Scheduled transaction with ID {{ id }} not found",
     "occurrenceAlreadyPosted": "This occurrence has already been posted.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "A different currency can only be used on a plain scheduled transaction, not a split, transfer or investment",
     "fxRateUnavailable": "No exchange rate is available for {{ from }} to {{ to }} on {{ date }}. Enter the amount in {{ to }} to post it.",
     "investmentActionRequired": "Investment action is required for scheduled investment transactions",

--- a/backend/src/i18n/locales/es/errors.json
+++ b/backend/src/i18n/locales/es/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Las transacciones de inversión planificadas requieren una cuenta de corretaje",
     "notFound": "Transacción planificada con ID {{ id }} no encontrada",
     "occurrenceAlreadyPosted": "Esta ocurrencia ya se ha registrado.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Solo se puede usar otra moneda en una transacción planificada simple, no en un desglose, una transferencia ni una inversión",
     "fxRateUnavailable": "No hay un tipo de cambio disponible de {{ from }} a {{ to }} el {{ date }}. Introduce el importe en {{ to }} para registrarlo.",
     "investmentActionRequired": "Se requiere acción de inversión para las transacciones de inversión planificadas",

--- a/backend/src/i18n/locales/fr/errors.json
+++ b/backend/src/i18n/locales/fr/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Les transactions d'investissement récurrentes nécessitent un compte de courtage",
     "notFound": "Transaction récurrente avec l'ID {{ id }} introuvable",
     "occurrenceAlreadyPosted": "Cette occurrence a déjà été enregistrée.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Une devise différente n'est possible que sur une transaction récurrente simple, pas sur une transaction fractionnée, un virement ou un investissement",
     "fxRateUnavailable": "Aucun taux de change n'est disponible de {{ from }} vers {{ to }} le {{ date }}. Saisissez le montant en {{ to }} pour l'enregistrer.",
     "investmentActionRequired": "Une action d'investissement est requise pour les transactions d'investissement récurrentes",

--- a/backend/src/i18n/locales/hi/errors.json
+++ b/backend/src/i18n/locales/hi/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "अनुसूचित निवेश लेनदेन के लिए ब्रोकरेज खाता आवश्यक है",
     "notFound": "ID {{ id }} वाला अनुसूचित लेनदेन नहीं मिला",
     "occurrenceAlreadyPosted": "यह घटना पहले ही दर्ज की जा चुकी है।",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "अलग मुद्रा केवल सामान्य अनुसूचित लेनदेन पर उपयोग की जा सकती है, विभाजन, स्थानांतरण या निवेश पर नहीं",
     "fxRateUnavailable": "{{ date }} को {{ from }} से {{ to }} के लिए कोई विनिमय दर उपलब्ध नहीं है। इसे पोस्ट करने के लिए राशि {{ to }} में दर्ज करें।",
     "investmentActionRequired": "अनुसूचित निवेश लेनदेन के लिए निवेश क्रिया आवश्यक है",

--- a/backend/src/i18n/locales/id/errors.json
+++ b/backend/src/i18n/locales/id/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Transaksi investasi terjadwal memerlukan akun pialang",
     "notFound": "Transaksi terjadwal dengan ID {{ id }} tidak ditemukan",
     "occurrenceAlreadyPosted": "Kejadian ini sudah dicatat.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Mata uang lain hanya dapat dipakai pada transaksi terjadwal biasa, bukan pada transaksi terbagi, transfer, atau investasi",
     "fxRateUnavailable": "Tidak ada nilai tukar yang tersedia untuk {{ from }} ke {{ to }} pada {{ date }}. Masukkan jumlah dalam {{ to }} untuk mempostingnya.",
     "investmentActionRequired": "Tindakan investasi diperlukan untuk transaksi investasi terjadwal",

--- a/backend/src/i18n/locales/it/errors.json
+++ b/backend/src/i18n/locales/it/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Le transazioni di investimento pianificate richiedono un conto di intermediazione",
     "notFound": "Transazione pianificata con ID {{ id }} non trovata",
     "occurrenceAlreadyPosted": "Questa occorrenza è già stata registrata.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Una valuta diversa può essere usata solo su una transazione pianificata semplice, non su una suddivisione, un trasferimento o un investimento",
     "fxRateUnavailable": "Non è disponibile alcun tasso di cambio da {{ from }} a {{ to }} il {{ date }}. Inserisci l'importo in {{ to }} per registrarla.",
     "investmentActionRequired": "L'azione di investimento è obbligatoria per le transazioni di investimento pianificate",

--- a/backend/src/i18n/locales/ja/errors.json
+++ b/backend/src/i18n/locales/ja/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "スケジュール投資取引には証券口座が必要です",
     "notFound": "ID {{ id }} のスケジュール取引が見つかりません",
     "occurrenceAlreadyPosted": "この回はすでに記帳されています。",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "別の通貨を使用できるのは通常のスケジュール取引のみで、分割、振替、投資では使用できません",
     "fxRateUnavailable": "{{ date }} の {{ from }} から {{ to }} への為替レートが利用できません。投稿するには金額を {{ to }} で入力してください。",
     "investmentActionRequired": "スケジュール投資取引には投資アクションが必要です",

--- a/backend/src/i18n/locales/ko/errors.json
+++ b/backend/src/i18n/locales/ko/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "예약 투자 거래에는 중개 계정이 필요합니다",
     "notFound": "ID가 {{ id }}인 예약 거래를 찾을 수 없습니다",
     "occurrenceAlreadyPosted": "이 발생 건은 이미 등록되었습니다.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "다른 통화는 일반 예약 거래에서만 사용할 수 있으며 분할, 이체, 투자에서는 사용할 수 없습니다",
     "fxRateUnavailable": "{{ date }}에 {{ from }}에서 {{ to }}로의 환율을 사용할 수 없습니다. 게시하려면 금액을 {{ to }}로 입력하세요.",
     "investmentActionRequired": "예약 투자 거래에는 투자 작업이 필요합니다",

--- a/backend/src/i18n/locales/nl/errors.json
+++ b/backend/src/i18n/locales/nl/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Geplande beleggingstransacties vereisen een brokerage-rekening",
     "notFound": "Geplande transactie met ID {{ id }} niet gevonden",
     "occurrenceAlreadyPosted": "Deze keer is al geboekt.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Een andere valuta kan alleen bij een gewone geplande transactie, niet bij een splitsing, overboeking of belegging",
     "fxRateUnavailable": "Er is voor {{ date }} geen wisselkoers beschikbaar voor {{ from }} naar {{ to }}. Voer het bedrag in {{ to }} in om te boeken.",
     "investmentActionRequired": "Beleggingsactie is vereist voor geplande beleggingstransacties",

--- a/backend/src/i18n/locales/pl/errors.json
+++ b/backend/src/i18n/locales/pl/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Zaplanowane transakcje inwestycyjne wymagają konta maklerskiego",
     "notFound": "Nie znaleziono zaplanowanej transakcji o ID {{ id }}",
     "occurrenceAlreadyPosted": "Ta rata została już zaksięgowana.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Innej waluty można użyć tylko w zwykłej zaplanowanej transakcji, a nie w podziale, przelewie ani inwestycji",
     "fxRateUnavailable": "Dla {{ date }} nie ma dostępnego kursu wymiany z {{ from }} na {{ to }}. Wprowadź kwotę w {{ to }}, aby ją zaksięgować.",
     "investmentActionRequired": "Operacja inwestycyjna jest wymagana dla zaplanowanych transakcji inwestycyjnych",

--- a/backend/src/i18n/locales/pt-BR/errors.json
+++ b/backend/src/i18n/locales/pt-BR/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "As transações de investimento agendadas requerem uma conta de corretagem",
     "notFound": "Transação agendada com ID {{ id }} não encontrada",
     "occurrenceAlreadyPosted": "Esta ocorrência já foi lançada.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Só é possível usar outra moeda em uma transação agendada simples, não em uma divisão, transferência ou investimento",
     "fxRateUnavailable": "Não há uma taxa de câmbio disponível de {{ from }} para {{ to }} em {{ date }}. Insira o valor em {{ to }} para lançá-la.",
     "investmentActionRequired": "A ação de investimento é obrigatória para transações de investimento agendadas",

--- a/backend/src/i18n/locales/pt/errors.json
+++ b/backend/src/i18n/locales/pt/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "As transações de investimento agendadas requerem uma conta de corretagem",
     "notFound": "Transação agendada com ID {{ id }} não encontrada",
     "occurrenceAlreadyPosted": "Esta ocorrência já foi lançada.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Só é possível usar outra moeda numa transação agendada simples, não numa divisão, transferência ou investimento",
     "fxRateUnavailable": "Não há uma taxa de câmbio disponível de {{ from }} para {{ to }} em {{ date }}. Introduza o montante em {{ to }} para a lançar.",
     "investmentActionRequired": "A ação de investimento é obrigatória para transações de investimento agendadas",

--- a/backend/src/i18n/locales/ru/errors.json
+++ b/backend/src/i18n/locales/ru/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Плановые инвестиционные проводки требуют брокерский счёт",
     "notFound": "Плановая проводка с ID {{ id }} не найдена",
     "occurrenceAlreadyPosted": "Это событие уже проведено.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Другую валюту можно использовать только в обычной плановой проводке, но не в разделении, переводе или инвестиционной",
     "fxRateUnavailable": "На {{ date }} курс обмена {{ from }} в {{ to }} недоступен. Введите сумму в {{ to }}, чтобы провести её.",
     "investmentActionRequired": "Для плановых инвестиционных проводок необходимо инвестиционное действие",

--- a/backend/src/i18n/locales/tr/errors.json
+++ b/backend/src/i18n/locales/tr/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Zamanlanmış yatırım işlemleri için aracı kurum hesabı gereklidir",
     "notFound": "{{ id }} kimliğine sahip zamanlanmış işlem bulunamadı",
     "occurrenceAlreadyPosted": "Bu tekrar zaten kaydedildi.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Farklı bir para birimi yalnızca sade bir zamanlanmış işlemde kullanılabilir; bölünmüş işlem, transfer veya yatırımda kullanılamaz",
     "fxRateUnavailable": "{{ date }} tarihinde {{ from }} biriminden {{ to }} birimine döviz kuru yok. Kaydetmek için tutarı {{ to }} cinsinden girin.",
     "investmentActionRequired": "Zamanlanmış yatırım işlemleri için yatırım eylemi gereklidir",

--- a/backend/src/i18n/locales/uk/errors.json
+++ b/backend/src/i18n/locales/uk/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Заплановані інвестиційні операції вимагають брокерського рахунку",
     "notFound": "Заплановану операцію з ідентифікатором {{ id }} не знайдено",
     "occurrenceAlreadyPosted": "Цю подію вже проведено.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Іншу валюту можна використати лише у звичайній запланованій операції, але не в розбитті, переказі чи інвестиції",
     "fxRateUnavailable": "На {{ date }} курс обміну {{ from }} на {{ to }} недоступний. Введіть суму в {{ to }}, щоб провести її.",
     "investmentActionRequired": "Для запланованих інвестиційних операцій необхідна інвестиційна дія",

--- a/backend/src/i18n/locales/vi/errors.json
+++ b/backend/src/i18n/locales/vi/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "Giao tác đầu tư theo lịch yêu cầu tài khoản môi giới",
     "notFound": "Không tìm thấy giao tác theo lịch với ID {{ id }}",
     "occurrenceAlreadyPosted": "Lần này đã được ghi nhận.",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "Chỉ có thể dùng đơn vị tiền tệ khác trên giao tác theo lịch thông thường, không dùng được cho giao tác chia nhỏ, chuyển tiền hoặc đầu tư",
     "fxRateUnavailable": "Không có tỷ giá từ {{ from }} sang {{ to }} vào {{ date }}. Hãy nhập số tiền bằng {{ to }} để đăng.",
     "investmentActionRequired": "Hành động đầu tư là bắt buộc cho giao tác đầu tư theo lịch",

--- a/backend/src/i18n/locales/xx/errors.json
+++ b/backend/src/i18n/locales/xx/errors.json
@@ -372,6 +372,7 @@
     "requiresBrokerageAccount": "[XX-Scheduled investment transactions require a brokerage account-XX]",
     "notFound": "[XX-Scheduled transaction with ID {{ id }} not found-XX]",
     "occurrenceAlreadyPosted": "[XX-This occurrence has already been posted.-XX]",
+    "changedConcurrently": "[XX-The scheduled transaction changed during the operation. Reload it and retry.-XX]",
     "fxPlainOnly": "[XX-A different currency can only be used on a plain scheduled transaction, not a split, transfer or investment-XX]",
     "fxRateUnavailable": "[XX-No exchange rate is available for {{ from }} to {{ to }} on {{ date }}. Enter the amount in {{ to }} to post it.-XX]",
     "investmentActionRequired": "[XX-Investment action is required for scheduled investment transactions-XX]",

--- a/backend/src/i18n/locales/zh-CN/errors.json
+++ b/backend/src/i18n/locales/zh-CN/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "计划投资交易需要经纪账户",
     "notFound": "未找到 ID 为 {{ id }} 的计划交易",
     "occurrenceAlreadyPosted": "该次记账已完成。",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "只有普通计划交易才能使用其他货币，拆分、转账和投资均不支持",
     "fxRateUnavailable": "{{ date }} 没有从 {{ from }} 到 {{ to }} 的可用汇率。请以 {{ to }} 输入金额后再过账。",
     "investmentActionRequired": "计划投资交易需要投资操作",

--- a/backend/src/i18n/locales/zh-TW/errors.json
+++ b/backend/src/i18n/locales/zh-TW/errors.json
@@ -363,6 +363,7 @@
     "requiresBrokerageAccount": "定期投資交易需要經紀科目",
     "notFound": "找不到 ID 為 {{ id }} 的定期交易",
     "occurrenceAlreadyPosted": "此次記帳已完成。",
+    "changedConcurrently": "The scheduled transaction changed during the operation. Reload it and retry.",
     "fxPlainOnly": "只有一般定期交易才能使用其他貨幣，分割、轉帳和投資均不支援",
     "fxRateUnavailable": "{{ date }} 沒有從 {{ from }} 到 {{ to }} 的可用匯率。請以 {{ to }} 輸入金額後再過帳。",
     "investmentActionRequired": "定期投資交易需要投資操作",

--- a/backend/src/import/mny/writers/write-bills.spec.ts
+++ b/backend/src/import/mny/writers/write-bills.spec.ts
@@ -259,6 +259,45 @@ describe("writeBills", () => {
     );
   });
 
+  it("does not persist a funding account on a non-BUY/SELL investment bill (issue #1154)", async () => {
+    // A DIVIDEND settles against the brokerage's linked cash account, not a
+    // funding account, so even though the account pair has a linked cash sleeve
+    // the imported row must not carry one -- the same stale-column invariant the
+    // scheduled-transaction service enforces on write.
+    const scheduled = repoDouble();
+    const splits = repoDouble();
+
+    await writeBills(
+      managerFor(scheduled, splits),
+      "user-1",
+      input({
+        bills: [
+          bill({
+            accountKey: "acct-10",
+            categoryHandle: null,
+            amount: 75,
+            investment: {
+              action: InvestmentAction.DIVIDEND,
+              securityHandle: 1,
+              quantity: null,
+              price: null,
+              commission: 0,
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(scheduled.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isInvestment: true,
+        investmentAction: InvestmentAction.DIVIDEND,
+        investmentSecurityId: "security-1",
+        investmentFundingAccountId: null,
+      }),
+    );
+  });
+
   it("still creates a bill whose payee, category or transfer account did not import", async () => {
     // A reference that did not survive the import must not take the bill down
     // with it: the schedule is still worth having with a blank field.

--- a/backend/src/import/mny/writers/write-bills.ts
+++ b/backend/src/import/mny/writers/write-bills.ts
@@ -4,6 +4,7 @@ import { ScheduledTransaction } from "../../../scheduled-transactions/entities/s
 import { ScheduledTransactionSplit } from "../../../scheduled-transactions/entities/scheduled-transaction-split.entity";
 import { SplitKind } from "../../../transactions/entities/split-kind.enum";
 import { roundMoney } from "../../../common/round.util";
+import { FUNDING_ACCOUNT_ACTIONS } from "../../../securities/investment-replay.util";
 import { MappedBill } from "../model/mny-import-model";
 
 /**
@@ -102,9 +103,15 @@ export async function writeBills(
       investment === null
         ? null
         : (input.securityIdByHandle.get(investment.securityHandle) ?? null);
+    // A funding account only belongs on a BUY/SELL; every other action settles
+    // against the brokerage's linked cash account. Persisting one on, say, an
+    // imported DIVIDEND leaves the same stale column the scheduled-transaction
+    // service now clears on write, so gate it on the action here too (#1154).
     const fundingKey = input.linkedKeyByKey.get(bill.accountKey);
     const fundingAccountId =
-      investment === null || fundingKey === undefined
+      investment === null ||
+      fundingKey === undefined ||
+      !FUNDING_ACCOUNT_ACTIONS.has(investment.action)
         ? null
         : (input.accountIdByKey.get(fundingKey) ?? null);
 

--- a/backend/src/scheduled-transactions/dto/create-scheduled-transaction.dto.ts
+++ b/backend/src/scheduled-transactions/dto/create-scheduled-transaction.dto.ts
@@ -12,6 +12,7 @@ import {
   Min,
   Max,
   MaxLength,
+  IsPositive,
 } from "class-validator";
 import { Type } from "class-transformer";
 import { CreateScheduledTransactionSplitDto } from "./create-scheduled-transaction-split.dto";
@@ -170,7 +171,7 @@ export class CreateScheduledTransactionDto {
 
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 10 })
-  @Min(0)
+  @IsPositive()
   investmentExchangeRate?: number;
 
   @IsOptional()

--- a/backend/src/scheduled-transactions/rls-context-smoke.spec.ts
+++ b/backend/src/scheduled-transactions/rls-context-smoke.spec.ts
@@ -114,6 +114,9 @@ describe("scheduled-transactions module RLS context smoke (real withScopedDb)", 
     };
     const overridesRepo = {
       createQueryBuilder: jest.fn().mockImplementation(overrideQueryBuilder),
+      // post() re-reads/locks the occurrence override inside the transaction
+      // (issue #1154 re-review); default to no override present.
+      findOne: jest.fn().mockResolvedValue(null),
     };
 
     const { service, manager, transactionsService } = await buildModule(
@@ -180,6 +183,9 @@ describe("scheduled-transactions module RLS context smoke (real withScopedDb)", 
     };
     const overridesRepo = {
       createQueryBuilder: jest.fn().mockImplementation(overrideQueryBuilder),
+      // post() re-reads/locks the occurrence override inside the transaction
+      // (issue #1154 re-review); default to no override present.
+      findOne: jest.fn().mockResolvedValue(null),
     };
 
     const { service, manager, exchangeRateService } = await buildModule(

--- a/backend/src/scheduled-transactions/scheduled-transaction-loan.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-loan.service.spec.ts
@@ -3,7 +3,7 @@ import { DataSource } from "typeorm";
 import { ScheduledTransactionLoanService } from "./scheduled-transaction-loan.service";
 import { ScheduledTransaction } from "./entities/scheduled-transaction.entity";
 import { ScheduledTransactionSplit } from "./entities/scheduled-transaction-split.entity";
-import { Account } from "../accounts/entities/account.entity";
+import { Account, AccountType } from "../accounts/entities/account.entity";
 import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
 
 jest.mock("../common/db/scoped-db", () =>
@@ -824,6 +824,56 @@ describe("ScheduledTransactionLoanService", () => {
       );
       // next_principal = 500 - 98 = 402
       expect(principalSave[0].amount).toBe(-402);
+    });
+
+    it("should recalculate a LINE_OF_CREDIT schedule (not only LOAN/MORTGAGE)", async () => {
+      // LoanPaymentSetupService accepts LINE_OF_CREDIT, so its scheduled payment
+      // must advance its next principal/interest split too (issue #1154
+      // re-review). balance=910, rate=12%, monthly, payment=100:
+      // periodicRate = 0.12/12 = 0.01
+      // next_interest  = 10 - 90 * 0.01 = 9.10
+      // next_principal = 100 - 9.10   = 90.90
+      const locAccount = makeLoanAccount({
+        accountType: AccountType.LINE_OF_CREDIT,
+        currentBalance: -910,
+        interestRate: 12,
+        paymentFrequency: "MONTHLY",
+        paymentAmount: 100,
+      });
+      accountsRepository.findOne.mockResolvedValue(locAccount);
+
+      const scheduledTx = makeScheduledTransaction({
+        amount: -100,
+        splits: [
+          {
+            id: "split-principal",
+            transferAccountId: loanAccountId,
+            categoryId: null,
+            amount: -90,
+            memo: "Principal",
+          },
+          {
+            id: "split-interest",
+            transferAccountId: null,
+            categoryId: "cat-interest",
+            amount: -10,
+            memo: "Interest",
+          },
+        ] as any,
+      });
+      scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
+
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
+
+      const interestSave = splitsRepository.save.mock.calls.find(
+        (call: any) => call[0].categoryId === "cat-interest",
+      );
+      expect(interestSave[0].amount).toBe(-9.1);
+
+      const principalSave = splitsRepository.save.mock.calls.find(
+        (call: any) => call[0].transferAccountId === loanAccountId,
+      );
+      expect(principalSave[0].amount).toBe(-90.9);
     });
 
     it("should use mortgage-specific rate calculation for MORTGAGE accounts", async () => {

--- a/backend/src/scheduled-transactions/scheduled-transaction-loan.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-loan.service.spec.ts
@@ -73,6 +73,13 @@ describe("ScheduledTransactionLoanService", () => {
       save: jest
         .fn()
         .mockImplementation((entity: any) => Promise.resolve(entity)),
+      // recalculateLoanPaymentSplits now re-reads the child set under the parent
+      // lock (issue #1154 re-review) instead of using the entity's relation;
+      // mirror whatever splits the mocked scheduled transaction carries.
+      find: jest.fn(async () => {
+        const st = await scheduledTransactionsRepository.findOne();
+        return (st && st.splits) || [];
+      }),
     };
 
     accountsRepository = {
@@ -105,10 +112,7 @@ describe("ScheduledTransactionLoanService", () => {
       const scheduledTx = makeScheduledTransaction();
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       // Should save both splits with updated amounts
       expect(splitsRepository.save).toHaveBeenCalledTimes(2);
@@ -165,10 +169,7 @@ describe("ScheduledTransactionLoanService", () => {
         } as never);
         scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-        await service.recalculateLoanPaymentSplits(
-          scheduledTransactionId,
-          loanAccountId,
-        );
+        await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
         const principalSave = splitsRepository.save.mock.calls.find(
           (call: any) => call[0].transferAccountId === loanAccountId,
@@ -195,10 +196,7 @@ describe("ScheduledTransactionLoanService", () => {
           makeScheduledTransaction(),
         );
 
-        await service.recalculateLoanPaymentSplits(
-          scheduledTransactionId,
-          loanAccountId,
-        );
+        await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
         expect(scheduledTransactionsRepository.update).not.toHaveBeenCalled();
       });
@@ -239,10 +237,7 @@ describe("ScheduledTransactionLoanService", () => {
         } as never);
         scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-        await service.recalculateLoanPaymentSplits(
-          scheduledTransactionId,
-          loanAccountId,
-        );
+        await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
         const saved = Object.fromEntries(
           splitsRepository.save.mock.calls.map((call: any) => [
@@ -300,10 +295,7 @@ describe("ScheduledTransactionLoanService", () => {
         } as never);
         scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-        await service.recalculateLoanPaymentSplits(
-          scheduledTransactionId,
-          loanAccountId,
-        );
+        await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
         const saved = Object.fromEntries(
           splitsRepository.save.mock.calls.map((call: any) => [
@@ -361,10 +353,7 @@ describe("ScheduledTransactionLoanService", () => {
         } as never);
         scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-        await service.recalculateLoanPaymentSplits(
-          scheduledTransactionId,
-          loanAccountId,
-        );
+        await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
         const saved = splitsRepository.save.mock.calls.map((call: any) => [
           call[0].id,
@@ -425,10 +414,7 @@ describe("ScheduledTransactionLoanService", () => {
           } as never),
         );
 
-        await service.recalculateLoanPaymentSplits(
-          scheduledTransactionId,
-          loanAccountId,
-        );
+        await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
         const extraSave = splitsRepository.save.mock.calls.find(
           (call: any) => call[0].id === "split-extra",
@@ -476,10 +462,7 @@ describe("ScheduledTransactionLoanService", () => {
           } as never),
         );
 
-        await service.recalculateLoanPaymentSplits(
-          scheduledTransactionId,
-          loanAccountId,
-        );
+        await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
         const saved = splitsRepository.save.mock.calls.map((call: any) => [
           call[0].id,
@@ -512,10 +495,7 @@ describe("ScheduledTransactionLoanService", () => {
           makeScheduledTransaction({ amount: -500 }),
         );
 
-        await service.recalculateLoanPaymentSplits(
-          scheduledTransactionId,
-          loanAccountId,
-        );
+        await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
         const principalSave = splitsRepository.save.mock.calls.find(
           (call: any) => call[0].transferAccountId === loanAccountId,
@@ -567,10 +547,7 @@ describe("ScheduledTransactionLoanService", () => {
           } as never),
         );
 
-        await service.recalculateLoanPaymentSplits(
-          scheduledTransactionId,
-          loanAccountId,
-        );
+        await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
         const update = scheduledTransactionsRepository.update.mock.calls.find(
           (call: any) => call[1]?.amount !== undefined,
@@ -625,10 +602,7 @@ describe("ScheduledTransactionLoanService", () => {
           } as never),
         );
 
-        await service.recalculateLoanPaymentSplits(
-          scheduledTransactionId,
-          loanAccountId,
-        );
+        await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
         const extraSave = splitsRepository.save.mock.calls.find(
           (call: any) => call[0].id === "split-extra",
@@ -652,10 +626,7 @@ describe("ScheduledTransactionLoanService", () => {
       const scheduledTx = makeScheduledTransaction();
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       expect(scheduledTransactionsRepository.update).toHaveBeenCalledWith(
         scheduledTransactionId,
@@ -670,10 +641,7 @@ describe("ScheduledTransactionLoanService", () => {
       const scheduledTx = makeScheduledTransaction();
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       expect(scheduledTransactionsRepository.update).toHaveBeenCalledWith(
         scheduledTransactionId,
@@ -681,26 +649,26 @@ describe("ScheduledTransactionLoanService", () => {
       );
     });
 
-    it("should return early when loan account is not found", async () => {
+    it("should return early when no loan account is found among the splits", async () => {
+      // The scheduled transaction and its splits exist, but none of the
+      // transfer targets is a LOAN/MORTGAGE account (issue #1154 re-review:
+      // the loan is derived from the current split set, not a passed id).
+      scheduledTransactionsRepository.findOne.mockResolvedValue(
+        makeScheduledTransaction(),
+      );
       accountsRepository.findOne.mockResolvedValue(null);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
-      expect(scheduledTransactionsRepository.findOne).not.toHaveBeenCalled();
       expect(splitsRepository.save).not.toHaveBeenCalled();
+      expect(scheduledTransactionsRepository.update).not.toHaveBeenCalled();
     });
 
     it("should return early when scheduled transaction is not found", async () => {
       accountsRepository.findOne.mockResolvedValue(makeLoanAccount());
       scheduledTransactionsRepository.findOne.mockResolvedValue(null);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       expect(splitsRepository.save).not.toHaveBeenCalled();
     });
@@ -711,10 +679,7 @@ describe("ScheduledTransactionLoanService", () => {
         makeScheduledTransaction({ isActive: false }),
       );
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       expect(splitsRepository.save).not.toHaveBeenCalled();
     });
@@ -731,10 +696,7 @@ describe("ScheduledTransactionLoanService", () => {
       });
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       // Should have called save - we verify the calculation used BIWEEKLY rate
       // by checking the interest amount is different from monthly
@@ -750,10 +712,7 @@ describe("ScheduledTransactionLoanService", () => {
       const scheduledTx = makeScheduledTransaction();
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       expect(splitsRepository.save).toHaveBeenCalledTimes(2);
     });
@@ -768,10 +727,7 @@ describe("ScheduledTransactionLoanService", () => {
       const scheduledTx = makeScheduledTransaction();
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       // With 0% interest, all payment goes to principal
       const interestSave = splitsRepository.save.mock.calls.find(
@@ -788,10 +744,7 @@ describe("ScheduledTransactionLoanService", () => {
       const scheduledTx = makeScheduledTransaction({ splits: null as any });
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       // principalSplit and interestSplit will be undefined
       // So save should not be called
@@ -805,26 +758,22 @@ describe("ScheduledTransactionLoanService", () => {
       const scheduledTx = makeScheduledTransaction({ splits: [] as any });
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       expect(splitsRepository.save).not.toHaveBeenCalled();
     });
 
-    it("should load scheduled transaction with splits relation", async () => {
+    it("should lock the parent scheduled transaction before recalculating", async () => {
       accountsRepository.findOne.mockResolvedValue(makeLoanAccount());
       scheduledTransactionsRepository.findOne.mockResolvedValue(null);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
+      // The recalculation mutates the child split set, so it must serialize on
+      // the same parent lock the posting path takes (issue #1154 re-review).
       expect(scheduledTransactionsRepository.findOne).toHaveBeenCalledWith({
         where: { id: scheduledTransactionId },
-        relations: ["splits"],
+        lock: { mode: "pessimistic_write" },
       });
     });
 
@@ -862,10 +811,7 @@ describe("ScheduledTransactionLoanService", () => {
       });
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       const interestSave = splitsRepository.save.mock.calls.find(
         (call: any) => call[0].categoryId === "cat-interest",
@@ -917,10 +863,7 @@ describe("ScheduledTransactionLoanService", () => {
       });
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       expect(splitsRepository.save).toHaveBeenCalledTimes(2);
 
@@ -971,10 +914,7 @@ describe("ScheduledTransactionLoanService", () => {
       });
       scheduledTransactionsRepository.findOne.mockResolvedValue(scheduledTx);
 
-      await service.recalculateLoanPaymentSplits(
-        scheduledTransactionId,
-        loanAccountId,
-      );
+      await service.recalculateLoanPaymentSplits(scheduledTransactionId);
 
       const interestSave = splitsRepository.save.mock.calls.find(
         (call: any) => call[0].categoryId === "cat-interest",

--- a/backend/src/scheduled-transactions/scheduled-transaction-loan.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-loan.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { DataSource } from "typeorm";
 import { ScheduledTransaction } from "./entities/scheduled-transaction.entity";
 import { ScheduledTransactionSplit } from "./entities/scheduled-transaction-split.entity";
-import { Account } from "../accounts/entities/account.entity";
+import { Account, AccountType } from "../accounts/entities/account.entity";
 import { PaymentFrequency } from "../accounts/loan-amortization.util";
 import {
   getPeriodicRate,
@@ -13,6 +13,18 @@ import { getPeriodsPerYear } from "../accounts/loan-amortization.util";
 import { roundMoney } from "../common/round.util";
 import { allocateLoanPayment } from "../accounts/loan-payment-waterfall.util";
 import { withScopedDb } from "../common/db/scoped-db";
+
+// The account types that carry a scheduled loan-payment structure and therefore
+// need their next principal/interest split advanced after each posting. This set
+// must stay in step with what `LoanPaymentSetupService` accepts when it creates
+// that structure -- it accepts LOAN, MORTGAGE and LINE_OF_CREDIT, so a LOC left
+// out of the recalculation would keep billing the first installment's split
+// forever (issue #1154 re-review).
+const LOAN_LIKE_ACCOUNT_TYPES: ReadonlySet<AccountType> = new Set([
+  AccountType.LOAN,
+  AccountType.MORTGAGE,
+  AccountType.LINE_OF_CREDIT,
+]);
 
 @Injectable()
 export class ScheduledTransactionLoanService {
@@ -53,11 +65,7 @@ export class ScheduledTransactionLoanService {
         const candidate = await m.getRepository(Account).findOne({
           where: { id: split.transferAccountId },
         });
-        if (
-          candidate &&
-          (candidate.accountType === "LOAN" ||
-            candidate.accountType === "MORTGAGE")
-        ) {
+        if (candidate && LOAN_LIKE_ACCOUNT_TYPES.has(candidate.accountType)) {
           loanAccount = candidate;
           break;
         }
@@ -280,11 +288,7 @@ export class ScheduledTransactionLoanService {
           const account = await m.getRepository(Account).findOne({
             where: { id: split.transferAccountId },
           });
-          if (
-            account &&
-            (account.accountType === "LOAN" ||
-              account.accountType === "MORTGAGE")
-          ) {
+          if (account && LOAN_LIKE_ACCOUNT_TYPES.has(account.accountType)) {
             return account.id;
           }
         }

--- a/backend/src/scheduled-transactions/scheduled-transaction-loan.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-loan.service.ts
@@ -22,27 +22,51 @@ export class ScheduledTransactionLoanService {
 
   async recalculateLoanPaymentSplits(
     scheduledTransactionId: string,
-    loanAccountId: string,
   ): Promise<void> {
     return withScopedDb(this.dataSource, async (m) => {
-      const loanAccount = await m.getRepository(Account).findOne({
-        where: { id: loanAccountId },
-      });
-
-      if (!loanAccount) {
-        return;
-      }
-
+      // This writer mutates the child split set, so it must serialize through
+      // the same parent lock the posting path takes (issue #1154 re-review): a
+      // recalculation that changed principal/interest without the lock could
+      // land between a poster's split-set guard and its write, and because a
+      // P/I reallocation leaves the parent total unchanged, the poster's own
+      // parent lock would not have blocked it. Lock the parent, then read the
+      // current child set and derive the loan from it -- never from a loan id
+      // captured off a pre-lock snapshot.
       const scheduledTransaction = await m
         .getRepository(ScheduledTransaction)
         .findOne({
           where: { id: scheduledTransactionId },
-          relations: ["splits"],
+          lock: { mode: "pessimistic_write" },
         });
 
       if (!scheduledTransaction || !scheduledTransaction.isActive) {
         return;
       }
+
+      const splits = await m.getRepository(ScheduledTransactionSplit).find({
+        where: { scheduledTransactionId },
+      });
+
+      let loanAccount: Account | null = null;
+      for (const split of splits) {
+        if (!split.transferAccountId) continue;
+        const candidate = await m.getRepository(Account).findOne({
+          where: { id: split.transferAccountId },
+        });
+        if (
+          candidate &&
+          (candidate.accountType === "LOAN" ||
+            candidate.accountType === "MORTGAGE")
+        ) {
+          loanAccount = candidate;
+          break;
+        }
+      }
+
+      if (!loanAccount) {
+        return;
+      }
+      const loanAccountId = loanAccount.id;
 
       const currentBalance = Math.abs(Number(loanAccount.currentBalance));
 
@@ -57,8 +81,6 @@ export class ScheduledTransactionLoanService {
       const interestRate = Number(loanAccount.interestRate) || 0;
       const frequency = (loanAccount.paymentFrequency ||
         scheduledTransaction.frequency) as PaymentFrequency;
-
-      const splits = scheduledTransaction.splits || [];
 
       // Identify splits: there may be a regular principal transfer, an interest
       // category split, and optionally a separate extra principal transfer.

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -2578,6 +2578,104 @@ describe("ScheduledTransactionsService", () => {
       expect(fundingClear).toBeUndefined();
     });
 
+    it("update() switching BUY to DIVIDEND nulls quantity/price/commission (issue #1154)", async () => {
+      // The action no longer uses shares or a per-share price, so the stale
+      // quantity/price/commission from the BUY must not linger on the row.
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "BUY" as any,
+          investmentSecurityId: "sec-voo",
+          investmentQuantity: 1,
+          investmentPrice: 500,
+          investmentCommission: 5,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await service.update(userId, stId, {
+        investmentAction: "DIVIDEND" as any,
+        investmentTotalAmount: 75,
+      } as any);
+
+      const fields = mockQueryRunner.manager.update.mock.calls.find(
+        (c: any[]) => c[1] === stId && c[2].investmentAction !== undefined,
+      )?.[2];
+      expect(fields).toBeDefined();
+      expect(fields.investmentQuantity).toBeNull();
+      expect(fields.investmentPrice).toBeNull();
+      expect(fields.investmentCommission).toBeNull();
+      // The DIVIDEND's own required field is written, not cleared.
+      expect(fields.investmentTotalAmount).toBe(75);
+    });
+
+    it("update() switching DIVIDEND to BUY nulls the stale total amount (issue #1154)", async () => {
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "DIVIDEND" as any,
+          investmentSecurityId: "sec-voo",
+          investmentTotalAmount: 75,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await service.update(userId, stId, {
+        investmentAction: "BUY" as any,
+        investmentQuantity: 2,
+        investmentPrice: 100,
+      } as any);
+
+      const fields = mockQueryRunner.manager.update.mock.calls.find(
+        (c: any[]) => c[1] === stId && c[2].investmentAction !== undefined,
+      )?.[2];
+      expect(fields).toBeDefined();
+      expect(fields.investmentTotalAmount).toBeNull();
+      expect(fields.investmentQuantity).toBe(2);
+      expect(fields.investmentPrice).toBe(100);
+    });
+
+    it("update() keeps quantity but nulls price/total when switching to ADD_SHARES", async () => {
+      // ADD_SHARES uses only a quantity; price/commission/total do not apply.
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "BUY" as any,
+          investmentSecurityId: "sec-voo",
+          investmentQuantity: 3,
+          investmentPrice: 500,
+          investmentCommission: 5,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await service.update(userId, stId, {
+        investmentAction: "ADD_SHARES" as any,
+        investmentQuantity: 4,
+      } as any);
+
+      const fields = mockQueryRunner.manager.update.mock.calls.find(
+        (c: any[]) => c[1] === stId && c[2].investmentAction !== undefined,
+      )?.[2];
+      expect(fields).toBeDefined();
+      expect(fields.investmentQuantity).toBe(4);
+      expect(fields.investmentPrice).toBeNull();
+      expect(fields.investmentCommission).toBeNull();
+      expect(fields.investmentTotalAmount).toBeNull();
+    });
+
     it("create() drops a funding account supplied for a non-funding action (issue #1154)", async () => {
       accountsService.findOne.mockImplementation(
         async (uid: string, id: string) => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -2572,10 +2572,19 @@ describe("ScheduledTransactionsService", () => {
         investmentPrice: 480,
       } as any);
 
-      const fundingClear = mockQueryRunner.manager.update.mock.calls.find(
-        (c: any[]) => c[1] === stId && c[2].investmentFundingAccountId === null,
+      // A BUY edit that does not touch the funding account must not write the
+      // column at all -- neither cleared to null nor emptied -- so the stored
+      // value survives. Asserting the key is absent (not merely "not null")
+      // also catches a future `|| ''`-style clear.
+      const touchesFunding = mockQueryRunner.manager.update.mock.calls.some(
+        (c: any[]) =>
+          c[1] === stId &&
+          Object.prototype.hasOwnProperty.call(
+            c[2],
+            "investmentFundingAccountId",
+          ),
       );
-      expect(fundingClear).toBeUndefined();
+      expect(touchesFunding).toBe(false);
     });
 
     it("update() switching BUY to DIVIDEND nulls quantity/price/commission (issue #1154)", async () => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -2176,6 +2176,29 @@ describe("ScheduledTransactionsService", () => {
       expect(dto.fundingAccountId).toBe("acc-checking");
     });
 
+    it("post() ignores a stale funding account on a REINVEST (issue #1154)", async () => {
+      // REINVEST moves shares but no external cash, so a funding account left on
+      // the row is stale like the cash-only actions and must not be forwarded.
+      const scheduled = makeScheduled({
+        isInvestment: true,
+        investmentAction: "REINVEST" as any,
+        investmentSecurityId: "sec-voo",
+        investmentFundingAccountId: "acc-checking",
+        investmentQuantity: 0.5,
+        investmentPrice: 200,
+      });
+      stubFindOne(scheduled);
+      const overrideQb = mockQueryBuilder();
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await service.post(userId, stId);
+
+      const dto = investmentTransactionsService.create.mock.calls[0][1];
+      expect(dto.action).toBe("REINVEST");
+      expect(dto.fundingAccountId).toBeUndefined();
+    });
+
     it("post() honours inline quantity / price overrides", async () => {
       const scheduled = makeScheduled({
         isInvestment: true,
@@ -2390,6 +2413,10 @@ describe("ScheduledTransactionsService", () => {
         userId,
         "acc-funding",
       );
+      // A BUY keeps the funding account it was given (the gate's keep branch).
+      expect(
+        scheduledRepo.create.mock.calls[0][0].investmentFundingAccountId,
+      ).toBe("acc-funding");
     });
 
     it("update() rejects mixing isTransfer and isInvestment", async () => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -280,6 +280,10 @@ describe("ScheduledTransactionsService", () => {
   // Helper: stub findOne to return a scheduled transaction for internal calls
   const stubFindOne = (scheduled: ScheduledTransaction) => {
     scheduledRepo.findOne.mockResolvedValue(scheduled);
+    // post() re-reads the split set under the parent lock to guard against a
+    // concurrent split retarget (issue #1154 re-review); default it to the same
+    // splits the schedule carries so the guard passes unless a test overrides it.
+    splitsRepo.find.mockResolvedValue(scheduled.splits ?? []);
   };
 
   // ==================== create ====================
@@ -1469,15 +1473,17 @@ describe("ScheduledTransactionsService", () => {
         amount: -1200,
       });
       stubFindOne(scheduled);
-      const overrideQb = mockQueryBuilder(null);
-      overrideQb.getOne.mockResolvedValue({
+      const storedOverride = {
         amount: -750,
         description: null,
         isSplit: null,
         categoryId: null,
         splits: null,
-      });
+      };
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(storedOverride);
       overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      overridesRepo.findOne.mockResolvedValue(storedOverride);
       accountsRepo.findOne.mockResolvedValue(null);
 
       await service.post(userId, stId);
@@ -1541,15 +1547,17 @@ describe("ScheduledTransactionsService", () => {
         description: "base desc",
       });
       stubFindOne(scheduled);
-      const overrideQb = mockQueryBuilder(null);
-      overrideQb.getOne.mockResolvedValue({
+      const storedOverride = {
         amount: null,
         description: "override desc",
         isSplit: null,
         categoryId: null,
         splits: null,
-      });
+      };
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(storedOverride);
       overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      overridesRepo.findOne.mockResolvedValue(storedOverride);
       accountsRepo.findOne.mockResolvedValue(null);
 
       await service.post(userId, stId);
@@ -1565,12 +1573,14 @@ describe("ScheduledTransactionsService", () => {
     it("should apply inline values with highest priority", async () => {
       const scheduled = makeScheduled({ amount: -1200 });
       stubFindOne(scheduled);
-      const overrideQb = mockQueryBuilder(null);
-      overrideQb.getOne.mockResolvedValue({
+      const storedOverride = {
         amount: -999,
         description: "override desc",
-      });
+      };
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(storedOverride);
       overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      overridesRepo.findOne.mockResolvedValue(storedOverride);
       accountsRepo.findOne.mockResolvedValue(null);
 
       await service.post(userId, stId, {
@@ -1590,15 +1600,17 @@ describe("ScheduledTransactionsService", () => {
         description: "base desc",
       });
       stubFindOne(scheduled);
-      const overrideQb = mockQueryBuilder(null);
-      overrideQb.getOne.mockResolvedValue({
+      const storedOverride = {
         amount: -999,
         description: "override desc",
         isSplit: null,
         categoryId: null,
         splits: null,
-      });
+      };
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(storedOverride);
       overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      overridesRepo.findOne.mockResolvedValue(storedOverride);
       accountsRepo.findOne.mockResolvedValue(null);
 
       await service.post(userId, stId);
@@ -2300,6 +2312,99 @@ describe("ScheduledTransactionsService", () => {
         ConflictException,
       );
       expect(investmentTransactionsService.create).not.toHaveBeenCalled();
+    });
+
+    it("post() rejects when a base scheduled split was retargeted concurrently (issue #1154 re-review)", async () => {
+      // Parent scalars are identical, but the transfer split's target account
+      // changed between the pre-lock read and the parent lock. Posting the
+      // pre-lock payload would credit the old account, so it is refused.
+      const scheduled = makeScheduled({
+        amount: -100,
+        isSplit: true,
+        frequency: "ONCE",
+        splits: [
+          {
+            id: "ss-1",
+            kind: "transfer" as any,
+            amount: -100,
+            memo: null,
+            categoryId: null,
+            transferAccountId: "acc-A",
+            tags: [],
+          } as any,
+        ],
+      });
+      stubFindOne(scheduled);
+      // The locked split re-read observes the retargeted split (acc-B).
+      splitsRepo.find.mockResolvedValue([
+        {
+          id: "ss-1",
+          kind: "transfer",
+          amount: -100,
+          memo: null,
+          categoryId: null,
+          transferAccountId: "acc-B",
+          tags: [],
+        } as any,
+      ]);
+      const overrideQb = mockQueryBuilder();
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await expect(service.post(userId, stId)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(transactionsService.create).not.toHaveBeenCalled();
+    });
+
+    it("post() rejects when the foreign-currency original amount changed concurrently (issue #1154 re-review)", async () => {
+      // amount (account currency) is unchanged, but originalAmount moved, so the
+      // guard must still refuse -- otherwise a stale converted total posts.
+      const beforeLock = makeScheduled({
+        amount: -110,
+        currencyCode: "USD",
+        originalAmount: -100,
+        originalCurrencyCode: "EUR",
+        exchangeRate: 1.1,
+      });
+      const locked = makeScheduled({
+        amount: -110,
+        currencyCode: "USD",
+        originalAmount: -200,
+        originalCurrencyCode: "EUR",
+        exchangeRate: 1.1,
+      });
+      scheduledRepo.findOne
+        .mockResolvedValueOnce(beforeLock)
+        .mockResolvedValue(locked);
+      // The FX resolution runs above the transaction; give it a rate so the post
+      // reaches the in-transaction guard rather than failing on a missing rate.
+      mockExchangeRateService.getRateForDate.mockResolvedValue(1.1);
+      const overrideQb = mockQueryBuilder();
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await expect(service.post(userId, stId)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(transactionsService.create).not.toHaveBeenCalled();
+    });
+
+    it("post({requireActiveAutoPost}) refuses a schedule turned off after cron selected it (issue #1154 re-review)", async () => {
+      const scheduled = makeScheduled({ isActive: true, autoPost: false });
+      stubFindOne(scheduled);
+      const overrideQb = mockQueryBuilder();
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await expect(
+        service.post(userId, stId, undefined, { requireActiveAutoPost: true }),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(transactionsService.create).not.toHaveBeenCalled();
+
+      // A manual post (no option) of the same row still works.
+      await service.post(userId, stId);
+      expect(transactionsService.create).toHaveBeenCalledTimes(1);
     });
 
     it("post() honours inline quantity / price overrides", async () => {
@@ -3873,16 +3978,18 @@ describe("ScheduledTransactionsService", () => {
       });
       scheduledRepo.findOne.mockResolvedValue(scheduled);
 
-      const overrideQb = mockQueryBuilder(null);
-      overrideQb.getOne.mockResolvedValue({
+      const storedOverride = {
         overrideDate: "2025-03-12",
         amount: null,
         categoryId: null,
         description: null,
         isSplit: null,
         splits: null,
-      });
+      };
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(storedOverride);
       overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      overridesRepo.findOne.mockResolvedValue(storedOverride);
       accountsRepo.findOne.mockResolvedValue(null);
 
       await service.post(userId, stId);
@@ -4126,6 +4233,8 @@ describe("ScheduledTransactionsService", () => {
         frequency: "ONCE",
       });
       scheduledRepo.findOne.mockResolvedValue(scheduled);
+      // The locked split re-read (issue #1154 re-review) returns the same set.
+      splitsRepo.find.mockResolvedValue(scheduled.splits);
       overridesRepo.createQueryBuilder = jest.fn().mockReturnValue({
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
@@ -4226,6 +4335,7 @@ describe("ScheduledTransactionsService", () => {
         andWhere: jest.fn().mockReturnThis(),
         getOne: jest.fn().mockResolvedValue(storedOverride),
       });
+      overridesRepo.findOne.mockResolvedValue(storedOverride);
       mockQueryRunner.manager.delete = jest
         .fn()
         .mockResolvedValue({ affected: 1 });
@@ -4266,6 +4376,7 @@ describe("ScheduledTransactionsService", () => {
         frequency: "ONCE",
       });
       scheduledRepo.findOne.mockResolvedValue(scheduled);
+      splitsRepo.find.mockResolvedValue(scheduled.splits);
       overridesRepo.createQueryBuilder = jest.fn().mockReturnValue({
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -2199,6 +2199,81 @@ describe("ScheduledTransactionsService", () => {
       expect(dto.fundingAccountId).toBeUndefined();
     });
 
+    it("post() rejects a negative amount-only override before creating money (issue #1154 review)", async () => {
+      const dividend = makeScheduled({
+        isInvestment: true,
+        investmentAction: "DIVIDEND" as any,
+        investmentSecurityId: "sec-voo",
+        investmentTotalAmount: 100,
+      });
+      stubFindOne(dividend);
+      const overrideQb = mockQueryBuilder();
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await expect(
+        service.post(userId, stId, { investmentTotalAmount: -25 } as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(investmentTransactionsService.create).not.toHaveBeenCalled();
+    });
+
+    it("post() rejects a zero-quantity BUY override before creating money (issue #1154 review)", async () => {
+      const buy = makeScheduled({
+        isInvestment: true,
+        investmentAction: "BUY" as any,
+        investmentSecurityId: "sec-voo",
+        investmentQuantity: 1,
+        investmentPrice: 500,
+      });
+      stubFindOne(buy);
+      const overrideQb = mockQueryBuilder();
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await expect(
+        service.post(userId, stId, { investmentQuantity: 0 } as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(investmentTransactionsService.create).not.toHaveBeenCalled();
+    });
+
+    it("post() posts the locked row, not a pre-lock BUY snapshot (issue #1154 review)", async () => {
+      // A concurrent edit switched BUY -> DIVIDEND (clearing the funding
+      // account) between the pre-lock read and the row lock. The post must use
+      // the locked DIVIDEND -- not forward the stale BUY through the old funding
+      // account. Both the pre-lock read and the locked read go through
+      // scheduledRepo.findOne (see the manager.findOne alias in beforeEach).
+      const beforeLock = makeScheduled({
+        isInvestment: true,
+        investmentAction: "BUY" as any,
+        investmentSecurityId: "sec-voo",
+        investmentFundingAccountId: "acc-old",
+        investmentQuantity: 1,
+        investmentPrice: 100,
+      });
+      const locked = makeScheduled({
+        isInvestment: true,
+        investmentAction: "DIVIDEND" as any,
+        investmentSecurityId: "sec-voo",
+        investmentFundingAccountId: null,
+        investmentQuantity: null,
+        investmentPrice: null,
+        investmentTotalAmount: 75,
+      });
+      scheduledRepo.findOne
+        .mockResolvedValueOnce(beforeLock)
+        .mockResolvedValueOnce(locked)
+        .mockResolvedValue(locked);
+      const overrideQb = mockQueryBuilder();
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await service.post(userId, stId);
+
+      const dto = investmentTransactionsService.create.mock.calls[0][1];
+      expect(dto.action).toBe("DIVIDEND");
+      expect(dto.fundingAccountId).toBeUndefined();
+    });
+
     it("post() honours inline quantity / price overrides", async () => {
       const scheduled = makeScheduled({
         isInvestment: true,
@@ -2683,6 +2758,151 @@ describe("ScheduledTransactionsService", () => {
       expect(fields.investmentPrice).toBeNull();
       expect(fields.investmentCommission).toBeNull();
       expect(fields.investmentTotalAmount).toBeNull();
+    });
+
+    it("update() rejects an explicit null total instead of validating the stored one (issue #1154 review)", async () => {
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "DIVIDEND" as any,
+          investmentSecurityId: "sec-voo",
+          investmentTotalAmount: 100,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await expect(
+        service.update(userId, stId, { investmentTotalAmount: null } as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      // Rejected before the write opens.
+      expect(mockQueryRunner.manager.update).not.toHaveBeenCalled();
+    });
+
+    it("update() rejects a zero stored investment exchange rate (issue #1154 review)", async () => {
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "BUY" as any,
+          investmentSecurityId: "sec-voo",
+          investmentQuantity: 1,
+          investmentPrice: 100,
+          investmentExchangeRate: 1.1,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await expect(
+        service.update(userId, stId, { investmentExchangeRate: 0 } as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it("update() clears a stored rate when the settlement basis changes (issue #1154 review)", async () => {
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "BUY" as any,
+          investmentSecurityId: "sec-voo",
+          investmentFundingAccountId: "acc-usd",
+          investmentQuantity: 1,
+          investmentPrice: 100,
+          investmentExchangeRate: 1.1,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await service.update(userId, stId, {
+        investmentAction: "DIVIDEND" as any,
+        investmentTotalAmount: 100,
+      } as any);
+
+      const fields = mockQueryRunner.manager.update.mock.calls.find(
+        (c: any[]) => c[1] === stId && c[2].investmentAction !== undefined,
+      )?.[2];
+      expect(fields).toBeDefined();
+      expect(fields.investmentExchangeRate).toBeNull();
+    });
+
+    it("update() keeps a stored rate on a presentation-only edit (issue #1154 review)", async () => {
+      // The settlement tuple is unchanged, so a name edit must not re-resolve or
+      // wipe a legitimate cross-currency rate (the over-clear guard).
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "BUY" as any,
+          investmentSecurityId: "sec-voo",
+          investmentFundingAccountId: "acc-usd",
+          investmentQuantity: 1,
+          investmentPrice: 100,
+          investmentExchangeRate: 1.1,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await service.update(userId, stId, { name: "Renamed" } as any);
+
+      const clearedRate = mockQueryRunner.manager.update.mock.calls.some(
+        (c: any[]) => c[1] === stId && c[2].investmentExchangeRate === null,
+      );
+      expect(clearedRate).toBe(false);
+    });
+
+    it("update() clears a hidden security when switching to INTEREST with the key omitted (issue #1154 review)", async () => {
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "BUY" as any,
+          investmentSecurityId: "sec-eur",
+          investmentQuantity: 1,
+          investmentPrice: 100,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await service.update(userId, stId, {
+        investmentAction: "INTEREST" as any,
+        investmentTotalAmount: 50,
+      } as any);
+
+      const fields = mockQueryRunner.manager.update.mock.calls.find(
+        (c: any[]) => c[1] === stId && c[2].investmentAction !== undefined,
+      )?.[2];
+      expect(fields).toBeDefined();
+      expect(fields.investmentSecurityId).toBeNull();
+    });
+
+    it("create() rejects a non-positive investment exchange rate (issue #1154 review)", async () => {
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-inv",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await expect(
+        service.create(userId, {
+          ...investmentBaseDto,
+          investmentExchangeRate: 0,
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
     });
 
     it("create() drops a funding account supplied for a non-funding action (issue #1154)", async () => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -2131,6 +2131,51 @@ describe("ScheduledTransactionsService", () => {
       expect(dto.fundingAccountId).toBe("acc-checking");
     });
 
+    it("post() ignores a stale funding account on a DIVIDEND (issue #1154)", async () => {
+      // A row edited from BUY to DIVIDEND may still carry the old funding
+      // account. The dividend cash must settle in the brokerage's linked cash
+      // account, so the funding account is not forwarded regardless of what the
+      // row stored.
+      const scheduled = makeScheduled({
+        isInvestment: true,
+        investmentAction: "DIVIDEND" as any,
+        investmentSecurityId: "sec-voo",
+        investmentFundingAccountId: "acc-checking",
+        investmentTotalAmount: 75,
+      });
+      stubFindOne(scheduled);
+      const overrideQb = mockQueryBuilder();
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await service.post(userId, stId);
+
+      const dto = investmentTransactionsService.create.mock.calls[0][1];
+      expect(dto.action).toBe("DIVIDEND");
+      expect(dto.fundingAccountId).toBeUndefined();
+    });
+
+    it("post() still forwards a funding account on a SELL", async () => {
+      const scheduled = makeScheduled({
+        isInvestment: true,
+        investmentAction: "SELL" as any,
+        investmentSecurityId: "sec-voo",
+        investmentFundingAccountId: "acc-checking",
+        investmentQuantity: 2,
+        investmentPrice: 100,
+      });
+      stubFindOne(scheduled);
+      const overrideQb = mockQueryBuilder();
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+
+      await service.post(userId, stId);
+
+      const dto = investmentTransactionsService.create.mock.calls[0][1];
+      expect(dto.action).toBe("SELL");
+      expect(dto.fundingAccountId).toBe("acc-checking");
+    });
+
     it("post() honours inline quantity / price overrides", async () => {
       const scheduled = makeScheduled({
         isInvestment: true,
@@ -2413,6 +2458,126 @@ describe("ScheduledTransactionsService", () => {
       expect(fields.investmentQuantity).toBe(2);
       expect(fields.investmentPrice).toBe(480);
       expect(fields.investmentCommission).toBe(5);
+    });
+
+    it("update() changing the action to DIVIDEND nulls the funding account (issue #1154)", async () => {
+      // The user switches a BUY (with a funding account) to a DIVIDEND. The
+      // funding account no longer applies and must be cleared, even though the
+      // client sent an explicit account earlier.
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "BUY" as any,
+          investmentSecurityId: "sec-voo",
+          investmentFundingAccountId: "acc-checking",
+          investmentQuantity: 1,
+          investmentPrice: 500,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await service.update(userId, stId, {
+        investmentAction: "DIVIDEND" as any,
+        investmentTotalAmount: 75,
+      } as any);
+
+      const fields = mockQueryRunner.manager.update.mock.calls.find(
+        (c: any[]) =>
+          c[1] === stId && c[2].investmentFundingAccountId !== undefined,
+      )?.[2];
+      expect(fields).toBeDefined();
+      expect(fields.investmentFundingAccountId).toBeNull();
+    });
+
+    it("update() nulls a stale funding account even when the client omits the key (issue #1154)", async () => {
+      // The exact reported path: the schedule is already a DIVIDEND carrying a
+      // stale funding account, and the edit touches only the amount. The absent
+      // key must not be read as "leave the stale account in place".
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "DIVIDEND" as any,
+          investmentSecurityId: "sec-voo",
+          investmentFundingAccountId: "acc-checking",
+          investmentTotalAmount: 50,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await service.update(userId, stId, {
+        investmentTotalAmount: 90,
+      } as any);
+
+      const fields = mockQueryRunner.manager.update.mock.calls.find(
+        (c: any[]) =>
+          c[1] === stId && c[2].investmentFundingAccountId !== undefined,
+      )?.[2];
+      expect(fields).toBeDefined();
+      expect(fields.investmentFundingAccountId).toBeNull();
+    });
+
+    it("update() keeps the funding account on a BUY", async () => {
+      stubFindOne(
+        makeScheduled({
+          isInvestment: true,
+          investmentAction: "BUY" as any,
+          investmentSecurityId: "sec-voo",
+          investmentFundingAccountId: "acc-checking",
+          investmentQuantity: 1,
+          investmentPrice: 500,
+        }),
+      );
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await service.update(userId, stId, {
+        investmentPrice: 480,
+      } as any);
+
+      const fundingClear = mockQueryRunner.manager.update.mock.calls.find(
+        (c: any[]) => c[1] === stId && c[2].investmentFundingAccountId === null,
+      );
+      expect(fundingClear).toBeUndefined();
+    });
+
+    it("create() drops a funding account supplied for a non-funding action (issue #1154)", async () => {
+      accountsService.findOne.mockImplementation(
+        async (uid: string, id: string) => {
+          if (id === "acc-checking")
+            return { id, userId: uid, accountType: "CHECKING" } as any;
+          return {
+            id,
+            userId: uid,
+            accountSubType: "INVESTMENT_BROKERAGE",
+          } as any;
+        },
+      );
+      const saved = makeScheduled({ isInvestment: true });
+      scheduledRepo.save.mockResolvedValue(saved);
+      stubFindOne(saved);
+
+      await service.create(userId, {
+        ...investmentBaseDto,
+        investmentAction: "DIVIDEND" as any,
+        investmentQuantity: undefined as any,
+        investmentPrice: undefined as any,
+        investmentTotalAmount: 75,
+        investmentFundingAccountId: "acc-checking",
+      });
+
+      const created = scheduledRepo.create.mock.calls[0][0];
+      expect(created.investmentFundingAccountId).toBeNull();
     });
 
     it("update() switching to isInvestment=true wipes split/transfer remnants", async () => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -4006,15 +4006,27 @@ describe("ScheduledTransactionsService", () => {
   // ==================== recalculateLoanPaymentSplits ====================
   describe("recalculateLoanPaymentSplits", () => {
     it("should deactivate scheduled transaction when loan is paid off", async () => {
+      // The loan account is now derived from the current split set under the
+      // parent lock (issue #1154 re-review), so provide a transfer split
+      // pointing at it rather than relying on a caller-passed loan id.
       accountsRepo.findOne.mockResolvedValue({
         id: "loan-1",
+        accountType: "LOAN",
         currentBalance: 0,
       });
+      splitsRepo.find.mockResolvedValue([
+        {
+          id: "s1",
+          transferAccountId: "loan-1",
+          categoryId: null,
+          amount: -800,
+        },
+      ]);
       scheduledRepo.findOne.mockResolvedValue(
-        makeScheduled({ isActive: true, splits: [] }),
+        makeScheduled({ isActive: true }),
       );
 
-      await service.recalculateLoanPaymentSplits(stId, "loan-1");
+      await service.recalculateLoanPaymentSplits(stId);
 
       expect(scheduledRepo.update).toHaveBeenCalledWith(stId, {
         isActive: false,
@@ -4024,7 +4036,7 @@ describe("ScheduledTransactionsService", () => {
     it("should do nothing when loan account not found", async () => {
       accountsRepo.findOne.mockResolvedValue(null);
 
-      await service.recalculateLoanPaymentSplits(stId, "loan-missing");
+      await service.recalculateLoanPaymentSplits(stId);
 
       expect(scheduledRepo.update).not.toHaveBeenCalled();
     });
@@ -4037,7 +4049,7 @@ describe("ScheduledTransactionsService", () => {
       });
       scheduledRepo.findOne.mockResolvedValue(null);
 
-      await service.recalculateLoanPaymentSplits(stId, "loan-1");
+      await service.recalculateLoanPaymentSplits(stId);
 
       expect(splitsRepo.save).not.toHaveBeenCalled();
     });
@@ -4045,6 +4057,7 @@ describe("ScheduledTransactionsService", () => {
     it("should update principal and interest splits", async () => {
       const loanAccount = {
         id: "loan-1",
+        accountType: "LOAN",
         currentBalance: -50000,
         interestRate: 6,
         paymentFrequency: "MONTHLY",
@@ -4064,13 +4077,14 @@ describe("ScheduledTransactionsService", () => {
       const scheduled = makeScheduled({
         isActive: true,
         amount: -1200,
-        splits: [principalSplit, interestSplit] as any,
       });
 
       accountsRepo.findOne.mockResolvedValue(loanAccount);
+      // Splits are re-read under the parent lock (issue #1154 re-review).
+      splitsRepo.find.mockResolvedValue([principalSplit, interestSplit]);
       scheduledRepo.findOne.mockResolvedValue(scheduled);
 
-      await service.recalculateLoanPaymentSplits(stId, "loan-1");
+      await service.recalculateLoanPaymentSplits(stId);
 
       // Both splits should have been saved with updated amounts
       expect(splitsRepo.save).toHaveBeenCalledTimes(2);

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -1623,6 +1623,9 @@ describe("ScheduledTransactionsService", () => {
       const overrideQb = mockQueryBuilder(null);
       overrideQb.getOne.mockResolvedValue(storedOverride);
       overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      // The locked re-read returns the same override revision (issue #1154
+      // re-review): same id, same (absent) updatedAt, so the change-guard passes.
+      overridesRepo.findOne.mockResolvedValue(storedOverride);
       accountsRepo.findOne.mockResolvedValue(null);
 
       await service.post(userId, stId);
@@ -1687,6 +1690,7 @@ describe("ScheduledTransactionsService", () => {
       const overrideQb = mockQueryBuilder(null);
       overrideQb.getOne.mockResolvedValue(storedOverride);
       overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      overridesRepo.findOne.mockResolvedValue(storedOverride);
       accountsRepo.findOne.mockResolvedValue(null);
       mockQueryRunner.manager.delete = jest
         .fn()
@@ -2236,12 +2240,11 @@ describe("ScheduledTransactionsService", () => {
       expect(investmentTransactionsService.create).not.toHaveBeenCalled();
     });
 
-    it("post() posts the locked row, not a pre-lock BUY snapshot (issue #1154 review)", async () => {
-      // A concurrent edit switched BUY -> DIVIDEND (clearing the funding
-      // account) between the pre-lock read and the row lock. The post must use
-      // the locked DIVIDEND -- not forward the stale BUY through the old funding
-      // account. Both the pre-lock read and the locked read go through
-      // scheduledRepo.findOne (see the manager.findOne alias in beforeEach).
+    it("post() rejects when the schedule changed between the pre-lock read and the lock (issue #1154 re-review)", async () => {
+      // A concurrent edit switched BUY -> DIVIDEND between the pre-lock read and
+      // the row lock. The prepared (pre-lock) payload no longer describes the
+      // row, so the post is refused rather than committing a stale operation.
+      // Both reads go through scheduledRepo.findOne (manager.findOne alias).
       const beforeLock = makeScheduled({
         isInvestment: true,
         investmentAction: "BUY" as any,
@@ -2261,17 +2264,42 @@ describe("ScheduledTransactionsService", () => {
       });
       scheduledRepo.findOne
         .mockResolvedValueOnce(beforeLock)
-        .mockResolvedValueOnce(locked)
         .mockResolvedValue(locked);
       const overrideQb = mockQueryBuilder();
       overrideQb.getOne.mockResolvedValue(null);
       overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
 
-      await service.post(userId, stId);
+      await expect(service.post(userId, stId)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(investmentTransactionsService.create).not.toHaveBeenCalled();
+    });
 
-      const dto = investmentTransactionsService.create.mock.calls[0][1];
-      expect(dto.action).toBe("DIVIDEND");
-      expect(dto.fundingAccountId).toBeUndefined();
+    it("post() rejects when the occurrence override changed after the pre-lock read (issue #1154 re-review)", async () => {
+      const scheduled = makeScheduled({
+        isInvestment: true,
+        investmentAction: "DIVIDEND" as any,
+        investmentSecurityId: "sec-voo",
+        investmentTotalAmount: 75,
+      });
+      stubFindOne(scheduled);
+      // Pre-lock override read (createQueryBuilder.getOne) returns one revision;
+      // the locked re-read (overridesRepo.findOne) returns a newer one.
+      const overrideQb = mockQueryBuilder();
+      overrideQb.getOne.mockResolvedValue({
+        id: "ovr-1",
+        updatedAt: new Date("2026-06-01T00:00:00Z"),
+      });
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      overridesRepo.findOne.mockResolvedValue({
+        id: "ovr-1",
+        updatedAt: new Date("2026-06-02T00:00:00Z"),
+      });
+
+      await expect(service.post(userId, stId)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(investmentTransactionsService.create).not.toHaveBeenCalled();
     });
 
     it("post() honours inline quantity / price overrides", async () => {
@@ -2905,6 +2933,40 @@ describe("ScheduledTransactionsService", () => {
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
+    it("update() rejects when the action changed concurrently (issue #1154 re-review)", async () => {
+      // The request read a DIVIDEND and derived DIVIDEND cleanup, but a
+      // concurrent edit switched the locked row to BUY. Writing the stale
+      // cleanup would null the quantity/price the BUY just set, so the update is
+      // refused. The pre-mutation read and the locked read both go through
+      // scheduledRepo.findOne.
+      const preEdit = makeScheduled({
+        isInvestment: true,
+        investmentAction: "DIVIDEND" as any,
+        investmentSecurityId: "sec-voo",
+        investmentTotalAmount: 100,
+      });
+      const lockedDifferent = makeScheduled({
+        isInvestment: true,
+        investmentAction: "BUY" as any,
+        investmentSecurityId: "sec-voo",
+        investmentQuantity: 2,
+        investmentPrice: 50,
+      });
+      scheduledRepo.findOne
+        .mockResolvedValueOnce(preEdit)
+        .mockResolvedValue(lockedDifferent);
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        userId,
+        accountSubType: "INVESTMENT_BROKERAGE",
+      });
+
+      await expect(
+        service.update(userId, stId, { name: "Renamed" } as any),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(mockQueryRunner.manager.update).not.toHaveBeenCalled();
+    });
+
     it("create() drops a funding account supplied for a non-funding action (issue #1154)", async () => {
       accountsService.findOne.mockImplementation(
         async (uid: string, id: string) => {
@@ -3237,14 +3299,16 @@ describe("ScheduledTransactionsService", () => {
           } as any,
         }),
       );
-      const overrideQb = mockQueryBuilder(null);
-      overrideQb.getOne.mockResolvedValue({
+      const storedOverride = {
         id: "ovr-1",
         originalDate: "2025-02-15",
         overrideDate: "2025-02-15",
         amount: -60,
-      });
+      };
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(storedOverride);
       overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      overridesRepo.findOne.mockResolvedValue(storedOverride);
       accountsRepo.findOne.mockResolvedValue(null);
 
       await service.post(userId, stId);

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -180,6 +180,13 @@ function sameScheduleMutationBasis(
       a.amount as unknown as number,
       b.amount as unknown as number,
     ) &&
+    // The foreign-currency tuple is mutable independently of `amount`
+    // (`update()` merges it partially, and normalizeFxEntry does not touch the
+    // account-currency amount), so a concurrent originalAmount edit would post a
+    // stale converted total otherwise (issue #1154 re-review).
+    sameNullableNumber(a.originalAmount, b.originalAmount) &&
+    a.originalCurrencyCode === b.originalCurrencyCode &&
+    sameNullableNumber(a.exchangeRate, b.exchangeRate) &&
     a.investmentAction === b.investmentAction &&
     a.investmentSecurityId === b.investmentSecurityId &&
     a.investmentFundingAccountId === b.investmentFundingAccountId &&
@@ -188,6 +195,83 @@ function sameScheduleMutationBasis(
     sameNullableNumber(a.investmentCommission, b.investmentCommission) &&
     sameNullableNumber(a.investmentTotalAmount, b.investmentTotalAmount) &&
     sameNullableNumber(a.investmentExchangeRate, b.investmentExchangeRate)
+  );
+}
+
+/**
+ * The money-shaping fields of one scheduled split. A split is not presentation
+ * metadata: a transfer split creates a counterpart transaction and moves the
+ * target account, and an investment split creates an embedded investment. So a
+ * post that builds its lines from the base scheduled splits must verify the set
+ * did not change under the parent lock (issue #1154 re-review).
+ */
+function scheduledSplitBasis(split: ScheduledTransactionSplit): string {
+  return JSON.stringify({
+    id: split.id,
+    kind: split.kind,
+    categoryId: split.categoryId ?? null,
+    transferAccountId: split.transferAccountId ?? null,
+    amount: Number(split.amount),
+    memo: split.memo ?? null,
+    investmentAction: split.investmentAction ?? null,
+    investmentSecurityId: split.investmentSecurityId ?? null,
+    investmentQuantity:
+      split.investmentQuantity == null
+        ? null
+        : Number(split.investmentQuantity),
+    investmentPrice:
+      split.investmentPrice == null ? null : Number(split.investmentPrice),
+    investmentCommission:
+      split.investmentCommission == null
+        ? null
+        : Number(split.investmentCommission),
+    investmentExchangeRate:
+      split.investmentExchangeRate == null
+        ? null
+        : Number(split.investmentExchangeRate),
+    tagIds: (split.tags ?? []).map((t) => t.id).sort(),
+  });
+}
+
+function sameScheduledSplitBasis(
+  before: ScheduledTransactionSplit[],
+  current: ScheduledTransactionSplit[],
+): boolean {
+  if (before.length !== current.length) return false;
+  const norm = (rows: ScheduledTransactionSplit[]) =>
+    rows.map(scheduledSplitBasis).sort();
+  const a = norm(before);
+  const b = norm(current);
+  return a.every((row, i) => row === b[i]);
+}
+
+/**
+ * Whether two occurrence-override snapshots describe the same effective posting
+ * state. Compared alongside `updatedAt` so a same-millisecond timestamp
+ * collision is harmless when the values actually differ (issue #1154 re-review).
+ */
+function sameOverrideMutationBasis(
+  before: ScheduledTransactionOverride | null,
+  current: ScheduledTransactionOverride | null,
+): boolean {
+  // null and undefined both mean "no override"; treat them as equal so an
+  // override-less post is not falsely flagged as changed.
+  if (!before || !current) return !before && !current;
+  return (
+    before.id === current.id &&
+    String(before.overrideDate) === String(current.overrideDate) &&
+    sameNullableNumber(before.amount, current.amount) &&
+    (before.categoryId ?? null) === (current.categoryId ?? null) &&
+    (before.description ?? null) === (current.description ?? null) &&
+    (before.isSplit ?? null) === (current.isSplit ?? null) &&
+    sameNullableNumber(before.investmentQuantity, current.investmentQuantity) &&
+    sameNullableNumber(before.investmentPrice, current.investmentPrice) &&
+    sameNullableNumber(
+      before.investmentTotalAmount,
+      current.investmentTotalAmount,
+    ) &&
+    JSON.stringify(before.splits ?? null) ===
+      JSON.stringify(current.splits ?? null)
   );
 }
 
@@ -296,7 +380,13 @@ export class ScheduledTransactionsService {
         for (const scheduled of dueTransactions) {
           try {
             await withUserContext(scheduled.userId, () =>
-              this.post(scheduled.userId, scheduled.id),
+              // Auto-post: refuse under the lock if the user turned the schedule
+              // inactive or off auto-post after cron selected it (issue #1154
+              // re-review). The ConflictException is treated as "claimed
+              // elsewhere" and skipped below.
+              this.post(scheduled.userId, scheduled.id, undefined, {
+                requireActiveAutoPost: true,
+              }),
             );
             totalSuccess++;
           } catch (error) {
@@ -1765,6 +1855,7 @@ export class ScheduledTransactionsService {
     userId: string,
     id: string,
     postDto?: PostScheduledTransactionDto,
+    options: { requireActiveAutoPost?: boolean } = {},
   ): Promise<ScheduledTransaction | null> {
     const scheduled = await this.findOne(userId, id);
 
@@ -2014,6 +2105,22 @@ export class ScheduledTransactionsService {
         );
       }
 
+      // Cron selected this row when it was active and auto-posting; if the user
+      // turned either off after selection but before the lock, the automatic
+      // post must not fire (issue #1154 re-review). Manual posts do not pass this
+      // option, so an explicit user post of an inactive schedule still works.
+      if (
+        options.requireActiveAutoPost &&
+        (!current.isActive || !current.autoPost)
+      ) {
+        throw new ConflictException(
+          tr(
+            "errors.scheduled.changedConcurrently",
+            "The scheduled transaction changed during the operation. Reload it and retry.",
+          ),
+        );
+      }
+
       // The transfer/plain payloads (preparedTransfer, transactionPayload) and
       // the FX amount were prepared from the pre-lock `scheduled` snapshot. If a
       // concurrent edit changed what the schedule *is* -- kind, accounts, amount,
@@ -2043,7 +2150,7 @@ export class ScheduledTransactionsService {
           lock: { mode: "pessimistic_write" },
         });
       if (
-        (storedOverride?.id ?? null) !== (lockedOverride?.id ?? null) ||
+        !sameOverrideMutationBasis(storedOverride, lockedOverride) ||
         (storedOverride?.updatedAt?.getTime() ?? null) !==
           (lockedOverride?.updatedAt?.getTime() ?? null)
       ) {
@@ -2053,6 +2160,33 @@ export class ScheduledTransactionsService {
             "The scheduled transaction changed during the operation. Reload it and retry.",
           ),
         );
+      }
+
+      // Split lines are money-shaping, not metadata (a transfer split moves the
+      // target account; an investment split creates an embedded trade), and the
+      // payload built them from the pre-lock `scheduled.splits`. When the post
+      // actually uses the base scheduled splits -- no inline splits and no
+      // override splits -- re-read the set under the parent lock and refuse if it
+      // changed, so a concurrently-retargeted split cannot post money to the old
+      // account (issue #1154 re-review). Scheduled split writers take the parent
+      // lock before replacing the child set, so this read sees one stable
+      // committed generation.
+      const usesScheduledSplits =
+        useSplits &&
+        !hasInlineSplits &&
+        !(lockedOverride?.splits && lockedOverride.splits.length > 0);
+      if (usesScheduledSplits) {
+        const currentSplits = await m
+          .getRepository(ScheduledTransactionSplit)
+          .find({ where: { scheduledTransactionId: id }, relations: ["tags"] });
+        if (!sameScheduledSplitBasis(scheduled.splits ?? [], currentSplits)) {
+          throw new ConflictException(
+            tr(
+              "errors.scheduled.changedConcurrently",
+              "The scheduled transaction changed during the operation. Reload it and retry.",
+            ),
+          );
+        }
       }
 
       // Claim the occurrence. The unique key on

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -134,6 +134,16 @@ const AMOUNT_ONLY_ACTIONS = new Set<InvestmentAction>([
   InvestmentAction.CAPITAL_GAIN,
 ]);
 
+// The only scheduled investment actions that route cash through an explicit
+// funding account: a BUY draws from it, a SELL deposits into it. Every other
+// action settles against the brokerage's linked cash account, so a funding
+// account stored on one is stale (issue #1154) -- cleared on write and ignored
+// on post rather than trusted to misroute the money.
+const FUNDING_ACCOUNT_ACTIONS = new Set<InvestmentAction>([
+  InvestmentAction.BUY,
+  InvestmentAction.SELL,
+]);
+
 @Injectable()
 export class ScheduledTransactionsService {
   private readonly logger = new Logger(ScheduledTransactionsService.name);
@@ -484,9 +494,15 @@ export class ScheduledTransactionsService {
         investmentSecurityId: isInvestment
           ? transactionData.investmentSecurityId || null
           : null,
-        investmentFundingAccountId: isInvestment
-          ? transactionData.investmentFundingAccountId || null
-          : null,
+        // A funding account only belongs on a BUY/SELL; storing one on any other
+        // action is what later misroutes the posted cash (issue #1154).
+        investmentFundingAccountId:
+          isInvestment &&
+          FUNDING_ACCOUNT_ACTIONS.has(
+            transactionData.investmentAction as InvestmentAction,
+          )
+            ? transactionData.investmentFundingAccountId || null
+            : null,
         investmentQuantity:
           isInvestment && transactionData.investmentQuantity !== undefined
             ? transactionData.investmentQuantity
@@ -1267,6 +1283,19 @@ export class ScheduledTransactionsService {
       if (updateData.investmentExchangeRate !== undefined)
         fieldsToUpdate.investmentExchangeRate =
           updateData.investmentExchangeRate ?? null;
+
+      // Editing an investment away from BUY/SELL must drop any funding account
+      // the row was carrying, even when the client omits the key rather than
+      // sending an explicit null (issue #1154). The effective action is the one
+      // being written, or the stored one when the edit leaves it untouched.
+      const effectiveInvestmentAction = (updateData.investmentAction ??
+        scheduled.investmentAction) as InvestmentAction | null;
+      if (
+        !effectiveInvestmentAction ||
+        !FUNDING_ACCOUNT_ACTIONS.has(effectiveInvestmentAction)
+      ) {
+        fieldsToUpdate.investmentFundingAccountId = null;
+      }
     }
 
     // Apply the split rewrite, any mode-switch split clearing, and the main
@@ -1958,7 +1987,14 @@ export class ScheduledTransactionsService {
       action,
       transactionDate: postDate,
       securityId: scheduled.investmentSecurityId || undefined,
-      fundingAccountId: scheduled.investmentFundingAccountId || undefined,
+      // Only a BUY/SELL settles through the funding account; for any other
+      // action the cash belongs in the brokerage's linked cash account, so a
+      // stale funding account left on the row is ignored rather than allowed to
+      // misroute the money (issue #1154). This also repairs rows that were
+      // already stored with a stale funding account before the write-path fix.
+      fundingAccountId: FUNDING_ACCOUNT_ACTIONS.has(action)
+        ? scheduled.investmentFundingAccountId || undefined
+        : undefined,
       description,
     };
 

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -1287,6 +1287,34 @@ export class ScheduledTransactionsService {
       ) {
         fieldsToUpdate.investmentFundingAccountId = null;
       }
+
+      // The same omit-doesn't-clear defect applies to the numeric fields the
+      // issue calls out (issue #1154): switching action leaves quantity/price/
+      // commission/total from the old action on the row. This is not a money
+      // bug -- postInvestment reads only the fields its effective action uses --
+      // but it leaves the row internally inconsistent, so clear each field the
+      // effective action does not use. The clear is safe: validateInvestmentFields
+      // (run above) guarantees the action's required field is present, and the
+      // fields dropped here are exactly the ones postInvestment ignores for that
+      // action, so no posted amount changes. Unlike investmentExchangeRate (see
+      // postInvestment), none of these carries a value that is legitimate under
+      // more than one action, so an action-keyed clear cannot over-clear.
+      const usesQuantity =
+        !!effectiveInvestmentAction &&
+        (QUANTITY_PRICE_ACTIONS.has(effectiveInvestmentAction) ||
+          QUANTITY_ONLY_ACTIONS.has(effectiveInvestmentAction));
+      const usesPrice =
+        !!effectiveInvestmentAction &&
+        QUANTITY_PRICE_ACTIONS.has(effectiveInvestmentAction);
+      const usesTotalAmount =
+        !!effectiveInvestmentAction &&
+        AMOUNT_ONLY_ACTIONS.has(effectiveInvestmentAction);
+      if (!usesQuantity) fieldsToUpdate.investmentQuantity = null;
+      if (!usesPrice) {
+        fieldsToUpdate.investmentPrice = null;
+        fieldsToUpdate.investmentCommission = null;
+      }
+      if (!usesTotalAmount) fieldsToUpdate.investmentTotalAmount = null;
     }
 
     // Apply the split rewrite, any mode-switch split clearing, and the main

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -29,6 +29,7 @@ import { AccountsService } from "../accounts/accounts.service";
 import { TransactionsService } from "../transactions/transactions.service";
 import { InvestmentTransactionsService } from "../securities/investment-transactions.service";
 import { InvestmentAction } from "../securities/entities/investment-transaction.entity";
+import { FUNDING_ACCOUNT_ACTIONS } from "../securities/investment-replay.util";
 import { Account, AccountSubType } from "../accounts/entities/account.entity";
 import { ScheduledTransactionOverrideService } from "./scheduled-transaction-override.service";
 import { ScheduledTransactionLoanService } from "./scheduled-transaction-loan.service";
@@ -132,16 +133,6 @@ const AMOUNT_ONLY_ACTIONS = new Set<InvestmentAction>([
   InvestmentAction.DIVIDEND,
   InvestmentAction.INTEREST,
   InvestmentAction.CAPITAL_GAIN,
-]);
-
-// The only scheduled investment actions that route cash through an explicit
-// funding account: a BUY draws from it, a SELL deposits into it. Every other
-// action settles against the brokerage's linked cash account, so a funding
-// account stored on one is stale (issue #1154) -- cleared on write and ignored
-// on post rather than trusted to misroute the money.
-const FUNDING_ACCOUNT_ACTIONS = new Set<InvestmentAction>([
-  InvestmentAction.BUY,
-  InvestmentAction.SELL,
 ]);
 
 @Injectable()

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -135,6 +135,17 @@ const AMOUNT_ONLY_ACTIONS = new Set<InvestmentAction>([
   InvestmentAction.CAPITAL_GAIN,
 ]);
 
+/**
+ * On an update, an omitted key means "leave the stored value"; an explicit null
+ * means "clear it". `??` collapses the two, which let a `{ field: null }` PATCH
+ * pass validation against the stored value and then persist the null anyway
+ * (issue #1154 review). Use this so validation sees the value that will be
+ * written.
+ */
+function suppliedOrStored<T>(supplied: T | undefined, stored: T): T {
+  return supplied === undefined ? stored : supplied;
+}
+
 @Injectable()
 export class ScheduledTransactionsService {
   private readonly logger = new Logger(ScheduledTransactionsService.name);
@@ -432,7 +443,14 @@ export class ScheduledTransactionsService {
         );
       }
       this.validateInvestmentFields(createDto);
-      if (createDto.investmentFundingAccountId) {
+      // Only validate a funding account the action will actually use; a value
+      // supplied for a non-BUY/SELL action is dropped at persist time, so
+      // rejecting it here would refuse a request the write would have cleaned.
+      if (
+        createDto.investmentAction &&
+        FUNDING_ACCOUNT_ACTIONS.has(createDto.investmentAction) &&
+        createDto.investmentFundingAccountId
+      ) {
         await this.accountsService.findOne(
           userId,
           createDto.investmentFundingAccountId,
@@ -596,11 +614,12 @@ export class ScheduledTransactionsService {
   }
 
   private validateInvestmentFields(dto: {
-    investmentAction?: InvestmentAction;
+    investmentAction?: InvestmentAction | null;
     investmentSecurityId?: string | null;
     investmentQuantity?: number | null;
     investmentPrice?: number | null;
     investmentTotalAmount?: number | null;
+    investmentExchangeRate?: number | null;
   }): void {
     const action = dto.investmentAction;
     if (!action) {
@@ -664,7 +683,8 @@ export class ScheduledTransactionsService {
     } else if (AMOUNT_ONLY_ACTIONS.has(action)) {
       if (
         dto.investmentTotalAmount === undefined ||
-        dto.investmentTotalAmount === null
+        dto.investmentTotalAmount === null ||
+        Number(dto.investmentTotalAmount) <= 0
       ) {
         throw new BadRequestException(
           tr(
@@ -674,6 +694,24 @@ export class ScheduledTransactionsService {
           ),
         );
       }
+    }
+
+    // An exchange rate, when present, must be a real rate on every action --
+    // zero or negative can never settle (issue #1154 review). A missing rate is
+    // fine here: it is resolved for the posting date at post time. Reuses the
+    // securities catalog key rather than adding a new one.
+    if (
+      dto.investmentExchangeRate !== undefined &&
+      dto.investmentExchangeRate !== null &&
+      (!Number.isFinite(Number(dto.investmentExchangeRate)) ||
+        Number(dto.investmentExchangeRate) <= 0)
+    ) {
+      throw new BadRequestException(
+        tr(
+          "errors.securities.exchangeRateNotPositive",
+          "Exchange rate must be greater than zero",
+        ),
+      );
     }
   }
 
@@ -1085,24 +1123,50 @@ export class ScheduledTransactionsService {
           ),
         );
       }
+      // Validate the values that will actually be written. `suppliedOrStored`
+      // keeps an explicit null distinct from an omitted key, so a
+      // `{ investmentTotalAmount: null }` PATCH is validated as null (and
+      // rejected for an amount-only action) rather than passing against the
+      // stored value and then persisting the null (issue #1154 review).
       const merged = {
-        investmentAction:
-          updateDto.investmentAction ??
-          (scheduled.investmentAction as InvestmentAction | undefined),
-        investmentSecurityId:
-          updateDto.investmentSecurityId ?? scheduled.investmentSecurityId,
-        investmentQuantity:
-          updateDto.investmentQuantity ?? scheduled.investmentQuantity,
-        investmentPrice: updateDto.investmentPrice ?? scheduled.investmentPrice,
-        investmentTotalAmount:
-          updateDto.investmentTotalAmount ?? scheduled.investmentTotalAmount,
+        investmentAction: suppliedOrStored(
+          updateDto.investmentAction as InvestmentAction | null | undefined,
+          scheduled.investmentAction as InvestmentAction | null,
+        ),
+        investmentSecurityId: suppliedOrStored(
+          updateDto.investmentSecurityId as string | null | undefined,
+          scheduled.investmentSecurityId,
+        ),
+        investmentQuantity: suppliedOrStored(
+          updateDto.investmentQuantity as number | null | undefined,
+          scheduled.investmentQuantity,
+        ),
+        investmentPrice: suppliedOrStored(
+          updateDto.investmentPrice as number | null | undefined,
+          scheduled.investmentPrice,
+        ),
+        investmentTotalAmount: suppliedOrStored(
+          updateDto.investmentTotalAmount as number | null | undefined,
+          scheduled.investmentTotalAmount,
+        ),
+        investmentExchangeRate: suppliedOrStored(
+          updateDto.investmentExchangeRate as number | null | undefined,
+          scheduled.investmentExchangeRate,
+        ),
       };
       this.validateInvestmentFields(merged);
-      if (updateDto.investmentFundingAccountId) {
-        await this.accountsService.findOne(
-          userId,
-          updateDto.investmentFundingAccountId,
-        );
+      // Only validate a funding account that will actually be used: a stale one
+      // on a non-BUY/SELL action is cleared below, so it need not resolve.
+      const effectiveFundingAccountId = suppliedOrStored(
+        updateDto.investmentFundingAccountId as string | null | undefined,
+        scheduled.investmentFundingAccountId,
+      );
+      if (
+        merged.investmentAction &&
+        FUNDING_ACCOUNT_ACTIONS.has(merged.investmentAction) &&
+        effectiveFundingAccountId
+      ) {
+        await this.accountsService.findOne(userId, effectiveFundingAccountId);
       }
     }
 
@@ -1315,6 +1379,69 @@ export class ScheduledTransactionsService {
         fieldsToUpdate.investmentCommission = null;
       }
       if (!usesTotalAmount) fieldsToUpdate.investmentTotalAmount = null;
+
+      const actionChanged =
+        updateData.investmentAction !== undefined &&
+        updateData.investmentAction !== scheduled.investmentAction;
+
+      // The scheduled UI has no security field for INTEREST, so switching to it
+      // must not keep the previous action's security -- the cash-settlement
+      // currency is derived from the security, so a stale one converts the
+      // interest in the wrong currency (issue #1154 review). Clear it only on
+      // the transition and only when the caller did not explicitly supply one,
+      // leaving a deliberate API value for a future product decision.
+      if (
+        actionChanged &&
+        effectiveInvestmentAction === InvestmentAction.INTEREST &&
+        updateData.investmentSecurityId === undefined
+      ) {
+        fieldsToUpdate.investmentSecurityId = null;
+      }
+
+      // A stored exchange rate describes a settlement tuple (account + security
+      // + cash destination), not just an action, and the column does not record
+      // the currency pair it was resolved for. If any part of that tuple changes
+      // and no replacement rate is supplied, force post-time re-resolution
+      // rather than applying a rate for the old pair (issue #1154 review). This
+      // is the value-difference guard the earlier deferral asked for -- a
+      // presentation-only edit (e.g. the name) does not touch the tuple, so a
+      // legitimate cross-currency dividend rate is preserved.
+      const effectiveSecurityIdForFx =
+        fieldsToUpdate.investmentSecurityId !== undefined
+          ? (fieldsToUpdate.investmentSecurityId as string | null)
+          : suppliedOrStored(
+              updateData.investmentSecurityId as string | null | undefined,
+              scheduled.investmentSecurityId,
+            );
+      const effectiveFundingForFx =
+        effectiveInvestmentAction &&
+        FUNDING_ACCOUNT_ACTIONS.has(effectiveInvestmentAction)
+          ? suppliedOrStored(
+              updateData.investmentFundingAccountId as
+                | string
+                | null
+                | undefined,
+              scheduled.investmentFundingAccountId,
+            )
+          : null;
+      const storedFundingForFx =
+        scheduled.investmentAction &&
+        FUNDING_ACCOUNT_ACTIONS.has(
+          scheduled.investmentAction as InvestmentAction,
+        )
+          ? scheduled.investmentFundingAccountId
+          : null;
+      const settlementBasisChanged =
+        (updateData.accountId !== undefined &&
+          updateData.accountId !== scheduled.accountId) ||
+        effectiveSecurityIdForFx !== scheduled.investmentSecurityId ||
+        effectiveFundingForFx !== storedFundingForFx;
+      if (
+        settlementBasisChanged &&
+        updateData.investmentExchangeRate === undefined
+      ) {
+        fieldsToUpdate.investmentExchangeRate = null;
+      }
     }
 
     // Apply the split rewrite, any mode-switch split clearing, and the main
@@ -1835,10 +1962,16 @@ export class ScheduledTransactionsService {
         );
       }
 
-      if (scheduled.isInvestment) {
+      if (current.isInvestment) {
+        // Post from the locked row, not the pre-lock `scheduled` snapshot: a
+        // concurrent edit that switched the action/funding/security between the
+        // snapshot read and this lock would otherwise post the stale action to
+        // the stale account (issue #1154 review). `current` carries the
+        // authoritative scalar investment fields; postInvestment reads only
+        // those, and the nested create resolves its own settlement account.
         await this.postInvestment(
           userId,
-          scheduled,
+          current,
           postDto,
           postDate,
           storedOverride,
@@ -2006,6 +2139,27 @@ export class ScheduledTransactionsService {
       postDto?.description !== undefined
         ? postDto.description || undefined
         : scheduled.description || undefined;
+
+    // Post-time overrides (inline > occurrence override > schedule) are another
+    // write boundary that create/update validation does not cover, and internal
+    // callers (cron, MCP) bypass the controller DTO. Revalidate the resolved
+    // values before creating money, so an override cannot post a zero BUY
+    // quantity or a negative dividend total (issue #1154 review). Amount-only
+    // actions may express the total as quantity*price, so mirror that here.
+    const effectiveAmountOnlyTotal =
+      totalAmount !== undefined
+        ? totalAmount
+        : quantity !== undefined && price !== undefined
+          ? quantity * price
+          : undefined;
+    this.validateInvestmentFields({
+      investmentAction: action,
+      investmentSecurityId: scheduled.investmentSecurityId,
+      investmentQuantity: quantity,
+      investmentPrice: price,
+      investmentTotalAmount: effectiveAmountOnlyTotal,
+      investmentExchangeRate: exchangeRate,
+    });
 
     const dto: any = {
       accountId: scheduled.accountId,

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -146,6 +146,51 @@ function suppliedOrStored<T>(supplied: T | undefined, stored: T): T {
   return supplied === undefined ? stored : supplied;
 }
 
+function sameNullableNumber(
+  left: number | null | undefined,
+  right: number | null | undefined,
+): boolean {
+  if (left == null || right == null) return left == null && right == null;
+  return Number(left) === Number(right);
+}
+
+/**
+ * The fields that decide what a post/edit will actually write -- the kind, the
+ * accounts money moves between, the amount and currency, and every investment
+ * scalar. `post()` and `update()` prepare their writes from a row read before
+ * the row lock; if any of these changed by the time the lock is held, the
+ * prepared write no longer describes the row and must be refused rather than
+ * committing a stale operation (issue #1154 review). Presentation-only fields
+ * (description, tags) are deliberately excluded so a cosmetic concurrent edit
+ * does not force a needless retry.
+ */
+function sameScheduleMutationBasis(
+  a: ScheduledTransaction,
+  b: ScheduledTransaction,
+): boolean {
+  return (
+    a.isInvestment === b.isInvestment &&
+    a.isTransfer === b.isTransfer &&
+    a.isSplit === b.isSplit &&
+    a.accountId === b.accountId &&
+    a.transferAccountId === b.transferAccountId &&
+    a.categoryId === b.categoryId &&
+    a.currencyCode === b.currencyCode &&
+    sameNullableNumber(
+      a.amount as unknown as number,
+      b.amount as unknown as number,
+    ) &&
+    a.investmentAction === b.investmentAction &&
+    a.investmentSecurityId === b.investmentSecurityId &&
+    a.investmentFundingAccountId === b.investmentFundingAccountId &&
+    sameNullableNumber(a.investmentQuantity, b.investmentQuantity) &&
+    sameNullableNumber(a.investmentPrice, b.investmentPrice) &&
+    sameNullableNumber(a.investmentCommission, b.investmentCommission) &&
+    sameNullableNumber(a.investmentTotalAmount, b.investmentTotalAmount) &&
+    sameNullableNumber(a.investmentExchangeRate, b.investmentExchangeRate)
+  );
+}
+
 @Injectable()
 export class ScheduledTransactionsService {
   private readonly logger = new Logger(ScheduledTransactionsService.name);
@@ -1448,6 +1493,34 @@ export class ScheduledTransactionsService {
     // row update atomically so a partial failure cannot leave the row and its
     // splits in an inconsistent state.
     await withScopedDb(this.dataSource, async (m) => {
+      // The effective action, validation and the action-dependent clears above
+      // were derived from `scheduled`, read before this transaction. Re-read the
+      // row under the lock and refuse if the mutation basis changed in between:
+      // otherwise a concurrent action switch that committed first would be
+      // overwritten by this request's stale derived clears (e.g. nulling the
+      // quantity/price a concurrent BUY just set) (issue #1154 review).
+      const current = await m.findOne(ScheduledTransaction, {
+        where: { id, userId },
+        lock: { mode: "pessimistic_write" },
+      });
+      if (!current) {
+        throw new NotFoundException(
+          tr(
+            "errors.scheduled.notFound",
+            `Scheduled transaction with ID ${id} not found`,
+            { id },
+          ),
+        );
+      }
+      if (!sameScheduleMutationBasis(scheduled, current)) {
+        throw new ConflictException(
+          tr(
+            "errors.scheduled.changedConcurrently",
+            "The scheduled transaction changed during the operation. Reload it and retry.",
+          ),
+        );
+      }
+
       if (splits !== undefined) {
         if (Array.isArray(splits) && splits.length > 0) {
           await m.delete(ScheduledTransactionSplit, {
@@ -1941,6 +2014,47 @@ export class ScheduledTransactionsService {
         );
       }
 
+      // The transfer/plain payloads (preparedTransfer, transactionPayload) and
+      // the FX amount were prepared from the pre-lock `scheduled` snapshot. If a
+      // concurrent edit changed what the schedule *is* -- kind, accounts, amount,
+      // currency, or any investment scalar -- committing the prepared write would
+      // post a different operation than the row now describes (e.g. a plain
+      // expense edited to a transfer, so money leaves but nothing arrives). Refuse
+      // and let the caller reload (issue #1154 review). The occurrence-claim and
+      // the row lock guarantee no double-post; this guards against a stale-shape
+      // post. Cron treats the ConflictException as "claimed elsewhere" and skips.
+      if (!sameScheduleMutationBasis(scheduled, current)) {
+        throw new ConflictException(
+          tr(
+            "errors.scheduled.changedConcurrently",
+            "The scheduled transaction changed during the operation. Reload it and retry.",
+          ),
+        );
+      }
+
+      // The occurrence override is a mutable row of its own, read before this
+      // lock. Re-read it under the lock and refuse if it changed, so a
+      // concurrently-edited override is neither posted stale nor deleted
+      // unread (issue #1154 review).
+      const lockedOverride = await m
+        .getRepository(ScheduledTransactionOverride)
+        .findOne({
+          where: { scheduledTransactionId: id, originalDate: nextDueDateStr },
+          lock: { mode: "pessimistic_write" },
+        });
+      if (
+        (storedOverride?.id ?? null) !== (lockedOverride?.id ?? null) ||
+        (storedOverride?.updatedAt?.getTime() ?? null) !==
+          (lockedOverride?.updatedAt?.getTime() ?? null)
+      ) {
+        throw new ConflictException(
+          tr(
+            "errors.scheduled.changedConcurrently",
+            "The scheduled transaction changed during the operation. Reload it and retry.",
+          ),
+        );
+      }
+
       // Claim the occurrence. The unique key on
       // (scheduled_transaction_id, original_due_date) is what makes the claim
       // the serialization point rather than the lock alone: it survives a
@@ -1974,7 +2088,7 @@ export class ScheduledTransactionsService {
           current,
           postDto,
           postDate,
-          storedOverride,
+          lockedOverride,
         );
       } else if (preparedTransfer) {
         // Already validated and authorized above; only the writes join this
@@ -1988,8 +2102,8 @@ export class ScheduledTransactionsService {
         await this.transactionsService.create(userId, transactionPayload);
       }
 
-      if (storedOverride) {
-        await m.remove(storedOverride);
+      if (lockedOverride) {
+        await m.remove(lockedOverride);
       }
 
       if (current.frequency === "ONCE") {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -1780,8 +1780,14 @@ export class ScheduledTransactionsService {
     // 0.00 instead of 50.00 (audit P4-004).
     //
     // Nested service calls join this transaction, so a refusal below rolls the
-    // money back with it. Everything that reaches outside PostgreSQL -- the FX
-    // rate lookup in particular -- has already run above.
+    // money back with it. The schedule's own account-currency FX lookup
+    // (resolveFxForPosting) has already run above. One external call is NOT
+    // hoisted: an investment's cash-settlement FX is resolved inside
+    // postInvestment -> InvestmentTransactionsService.create, which can fetch a
+    // cross-currency rate from the quote provider while this lock is held. That
+    // is a pre-existing cost (a network round-trip inside the transaction), not
+    // a correctness bug -- rollback still unwinds cleanly -- and is tracked as a
+    // follow-up rather than reshaped here.
     let writtenTransfer: { savedFromId: string; savedToId: string } | undefined;
     const removedAfterOnce = await withScopedDb(this.dataSource, async (m) => {
       // Lock the schedule and confirm this occurrence is still the due one. A

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -2173,13 +2173,15 @@ export class ScheduledTransactionsService {
       // actually uses the base scheduled splits -- no inline splits and no
       // override splits -- re-read the set under the parent lock and refuse if it
       // changed, so a concurrently-retargeted split cannot post money to the old
-      // account (issue #1154 re-review). This re-read is the safety net on its
-      // own: it compares the committed child set against the pre-lock snapshot
-      // and refuses on any difference, so it does not depend on every writer
-      // taking the parent lock first. Writers that do serialize on that lock
-      // (the loan recalculator) simply never produce a mid-write generation for
-      // it to see; a writer that does not (a bulk category reassignment) is
-      // still caught, because what the guard checks is the value, not the lock.
+      // account (issue #1154 re-review). This is a point-in-time comparison, so
+      // what it protects against depends on when the other writer commits.
+      // Writers that serialize on the parent lock (the loan recalculator) cannot
+      // mutate the split set after this read at all -- the lock is held until the
+      // post commits. A writer that does NOT take the parent lock can still
+      // commit a change *after* this comparison and before the post commits; the
+      // only such known path is bulk category reassignment, whose residual
+      // effect is categorization-only (no amount or account routing changes), so
+      // it is accepted here rather than made to lock every affected parent.
       const usesScheduledSplits =
         useSplits &&
         !hasInlineSplits &&

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -2012,6 +2012,20 @@ export class ScheduledTransactionsService {
       }
     }
 
+    // Unlike the funding account above, the stored exchange rate is forwarded
+    // for every action rather than gated on FUNDING_ACCOUNT_ACTIONS. That is
+    // deliberate and asymmetric: a cross-currency DIVIDEND/INTEREST/CAPITAL_GAIN
+    // legitimately settles at a rate, so it cannot simply be dropped for
+    // non-BUY/SELL actions the way the funding account can. A known, separate
+    // gap remains -- a rate stored (only reachable via the direct API; no UI or
+    // MNY-import path ever sets investmentExchangeRate) for one settlement basis
+    // and then applied after the action switches settlement account -- because
+    // the column carries no record of the currency pair it was resolved for.
+    // Closing it needs the "account, currency, rate and amount are one tuple"
+    // spec (a value-difference clear on a settlement-basis change, not a
+    // presence check), tracked as a follow-up to issue #1154 rather than
+    // fixed by a naive mirror of the funding-account gate that would wipe a
+    // legitimate dividend rate on every unrelated edit.
     if (exchangeRate !== undefined) dto.exchangeRate = exchangeRate;
 
     await this.investmentTransactionsService.create(userId, dto);

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -160,9 +160,14 @@ function sameNullableNumber(
  * scalar. `post()` and `update()` prepare their writes from a row read before
  * the row lock; if any of these changed by the time the lock is held, the
  * prepared write no longer describes the row and must be refused rather than
- * committing a stale operation (issue #1154 review). Presentation-only fields
- * (description, tags) are deliberately excluded so a cosmetic concurrent edit
- * does not force a needless retry.
+ * committing a stale operation (issue #1154 review). Presentation-only content
+ * (name/payee, description, memo, tags) is deliberately excluded: it does not
+ * change where money moves or how much, so a concurrent cosmetic edit does not
+ * force a needless retry. The accepted trade-off is that a post racing such an
+ * edit carries the pre-lock text -- the posted transaction may show the older
+ * name/description while the schedule already shows the newer one. That is a
+ * content-consistency gap, not a financial one, and is chosen over rejecting a
+ * post because someone renamed the payee at the same instant.
  */
 function sameScheduleMutationBasis(
   a: ScheduledTransaction,
@@ -2168,9 +2173,13 @@ export class ScheduledTransactionsService {
       // actually uses the base scheduled splits -- no inline splits and no
       // override splits -- re-read the set under the parent lock and refuse if it
       // changed, so a concurrently-retargeted split cannot post money to the old
-      // account (issue #1154 re-review). Scheduled split writers take the parent
-      // lock before replacing the child set, so this read sees one stable
-      // committed generation.
+      // account (issue #1154 re-review). This re-read is the safety net on its
+      // own: it compares the committed child set against the pre-lock snapshot
+      // and refuses on any difference, so it does not depend on every writer
+      // taking the parent lock first. Writers that do serialize on that lock
+      // (the loan recalculator) simply never produce a mid-write generation for
+      // it to see; a writer that does not (a bulk category reassignment) is
+      // still caught, because what the guard checks is the value, not the lock.
       const usesScheduledSplits =
         useSplits &&
         !hasInlineSplits &&
@@ -2311,12 +2320,11 @@ export class ScheduledTransactionsService {
     }
 
     if (scheduled.splits && scheduled.splits.length > 0) {
-      const loanAccountId = await this.loanService.findLoanAccountFromSplits(
-        scheduled.splits,
-      );
-      if (loanAccountId) {
-        await this.loanService.recalculateLoanPaymentSplits(id, loanAccountId);
-      }
+      // Do not pass a loan id captured off the pre-lock snapshot: the
+      // recalculation locks the parent and derives the loan from the current
+      // split set itself, so a concurrent retarget (Loan A -> Loan B) cannot
+      // recalculate the wrong loan (issue #1154 re-review).
+      await this.loanService.recalculateLoanPaymentSplits(id);
     }
 
     return this.findOne(userId, id);
@@ -2566,11 +2574,9 @@ export class ScheduledTransactionsService {
 
   async recalculateLoanPaymentSplits(
     scheduledTransactionId: string,
-    loanAccountId: string,
   ): Promise<void> {
     return this.loanService.recalculateLoanPaymentSplits(
       scheduledTransactionId,
-      loanAccountId,
     );
   }
 }

--- a/backend/src/securities/investment-replay.util.spec.ts
+++ b/backend/src/securities/investment-replay.util.spec.ts
@@ -3,6 +3,7 @@ import {
   acquisitionCost,
   acquisitionUnitCost,
   applyActionToQuantity,
+  FUNDING_ACCOUNT_ACTIONS,
   isQuantityOnlyAction,
   SHARE_MOVING_ACTIONS,
 } from "./investment-replay.util";
@@ -109,6 +110,28 @@ describe("applyActionToQuantity", () => {
       (action) => applyActionToQuantity(10, action, 2) !== 10,
     );
     expect([...SHARE_MOVING_ACTIONS].sort()).toEqual(moving.sort());
+  });
+});
+
+describe("FUNDING_ACCOUNT_ACTIONS", () => {
+  it("is exactly BUY and SELL", () => {
+    expect([...FUNDING_ACCOUNT_ACTIONS].sort()).toEqual(
+      [InvestmentAction.BUY, InvestmentAction.SELL].sort(),
+    );
+  });
+
+  it("excludes cash-only and share-only actions", () => {
+    for (const action of [
+      InvestmentAction.DIVIDEND,
+      InvestmentAction.INTEREST,
+      InvestmentAction.CAPITAL_GAIN,
+      InvestmentAction.REINVEST,
+      InvestmentAction.ADD_SHARES,
+      InvestmentAction.REMOVE_SHARES,
+      InvestmentAction.SPLIT,
+    ]) {
+      expect(FUNDING_ACCOUNT_ACTIONS.has(action)).toBe(false);
+    }
   });
 });
 

--- a/backend/src/securities/investment-replay.util.ts
+++ b/backend/src/securities/investment-replay.util.ts
@@ -67,6 +67,22 @@ export const SHARE_MOVING_ACTIONS: readonly InvestmentAction[] = [
 ];
 
 /**
+ * Actions whose cash settles through an explicit funding account: a BUY draws
+ * the purchase cost from it, a SELL deposits the proceeds into it. Every other
+ * action settles against the brokerage's linked cash account, so a funding
+ * account stored on one is stale and must never route the money (issue #1154).
+ *
+ * Centralized so the scheduled-transaction service (which clears the column on
+ * write and ignores it on post) and the MNY import writer (which must not
+ * persist one on a non-funding action) share one authority rather than each
+ * spelling out `{BUY, SELL}` and drifting apart.
+ */
+export const FUNDING_ACCOUNT_ACTIONS: ReadonlySet<InvestmentAction> = new Set([
+  InvestmentAction.BUY,
+  InvestmentAction.SELL,
+]);
+
+/**
  * Whether an action adds shares to a position without supplying a cost for
  * them. Basis-carrying replays must record that the basis they computed is
  * incomplete rather than treating the shares as free.

--- a/backend/src/securities/investment-replay.util.ts
+++ b/backend/src/securities/investment-replay.util.ts
@@ -67,10 +67,12 @@ export const SHARE_MOVING_ACTIONS: readonly InvestmentAction[] = [
 ];
 
 /**
- * Actions whose cash settles through an explicit funding account: a BUY draws
- * the purchase cost from it, a SELL deposits the proceeds into it. Every other
- * action settles against the brokerage's linked cash account, so a funding
- * account stored on one is stale and must never route the money (issue #1154).
+ * The only actions allowed to use an explicit funding account: a BUY draws the
+ * purchase cost from it, a SELL deposits the proceeds into it. Cash-bearing
+ * DIVIDEND / INTEREST / CAPITAL_GAIN settle against the brokerage's linked cash
+ * account; REINVEST and the share-only actions have no external cash leg at all.
+ * So a funding account stored on any non-BUY/SELL action is stale and must never
+ * route the money (issue #1154).
  *
  * Centralized so the scheduled-transaction service (which clears the column on
  * write and ignores it on post) and the MNY import writer (which must not

--- a/docs/future-plans/scheduled-investment-fx-currency-pair.md
+++ b/docs/future-plans/scheduled-investment-fx-currency-pair.md
@@ -1,0 +1,66 @@
+# Scheduled-investment FX rate: currency-pair invalidation (follow-up to issue #1154)
+
+Status: deferred. Tracked here because it is a real gap, but it is a
+maintenance/consistency issue rather than a live money-misrouting defect, and it
+was out of scope for the #1154 posting-path fix. This document is the durable
+record until a GitHub issue is filed for it.
+
+## The gap
+
+A scheduled investment (and a scheduled split, and an occurrence override) can
+store an FX rate that converts the security's currency into the settlement
+account's currency. That rate is a single scalar with **no companion
+from/to currency pair persisted beside it**. So if the security's `currencyCode`
+or the settlement account's `currencyCode` changes *after* the rate was stored
+-- with the id unchanged -- the stored rate silently becomes a rate for a pair
+that no longer applies. Posting later would convert with a rate that answers a
+question nobody is asking anymore.
+
+This is the same family as the "settlement-basis change invalidates the stored
+rate" fix already landed in the posting/update path (issue #1154): that fix
+re-resolves the rate when the *schedule's own* settlement structure changes, but
+it cannot see a currency change made on the referenced security or account row.
+
+## The three rate surfaces (all must be covered by any fix)
+
+1. `scheduled_transactions.investment_exchange_rate`
+   (`NUMERIC(20, 10)`, entity field `investmentExchangeRate`).
+2. `scheduled_transaction_splits.investment_exchange_rate`
+   (`NUMERIC(20, 10)`) -- the per-split rate on an embedded investment split.
+3. Occurrence-override embedded investment rate -- the `exchangeRate` inside an
+   override's `splits[*].investment` payload.
+
+A fix that clears only surface (1) leaves a split or an override carrying the
+same stale rate, so all three have to be addressed together.
+
+## Two candidate fixes
+
+- **Invalidate on currency change (narrow).** When
+  `SecuritiesService.update` changes a security's `currencyCode`, or an account's
+  currency is changed, clear the stored `investment_exchange_rate` on every
+  affected scheduled transaction, scheduled split, and occurrence override that
+  references that security/account. Posting then re-resolves the rate through the
+  same resolver the commit uses. Cheap, but it is one more write path that has to
+  remember the three surfaces.
+
+- **Persist the currency pair (durable).** Store the rate's from/to currency
+  codes beside each rate, so the posting path self-verifies: if the stored pair
+  no longer matches (security currency, settlement account currency), treat the
+  rate as absent and re-resolve, exactly as a missing rate is handled. This makes
+  the rate self-describing and removes the need for any external write path to
+  remember to invalidate it. Preferred, but it is a schema change on three
+  tables/payloads.
+
+Either way, the acceptance test is a round trip: store a rate, change the
+security (or account) currency, post, and assert the posted cash was converted
+with a freshly resolved rate for the *current* pair -- never with the stale
+scalar.
+
+## Why it is safe to defer
+
+Changing a security's or an account's currency after scheduling an investment in
+it is rare, and the failure is a wrong conversion rate on a future posting, not
+an immediate incorrect balance or a data-loss event. The #1154 fix closes the
+misrouting and the settlement-basis staleness that were the reported defect; this
+residual is the remaining edge that needs a schema decision rather than a
+point fix, which is why it is written down here instead of rushed in.

--- a/docs/future-plans/scheduled-investment-fx-currency-pair.md
+++ b/docs/future-plans/scheduled-investment-fx-currency-pair.md
@@ -1,9 +1,16 @@
 # Scheduled-investment FX rate: currency-pair invalidation (follow-up to issue #1154)
 
-Status: deferred. Tracked here because it is a real gap, but it is a
-maintenance/consistency issue rather than a live money-misrouting defect, and it
-was out of scope for the #1154 posting-path fix. This document is the durable
-record until a GitHub issue is filed for it.
+Status: deferred. Tracked here because it is a real gap that was out of scope for
+the #1154 posting-path fix. It is ultimately a **financial-correctness** defect,
+not merely a consistency one: once a future occurrence posts with the stale
+scalar, the cash lands at the wrong converted amount and the account balance is
+wrong. What makes deferral reasonable is that nothing corrupts at the moment the
+security/account currency is edited -- the defect materializes only on a later
+scheduled posting, and no data is lost in the meantime. This document is the
+durable record until a GitHub issue is filed for it.
+
+If a GitHub issue is filed, the upstream review target is `kenlasko/monize`
+(where issue #1154 lives), not the mirror this branch is pushed to.
 
 ## The gap
 
@@ -59,8 +66,9 @@ scalar.
 ## Why it is safe to defer
 
 Changing a security's or an account's currency after scheduling an investment in
-it is rare, and the failure is a wrong conversion rate on a future posting, not
-an immediate incorrect balance or a data-loss event. The #1154 fix closes the
+it is rare, and the failure surfaces only on a future posting (a wrong converted
+cash amount and balance then), not at the moment of the currency edit and not as
+a data-loss event. The #1154 fix closes the
 misrouting and the settlement-basis staleness that were the reported defect; this
 residual is the remaining edge that needs a schema decision rather than a
 point fix, which is why it is written down here instead of rushed in.

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -140,7 +140,17 @@ export function PostTransactionDialog({
     // paired INVESTMENT_CASH account. Fall back to the brokerage only if no
     // pair exists, so we still show *something* useful.
     if (scheduledTransaction.isInvestment) {
-      if (scheduledTransaction.investmentFundingAccountId) {
+      // Only a BUY/SELL settles through the funding account; for any other
+      // action the backend routes cash to the brokerage's linked cash account
+      // and ignores a stale stored funding account, so the preview must too or
+      // a legacy DIVIDEND projects a balance for the wrong account (issue #1154).
+      const usesExplicitFunding =
+        scheduledTransaction.investmentAction === 'BUY' ||
+        scheduledTransaction.investmentAction === 'SELL';
+      if (
+        usesExplicitFunding &&
+        scheduledTransaction.investmentFundingAccountId
+      ) {
         return (
           accounts.find(
             (a) => a.id === scheduledTransaction.investmentFundingAccountId,
@@ -169,6 +179,7 @@ export function PostTransactionDialog({
     scheduledTransaction.account,
     scheduledTransaction.accountId,
     scheduledTransaction.isInvestment,
+    scheduledTransaction.investmentAction,
     scheduledTransaction.investmentFundingAccountId,
     scheduledTransaction.investmentFundingAccount,
   ]);
@@ -629,7 +640,10 @@ export function PostTransactionDialog({
         }
       }
       if (isInvestmentAmountOnly) {
-        if (investmentTotalAmount === '') {
+        if (
+          investmentTotalAmount === '' ||
+          Number(investmentTotalAmount) <= 0
+        ) {
           toast.error(t('postDialog.toasts.totalAmountRequired'));
           return;
         }
@@ -923,6 +937,7 @@ export function PostTransactionDialog({
                 prefix={getCurrencySymbol(scheduledTransaction.currencyCode)}
                 value={typeof investmentTotalAmount === 'number' ? investmentTotalAmount : undefined}
                 onChange={(value) => setInvestmentTotalAmount(value ?? '')}
+                allowNegative={false}
               />
             )}
             <div>

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
@@ -1654,8 +1654,67 @@ describe('ScheduledTransactionForm', () => {
     expect(toast.error).not.toHaveBeenCalled();
     const [, payload] = mockUpdate.mock.calls[0];
     expect(payload.investmentAction).toBe('INTEREST');
-    expect(payload.investmentSecurityId).toBeNull();
+    // The key is omitted (undefined), not null: the backend clears the hidden
+    // security on the action transition. Sending null unconditionally would also
+    // destroy a deliberate security-specific INTEREST on a later unrelated edit.
+    expect(payload.investmentSecurityId).toBeUndefined();
     expect(payload.investmentFundingAccountId).toBeNull();
+  });
+
+  it('does not clear a deliberate INTEREST security on a name-only edit (issue #1154 re-review)', async () => {
+    // An existing security-specific INTEREST (e.g. created via the API) must
+    // survive a presentation-only edit: the form omits the security key rather
+    // than sending null, so the backend leaves the stored value untouched
+    // because the action did not change.
+    const existingInterest = {
+      id: 's-int',
+      accountId: 'acc-4', // Brokerage
+      name: 'Bond interest',
+      amount: 100,
+      currencyCode: 'CAD',
+      frequency: 'MONTHLY' as const,
+      nextDueDate: '2026-06-15',
+      isActive: true,
+      autoPost: false,
+      reminderDaysBefore: 3,
+      isTransfer: false,
+      isSplit: false,
+      isInvestment: true,
+      investmentAction: 'INTEREST' as const,
+      investmentSecurityId: 'sec-voo',
+      investmentTotalAmount: 100,
+    } as any;
+
+    const { container } = render(
+      <ScheduledTransactionForm scheduledTransaction={existingInterest} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Name'), {
+        target: { value: 'Bond interest (renamed)' },
+      });
+    });
+
+    const submitButton = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+    const [, payload] = mockUpdate.mock.calls[0];
+    expect(payload.investmentAction).toBe('INTEREST');
+    // Omitted, not null -> backend preserves the deliberate security.
+    expect(payload.investmentSecurityId).toBeUndefined();
   });
 
   // ============================================================

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
@@ -1494,6 +1494,113 @@ describe('ScheduledTransactionForm', () => {
   });
 
   // ============================================================
+  // Investment funding account clearing (issue #1154)
+  // ============================================================
+
+  it('sends an explicit null funding account when editing BUY to DIVIDEND', async () => {
+    const existingBuy = {
+      id: 's-inv',
+      accountId: 'acc-4', // Brokerage
+      name: 'Quarterly holding',
+      amount: -500,
+      currencyCode: 'CAD',
+      frequency: 'QUARTERLY' as const,
+      nextDueDate: '2026-06-15',
+      isActive: true,
+      autoPost: false,
+      reminderDaysBefore: 3,
+      isTransfer: false,
+      isSplit: false,
+      isInvestment: true,
+      investmentAction: 'BUY' as const,
+      investmentSecurityId: 'sec-voo',
+      // The stale funding account that must be cleared once the action no longer
+      // uses one.
+      investmentFundingAccountId: 'acc-1',
+      investmentQuantity: 1,
+      investmentPrice: 500,
+      // Carried so the DIVIDEND branch's total-amount validation passes on save.
+      investmentTotalAmount: 75,
+    } as any;
+
+    const { container } = render(
+      <ScheduledTransactionForm scheduledTransaction={existingBuy} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Action')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Action'), {
+        target: { value: 'DIVIDEND' },
+      });
+    });
+
+    const submitButton = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    await act(async () => {}); // flush the async submit handler
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+    const [, payload] = mockUpdate.mock.calls[0];
+    expect(payload.investmentAction).toBe('DIVIDEND');
+    expect(payload.investmentFundingAccountId).toBeNull();
+  });
+
+  it('keeps the funding account when saving a BUY unchanged', async () => {
+    const existingBuy = {
+      id: 's-inv',
+      accountId: 'acc-4',
+      name: 'Quarterly holding',
+      amount: -500,
+      currencyCode: 'CAD',
+      frequency: 'QUARTERLY' as const,
+      nextDueDate: '2026-06-15',
+      isActive: true,
+      autoPost: false,
+      reminderDaysBefore: 3,
+      isTransfer: false,
+      isSplit: false,
+      isInvestment: true,
+      investmentAction: 'BUY' as const,
+      investmentSecurityId: 'sec-voo',
+      investmentFundingAccountId: 'acc-1',
+      investmentQuantity: 1,
+      investmentPrice: 500,
+    } as any;
+
+    const { container } = render(
+      <ScheduledTransactionForm scheduledTransaction={existingBuy} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Action')).toBeInTheDocument();
+    });
+
+    const submitButton = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+    const [, payload] = mockUpdate.mock.calls[0];
+    expect(payload.investmentAction).toBe('BUY');
+    expect(payload.investmentFundingAccountId).toBe('acc-1');
+  });
+
+  // ============================================================
   // NEW TESTS: templateTransaction prop initialization
   // ============================================================
 

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
@@ -1600,6 +1600,64 @@ describe('ScheduledTransactionForm', () => {
     expect(payload.investmentFundingAccountId).toBe('acc-1');
   });
 
+  it('clears the hidden security (and funding) when editing BUY to INTEREST', async () => {
+    // INTEREST has no security field in the scheduled UI; a security carried in
+    // from the prior BUY would settle the interest in the security's currency,
+    // so the form must send an explicit null (issue #1154 review).
+    const existingBuy = {
+      id: 's-inv',
+      accountId: 'acc-4', // Brokerage
+      name: 'Bond interest',
+      amount: -500,
+      currencyCode: 'CAD',
+      frequency: 'MONTHLY' as const,
+      nextDueDate: '2026-06-15',
+      isActive: true,
+      autoPost: false,
+      reminderDaysBefore: 3,
+      isTransfer: false,
+      isSplit: false,
+      isInvestment: true,
+      investmentAction: 'BUY' as const,
+      investmentSecurityId: 'sec-voo',
+      investmentFundingAccountId: 'acc-1',
+      investmentQuantity: 1,
+      investmentPrice: 500,
+      investmentTotalAmount: 25,
+    } as any;
+
+    const { container } = render(
+      <ScheduledTransactionForm scheduledTransaction={existingBuy} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Action')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Action'), {
+        target: { value: 'INTEREST' },
+      });
+    });
+
+    const submitButton = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+    const [, payload] = mockUpdate.mock.calls[0];
+    expect(payload.investmentAction).toBe('INTEREST');
+    expect(payload.investmentSecurityId).toBeNull();
+    expect(payload.investmentFundingAccountId).toBeNull();
+  });
+
   // ============================================================
   // NEW TESTS: templateTransaction prop initialization
   // ============================================================

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
@@ -1603,7 +1603,8 @@ describe('ScheduledTransactionForm', () => {
   it('clears the hidden security (and funding) when editing BUY to INTEREST', async () => {
     // INTEREST has no security field in the scheduled UI; a security carried in
     // from the prior BUY would settle the interest in the security's currency,
-    // so the form must send an explicit null (issue #1154 review).
+    // so the form omits the key and lets the backend clear it on the
+    // BUY -> INTEREST transition (issue #1154 review).
     const existingBuy = {
       id: 's-inv',
       accountId: 'acc-4', // Brokerage

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
@@ -1091,13 +1091,15 @@ export function ScheduledTransactionForm({
           transferAccountId: undefined,
           isInvestment: true,
           investmentAction,
-          // Send an explicit null (not undefined) when the action's UI has no
-          // security field, so an edit clears a security hidden by an earlier
-          // BUY/SELL/etc. rather than leaving it stored (issue #1154 review).
-          investmentSecurityId:
-            SECURITY_REQUIRED_ACTIONS.includes(investmentAction) && investmentSecurityId
-              ? investmentSecurityId
-              : null,
+          // For an action whose UI has no security field, omit the key rather
+          // than sending null. The backend clears a hidden security on the
+          // action transition (BUY -> INTEREST with the key omitted), so a
+          // fresh switch is still cleaned -- but a deliberately-stored
+          // security-specific INTEREST survives a later presentation-only edit
+          // instead of being destroyed by every save (issue #1154 re-review).
+          investmentSecurityId: SECURITY_REQUIRED_ACTIONS.includes(investmentAction)
+            ? investmentSecurityId || undefined
+            : undefined,
           // Send an explicit null (not undefined) when the action does not use a
           // funding account, so editing an existing schedule away from BUY/SELL
           // clears the stored account. Omitting the key would leave the stale

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
@@ -1078,9 +1078,13 @@ export function ScheduledTransactionForm({
           isInvestment: true,
           investmentAction,
           investmentSecurityId: investmentSecurityId || undefined,
+          // Send an explicit null (not undefined) when the action does not use a
+          // funding account, so editing an existing schedule away from BUY/SELL
+          // clears the stored account. Omitting the key would leave the stale
+          // value in place and misroute the posted cash (issue #1154).
           investmentFundingAccountId: FUNDING_ACCOUNT_ACTIONS.includes(investmentAction) && investmentFundingAccountId
             ? investmentFundingAccountId
-            : undefined,
+            : null,
           investmentQuantity: investmentQuantity === '' ? undefined : Number(investmentQuantity),
           investmentPrice: investmentPrice === '' ? undefined : Number(investmentPrice),
           investmentCommission: investmentCommission === '' ? undefined : Number(investmentCommission),

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
@@ -698,6 +698,16 @@ export function ScheduledTransactionForm({
   // will persist.
   const handleInvestmentActionChange = (nextAction: InvestmentAction) => {
     setInvestmentAction(nextAction);
+    // Clear fields the new action's UI does not show, so a hidden stale value is
+    // not submitted: a security carried into INTEREST would settle the cash in
+    // the security's currency, and a funding account carried out of BUY/SELL
+    // would misroute it (issue #1154 review).
+    if (!SECURITY_REQUIRED_ACTIONS.includes(nextAction)) {
+      setInvestmentSecurityId('');
+    }
+    if (!FUNDING_ACCOUNT_ACTIONS.includes(nextAction)) {
+      setInvestmentFundingAccountId('');
+    }
     if (
       QUANTITY_PRICE_ACTIONS.includes(nextAction) &&
       investmentQuantity !== '' &&
@@ -1012,7 +1022,11 @@ export function ScheduledTransactionForm({
           return;
         }
       } else if (AMOUNT_ONLY_ACTIONS.includes(investmentAction)) {
-        if (investmentTotalAmount === '' || investmentTotalAmount === undefined) {
+        if (
+          investmentTotalAmount === '' ||
+          investmentTotalAmount === undefined ||
+          Number(investmentTotalAmount) <= 0
+        ) {
           toast.error(t('form.toasts.totalAmountRequired'));
           return;
         }
@@ -1077,7 +1091,13 @@ export function ScheduledTransactionForm({
           transferAccountId: undefined,
           isInvestment: true,
           investmentAction,
-          investmentSecurityId: investmentSecurityId || undefined,
+          // Send an explicit null (not undefined) when the action's UI has no
+          // security field, so an edit clears a security hidden by an earlier
+          // BUY/SELL/etc. rather than leaving it stored (issue #1154 review).
+          investmentSecurityId:
+            SECURITY_REQUIRED_ACTIONS.includes(investmentAction) && investmentSecurityId
+              ? investmentSecurityId
+              : null,
           // Send an explicit null (not undefined) when the action does not use a
           // funding account, so editing an existing schedule away from BUY/SELL
           // clears the stored account. Omitting the key would leave the stale
@@ -1934,6 +1954,7 @@ export function ScheduledTransactionForm({
                 prefix={currencySymbol}
                 value={typeof investmentTotalAmount === 'number' ? investmentTotalAmount : undefined}
                 onChange={(value) => setInvestmentTotalAmount(value ?? '')}
+                allowNegative={false}
               />
             </div>
           )}

--- a/frontend/src/types/scheduled-transaction.ts
+++ b/frontend/src/types/scheduled-transaction.ts
@@ -144,7 +144,10 @@ export interface CreateScheduledTransactionData {
   isInvestment?: boolean;
   investmentAction?: InvestmentAction;
   investmentSecurityId?: string;
-  investmentFundingAccountId?: string;
+  // Nullable so an edit away from BUY/SELL can send an explicit null that clears
+  // the stored funding account, rather than omitting the key and leaving the
+  // stale value in place (issue #1154).
+  investmentFundingAccountId?: string | null;
   investmentQuantity?: number;
   investmentPrice?: number;
   investmentCommission?: number;

--- a/frontend/src/types/scheduled-transaction.ts
+++ b/frontend/src/types/scheduled-transaction.ts
@@ -143,7 +143,9 @@ export interface CreateScheduledTransactionData {
   transferAccountId?: string;
   isInvestment?: boolean;
   investmentAction?: InvestmentAction;
-  investmentSecurityId?: string;
+  // Nullable so an action whose UI has no security field (INTEREST) can send an
+  // explicit null to clear a security hidden by an earlier edit (issue #1154).
+  investmentSecurityId?: string | null;
   // Nullable so an edit away from BUY/SELL can send an explicit null that clears
   // the stored funding account, rather than omitting the key and leaving the
   // stale value in place (issue #1154).


### PR DESCRIPTION
## Summary

This PR fixes issue #1154 and then hardens the same scheduled-investment posting path through a multi-round adversarial review.

The original defect was straightforward but financially dangerous: a scheduled investment edited away from `BUY` / `SELL` could retain a stale `investmentFundingAccountId`. When a later `DIVIDEND`, `INTEREST`, or `CAPITAL_GAIN` occurrence posted, that stale account could be forwarded into the investment posting path and route cash to the wrong account instead of the brokerage's linked cash account.

The fix is intentionally defensive:

- only `BUY` and `SELL` are allowed to use an explicit funding account;
- stale funding accounts are cleared on create/update and ignored at post time;
- MNY import follows the same invariant;
- action-specific stale investment fields are cleared;
- post-time overrides are revalidated after precedence resolution;
- posting refuses stale pre-lock schedule, override, FX-tuple, and split generations;
- cron rechecks `isActive` / `autoPost` under the row lock;
- loan split recalculation now serializes on the same parent schedule lock;
- `LINE_OF_CREDIT` uses the same loan-payment recalculation path as `LOAN` and `MORTGAGE`.

The branch was repeatedly reviewed after the initial fix. The review cycle found several adjacent edge cases that were real enough to fix rather than leave as unrelated follow-up debt.

**Base:** `09d7396d90aec8f7a865b802b7d50b58115ac735`  
**Current head:** `0e0beca1484b522cfa77db32a282246c3e778ec0`  
**Branch delta:** 12 commits

---

## AI review / implementation trail

Two AI systems had distinct roles in this branch:

- **Claude Code / Claude Opus 4.8** implemented the branch and performed the initial/internal review passes. Those passes found several write-side consistency gaps before the external re-review cycle, including the MNY writer bypass, stale action-specific numeric fields, an insufficient regression assertion, and inaccurate comments about FX/settlement behavior.
- **ChatGPT** performed the external adversarial re-review rounds in this review thread. Those rounds found the broader API validation, stale-snapshot, split-generation, cron, loan-recalculation, and `LINE_OF_CREDIT` defects that were subsequently implemented by Claude Code.

The table below records the discovery source separately from the implementation commit so the review provenance is explicit.

---

## Edge cases closed

| # | Edge case / invariant | Failure before the fix | Found by | Fixed / documented in |
|---|---|---|---|---|
| 1 | Stale funding account after changing away from `BUY` / `SELL` | A later dividend/interest/capital-gain occurrence could route cash through the old funding account instead of brokerage linked cash | Original issue #1154 | `28a5d49` |
| 2 | Non-funding action created/updated with a funding account | Invalid state could remain persisted even when the action would never use that account | Original #1154 implementation review | `28a5d49` |
| 3 | Frontend omitted the clear on action change | Editing `BUY -> DIVIDEND` could leave the backend column unchanged | Original #1154 implementation review | `28a5d49` |
| 4 | MNY bill import bypassed the funding-account invariant | Imported non-`BUY`/`SELL` investments could persist the same stale column even though normal create/update cleaned it | Claude Code internal multi-pass review | `7ce0b1e` |
| 5 | Funding-action membership duplicated across writers | Scheduled service and import could drift on which actions may use funding accounts | Claude Code internal multi-pass review | `7ce0b1e` |
| 6 | `REINVEST` legacy row carried a stale funding account | Share-moving but cashless action could still contain an irrelevant funding account; post must ignore it | Claude Code internal review | `7ce0b1e` |
| 7 | Stored FX rate could outlive its settlement basis | A stored scalar rate could be reused after action/account/security settlement basis changed | Claude Code review; later expanded by ChatGPT | documented `fe2b9be`, behavioral partial fix `b2f7c1d`, durable follow-up `95eead2` |
| 8 | Action switch retained stale numeric fields | `BUY -> DIVIDEND`, `DIVIDEND -> BUY`, or `BUY -> ADD_SHARES` left irrelevant quantity/price/commission/total values on the row | Claude Code review | `5cba485` |
| 9 | BUY “keep funding account” test was too weak | A future accidental empty-string/other write could pass while still corrupting the stored funding account | Claude Code adversarial test review | `31386b7` |
| 10 | Comment claimed all external FX work was hoisted before the DB transaction | Investment settlement FX can still call the quote provider while the schedule lock is held | Claude Code end-to-end review | `ffc05b8` |
| 11 | Post-time overrides bypassed create/update validation | A negative dividend total or zero-quantity BUY supplied at posting time could create money despite valid stored configuration | ChatGPT external adversarial re-review #1 | `b2f7c1d` |
| 12 | Explicit `null` was collapsed into “use stored value” during update validation | `{ investmentTotalAmount: null }` could validate against the old value and then persist `null` | ChatGPT re-review #1 | `b2f7c1d` |
| 13 | Zero/non-positive investment FX rate accepted | Invalid persisted rate could reach settlement code | ChatGPT re-review #1 | `b2f7c1d` |
| 14 | Settlement-basis edit retained an old stored FX rate | A rate for the old settlement tuple could be applied after account/security/action basis changed | ChatGPT re-review #1 | `b2f7c1d` |
| 15 | `INTEREST` could retain a hidden security | UI/action transition could leave security-derived settlement state that no longer belonged to the effective action | ChatGPT re-review #1 | `b2f7c1d` |
| 16 | Funding account validation ran for actions that do not use it | A request could be rejected for an irrelevant field that would be dropped at persistence time | ChatGPT re-review #1 | `b2f7c1d` |
| 17 | Investment posting used a pre-lock row snapshot | Concurrent `BUY -> DIVIDEND` / security / funding edit could post the old action to the old account | ChatGPT re-review #1 | `b2f7c1d` |
| 18 | Post dialog preview could still show the stale funding account | UI projected the wrong account even though backend posting no longer used it | ChatGPT re-review #1 | `b2f7c1d` |
| 19 | Funding-action documentation overclaimed non-BUY/SELL behavior | `REINVEST` and share-only actions have no external cash leg; they do not all “settle to linked cash” | ChatGPT re-review #1 follow-up | `9339e14` |
| 20 | Locked-row protection covered only part of the posting shape | Concurrent plain/transfer/investment mode, account, amount, category, or investment-scalar changes could leave a prebuilt stale payload | ChatGPT external adversarial re-review #2 | `a50fc77` |
| 21 | Occurrence override was read before the transaction and then consumed/deleted | Concurrently edited override could be posted stale or deleted without posting its new state | ChatGPT re-review #2 | `a50fc77` |
| 22 | `update()` could apply action-dependent clears from a stale snapshot | One edit could overwrite a concurrent action change | ChatGPT re-review #2 | `a50fc77` |
| 23 | Frontend `INTEREST` fix over-cleared a legitimate security | A presentation-only edit could clear security state that was intentionally stored for a security-specific interest entry | ChatGPT re-review #2 | `a50fc77` |
| 24 | Base scheduled split set was outside the parent mutation guard | Concurrent transfer/investment split retarget could post money to the old account even though parent scalars were unchanged | ChatGPT external adversarial re-review #3 | `e709eb3` |
| 25 | Foreign-currency tuple omitted from mutation basis | `originalAmount`, `originalCurrencyCode`, or `exchangeRate` could change while account-currency `amount` stayed the same, allowing a stale converted post | ChatGPT re-review #3 | `e709eb3` |
| 26 | Cron did not re-check live `isActive` / `autoPost` after candidate selection | User could disable auto-post after cron selection and still get an automatic post | ChatGPT re-review #3 | `e709eb3` |
| 27 | Override guard depended too heavily on `updatedAt` | Same-millisecond changes could escape timestamp-only detection | ChatGPT re-review #3 | `e709eb3` |
| 28 | Loan split recalculation mutated child splits without the parent schedule lock | Principal/interest could change after the posting split guard but before the financial write, causing a stale occurrence | ChatGPT external adversarial re-review #4 | `95eead2` |
| 29 | Loan recalculation accepted a loan ID derived from a stale pre-lock split snapshot | Concurrent retarget `Loan A -> Loan B` could recalculate current splits using the wrong loan account | ChatGPT re-review #4 | `95eead2` |
| 30 | FX currency-pair residual was only partially described | Durable rates exist on parent schedules, scheduled investment splits, and override JSON; all three can become stale when referenced currency changes with stable IDs | ChatGPT re-review #4 | `95eead2` tracker |
| 31 | `LINE_OF_CREDIT` excluded from loan split recalculation | LOC scheduled payments kept reusing the first principal/interest allocation rather than advancing after each payment | ChatGPT external adversarial re-review #5 | `0e0beca` |
| 32 | Split-guard comment claimed an unlocked category writer was “still caught” | A category reassignment can commit after the point-in-time split comparison; the guarantee was stronger than the mechanism | ChatGPT re-review #5 | `0e0beca` comment corrected; residual explicitly accepted |

---

## Detailed implementation

### 1. Funding-account routing is now action-authoritative

The central invariant is:

> An explicit investment funding account is meaningful only for `BUY` and `SELL`.

`BUY` draws purchase cash from the funding account. `SELL` deposits proceeds there. Cash-bearing `DIVIDEND`, `INTEREST`, and `CAPITAL_GAIN` settle through the brokerage's linked cash account. `REINVEST` and share-only actions do not have an external funding-account cash leg.

The branch enforces this at multiple boundaries:

- `postInvestment()` only forwards `investmentFundingAccountId` for `BUY` / `SELL`;
- create/update clear the field for every other effective action;
- the frontend sends the required clear when the user changes actions;
- MNY import uses the same shared `FUNDING_ACCOUNT_ACTIONS` authority;
- regression tests cover both the “drop” and “keep” branches.

The post-time gate is the authoritative safety net: legacy rows already carrying stale data cannot misroute cash even before they are edited again.

### 2. Action changes clean their obsolete state

Changing a scheduled investment action now removes fields that are not part of the new action's model.

Examples:

- `BUY -> DIVIDEND`: clear quantity, price, commission, and funding account; keep/write the dividend total.
- `DIVIDEND -> BUY`: clear the old total; keep/write BUY quantity and price.
- `BUY -> ADD_SHARES`: keep quantity, clear price, commission, total, and funding account.
- switching to a non-security action clears a security that no longer belongs to the effective action.

This prevents old action state from silently surviving behind hidden form controls.

### 3. Validation matches the value that will actually be written

Updates now distinguish:

- **omitted key** → preserve stored value;
- **explicit `null`** → clear the value.

The previous nullish merge could validate the stored value while persisting the explicit `null`.

The branch introduces explicit “supplied or stored” semantics for validation and also validates resolved post-time overrides, because manual/cron/internal posting callers can bypass the controller DTO.

Consequences:

- zero BUY quantity is rejected;
- negative/zero amount-only investment totals are rejected;
- a provided FX rate must be positive;
- invalid post-time overrides are rejected before any financial write.

### 4. Stored FX is invalidated when the settlement basis changes

A stored `investmentExchangeRate` is preserved for presentation-only edits but cleared when the schedule's settlement basis changes and no replacement rate is supplied.

The relevant basis includes the action/account/security/effective funding-account structure that determines what currencies are being settled.

This closes the immediate “same stored rate, different scheduled settlement tuple” defect without blindly clearing legitimate rates on unrelated edits.

A broader residual remains when a **referenced security or account changes its own `currencyCode` while keeping the same ID**. See “Known follow-up: currency-pair provenance” below.

### 5. Posting now validates the generation it is about to commit

Several payloads are necessarily prepared before the schedule row is locked. The branch therefore verifies that the locked/current generation still describes the same financial operation before committing money.

The mutation basis covers:

- plain / transfer / investment shape;
- source/destination accounts;
- amount and currency;
- category where it shapes the posting;
- `originalAmount`, `originalCurrencyCode`, and `exchangeRate`;
- investment action, security, funding account, quantity, price, commission, total, and investment FX.

If those values changed between the pre-lock read and the row lock, posting returns a conflict instead of committing the stale payload.

### 6. Base split generations are checked separately

Parent scalar equality is not enough for a split scheduled transaction.

A child split can independently change:

- transfer destination;
- category;
- amount;
- embedded investment action/security/quantity/price/commission/FX;
- memo/tags relevant to that split generation.

When posting actually uses the base scheduled split set (rather than inline or occurrence-override splits), the service re-reads that set while holding the parent schedule lock and compares its semantic basis with the pre-lock generation.

A concurrent retarget such as:

```text
transfer split: Account A -> Account B
```

therefore causes a conflict rather than posting to Account A from stale data.

### 7. Occurrence overrides are re-read under the lock

The occurrence override is a mutable record of its own.

Posting now:

1. reads the candidate override before the transaction as needed for preparation;
2. locks/re-reads the override while the parent schedule lock is held;
3. compares semantic state plus `updatedAt`;
4. refuses on any meaningful change;
5. posts/removes the locked generation.

This prevents both stale posting and deleting a concurrent override edit that was never actually posted.

### 8. Cron eligibility is checked twice

Cron discovery still selects active auto-post schedules, but that selection is only a candidate snapshot.

For automatic posting, `post()` now receives `requireActiveAutoPost` and re-checks the locked row:

- `isActive === true`
- `autoPost === true`

If the user disabled the schedule after cron selected it, the automatic post is refused.

Manual posting intentionally does not use this restriction.

### 9. Loan split recalculation shares the parent serialization lock

Scheduled loan payments recalculate principal/interest children after posting. That writer previously modified child rows without locking the parent scheduled transaction.

This created a real interleaving:

```text
poster reads principal 700 / interest 300
poster locks parent
poster verifies child set
loan recalculator writes principal 720 / interest 280
poster posts stale 700 / 300
```

Because the parent total remains 1,000 in both versions, parent scalar checks alone cannot detect that reallocation.

`recalculateLoanPaymentSplits()` now:

1. takes `pessimistic_write` on the parent scheduled transaction;
2. re-reads the current child split set under that lock;
3. derives the current loan account from those rows;
4. recalculates and writes the children while still serialized by the parent.

Callers no longer pass a loan ID derived from an older snapshot.

### 10. `LINE_OF_CREDIT` follows the loan-payment recalculation contract

`LoanPaymentSetupService` supports:

- `LOAN`
- `MORTGAGE`
- `LINE_OF_CREDIT`

but the recalculator historically recognized only the first two.

The branch centralizes the discriminator in `LOAN_LIKE_ACCOUNT_TYPES` and uses it in both loan-account derivation sites.

Regression example:

```text
LOC balance:           910.00
annual rate:            12%
monthly payment:       100.00
previous principal:     90.00
previous interest:      10.00

periodic rate = 0.12 / 12 = 0.01

next interest  = 10.00 - 90.00 * 0.01 =  9.10
next principal = 100.00 - 9.10        = 90.90
```

The regression test asserts the next template is `90.90 / 9.10`, not the stale first-installment `90.00 / 10.00`.

---

## Commit-by-commit review history

| Commit | Review stage | Main purpose |
|---|---|---|
| `28a5d49` | Initial #1154 fix | Make funding-account routing action-authoritative across post/create/update/frontend |
| `7ce0b1e` | Claude Code internal review | Gate MNY import and centralize `FUNDING_ACCOUNT_ACTIONS`; add REINVEST coverage |
| `fe2b9be` | Claude Code internal review | Record the non-trivial stored-FX settlement-basis concern |
| `5cba485` | Claude Code internal review | Clear stale action-specific numeric fields |
| `31386b7` | Claude Code adversarial test review | Strengthen BUY keep-path regression assertion |
| `ffc05b8` | Claude Code end-to-end review | Correct the FX-hoisting / external-call documentation |
| `b2f7c1d` | ChatGPT re-review #1 | Post-time validation, explicit-null semantics, FX validity/invalidation, hidden security cleanup, locked investment row, frontend preview |
| `9339e14` | ChatGPT re-review #1 follow-up | Correct over-broad description of non-BUY/SELL settlement behavior |
| `a50fc77` | ChatGPT re-review #2 | Full schedule mutation guard, locked override generation, update concurrency, INTEREST frontend regression |
| `e709eb3` | ChatGPT re-review #3 | Child split generation guard, foreign FX tuple, live cron eligibility, semantic override comparison |
| `95eead2` | ChatGPT re-review #4 | Parent-lock loan recalculation, current-loan derivation, durable three-surface FX tracker |
| `0e0beca` | ChatGPT re-review #5 | Include `LINE_OF_CREDIT`; correct the accepted category-race documentation |

---

## Regression coverage added or strengthened

The branch adds targeted coverage for, among others:

- stale `DIVIDEND` funding account ignored at post;
- `SELL` still forwards the valid funding account;
- `REINVEST` ignores a stale funding account;
- create/update drop funding accounts for non-funding actions;
- MNY import does the same;
- BUY edits that do not touch funding do not write the column;
- action-specific numeric cleanup;
- explicit-null update semantics;
- positive investment FX;
- post-time negative/zero override rejection;
- locked-row investment posting;
- settlement-basis FX invalidation and presentation-only non-invalidation;
- INTEREST security cleanup and preservation where legitimate;
- schedule mutation conflicts;
- occurrence-override mutation conflicts;
- base split retarget conflicts;
- foreign-currency tuple conflicts;
- cron disabled-after-selection behavior;
- parent-lock loan recalculation;
- `LINE_OF_CREDIT` 90.90 / 9.10 recalculation.

The LOC test was also mutation-checked during review: removing `LINE_OF_CREDIT` from the discriminator makes the targeted test fail.

---

## Known non-blocking residuals

### Category reassignment can race after the point-in-time split comparison

`CategoriesService.reassignTransactions()` can update `ScheduledTransactionSplit.categoryId` without taking every affected scheduled parent lock.

Therefore a category-only write can still commit after the posting path's split comparison.

This residual is explicitly accepted because it affects categorization/reporting metadata, not the amount or account routing of the occurrence.

The code comment now describes this as a point-in-time guarantee rather than claiming that every unlocked writer is automatically caught.

### Presentation-only parent fields are not part of the financial mutation basis

Description/payee/tag changes can race with posting and one occurrence may carry the pre-lock presentation text.

Those fields are deliberately excluded from the financial mutation basis because they do not change account routing or monetary shape.

### Two-connection integration test remains desirable

Unit tests verify that the parent lock is requested and that current child state is used.

The strongest regression for the loan race would still be a real two-connection PostgreSQL test proving:

```text
A: post acquires parent lock
B: recalculation blocks on same parent
A: verifies/posts/commits
B: proceeds and reads the committed generation
```

That test is desirable but was treated as non-blocking rather than faking database serialization with mocks.

---

## Known follow-up: currency-pair provenance for persisted scheduled-investment FX

This PR fixes stale FX when the **scheduled settlement basis itself** changes.

A separate financial-correctness residual remains when a referenced security or account changes `currencyCode` while retaining the same ID.

A persisted rate is currently a scalar without durable `fromCurrency` / `toCurrency` provenance. The problem exists on three surfaces:

1. `scheduled_transactions.investment_exchange_rate`
2. `scheduled_transaction_splits.investment_exchange_rate`
3. occurrence override `splits[*].investment.exchangeRate`

Example:

```text
stored pair: EUR -> CAD
stored rate: 1.50

security is later changed to USD
current USD -> CAD rate: 1.35

quantity = 10
price    = 100
```

Reusing the stale scalar yields:

```text
10 * 100 * 1.50 = 1,500 CAD
```

while the current pair yields:

```text
10 * 100 * 1.35 = 1,350 CAD
```

Difference: **150 CAD / 11.11%**.

The preferred future fix is to persist the currency pair alongside every durable rate and treat a pair mismatch exactly like a missing rate. The narrower alternative is comprehensive invalidation of all three surfaces whenever a referenced security/account currency changes.

This residual is tracked separately and does not block #1154.

---

## Why this is safe to merge

The original #1154 money-misrouting scenario is closed at the authoritative posting boundary and at every normal write boundary.

The adversarial review then exercised adjacent failure classes:

- stale state left by action transitions;
- direct/internal callers bypassing DTO validation;
- pre-lock vs locked generation mismatch;
- mutable child split generations;
- mutable occurrence overrides;
- cron selection vs live state;
- post-commit loan-template mutation;
- loan-like account discriminator drift.

After five external re-review rounds, no unresolved `BLOCKER`, `HIGH`, or `MEDIUM` defect remains in the focused #1154 scope.

The remaining known items are either:

- explicitly accepted LOW content/categorization consistency trade-offs;
- stronger integration-test coverage;
- or the separately tracked FX currency-pair provenance problem.

---

## Verification

During the review cycle the branch was repeatedly checked with targeted scheduled-transaction/loan tests, TypeScript typechecking, ESLint, i18n parity/checks, and documentation-path validation.

The final review round reported the relevant scheduled-transaction suites and new LOC regression passing after the mutation check.

No frontend behavior change was made in the final LOC-only round; the frontend changes belong to the earlier funding-state, validation, and INTEREST-regression fixes.

---

## AI assistance disclosure

This PR was implemented with **Claude Code / Claude Opus 4.8**.

The implementation was then subjected to repeated external adversarial review by **ChatGPT**. Findings that survived source-level verification were implemented in subsequent Claude Code commits and accompanied by regression coverage.

The AI split is intentionally recorded in the tables above:

- Claude Code: implementation plus initial/internal review findings.
- ChatGPT: external re-review findings.
- Repository maintainer: owns the resulting behavior, review decisions, and merge.

