### PR TITLE
Cash Flow Forecast: select multiple accounts, one coloured line each

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -678,7 +678,9 @@ Pick the treatment from what the figure is:
 - **A cumulative series** (a running balance, a forecast) is withheld whole:
   one missing rate invalidates every point after it, so `buildForecast` returns
   no points and names the currencies. A short series there is not a partial
-  answer, it is a wrong one.
+  answer, it is a wrong one. `buildMultiAccountForecast` withholds every line
+  and the total together for the same reason -- the accounts that *did* convert
+  are not a smaller forecast, they are a total labelled as something it is not.
 - **A summary over a series** (`computeBalanceSummary`) refuses when any point
   is unknown. "Minimum" and "goes negative" are claims about all of it.
 
@@ -778,6 +780,8 @@ Colour themes are pure CSS variable overrides in `src/app/themes.css` (`html[dat
 **The tokens cover more than series colour.** `chartColors.grid` and `.axis` carry their own dark overrides, so a `CartesianGrid` using them needs no `dark:stroke-*` class beside it. `chartColors.surface` is the card behind the chart -- use it for the ring around a marker dot, which exists to separate the dot from the line beneath it and so must be the background, not white. `chartColors.neutral` is for unclassified data (an "Other" slice, an item with no colour). `ui-conventions.test.ts` fails on any hex reaching a `fill`, `stroke` or `stopColor` in a component that imports recharts. Two things it deliberately does not police: `summaryCards[].color` for the PDF export, where `pdf-export.ts` parses the string as hex and a `var(...)` would produce NaN, and colour on a *data* field (`color:` on a datum), which is indistinguishable from the PDF case by regex. White drawn on top of a filled shape -- label text inside a coloured flag bubble -- is contrast-on-fill and stays literal; `surface` there would be invisible in dark mode.
 
 **Spending is not an error: default a breakdown to `chartColors.primary`, not `chartColors.expense`.** Red is loud and the app spends it deliberately -- the Monthly Totals chart, where a loss month is the point. A routine breakdown (top categories, paid-from accounts, a seasonality strip) is a magnitude comparison, so its bars take the theme accent, which re-colours per palette because `--chart-primary` follows the theme's blue ramp. Keep `chartColors.income` for genuine inflows so a refund is still distinguishable; that leaves red spent only where it means something. `TopGroupsPanel` and `PayeeSeasonalityPanel` are the worked examples, and both carry a guard test asserting no `bg-`/`text-red|green-N` and no `var(--chart-expense)` survives in their output. Note that `income`/`expense` remain right for a chart genuinely *about* the in/out split -- the rule is about breakdowns that merely happen to be negative.
+
+**A member series drawn beside a total takes `chartSeriesColorAsidePrimary`, not `chartSeriesColor`.** `--chart-1` is the theme accent in every palette in `themes.css`, and so is `--chart-primary` -- so a chart that draws an aggregate line in `chartColors.primary` and starts its members at palette slot 0 hands the first member the total's own colour, in the chart, the legend and the tooltip alike. The helper excludes that slot from the cycle rather than deferring it, because a modulo over the full palette gives it back on the tenth series: the same collision, arriving late. `CashFlowForecastChart`'s "Total of Accounts" line and its per-account lines are the worked example; `chart-colors.test.ts` pins both halves. Use plain `chartSeriesColor` where there is no primary series to collide with.
 
 ## Security Notes
 

--- a/frontend/src/components/bills/CashFlowForecastChart.test.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/render';
+import { render, screen, fireEvent, within } from '@/test/render';
 import { CashFlowForecastChart } from './CashFlowForecastChart';
 
 // The recharts mock invokes the Area `dot` render-prop and the Tooltip
@@ -8,11 +8,33 @@ import { CashFlowForecastChart } from './CashFlowForecastChart';
 // The render-prop output is exposed via test ids those tests opt into;
 // existing assertions are unaffected since the chart only renders when
 // forecast data is present.
+//
+// `charts.tooltipPoint` is the data point the mocked Tooltip feeds to the
+// component's own tooltip. A multi-account test swaps it for a point carrying
+// `balances` so the per-account rows are exercised with real values.
+const charts = vi.hoisted(() => ({
+  tooltipPoint: null as any,
+}));
+
+const DEFAULT_TOOLTIP_POINT = {
+  date: '2025-01-15',
+  balance: -150,
+  transactions: [
+    { name: 'Rent', amount: -1000 },
+    { name: 'Pay', amount: 3000 },
+    { name: 'A', amount: -1 },
+    { name: 'B', amount: -2 },
+    { name: 'C', amount: -3 },
+    { name: 'D', amount: -4 },
+  ],
+};
+
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
   AreaChart: ({ children }: any) => <div data-testid="area-chart">{children}</div>,
-  Area: ({ dot, fill, stroke }: any) => (
-    <div data-testid="area" data-fill={fill} data-stroke={stroke}>
+  ComposedChart: ({ children }: any) => <div data-testid="composed-chart">{children}</div>,
+  Area: ({ dot, fill, stroke, name }: any) => (
+    <div data-testid="area" data-fill={fill} data-stroke={stroke} data-name={name}>
       {typeof dot === 'function' && (
         <svg data-testid="line-dots">
           {dot({ cx: 50, cy: 60, index: 0 })}
@@ -22,7 +44,15 @@ vi.mock('recharts', () => ({
     </div>
   ),
   LineChart: ({ children }: any) => <div data-testid="line-chart">{children}</div>,
-  Line: () => <div data-testid="line" />,
+  Line: ({ dataKey, name, stroke, fill }: any) => (
+    <div
+      data-testid="line"
+      data-key={dataKey}
+      data-name={name}
+      data-stroke={stroke}
+      data-fill={fill}
+    />
+  ),
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: ({ tickFormatter }: any) => (
     <div data-testid="y-axis">{tickFormatter ? tickFormatter(2000) : null}</div>
@@ -35,22 +65,7 @@ vi.mock('recharts', () => ({
     const Comp = content?.type;
     const tooltipProps = {
       active: true,
-      payload: [
-        {
-          payload: {
-            date: '2025-01-15',
-            balance: -150,
-            transactions: [
-              { name: 'Rent', amount: -1000 },
-              { name: 'Pay', amount: 3000 },
-              { name: 'A', amount: -1 },
-              { name: 'B', amount: -2 },
-              { name: 'C', amount: -3 },
-              { name: 'D', amount: -4 },
-            ],
-          },
-        },
-      ],
+      payload: [{ payload: charts.tooltipPoint }],
     };
     return (
       <div data-testid="tooltip">
@@ -89,7 +104,14 @@ const forecastOf = (points: any[], missingCurrencies: string[] = []) => ({
   points,
   missingCurrencies,
 });
+/** The multi-account shape: the same envelope plus the per-account series. */
+const multiForecastOf = (
+  points: any[],
+  series: any[] = [],
+  missingCurrencies: string[] = [],
+) => ({ points, series, missingCurrencies });
 const mockBuildForecast = vi.fn().mockReturnValue(forecastOf([]));
+const mockBuildMultiAccountForecast = vi.fn().mockReturnValue(multiForecastOf([]));
 const mockGetForecastSummary = vi.fn().mockReturnValue({
   startingBalance: 1000,
   endingBalance: 800,
@@ -99,6 +121,7 @@ const mockGetForecastSummary = vi.fn().mockReturnValue({
 
 vi.mock('@/lib/forecast', () => ({
   buildForecast: (...args: any[]) => mockBuildForecast(...args),
+  buildMultiAccountForecast: (...args: any[]) => mockBuildMultiAccountForecast(...args),
   getForecastSummary: (...args: any[]) => mockGetForecastSummary(...args),
   FORECAST_PERIOD_LABELS: {
     week: '1W',
@@ -119,10 +142,33 @@ const makeAccount = (overrides: Record<string, any> = {}) => ({
   ...overrides,
 }) as any;
 
+/**
+ * The account picker is a checkbox list behind a trigger, so its options exist
+ * only while it is open.
+ */
+const openAccountPicker = () => {
+  fireEvent.click(screen.getByLabelText('Accounts to forecast'));
+};
+
+const accountOptionLabels = () =>
+  Array.from(document.querySelectorAll('input[type="checkbox"]')).map(
+    (input) => input.closest('label')?.textContent ?? '',
+  );
+
+const toggleAccount = (name: string) => {
+  const option = Array.from(document.querySelectorAll('label')).find(
+    (label) => label.textContent === name,
+  );
+  if (!option) throw new Error(`No account option labelled "${name}"`);
+  fireEvent.click(option.querySelector('input') as HTMLInputElement);
+};
+
 describe('CashFlowForecastChart', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    charts.tooltipPoint = DEFAULT_TOOLTIP_POINT;
     mockBuildForecast.mockReturnValue(forecastOf([]));
+    mockBuildMultiAccountForecast.mockReturnValue(multiForecastOf([]));
     mockGetForecastSummary.mockReturnValue({
       startingBalance: 1000,
       endingBalance: 800,
@@ -172,7 +218,7 @@ describe('CashFlowForecastChart', () => {
     expect(screen.getByText('1Y')).toBeInTheDocument();
   });
 
-  it('shows All Accounts option in account selector', () => {
+  it('shows All Accounts when nothing is selected', () => {
     render(
       <CashFlowForecastChart scheduledTransactions={[]} accounts={[]} isLoading={false} />
     );
@@ -187,10 +233,24 @@ describe('CashFlowForecastChart', () => {
     render(
       <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
     );
-    const select = screen.getByRole('combobox') as HTMLSelectElement;
-    const labels = Array.from(select.options).map((o) => o.textContent);
-    expect(labels[0]).toBe('All Accounts');
+    openAccountPicker();
+    const labels = accountOptionLabels();
     expect(labels.indexOf('Zebra')).toBeLessThan(labels.indexOf('Apple'));
+  });
+
+  // `buildAccountDropdownOptions` puts a disabled rule between favourites and
+  // the rest. A `<select>` can render that; a checkbox list would turn it into
+  // a selectable account made of box-drawing characters.
+  it('does not offer the favourites separator as a selectable account', () => {
+    const accounts = [
+      makeAccount({ id: 'a1', name: 'Apple', isFavourite: false }),
+      makeAccount({ id: 'a2', name: 'Zebra', isFavourite: true, favouriteSortOrder: 0 }),
+    ];
+    render(
+      <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
+    );
+    openAccountPicker();
+    expect(accountOptionLabels()).toEqual(['Zebra', 'Apple']);
   });
 
   it('renders chart with forecast data and summary footer', () => {
@@ -287,6 +347,7 @@ describe('CashFlowForecastChart', () => {
     render(
       <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
     );
+    openAccountPicker();
     expect(screen.getByText('Checking')).toBeInTheDocument();
     expect(screen.getByText('Savings')).toBeInTheDocument();
   });
@@ -302,6 +363,7 @@ describe('CashFlowForecastChart', () => {
     render(
       <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
     );
+    openAccountPicker();
     expect(screen.getByText('Checking')).toBeInTheDocument();
     expect(screen.queryByText('Closed Account')).not.toBeInTheDocument();
     expect(screen.queryByText('House')).not.toBeInTheDocument();
@@ -639,6 +701,329 @@ describe('CashFlowForecastChart', () => {
       );
 
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Selecting more than one account draws a line per account plus the total
+   * they sum to. The total keeps the single-account filled area so the shape
+   * the page has always had still means the same thing; the members are plain
+   * unfilled lines, because a stack of translucent fills reads as an area chart
+   * of parts rather than as several independent balances.
+   */
+  describe('multiple selected accounts', () => {
+    const twoAccounts = [
+      makeAccount({ id: 'a1', name: 'Checking' }),
+      makeAccount({ id: 'a2', name: 'Savings', accountType: 'SAVINGS' }),
+    ];
+
+    const multiPoints = [
+      { date: '2025-01-15', balance: 1500, balances: { a1: 1000, a2: 500 }, transactions: [] },
+      {
+        date: '2025-01-16',
+        balance: 1300,
+        balances: { a1: 800, a2: 500 },
+        transactions: [{ name: 'Bill', amount: -200, accountId: 'a1' }],
+      },
+    ];
+    const twoSeries = [
+      { accountId: 'a1', name: 'Checking' },
+      { accountId: 'a2', name: 'Savings' },
+    ];
+
+    const renderWithBothSelected = () => {
+      mockBuildMultiAccountForecast.mockReturnValue(multiForecastOf(multiPoints, twoSeries));
+      const result = render(
+        <CashFlowForecastChart
+          scheduledTransactions={[{} as any]}
+          accounts={twoAccounts}
+          isLoading={false}
+        />,
+      );
+      openAccountPicker();
+      toggleAccount('Checking');
+      toggleAccount('Savings');
+      return result;
+    };
+
+    it('draws one line per selected account, keyed to that account', () => {
+      renderWithBothSelected();
+      const lines = screen.getAllByTestId('line');
+      expect(lines.map((l) => l.getAttribute('data-name'))).toEqual(['Checking', 'Savings']);
+      expect(lines.map((l) => l.getAttribute('data-key'))).toEqual([
+        'balances.a1',
+        'balances.a2',
+      ]);
+      // recharts reads the key as a path into the datum, so a key that merely
+      // looks plausible draws an empty line. Resolve it the way recharts does.
+      const resolve = (point: any, key: string) =>
+        key.split('.').reduce((value, part) => value?.[part], point);
+      expect(
+        lines.map((l) => resolve(multiPoints[1], l.getAttribute('data-key') as string)),
+      ).toEqual([800, 500]);
+    });
+
+    it('leaves the per-account lines unfilled', () => {
+      renderWithBothSelected();
+      for (const line of screen.getAllByTestId('line')) {
+        expect(line.getAttribute('data-fill')).toBe('none');
+      }
+    });
+
+    it('gives each account its own colour, none of them the total line colour', () => {
+      renderWithBothSelected();
+      const strokes = screen.getAllByTestId('line').map((l) => l.getAttribute('data-stroke'));
+      expect(new Set(strokes).size).toBe(strokes.length);
+      // `--chart-1` is the theme accent, which is what `--chart-primary` is too,
+      // so an account taking the first palette slot would be indistinguishable
+      // from the total.
+      expect(strokes).not.toContain('var(--chart-primary)');
+    });
+
+    it('keeps the filled area for the "Total of Accounts" line', () => {
+      renderWithBothSelected();
+      const area = screen.getByTestId('area');
+      expect(area.getAttribute('data-fill')).toBe('url(#forecastBalance)');
+      expect(area.getAttribute('data-stroke')).toBe('var(--chart-primary)');
+      expect(area.getAttribute('data-name')).toBe('Total of Accounts');
+    });
+
+    it('legends the total and every selected account', () => {
+      renderWithBothSelected();
+      const legend = within(screen.getByRole('list', { name: 'Forecast lines' }));
+      expect(legend.getByText('Total of Accounts')).toBeInTheDocument();
+      expect(legend.getByText('Checking')).toBeInTheDocument();
+      expect(legend.getByText('Savings')).toBeInTheDocument();
+    });
+
+    it('names each account and its balance at the hovered point', () => {
+      charts.tooltipPoint = {
+        date: '2025-01-16',
+        balance: 1300,
+        balances: { a1: 800, a2: 500 },
+        transactions: [{ name: 'Bill', amount: -200, accountId: 'a1' }],
+      };
+      renderWithBothSelected();
+      const tooltip = within(screen.getByTestId('tooltip'));
+      expect(tooltip.getByText('Total of Accounts')).toBeInTheDocument();
+      expect(tooltip.getByText('$1300.00')).toBeInTheDocument();
+      expect(tooltip.getByText('Checking')).toBeInTheDocument();
+      expect(tooltip.getByText('$800.00')).toBeInTheDocument();
+      expect(tooltip.getByText('Savings')).toBeInTheDocument();
+      expect(tooltip.getByText('$500.00')).toBeInTheDocument();
+    });
+
+    it('says which account a hovered transaction belongs to', () => {
+      charts.tooltipPoint = {
+        date: '2025-01-16',
+        balance: 1300,
+        balances: { a1: 800, a2: 500 },
+        transactions: [{ name: 'Bill', amount: -200, accountId: 'a1' }],
+      };
+      renderWithBothSelected();
+      expect(
+        within(screen.getByTestId('tooltip')).getByText('Bill (Checking)'),
+      ).toBeInTheDocument();
+    });
+
+    it('builds the forecast from the picker order, not the click order', () => {
+      mockBuildMultiAccountForecast.mockReturnValue(multiForecastOf(multiPoints, twoSeries));
+      render(
+        <CashFlowForecastChart
+          scheduledTransactions={[{} as any]}
+          accounts={twoAccounts}
+          isLoading={false}
+        />,
+      );
+      openAccountPicker();
+      toggleAccount('Savings');
+      toggleAccount('Checking');
+
+      expect(mockBuildMultiAccountForecast).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        ['a1', 'a2'],
+        expect.anything(),
+        undefined,
+      );
+    });
+
+    it('withholds the whole chart when a rate is missing', () => {
+      mockBuildMultiAccountForecast.mockReturnValue(multiForecastOf([], [], ['EUR']));
+      render(
+        <CashFlowForecastChart
+          scheduledTransactions={[{} as any]}
+          accounts={twoAccounts}
+          isLoading={false}
+        />,
+      );
+      openAccountPicker();
+      toggleAccount('Checking');
+      toggleAccount('Savings');
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'no exchange rate is available for EUR',
+      );
+      expect(screen.queryByTestId('composed-chart')).not.toBeInTheDocument();
+    });
+
+    it('stays on the single filled area while only one account is selected', () => {
+      mockBuildForecast.mockReturnValue(
+        forecastOf([
+          { date: '2025-01-15', balance: 1000, transactions: [{ amount: -100, name: 'Bill' }] },
+          { date: '2025-01-16', balance: 900, transactions: [] },
+        ]),
+      );
+      render(
+        <CashFlowForecastChart
+          scheduledTransactions={[{} as any]}
+          accounts={twoAccounts}
+          isLoading={false}
+        />,
+      );
+      openAccountPicker();
+      toggleAccount('Checking');
+
+      expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+      expect(screen.queryByTestId('composed-chart')).not.toBeInTheDocument();
+      expect(screen.queryAllByTestId('line')).toHaveLength(0);
+      expect(mockBuildForecast).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'a1',
+        expect.anything(),
+        undefined,
+      );
+    });
+  });
+
+  describe('remembering the selection', () => {
+    const twoAccounts = [
+      makeAccount({ id: 'a1', name: 'Checking' }),
+      makeAccount({ id: 'a2', name: 'Savings', accountType: 'SAVINGS' }),
+    ];
+
+    it('restores a stored multi-account selection, in picker order', () => {
+      localStorage.setItem('cashFlowForecast.accountIds', JSON.stringify(['a2', 'a1']));
+      render(
+        <CashFlowForecastChart
+          scheduledTransactions={[]}
+          accounts={twoAccounts}
+          isLoading={false}
+        />,
+      );
+
+      expect(mockBuildMultiAccountForecast).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        ['a1', 'a2'],
+        expect.anything(),
+        undefined,
+      );
+    });
+
+    // The selector used to store a single id (or the string 'all'), so an
+    // existing user must not be silently moved back to every account.
+    it('carries a single account forward from the pre-multi-select key', () => {
+      localStorage.setItem('cashFlowForecast.accountId', 'a2');
+      render(
+        <CashFlowForecastChart
+          scheduledTransactions={[]}
+          accounts={twoAccounts}
+          isLoading={false}
+        />,
+      );
+
+      expect(mockBuildForecast).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'a2',
+        expect.anything(),
+        undefined,
+      );
+    });
+
+    it('reads a stored "all" from the pre-multi-select key as every account', () => {
+      localStorage.setItem('cashFlowForecast.accountId', 'all');
+      render(
+        <CashFlowForecastChart
+          scheduledTransactions={[]}
+          accounts={twoAccounts}
+          isLoading={false}
+        />,
+      );
+
+      expect(mockBuildForecast).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'all',
+        expect.anything(),
+        undefined,
+      );
+    });
+
+    it('falls back to the legacy key rather than throwing on unparseable storage', () => {
+      localStorage.setItem('cashFlowForecast.accountIds', '{not json');
+      localStorage.setItem('cashFlowForecast.accountId', 'a1');
+      render(
+        <CashFlowForecastChart
+          scheduledTransactions={[]}
+          accounts={twoAccounts}
+          isLoading={false}
+        />,
+      );
+
+      expect(mockBuildForecast).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'a1',
+        expect.anything(),
+        undefined,
+      );
+    });
+
+    it('persists a new selection', () => {
+      render(
+        <CashFlowForecastChart
+          scheduledTransactions={[]}
+          accounts={twoAccounts}
+          isLoading={false}
+        />,
+      );
+      openAccountPicker();
+      toggleAccount('Savings');
+
+      expect(localStorage.getItem('cashFlowForecast.accountIds')).toBe(
+        JSON.stringify(['a2']),
+      );
+    });
+
+    // A stored account that has since been closed or deleted is no longer on
+    // offer, so it must not quietly narrow the forecast to nothing.
+    it('ignores stored ids for accounts that are no longer available', () => {
+      localStorage.setItem('cashFlowForecast.accountIds', JSON.stringify(['gone']));
+      render(
+        <CashFlowForecastChart
+          scheduledTransactions={[]}
+          accounts={twoAccounts}
+          isLoading={false}
+        />,
+      );
+
+      expect(mockBuildForecast).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'all',
+        expect.anything(),
+        undefined,
+      );
     });
   });
 });

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   AreaChart,
   Area,
+  ComposedChart,
   LineChart,
   Line,
   XAxis,
@@ -16,7 +17,7 @@ import {
   ResponsiveContainer,
   ReferenceLine,
 } from 'recharts';
-import { chartColors } from '@/lib/chart-colors';
+import { chartColors, chartSeriesColorAsidePrimary } from '@/lib/chart-colors';
 import { computeBalanceGradient } from '@/lib/balance-history';
 import {
   ChartFlagShadowFilter,
@@ -25,13 +26,15 @@ import {
 } from '@/components/investments/portfolio-chart-utils';
 import { ScheduledTransaction } from '@/types/scheduled-transaction';
 import { Account } from '@/types/account';
-import { Select } from '@/components/ui/Select';
+import { MultiSelect } from '@/components/ui/MultiSelect';
 import { buildAccountDropdownOptions } from '@/lib/account-utils';
 import {
   buildForecast,
+  buildMultiAccountForecast,
   getForecastSummary,
   ForecastPeriod,
   ForecastDataPoint,
+  ForecastAccountSeries,
   FutureTransaction,
   FORECAST_PERIOD_LABELS,
 } from '@/lib/forecast';
@@ -46,25 +49,52 @@ interface CashFlowForecastChartProps {
   isLoading: boolean;
 }
 
+/** One account line, as the chart and its tooltip need it. */
+interface AccountLine {
+  accountId: string;
+  name: string;
+  color: string;
+}
+
+/**
+ * A point on screen. `balances` is present only in multi-account mode, where
+ * `balance` is the total of those per-account figures.
+ */
+type ChartPoint = ForecastDataPoint & { balances?: Record<string, number> };
+
 function CashFlowTooltip({
   active,
   payload,
   formatCurrency,
   formatChartDate,
+  lines = [],
 }: {
   active?: boolean;
-  payload?: Array<{ payload: ForecastDataPoint }>;
+  payload?: Array<{ payload: ChartPoint }>;
   formatCurrency: (v: number) => string;
   formatChartDate: (date: Date | string, pattern: 'MMM d') => string;
+  lines?: AccountLine[];
 }) {
   const t = useTranslations('bills');
   if (active && payload?.[0]) {
     const data = payload[0].payload;
+    const balances = data.balances ?? {};
+    // Every selected account gets a balance at every point, so this only drops
+    // a line the series and the data disagree about -- never a known value.
+    const accountRows = lines.filter(
+      (line) => typeof balances[line.accountId] === 'number',
+    );
+    const accountNames = new Map(lines.map((line) => [line.accountId, line.name]));
     return (
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 max-w-xs">
         <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">
           {formatChartDate(data.date, 'MMM d')}
         </p>
+        {accountRows.length > 0 && (
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {t('forecast.totalOfAccounts')}
+          </p>
+        )}
         <p
           className={`text-lg font-semibold ${
             gainLossColor(data.balance)
@@ -72,23 +102,48 @@ function CashFlowTooltip({
         >
           {formatCurrency(data.balance)}
         </p>
+        {accountRows.length > 0 && (
+          <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-700 space-y-0.5">
+            {accountRows.map((line) => (
+              <p key={line.accountId} className="flex items-center gap-2 text-sm">
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-2 w-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: line.color }}
+                />
+                <span className="truncate text-gray-700 dark:text-gray-300">{line.name}</span>
+                <span className="ml-auto shrink-0 font-medium text-gray-900 dark:text-gray-100">
+                  {formatCurrency(balances[line.accountId])}
+                </span>
+              </p>
+            ))}
+          </div>
+        )}
         {data.transactions.length > 0 && (
           <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-700">
             <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
               {t('forecast.tooltipTransactions')}
             </p>
-            {data.transactions.slice(0, 5).map((tx, i) => (
-              <p key={i} className="text-sm text-gray-700 dark:text-gray-300">
-                <span
-                  className={
-                    gainLossColor(tx.amount)
-                  }
-                >
-                  {formatCurrency(tx.amount)}
-                </span>{' '}
-                {tx.name}
-              </p>
-            ))}
+            {data.transactions.slice(0, 5).map((tx, i) => {
+              const accountName = tx.accountId ? accountNames.get(tx.accountId) : undefined;
+              return (
+                <p key={i} className="text-sm text-gray-700 dark:text-gray-300">
+                  <span
+                    className={
+                      gainLossColor(tx.amount)
+                    }
+                  >
+                    {formatCurrency(tx.amount)}
+                  </span>{' '}
+                  {accountName
+                    ? t('forecast.tooltipTransactionForAccount', {
+                        name: tx.name,
+                        account: accountName,
+                      })
+                    : tx.name}
+                </p>
+              );
+            })}
             {data.transactions.length > 5 && (
               <p className="text-xs text-gray-400 dark:text-gray-500">
                 {t('forecast.tooltipMore', { count: data.transactions.length - 5 })}
@@ -104,7 +159,9 @@ function CashFlowTooltip({
 
 const PERIODS: ForecastPeriod[] = ['week', 'month', '90days', '6months', 'year'];
 const STORAGE_KEY_PERIOD = 'cashFlowForecast.period';
-const STORAGE_KEY_ACCOUNT = 'cashFlowForecast.accountId';
+const STORAGE_KEY_ACCOUNTS = 'cashFlowForecast.accountIds';
+/** Pre-multi-select key, holding a single account id or the string 'all'. */
+const STORAGE_KEY_ACCOUNT_LEGACY = 'cashFlowForecast.accountId';
 
 function getStoredPeriod(): ForecastPeriod {
   if (typeof window === 'undefined') return 'month';
@@ -115,9 +172,27 @@ function getStoredPeriod(): ForecastPeriod {
   return 'month';
 }
 
-function getStoredAccountId(): string {
-  if (typeof window === 'undefined') return 'all';
-  return localStorage.getItem(STORAGE_KEY_ACCOUNT) || 'all';
+/**
+ * The stored selection. An empty array means "all accounts", so a user who
+ * never picked one -- and one upgrading from the single-account selector with
+ * 'all' stored -- lands on the same view they had.
+ */
+function getStoredAccountIds(): string[] {
+  if (typeof window === 'undefined') return [];
+  const stored = localStorage.getItem(STORAGE_KEY_ACCOUNTS);
+  if (stored) {
+    try {
+      const parsed: unknown = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((id): id is string => typeof id === 'string');
+      }
+    } catch {
+      // Unparseable: fall through to the legacy key rather than throwing during
+      // the first render.
+    }
+  }
+  const legacy = localStorage.getItem(STORAGE_KEY_ACCOUNT_LEGACY);
+  return legacy && legacy !== 'all' ? [legacy] : [];
 }
 
 export function CashFlowForecastChart({
@@ -133,7 +208,9 @@ export function CashFlowForecastChart({
   const formatChartDate = useChartDateFormat();
   const { convertToDefault, defaultCurrency } = useExchangeRates();
   const [selectedPeriod, setSelectedPeriod] = useState<ForecastPeriod>(() => getStoredPeriod());
-  const [selectedAccountId, setSelectedAccountId] = useState<string>(() => getStoredAccountId());
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>(() =>
+    getStoredAccountIds(),
+  );
   // High/low value bubbles the user has temporarily dismissed, keyed by the
   // value they marked so a forecast change with a new extreme shows its bubble
   // again. Component-local (not persisted), so it resets on navigation.
@@ -147,31 +224,45 @@ export function CashFlowForecastChart({
 
   // Persist account changes
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY_ACCOUNT, selectedAccountId);
-  }, [selectedAccountId]);
+    localStorage.setItem(STORAGE_KEY_ACCOUNTS, JSON.stringify(selectedAccountIds));
+  }, [selectedAccountIds]);
 
   const accountOptions = useMemo(() => {
-    return [
-      { value: 'all', label: t('forecast.allAccounts') },
-      ...buildAccountDropdownOptions(
-        accounts,
-        a => !a.isClosed && a.accountType !== 'ASSET' && a.accountSubType !== 'INVESTMENT_BROKERAGE',
-        a => a.name,
-      ),
-    ];
-  }, [accounts, t]);
+    return buildAccountDropdownOptions(
+      accounts,
+      a => !a.isClosed && a.accountType !== 'ASSET' && a.accountSubType !== 'INVESTMENT_BROKERAGE',
+      a => a.name,
+      // The favourites/rest separator is a disabled row a `<select>` can render
+      // and a checkbox list cannot, so drop it here rather than offering a
+      // selectable rule.
+    ).filter(option => !option.disabled);
+  }, [accounts]);
+
+  /**
+   * The selection, in the picker's own order (favourites first, then
+   * alphabetical) and restricted to accounts still on offer. That order is what
+   * the legend reads and what colours are assigned from, so toggling a checkbox
+   * cannot recolour the lines already drawn.
+   */
+  const orderedAccountIds = useMemo(() => {
+    const selected = new Set(selectedAccountIds);
+    return accountOptions.map(o => o.value).filter(id => selected.has(id));
+  }, [accountOptions, selectedAccountIds]);
+
+  const isMultiAccount = orderedAccountIds.length > 1;
 
   // Determine display currency from selected accounts
   const { chartCurrency, needsConversion } = useMemo(() => {
-    const targetAccounts = selectedAccountId === 'all'
+    const selected = new Set(orderedAccountIds);
+    const targetAccounts = selected.size === 0
       ? accounts.filter(a => !a.isClosed)
-      : accounts.filter(a => a.id === selectedAccountId);
+      : accounts.filter(a => selected.has(a.id));
     const currencies = new Set(targetAccounts.map(a => a.currencyCode));
     return {
       chartCurrency: currencies.size === 1 ? [...currencies][0] : defaultCurrency,
       needsConversion: currencies.size > 1,
     };
-  }, [accounts, selectedAccountId, defaultCurrency]);
+  }, [accounts, orderedAccountIds, defaultCurrency]);
 
   const formatCurrency = useCallback(
     (value: number) => formatCurrencyFull(value, chartCurrency),
@@ -188,17 +279,41 @@ export function CashFlowForecastChart({
     [formatCurrencyFlag, chartCurrency],
   );
 
-  const forecast = useMemo(() => {
-    return buildForecast(
-      accounts, scheduledTransactions, selectedPeriod, selectedAccountId, futureTransactions,
-      needsConversion ? convertToDefault : undefined,
+  const forecast = useMemo<{
+    points: ChartPoint[];
+    series: ForecastAccountSeries[];
+    missingCurrencies: string[];
+  }>(() => {
+    const convert = needsConversion ? convertToDefault : undefined;
+    if (isMultiAccount) {
+      return buildMultiAccountForecast(
+        accounts, scheduledTransactions, selectedPeriod, orderedAccountIds, futureTransactions,
+        convert,
+      );
+    }
+    // One account (or none, meaning all of them) is a single line, and that
+    // line already is the total -- so it keeps the filled-area presentation
+    // unchanged.
+    const single = buildForecast(
+      accounts, scheduledTransactions, selectedPeriod, orderedAccountIds[0] ?? 'all',
+      futureTransactions, convert,
     );
-  }, [accounts, scheduledTransactions, selectedPeriod, selectedAccountId, futureTransactions, needsConversion, convertToDefault]);
+    return { points: single.points as ChartPoint[], series: [], missingCurrencies: single.missingCurrencies };
+  }, [accounts, scheduledTransactions, selectedPeriod, orderedAccountIds, isMultiAccount, futureTransactions, needsConversion, convertToDefault]);
   const forecastData = forecast.points;
   // A projected balance is cumulative, so one missing rate makes every day after
-  // it wrong. `buildForecast` returns no points in that case and names the
+  // it wrong. The forecast builders return no points in that case and name the
   // currencies; the chart says so instead of drawing a plausible line.
   const forecastUnavailable = forecast.missingCurrencies.length > 0;
+
+  const accountLines: AccountLine[] = useMemo(
+    () => forecast.series.map((s, i) => ({
+      accountId: s.accountId,
+      name: s.name,
+      color: chartSeriesColorAsidePrimary(i),
+    })),
+    [forecast.series],
+  );
 
   const summary = useMemo(() => {
     return getForecastSummary(forecastData);
@@ -227,6 +342,24 @@ export function CashFlowForecastChart({
     () => computeBalanceGradient(forecastData.map((point) => point.balance)),
     [forecastData],
   );
+
+  const renderTotalFlagDots = (props: { cx?: number; cy?: number; index?: number }) =>
+    renderMinMaxFlagDots({
+      cx: props.cx,
+      cy: props.cy,
+      index: props.index,
+      flags,
+      pointCount: forecastData.length,
+      highColor: chartColors.income,
+      lowColor: chartColors.expense,
+      highLabel,
+      lowLabel,
+      highDismissed,
+      lowDismissed,
+      onDismissHigh: () => setDismissedHigh(highValue),
+      onDismissLow: () => setDismissedLow(lowValue),
+      dismissLabel: tc('chartFlag.dismiss'),
+    });
 
   if (isLoading) {
     return (
@@ -293,17 +426,41 @@ export function CashFlowForecastChart({
               </button>
             ))}
           </div>
-          {/* Account selector */}
+          {/* Account selector: no selection means every account, as one line */}
           <div className="w-48">
-            <Select
-              value={selectedAccountId}
-              onChange={(e) => setSelectedAccountId(e.target.value)}
-              options={accountOptions}
-              className="text-sm"
+            <MultiSelect
+              ariaLabel={t('forecast.accountsAriaLabel')}
+              placeholder={t('forecast.allAccounts')}
+              options={accountOptions.map(o => ({ value: o.value, label: o.label }))}
+              value={orderedAccountIds}
+              onChange={setSelectedAccountIds}
             />
           </div>
         </div>
       </div>
+
+      {/* Legend: only meaningful once there is more than one line */}
+      {accountLines.length > 0 && forecastData.length > 0 && (
+        <ul
+          aria-label={t('forecast.legendAriaLabel')}
+          className="flex flex-wrap items-center gap-x-4 gap-y-1 mb-3 text-xs"
+        >
+          {([
+            { accountId: '', name: t('forecast.totalOfAccounts'), color: chartColors.primary },
+            ...accountLines,
+          ] as AccountLine[])
+            .map((line) => (
+              <li key={line.accountId} className="flex items-center gap-1.5">
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-2.5 w-2.5 rounded-sm"
+                  style={{ backgroundColor: line.color }}
+                />
+                <span className="text-gray-600 dark:text-gray-300">{line.name}</span>
+              </li>
+            ))}
+        </ul>
+      )}
 
       {/* Chart */}
       {forecastData.length === 0 ? (
@@ -314,6 +471,92 @@ export function CashFlowForecastChart({
              scheduledTransactions.length === 0 ? t('forecast.noScheduled') :
              t('forecast.noMatchingAccount')}
           </p>
+        </div>
+      ) : isMultiAccount ? (
+        <div className="h-72" style={{ minHeight: 288 }}>
+          {totalForecastedTransactions === 0 && (
+            <div className="text-center text-sm text-gray-500 dark:text-gray-400 mb-2">
+              {t('forecast.noUpcoming')}
+            </div>
+          )}
+          <ResponsiveContainer
+            width="100%"
+            height={totalForecastedTransactions === 0 ? '90%' : '100%'}
+            minWidth={0}
+          >
+            {/* top margin leaves headroom for the high-value bubble callout */}
+            <ComposedChart data={forecastData} margin={{ left: 0, right: 8, top: 20, bottom: 0 }}>
+              <defs>
+                <linearGradient id="forecastBalance" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset={0} stopColor={chartColors.primary} stopOpacity={areaGradient.topOpacity} />
+                  <stop offset={areaGradient.zeroOffset} stopColor={chartColors.primary} stopOpacity={0} />
+                  <stop offset={1} stopColor={chartColors.primary} stopOpacity={areaGradient.bottomOpacity} />
+                </linearGradient>
+              </defs>
+              <ChartFlagShadowFilter />
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
+              <XAxis
+                dataKey="date"
+                tickFormatter={(value: string) => formatChartDate(value, 'MMM d')}
+                tick={{ fill: chartColors.axis, fontSize: 12 }}
+                tickLine={false}
+                axisLine={{ stroke: chartColors.grid }}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                tick={{ fill: chartColors.axis, fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={formatAxis}
+                width="auto"
+                domain={['auto', 'auto']}
+              />
+              <Tooltip
+                content={
+                  <CashFlowTooltip
+                    formatCurrency={formatCurrency}
+                    formatChartDate={formatChartDate}
+                    lines={accountLines}
+                  />
+                }
+              />
+              <ReferenceLine y={0} stroke={chartColors.expense} strokeDasharray="5 5" strokeOpacity={0.5} />
+              {summary.minBalance !== summary.startingBalance && (
+                <ReferenceLine
+                  y={summary.minBalance}
+                  stroke={summary.minBalance < 0 ? chartColors.expense : chartColors.warning}
+                  strokeDasharray="3 3"
+                  strokeOpacity={0.4}
+                />
+              )}
+              {/* The total keeps the single-account fill; the members are lines */}
+              <Area
+                type="monotone"
+                dataKey="balance"
+                name={t('forecast.totalOfAccounts')}
+                stroke={chartColors.primary}
+                strokeWidth={2}
+                fillOpacity={1}
+                fill="url(#forecastBalance)"
+                dot={renderTotalFlagDots}
+                activeDot={{ r: 6, fill: chartColors.primary }}
+              />
+              {accountLines.map((line) => (
+                <Line
+                  key={line.accountId}
+                  type="monotone"
+                  dataKey={`balances.${line.accountId}`}
+                  name={line.name}
+                  stroke={line.color}
+                  strokeWidth={1.5}
+                  fill="none"
+                  dot={false}
+                  connectNulls={false}
+                  activeDot={{ r: 4, fill: line.color }}
+                />
+              ))}
+            </ComposedChart>
+          </ResponsiveContainer>
         </div>
       ) : totalForecastedTransactions === 0 ? (
         <div className="h-72" style={{ minHeight: 288 }}>
@@ -388,24 +631,7 @@ export function CashFlowForecastChart({
                 strokeWidth={2}
                 fillOpacity={1}
                 fill="url(#forecastBalance)"
-                dot={(props: { cx?: number; cy?: number; index?: number }) =>
-                  renderMinMaxFlagDots({
-                    cx: props.cx,
-                    cy: props.cy,
-                    index: props.index,
-                    flags,
-                    pointCount: forecastData.length,
-                    highColor: chartColors.income,
-                    lowColor: chartColors.expense,
-                    highLabel,
-                    lowLabel,
-                    highDismissed,
-                    lowDismissed,
-                    onDismissHigh: () => setDismissedHigh(highValue),
-                    onDismissLow: () => setDismissedLow(lowValue),
-                    dismissLabel: tc('chartFlag.dismiss'),
-                  })
-                }
+                dot={renderTotalFlagDots}
                 activeDot={{ r: 6, fill: chartColors.primary }}
               />
             </AreaChart>

--- a/frontend/src/i18n/messages/de/bills.json
+++ b/frontend/src/i18n/messages/de/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Niedrigster",
     "summaryMinBalance": "Mindestsaldo",
     "allAccounts": "Alle Konten",
+    "accountsAriaLabel": "Konten für die Prognose",
+    "totalOfAccounts": "Gesamt aller Konten",
+    "legendAriaLabel": "Prognoselinien",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Diese Prognose kann nicht in {displayCurrency} angezeigt werden: Für {currencies} ist kein Wechselkurs verfügbar, und ein prognostizierter Saldo baut auf jedem vorherigen Tag auf. Fügen Sie einen Kurs hinzu, oder wählen Sie ein Konto mit nur einer Währung."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/en/bills.json
+++ b/frontend/src/i18n/messages/en/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Lowest",
     "summaryMinBalance": "Min Balance",
     "allAccounts": "All Accounts",
+    "accountsAriaLabel": "Accounts to forecast",
+    "totalOfAccounts": "Total of Accounts",
+    "legendAriaLabel": "Forecast lines",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "This forecast cannot be shown in {displayCurrency}: no exchange rate is available for {currencies}, and a projected balance builds on every day before it. Add a rate, or pick a single-currency account."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/es/bills.json
+++ b/frontend/src/i18n/messages/es/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Más bajo",
     "summaryMinBalance": "Saldo mínimo",
     "allAccounts": "Todas las cuentas",
+    "accountsAriaLabel": "Cuentas del pronóstico",
+    "totalOfAccounts": "Total de cuentas",
+    "legendAriaLabel": "Líneas del pronóstico",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Esta previsión no puede mostrarse en {displayCurrency}: no hay tipo de cambio disponible para {currencies}, y un saldo proyectado se apoya en cada día anterior. Añade un tipo, o elige una cuenta de una sola moneda."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/fr/bills.json
+++ b/frontend/src/i18n/messages/fr/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Le plus bas",
     "summaryMinBalance": "Solde min.",
     "allAccounts": "Tous les comptes",
+    "accountsAriaLabel": "Comptes de la prévision",
+    "totalOfAccounts": "Total des comptes",
+    "legendAriaLabel": "Courbes de la prévision",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Cette prévision ne peut pas être affichée en {displayCurrency} : aucun taux de change n'est disponible pour {currencies}, et un solde projeté s'appuie sur chaque jour précédent. Ajoutez un taux, ou choisissez un compte à devise unique."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/hi/bills.json
+++ b/frontend/src/i18n/messages/hi/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "न्यूनतम",
     "summaryMinBalance": "न्यूनतम शेष",
     "allAccounts": "सभी खाते",
+    "accountsAriaLabel": "पूर्वानुमान के लिए खाते",
+    "totalOfAccounts": "खातों का कुल",
+    "legendAriaLabel": "पूर्वानुमान रेखाएँ",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "यह पूर्वानुमान {displayCurrency} में नहीं दिखाया जा सकता: {currencies} के लिए कोई विनिमय दर उपलब्ध नहीं है, और अनुमानित शेष उससे पहले के हर दिन पर आधारित होता है। एक दर जोड़ें, या एकल-मुद्रा खाता चुनें।"
   },
   "calendar": {

--- a/frontend/src/i18n/messages/id/bills.json
+++ b/frontend/src/i18n/messages/id/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Terendah",
     "summaryMinBalance": "Saldo Min",
     "allAccounts": "Semua Akun",
+    "accountsAriaLabel": "Akun untuk prakiraan",
+    "totalOfAccounts": "Total Akun",
+    "legendAriaLabel": "Garis prakiraan",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Prakiraan ini tidak dapat ditampilkan dalam {displayCurrency}: tidak ada nilai tukar untuk {currencies}, dan saldo proyeksi dibangun dari setiap hari sebelumnya. Tambahkan kurs, atau pilih akun satu mata uang."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/it/bills.json
+++ b/frontend/src/i18n/messages/it/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Minimo",
     "summaryMinBalance": "Saldo minimo",
     "allAccounts": "Tutti i conti",
+    "accountsAriaLabel": "Conti della previsione",
+    "totalOfAccounts": "Totale dei conti",
+    "legendAriaLabel": "Linee della previsione",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Questa previsione non può essere mostrata in {displayCurrency}: nessun tasso di cambio disponibile per {currencies}, e un saldo proiettato si basa su ogni giorno precedente. Aggiungi un tasso, oppure scegli un conto a valuta singola."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/ja/bills.json
+++ b/frontend/src/i18n/messages/ja/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "最低",
     "summaryMinBalance": "最低残高",
     "allAccounts": "すべての勘定科目",
+    "accountsAriaLabel": "予測する勘定科目",
+    "totalOfAccounts": "勘定科目の合計",
+    "legendAriaLabel": "予測の線",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "この予測は {displayCurrency} では表示できません。{currencies} の為替レートがなく、予測残高はそれ以前のすべての日を土台にするためです。レートを追加するか、単一通貨の口座を選んでください。"
   },
   "calendar": {

--- a/frontend/src/i18n/messages/ko/bills.json
+++ b/frontend/src/i18n/messages/ko/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "최저",
     "summaryMinBalance": "최소 잔액",
     "allAccounts": "모든 계정",
+    "accountsAriaLabel": "예측할 계정",
+    "totalOfAccounts": "계정 합계",
+    "legendAriaLabel": "예측 선",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "이 예측은 {displayCurrency}(으)로 표시할 수 없습니다. {currencies}의 환율이 없고, 예상 잔액은 이전의 모든 날을 기반으로 하기 때문입니다. 환율을 추가하거나 단일 통화 계좌를 선택하세요."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/nl/bills.json
+++ b/frontend/src/i18n/messages/nl/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Laagste",
     "summaryMinBalance": "Minimumsaldo",
     "allAccounts": "Alle rekeningen",
+    "accountsAriaLabel": "Rekeningen voor de prognose",
+    "totalOfAccounts": "Totaal van rekeningen",
+    "legendAriaLabel": "Prognoselijnen",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Deze prognose kan niet worden getoond in {displayCurrency}: er is geen wisselkoers beschikbaar voor {currencies}, en een geprojecteerd saldo bouwt voort op elke eerdere dag. Voeg een koers toe, of kies een rekening met één valuta."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/pl/bills.json
+++ b/frontend/src/i18n/messages/pl/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Najniższe",
     "summaryMinBalance": "Min. saldo",
     "allAccounts": "Wszystkie konta",
+    "accountsAriaLabel": "Konta do prognozy",
+    "totalOfAccounts": "Suma kont",
+    "legendAriaLabel": "Linie prognozy",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Tej prognozy nie można pokazać w {displayCurrency}: brak kursu wymiany dla {currencies}, a prognozowane saldo opiera się na każdym wcześniejszym dniu. Dodaj kurs lub wybierz konto jednowalutowe."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/pt-BR/bills.json
+++ b/frontend/src/i18n/messages/pt-BR/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Mais baixo",
     "summaryMinBalance": "Saldo mínimo",
     "allAccounts": "Todas as contas",
+    "accountsAriaLabel": "Contas da previsão",
+    "totalOfAccounts": "Total das contas",
+    "legendAriaLabel": "Linhas da previsão",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Esta projeção não pode ser mostrada em {displayCurrency}: não há taxa de câmbio disponível para {currencies}, e um saldo projetado depende de cada dia anterior. Adicione uma taxa, ou escolha uma conta de moeda única."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/pt/bills.json
+++ b/frontend/src/i18n/messages/pt/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Mais baixo",
     "summaryMinBalance": "Saldo mínimo",
     "allAccounts": "Todas as contas",
+    "accountsAriaLabel": "Contas da previsão",
+    "totalOfAccounts": "Total das contas",
+    "legendAriaLabel": "Linhas da previsão",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Esta previsão não pode ser mostrada em {displayCurrency}: não há taxa de câmbio disponível para {currencies}, e um saldo projetado assenta em cada dia anterior. Adicione uma taxa, ou escolha uma conta de moeda única."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/ru/bills.json
+++ b/frontend/src/i18n/messages/ru/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Минимум",
     "summaryMinBalance": "Мин. остаток",
     "allAccounts": "Все счета",
+    "accountsAriaLabel": "Счета для прогноза",
+    "totalOfAccounts": "Итого по счетам",
+    "legendAriaLabel": "Линии прогноза",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Этот прогноз нельзя показать в {displayCurrency}: нет курса обмена для {currencies}, а прогнозируемый баланс опирается на каждый предыдущий день. Добавьте курс или выберите счёт с одной валютой."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/tr/bills.json
+++ b/frontend/src/i18n/messages/tr/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "En Düşük",
     "summaryMinBalance": "Min Bakiye",
     "allAccounts": "Tüm Hesaplar",
+    "accountsAriaLabel": "Tahmin edilecek hesaplar",
+    "totalOfAccounts": "Hesapların toplamı",
+    "legendAriaLabel": "Tahmin çizgileri",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Bu tahmin {displayCurrency} cinsinden gösterilemiyor: {currencies} için döviz kuru yok ve öngörülen bakiye önceki her güne dayanır. Bir kur ekleyin veya tek para birimli bir hesap seçin."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/uk/bills.json
+++ b/frontend/src/i18n/messages/uk/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Найнижчий",
     "summaryMinBalance": "Мін. баланс",
     "allAccounts": "Усі рахунки",
+    "accountsAriaLabel": "Рахунки для прогнозу",
+    "totalOfAccounts": "Разом за рахунками",
+    "legendAriaLabel": "Лінії прогнозу",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Цей прогноз не можна показати у {displayCurrency}: немає курсу обміну для {currencies}, а прогнозований баланс спирається на кожен попередній день. Додайте курс або виберіть рахунок з однією валютою."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/vi/bills.json
+++ b/frontend/src/i18n/messages/vi/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "Thấp nhất",
     "summaryMinBalance": "Số dư tối thiểu",
     "allAccounts": "Tất cả tài khoản",
+    "accountsAriaLabel": "Tài khoản cần dự báo",
+    "totalOfAccounts": "Tổng các tài khoản",
+    "legendAriaLabel": "Các đường dự báo",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "Không thể hiển thị dự báo này bằng {displayCurrency}: không có tỷ giá cho {currencies}, và số dư dự phóng dựa trên mọi ngày trước đó. Hãy thêm tỷ giá, hoặc chọn một tài khoản chỉ dùng một loại tiền tệ."
   },
   "calendar": {

--- a/frontend/src/i18n/messages/xx/bills.json
+++ b/frontend/src/i18n/messages/xx/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "[XX-Lowest-XX]",
     "summaryMinBalance": "[XX-Min Balance-XX]",
     "allAccounts": "[XX-All Accounts-XX]",
+    "accountsAriaLabel": "[XX-Accounts to forecast-XX]",
+    "totalOfAccounts": "[XX-Total of Accounts-XX]",
+    "legendAriaLabel": "[XX-Forecast lines-XX]",
+    "tooltipTransactionForAccount": "[XX-{name} ({account})-XX]",
     "unavailableMissingRates": "[XX-This forecast cannot be shown in {displayCurrency}: no exchange rate is available for {currencies}, and a projected balance builds on every day before it. Add a rate, or pick a single-currency account.-XX]"
   },
   "calendar": {

--- a/frontend/src/i18n/messages/zh-CN/bills.json
+++ b/frontend/src/i18n/messages/zh-CN/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "最低",
     "summaryMinBalance": "最低余额",
     "allAccounts": "所有账户",
+    "accountsAriaLabel": "要预测的账户",
+    "totalOfAccounts": "账户合计",
+    "legendAriaLabel": "预测折线",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "此预测无法以 {displayCurrency} 显示：{currencies} 没有可用汇率，而预测余额依赖之前的每一天。请添加汇率，或选择单一货币的账户。"
   },
   "calendar": {

--- a/frontend/src/i18n/messages/zh-TW/bills.json
+++ b/frontend/src/i18n/messages/zh-TW/bills.json
@@ -44,6 +44,10 @@
     "summaryLowest": "最低",
     "summaryMinBalance": "最低結餘",
     "allAccounts": "所有科目",
+    "accountsAriaLabel": "要預測的科目",
+    "totalOfAccounts": "科目總計",
+    "legendAriaLabel": "預測折線",
+    "tooltipTransactionForAccount": "{name} ({account})",
     "unavailableMissingRates": "此預測無法以 {displayCurrency} 顯示：{currencies} 沒有可用匯率，而預測餘額依賴之前的每一天。請新增匯率，或選擇單一貨幣的帳戶。"
   },
   "calendar": {

--- a/frontend/src/lib/chart-colors.test.ts
+++ b/frontend/src/lib/chart-colors.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CHART_SERIES,
+  chartColors,
+  chartSeriesColor,
+  chartSeriesColorAsidePrimary,
+} from './chart-colors';
+
+describe('chartColors', () => {
+  it('exposes CSS variables, never literal colours', () => {
+    for (const value of Object.values(chartColors)) {
+      expect(value).toMatch(/^var\(--chart-[a-z]+\)$/);
+    }
+  });
+});
+
+describe('chartSeriesColor', () => {
+  it('walks the categorical palette from its first slot', () => {
+    expect(chartSeriesColor(0)).toBe(CHART_SERIES[0]);
+    expect(chartSeriesColor(3)).toBe(CHART_SERIES[3]);
+  });
+
+  it('cycles once the palette runs out', () => {
+    expect(chartSeriesColor(CHART_SERIES.length)).toBe(CHART_SERIES[0]);
+  });
+});
+
+describe('chartSeriesColorAsidePrimary', () => {
+  /**
+   * `--chart-1` is the theme accent in every palette, and so is
+   * `--chart-primary`. A member series drawn beside a total must not be handed
+   * the total's own colour, which is the whole reason this variant exists.
+   */
+  it('never hands out the slot that collides with the primary series', () => {
+    for (let i = 0; i < CHART_SERIES.length * 2; i++) {
+      expect(chartSeriesColorAsidePrimary(i)).not.toBe(CHART_SERIES[0]);
+    }
+  });
+
+  it('starts at the second slot and stays distinct within one palette pass', () => {
+    expect(chartSeriesColorAsidePrimary(0)).toBe(CHART_SERIES[1]);
+    const assigned = Array.from({ length: CHART_SERIES.length - 1 }, (_, i) =>
+      chartSeriesColorAsidePrimary(i),
+    );
+    expect(new Set(assigned).size).toBe(assigned.length);
+  });
+
+  // Cycling over the full palette would give slot 0 back on the tenth series:
+  // the same collision, arriving late.
+  it('cycles back to the second slot, skipping the first, once the palette runs out', () => {
+    expect(chartSeriesColorAsidePrimary(CHART_SERIES.length - 1)).toBe(CHART_SERIES[1]);
+    expect(chartSeriesColorAsidePrimary(CHART_SERIES.length)).toBe(CHART_SERIES[2]);
+  });
+});

--- a/frontend/src/lib/chart-colors.ts
+++ b/frontend/src/lib/chart-colors.ts
@@ -56,3 +56,21 @@ export const CHART_SERIES = [
 export function chartSeriesColor(i: number): string {
   return CHART_SERIES[i % CHART_SERIES.length];
 }
+
+/**
+ * Categorical colour for series `i` in a chart that *also* draws a
+ * `chartColors.primary` series -- a total, a benchmark, an aggregate line the
+ * members sit beside.
+ *
+ * `--chart-1` is the theme accent in every palette, which is what
+ * `--chart-primary` is too, so `chartSeriesColor(0)` would hand the first
+ * member the total's own colour and make the two indistinguishable in the
+ * chart, the legend and the tooltip. The first slot is excluded from the cycle
+ * entirely rather than merely deferred -- a modulo over the full palette gives
+ * it back on the tenth series, which is the same collision arriving late. Use
+ * `chartSeriesColor` when there is no primary series to collide with.
+ */
+export function chartSeriesColorAsidePrimary(i: number): string {
+  const usable = CHART_SERIES.length - 1;
+  return CHART_SERIES[1 + (i % usable)];
+}

--- a/frontend/src/lib/forecast.test.ts
+++ b/frontend/src/lib/forecast.test.ts
@@ -3,6 +3,7 @@ import type { Account } from '@/types/account';
 import type { ScheduledTransaction } from '@/types/scheduled-transaction';
 import {
   buildForecast,
+  buildMultiAccountForecast,
   getForecastSummary,
   getProjectedBalanceAtDate,
   FORECAST_PERIOD_DAYS,
@@ -1430,5 +1431,196 @@ describe('buildForecast — a missing rate withholds the series', () => {
   it('reports no series and no missing currencies for no accounts', () => {
     const result = buildForecast([], [], 'week', 'all', [], convertCadOnly);
     expect(result).toEqual({ points: [], missingCurrencies: [] });
+  });
+});
+
+describe('buildMultiAccountForecast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2025, 0, 15)); // Jan 15, 2025
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const chequing = makeAccount({ id: 'acc-1', name: 'Chequing', currentBalance: 1000 });
+  const savings = makeAccount({ id: 'acc-2', name: 'Savings', currentBalance: 500 });
+  const on = (
+    result: ReturnType<typeof buildMultiAccountForecast>,
+    date: string,
+  ) => result.points.find(p => p.date === date);
+
+  it('returns one series per selected account, in the order it was given', () => {
+    const result = buildMultiAccountForecast(
+      [chequing, savings], [], 'month', ['acc-2', 'acc-1'],
+    );
+    expect(result.series).toEqual([
+      { accountId: 'acc-2', name: 'Savings' },
+      { accountId: 'acc-1', name: 'Chequing' },
+    ]);
+  });
+
+  it('starts each line at its own balance and the total at their sum', () => {
+    const result = buildMultiAccountForecast(
+      [chequing, savings], [], 'month', ['acc-1', 'acc-2'],
+    );
+    const first = result.points[0];
+    expect(first.balances).toEqual({ 'acc-1': 1000, 'acc-2': 500 });
+    expect(first.balance).toBe(1500);
+  });
+
+  /**
+   * The total is summed from the same rounded per-account figures the lines are
+   * drawn from. Rounding the raw sum instead would put 3000.25 under two lines
+   * reading 1000.13 and 2000.13.
+   */
+  it('totals the rounded per-account figures, not the raw sum', () => {
+    const result = buildMultiAccountForecast(
+      [
+        makeAccount({ id: 'acc-1', name: 'A', currentBalance: 1000.125 }),
+        makeAccount({ id: 'acc-2', name: 'B', currentBalance: 2000.125 }),
+      ],
+      [], 'month', ['acc-1', 'acc-2'],
+    );
+    const first = result.points[0];
+    expect(first.balances).toEqual({ 'acc-1': 1000.13, 'acc-2': 2000.13 });
+    expect(first.balance).toBe(3000.26);
+  });
+
+  it('moves only the account a scheduled transaction belongs to', () => {
+    const transactions = [makeScheduled({
+      id: 'st-1', accountId: 'acc-1', amount: -200,
+      frequency: 'ONCE', nextDueDate: '2025-01-20',
+    })];
+    const result = buildMultiAccountForecast(
+      [chequing, savings], transactions, 'month', ['acc-1', 'acc-2'],
+    );
+    const jan20 = on(result, '2025-01-20');
+    expect(jan20?.balances).toEqual({ 'acc-1': 800, 'acc-2': 500 });
+    expect(jan20?.balance).toBe(1300);
+  });
+
+  it('tags each transaction with the account it moved', () => {
+    const transactions = [makeScheduled({
+      id: 'st-1', name: 'Rent', accountId: 'acc-1', amount: -200,
+      frequency: 'ONCE', nextDueDate: '2025-01-20',
+    })];
+    const result = buildMultiAccountForecast(
+      [chequing, savings], transactions, 'month', ['acc-1', 'acc-2'],
+    );
+    expect(on(result, '2025-01-20')?.transactions).toEqual([
+      { name: 'Rent', amount: -200, scheduledTransactionId: 'st-1', accountId: 'acc-1' },
+    ]);
+  });
+
+  /**
+   * A transfer between two selected accounts is money moving inside the set, so
+   * both lines move and the total does not -- which is what a total of those
+   * accounts means.
+   */
+  it('moves both lines and leaves the total alone for a transfer inside the selection', () => {
+    const transactions = [makeScheduled({
+      id: 'st-1', accountId: 'acc-1', amount: -300,
+      isTransfer: true, transferAccountId: 'acc-2',
+      frequency: 'ONCE', nextDueDate: '2025-01-20',
+    })];
+    const result = buildMultiAccountForecast(
+      [chequing, savings], transactions, 'month', ['acc-1', 'acc-2'],
+    );
+    const jan20 = on(result, '2025-01-20');
+    expect(jan20?.balances).toEqual({ 'acc-1': 700, 'acc-2': 800 });
+    expect(jan20?.balance).toBe(1500);
+  });
+
+  it('takes a transfer out to an unselected account off the total', () => {
+    const outside = makeAccount({ id: 'acc-3', name: 'Outside', currentBalance: 0 });
+    const transactions = [makeScheduled({
+      id: 'st-1', accountId: 'acc-1', amount: -300,
+      isTransfer: true, transferAccountId: 'acc-3',
+      frequency: 'ONCE', nextDueDate: '2025-01-20',
+    })];
+    const result = buildMultiAccountForecast(
+      [chequing, savings, outside], transactions, 'month', ['acc-1', 'acc-2'],
+    );
+    const jan20 = on(result, '2025-01-20');
+    expect(jan20?.balances).toEqual({ 'acc-1': 700, 'acc-2': 500 });
+    expect(jan20?.balance).toBe(1200);
+  });
+
+  it('layers future-dated posted transactions onto their own account', () => {
+    const future: FutureTransaction[] = [
+      { id: 'ft-1', accountId: 'acc-2', name: 'Bonus', amount: 250, date: '2025-01-20' },
+    ];
+    const result = buildMultiAccountForecast(
+      [chequing, savings], [], 'month', ['acc-1', 'acc-2'], future,
+    );
+    const jan20 = on(result, '2025-01-20');
+    expect(jan20?.balances).toEqual({ 'acc-1': 1000, 'acc-2': 750 });
+    expect(jan20?.balance).toBe(1750);
+  });
+
+  it('converts each account through its own currency', () => {
+    const accounts = [
+      makeAccount({ id: 'acc-1', name: 'CAD', currentBalance: 1000, currencyCode: 'CAD' }),
+      makeAccount({ id: 'acc-2', name: 'EUR', currentBalance: 500, currencyCode: 'EUR' }),
+    ];
+    const convert = (amount: number, currency: string) =>
+      currency === 'EUR' ? amount * 2 : amount;
+    const result = buildMultiAccountForecast(
+      accounts, [], 'month', ['acc-1', 'acc-2'], [], convert,
+    );
+    expect(result.points[0].balances).toEqual({ 'acc-1': 1000, 'acc-2': 1000 });
+    expect(result.points[0].balance).toBe(2000);
+  });
+
+  // A projected balance is cumulative: one missing rate makes every later day
+  // wrong, so no line is drawn at all rather than a plausible short one.
+  it('withholds every line and names the currency when one cannot convert', () => {
+    const accounts = [
+      makeAccount({ id: 'acc-1', name: 'CAD', currentBalance: 1000, currencyCode: 'CAD' }),
+      makeAccount({ id: 'acc-2', name: 'EUR', currentBalance: 500, currencyCode: 'EUR' }),
+    ];
+    const convert = (amount: number, currency: string) =>
+      currency === 'EUR' ? null : amount;
+    const result = buildMultiAccountForecast(
+      accounts, [], 'month', ['acc-1', 'acc-2'], [], convert,
+    );
+    expect(result).toEqual({ points: [], series: [], missingCurrencies: ['EUR'] });
+  });
+
+  it('ignores ids with no account behind them', () => {
+    const result = buildMultiAccountForecast(
+      [chequing, savings], [], 'month', ['acc-1', 'gone'],
+    );
+    expect(result.series).toEqual([{ accountId: 'acc-1', name: 'Chequing' }]);
+    expect(result.points[0].balances).toEqual({ 'acc-1': 1000 });
+  });
+
+  it('returns nothing when no selected id matches an account', () => {
+    const result = buildMultiAccountForecast([chequing], [], 'month', ['gone']);
+    expect(result).toEqual({ points: [], series: [], missingCurrencies: [] });
+  });
+
+  it('does not count a repeated id twice', () => {
+    const result = buildMultiAccountForecast(
+      [chequing, savings], [], 'month', ['acc-1', 'acc-1'],
+    );
+    expect(result.series).toEqual([{ accountId: 'acc-1', name: 'Chequing' }]);
+    expect(result.points[0].balance).toBe(1000);
+  });
+
+  it('remaps a scheduled investment onto its funding cash account', () => {
+    const brokerage = makeAccount({ id: 'acc-3', name: 'Brokerage', currentBalance: 0 });
+    const transactions = [makeScheduled({
+      id: 'st-1', accountId: 'acc-3', amount: -400,
+      isInvestment: true, investmentFundingAccountId: 'acc-1',
+      frequency: 'ONCE', nextDueDate: '2025-01-20',
+    } as Partial<ScheduledTransaction>)];
+    const result = buildMultiAccountForecast(
+      [chequing, savings, brokerage], transactions, 'month', ['acc-1', 'acc-2'],
+    );
+    const jan20 = on(result, '2025-01-20');
+    expect(jan20?.balances).toEqual({ 'acc-1': 600, 'acc-2': 500 });
   });
 });

--- a/frontend/src/lib/forecast.ts
+++ b/frontend/src/lib/forecast.ts
@@ -17,12 +17,42 @@ export interface ForecastTransaction {
   name: string;
   amount: number;
   scheduledTransactionId: string;
+  /**
+   * The account the amount moved. Only the multi-account forecast populates it,
+   * because only there can one point carry transactions from more than one
+   * account and the tooltip has to say which.
+   */
+  accountId?: string;
 }
 
 export interface ForecastDataPoint {
   date: string;
   balance: number;
   transactions: ForecastTransaction[];
+}
+
+/** One account's line in a multi-account forecast. */
+export interface ForecastAccountSeries {
+  accountId: string;
+  name: string;
+}
+
+/**
+ * A forecast point covering several accounts at once.
+ *
+ * `balance` is the "Total of Accounts" figure and is the sum of `balances` --
+ * summed from the same rounded per-account values the lines are drawn from, so
+ * the total on screen is exactly the total of the lines on screen rather than a
+ * separately rounded figure that can sit a cent away from them.
+ */
+export interface MultiAccountForecastPoint extends ForecastDataPoint {
+  balances: Record<string, number>;
+}
+
+export interface MultiAccountForecastResult {
+  points: MultiAccountForecastPoint[];
+  series: ForecastAccountSeries[];
+  missingCurrencies: string[];
 }
 
 /**
@@ -240,6 +270,34 @@ function normalizeInvestmentForForecast(
 }
 
 /**
+ * The active scheduled transactions that move `accountId`, each flagged with
+ * whether this account is the *destination* of a transfer -- the stored amount
+ * is the source's (negative), so the destination receives its negation.
+ *
+ * The single-account forecast and every line of the multi-account forecast go
+ * through this, so one account's projection cannot mean two different things
+ * depending on which chart drew it.
+ */
+function scheduledFlowsForAccount(
+  transactions: ScheduledTransaction[],
+  accountId: string,
+): Array<{ transaction: ScheduledTransaction; isInbound: boolean }> {
+  return transactions
+    .filter(
+      t =>
+        t.isActive &&
+        (t.accountId === accountId || (isTransfer(t) && t.transferAccountId === accountId)),
+    )
+    .map(transaction => ({
+      transaction,
+      isInbound:
+        isTransfer(transaction) &&
+        transaction.transferAccountId === accountId &&
+        transaction.accountId !== accountId,
+    }));
+}
+
+/**
  * Build forecast data points for the cash flow chart.
  *
  * futureTransactions: already-posted transactions with a date after today.
@@ -327,18 +385,16 @@ export function buildForecast(
   // Filter scheduled transactions by account
   // For a specific account, include transfers where this account is the destination
   // (transferAccountId) since those represent money coming IN to this account.
-  const relevantTransactions = accountId === 'all'
+  // Inbound transfers (this account is the destination) carry the source's
+  // negative amount, so they are negated below.
+  const relevantFlows = accountId === 'all'
     ? // Only target (non-closed) accounts: a schedule on a closed account is not
       // part of this forecast, and its currency is not in the map, so including
       // it would add an unconverted foreign amount to the running balance.
-      transactions.filter(t => t.isActive && !isTransfer(t) && targetAccountIds.has(t.accountId))
-    : transactions.filter(t => t.isActive && (t.accountId === accountId || (isTransfer(t) && t.transferAccountId === accountId)));
-
-  // Track which transactions are inbound transfers (destination account matches)
-  // so we can negate their amounts (source amount is negative, destination receives positive)
-  const inboundTransferIds = accountId !== 'all'
-    ? new Set(transactions.filter(t => t.isActive && isTransfer(t) && t.transferAccountId === accountId && t.accountId !== accountId).map(t => t.id))
-    : new Set<string>();
+      transactions
+        .filter(t => t.isActive && !isTransfer(t) && targetAccountIds.has(t.accountId))
+        .map(transaction => ({ transaction, isInbound: false }))
+    : scheduledFlowsForAccount(transactions, accountId);
 
   // Generate all occurrences and group by date
   const transactionsByDate = new Map<string, ForecastTransaction[]>();
@@ -354,9 +410,8 @@ export function buildForecast(
     transactionsByDate.set(ft.date, existing);
   }
 
-  for (const tx of relevantTransactions) {
+  for (const { transaction: tx, isInbound } of relevantFlows) {
     const occurrences = generateOccurrences(tx, today, endDate);
-    const isInbound = inboundTransferIds.has(tx.id);
     const txAccountId = isInbound ? (tx.transferAccountId ?? tx.accountId) : tx.accountId;
     for (const occ of occurrences) {
       const existing = transactionsByDate.get(occ.date) || [];
@@ -413,6 +468,167 @@ export function buildForecast(
     return { points: [], missingCurrencies: [...missingRateCurrencies] };
   }
   return { points: dataPoints, missingCurrencies: [] };
+}
+
+/**
+ * Build one forecast line per selected account, plus the "Total of Accounts"
+ * line that is their sum.
+ *
+ * Each line uses the same rules as the single-account forecast
+ * (`scheduledFlowsForAccount`): the account's own schedules, plus transfers
+ * where it is the destination. So a transfer between two selected accounts
+ * moves both lines and nets to zero in the total -- which is what a total of
+ * those accounts means -- while a transfer out to an account that is not
+ * selected leaves the total, as it should.
+ *
+ * Every line shares one y-axis, so every line is in one currency: each
+ * account's balances and amounts are converted into the display currency
+ * through `convertAmount`. As in `buildForecast`, a projected balance is
+ * cumulative, so one missing rate withholds the whole result rather than
+ * drawing a plausible line.
+ *
+ * `accountIds` order is preserved: it is the order the legend reads and the
+ * order colours are assigned in, and the caller -- not this function -- knows
+ * how its account picker sorts.
+ */
+export function buildMultiAccountForecast(
+  accounts: Account[],
+  transactions: ScheduledTransaction[],
+  period: ForecastPeriod,
+  accountIds: string[],
+  futureTransactions: FutureTransaction[] = [],
+  convertAmount?: (amount: number, currencyCode: string) => number | null,
+): MultiAccountForecastResult {
+  const accountsById = new Map(accounts.map(a => [a.id, a]));
+  const normalized = transactions.map(t => normalizeInvestmentForForecast(t, accountsById));
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const todayKey = formatDateKey(today);
+
+  const days = FORECAST_PERIOD_DAYS[period];
+  const endDate = new Date(today);
+  endDate.setDate(endDate.getDate() + days);
+  const granularity = getGranularity(period);
+
+  const targetAccounts = [...new Set(accountIds)]
+    .map(id => accountsById.get(id))
+    .filter((a): a is Account => a !== undefined);
+
+  if (targetAccounts.length === 0) {
+    return { points: [], series: [], missingCurrencies: [] };
+  }
+
+  // An unknown rate contributes nothing and sets the flag; the whole result is
+  // withheld below rather than reported as a shorter, wrong series.
+  const missingRateCurrencies = new Set<string>();
+  const conv = (amount: number, currencyCode: string): number => {
+    if (!convertAmount) return amount;
+    const converted = convertAmount(amount, currencyCode);
+    if (converted === null) {
+      missingRateCurrencies.add(currencyCode);
+      return 0;
+    }
+    return converted;
+  };
+
+  const startingBalances = new Map<string, number>();
+  const flowsByAccount = new Map<string, Map<string, ForecastTransaction[]>>();
+
+  for (const account of targetAccounts) {
+    startingBalances.set(
+      account.id,
+      conv(Number(account.currentBalance), account.currencyCode),
+    );
+
+    const byDate = new Map<string, ForecastTransaction[]>();
+    const add = (date: string, entry: ForecastTransaction) => {
+      byDate.set(date, [...(byDate.get(date) ?? []), entry]);
+    };
+
+    // currentBalance excludes future-dated posted transactions, so they are
+    // layered onto their own dates -- same as the single-account forecast.
+    for (const ft of futureTransactions) {
+      if (ft.accountId !== account.id || ft.date <= todayKey) continue;
+      add(ft.date, {
+        name: ft.name,
+        amount: conv(ft.amount, account.currencyCode),
+        scheduledTransactionId: ft.id,
+        accountId: account.id,
+      });
+    }
+
+    for (const { transaction, isInbound } of scheduledFlowsForAccount(normalized, account.id)) {
+      for (const occ of generateOccurrences(transaction, today, endDate)) {
+        add(occ.date, {
+          name: transaction.name,
+          amount: conv(isInbound ? -occ.amount : occ.amount, account.currencyCode),
+          scheduledTransactionId: transaction.id,
+          accountId: account.id,
+        });
+      }
+    }
+
+    flowsByAccount.set(account.id, byDate);
+  }
+
+  const running = new Map<string, number>(startingBalances);
+  const points: MultiAccountForecastPoint[] = [];
+  let lastAddedTime: number | null = null;
+
+  for (let dayOffset = 0; dayOffset <= days; dayOffset++) {
+    const currentDate = new Date(today.getTime());
+    currentDate.setDate(today.getDate() + dayOffset);
+    const currentTime = currentDate.getTime();
+    const dateKey = formatDateKey(currentDate);
+
+    const dayTransactions: ForecastTransaction[] = [];
+    for (const account of targetAccounts) {
+      const dayFlows = flowsByAccount.get(account.id)?.get(dateKey);
+      if (!dayFlows) continue;
+      running.set(
+        account.id,
+        dayFlows.reduce((sum, tx) => sum + tx.amount, running.get(account.id) ?? 0),
+      );
+      dayTransactions.push(...dayFlows);
+    }
+
+    const daysSinceLastPoint = lastAddedTime === null
+      ? granularity
+      : Math.floor((currentTime - lastAddedTime) / (1000 * 60 * 60 * 24));
+    const shouldAddPoint = daysSinceLastPoint >= granularity;
+    const isLastDay = dayOffset === days;
+
+    if (shouldAddPoint || dayTransactions.length > 0 || isLastDay) {
+      // Integer cents: the total is summed from the same rounded per-account
+      // figures the lines are drawn from, so the total on screen is exactly the
+      // total of the lines on screen.
+      const balances: Record<string, number> = {};
+      let totalCents = 0;
+      for (const account of targetAccounts) {
+        const cents = Math.round((running.get(account.id) ?? 0) * 100);
+        balances[account.id] = cents / 100;
+        totalCents += cents;
+      }
+      points.push({
+        date: dateKey,
+        balance: totalCents / 100,
+        balances,
+        transactions: dayTransactions,
+      });
+      lastAddedTime = currentTime;
+    }
+  }
+
+  if (missingRateCurrencies.size > 0) {
+    return { points: [], series: [], missingCurrencies: [...missingRateCurrencies] };
+  }
+
+  return {
+    points,
+    series: targetAccounts.map(a => ({ accountId: a.id, name: a.name })),
+    missingCurrencies: [],
+  };
 }
 
 /**


### PR DESCRIPTION
## Linked discussion / issue

Closes #1178 
Approved in: #1178

## Summary

The Bills & Deposits Cash Flow Forecast could show one account or all of them summed into a single line. Comparing two accounts meant switching back and forth and holding the shapes in your head.

The account picker is now the shared `MultiSelect`. No selection still means every account, drawn as one filled line exactly as before. Pick two or more and the chart draws an unfilled coloured line per account plus a **Total of Accounts** line that keeps the gradient-filled area the single-account view has always had, so the familiar shape still means the same thing. Hovering anywhere on the plot names every selected account with its balance at that point, and says which account each listed transaction moved.

**`buildMultiAccountForecast`** (`frontend/src/lib/forecast.ts`) is the new builder. Each line uses the rules the single-account forecast already used — extracted as `scheduledFlowsForAccount` and now shared by both, so one account's projection cannot mean two different things depending on which chart drew it: the account's own schedules, plus transfers where it is the destination. Consequences worth reviewing:

- A transfer **between two selected accounts** moves both lines and nets to zero in the total, which is what a total of those accounts means. One leaving the selection leaves the total.
- The total is summed in **integer cents from the same rounded per-account figures the lines are drawn from**, so the total on screen is exactly the total of the lines on screen, not a separately rounded figure a cent away from them.
- Every line shares one y-axis, so every line is converted into one currency. As with the single-account forecast, **one missing rate withholds every line and the total together** — a running balance is cumulative, and the accounts that did convert are not a smaller forecast, they are a total labelled as something it is not.

**`chartSeriesColorAsidePrimary`** (`frontend/src/lib/chart-colors.ts`) is new. `--chart-1` is the theme accent in every palette in `themes.css`, and so is `--chart-primary` — so a member series starting at palette slot 0 would take the total line's own colour in the chart, the legend and the tooltip alike. The helper excludes that slot from the cycle rather than deferring it, because a modulo over the full palette gives it back on the tenth series: the same collision, arriving late.

The stored selection moves to `cashFlowForecast.accountIds`; the previous single-id key is read as a fallback so an existing choice carries forward, and a stored `'all'` still means all. Stored ids for accounts that are no longer on offer are ignored rather than silently narrowing the forecast to nothing.

Two rules were written into `frontend/CLAUDE.md`: the colour-collision one above, and an extension of the cumulative-series rule to name the new builder.

## Checklist

- [x] An approved discussion or issue exists and is linked above. — **no**, see above; requested directly by the repository owner.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement. — the only shared touch is an *additive* helper in `chart-colors.ts`; no existing export changed behaviour.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

### Tests

44 new tests, added with the behaviour they cover:

- **`forecast.test.ts`** (18) — transfers inside and out of the selection, per-account currency conversion, cent-accurate totalling (`1000.125 + 2000.125` must be `3000.26`, not `3000.25`), missing rates withholding everything, stale and duplicated ids, investment funding-account remap.
- **`CashFlowForecastChart.test.tsx`** (20) — one line per account with a `dataKey` that is *resolved against the data* rather than merely string-compared, unfilled member lines, distinct colours none of which is the total's, the total keeping its fill, the legend, the tooltip's per-account rows and account-tagged transactions, storage migration from the single-id key, and the picker no longer offering the favourites separator as a selectable account.
- **`chart-colors.test.ts`** (6, new file) — pins both halves of the colour-slot rule.

`npm run type-check`, `npm run lint`, `npm run i18n:check` and the full `TZ=UTC npx vitest run` (676 files, 13291 tests) all pass.

### i18n

Four new `bills.forecast.*` strings, translated for all 18 locales that carry a catalog. `en-CA`, `en-GB` and `en-US` ship nothing, because none of these strings differ from the `en` base they inherit from; `xx` was regenerated. Each locale uses the terms its own catalog already uses for "account" and "total" rather than a fresh rendering — `ja` and `zh-TW` keep 勘定科目 / 科目, `pl` keeps *Suma*, `ru` *Итого*, `uk` *Разом*. `tooltipTransactionForAccount` is `{name} ({account})` everywhere: it is punctuation around two placeholders, and it lives in the catalog rather than in JSX precisely so a translator can reorder it if theirs needs it.

### Worth a reviewer's eye

The chart itself is only covered by tests against a mocked `recharts`, so the visual result is unverified in a browser. The specific things a real render would confirm: `ComposedChart` layering the `Area` under the `Line`s, and the `balances.<uuid>` dot-path `dataKey` resolving (recharts reads it through lodash `get`, and account ids are UUIDs, so no path characters — but that is reasoning, not observation).

## AI assistance disclosure

Written by Claude Code (Claude Opus) in a Claude Code on the web session, from a prompt by @kenlasko describing the desired behaviour. All design decisions above — the per-account transfer semantics, the cent-wise totalling, the colour-slot exclusion, the storage migration — were made by the model and are stated here so they can be checked rather than assumed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7t345UMxfCjGU5V1hfRu7)_