### PR TITLE
Fix trade cash legs and register ordering for imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,6 +478,30 @@ Nested totals need their own answer, too. A per-account total is converted into 
 different conversion graphs, so a portfolio can be complete at the top and
 unconvertible underneath. A global flag cannot speak for a total it did not compute.
 
+### `created_at` cannot order rows written in one transaction
+
+`CURRENT_TIMESTAMP` is **transaction start time** in PostgreSQL, and TypeORM
+leans on that column default rather than sending a per-row value. So every row a
+single transaction writes -- a whole `.mny` import, a whole restore -- carries
+the *same* `created_at`, and any ordering that tiebreaks on it falls through to
+whatever comes next. In the register that was `id`, a random UUID: same-day
+imported rows were listed in an arbitrary order.
+
+Nothing about a stored balance depends on that, which is why it survived; the
+running balance beside it does. A purchase and the transfer that funded it on
+the same day are two rows, and with the debit ordered first the register shows
+the account overdrawn on a day it was never short -- recovering one row later,
+so it reads as a broken balance rather than a broken sort.
+
+When the clock cannot separate two rows, their signs do: **credits are ordered
+before debits, chronologically**, which for a newest-first list means the
+tiebreak runs *opposite* to the list direction. `applyRegisterOrder`
+(`backend/src/transactions/register-order.ts`) is the only place that order is
+written -- and the reason it has to be one place is that three of its four call
+sites are not the register at all, but the queries that sum the rows on previous
+pages to find where page N's running balance starts. A tiebreak added to the
+register alone re-splits the pages under those sums.
+
 ### The difference of two 4dp decimals is not a 4dp decimal
 
 `roundMoney` the delta, not just its operands. `newAmount - oldAmount` on two

--- a/backend/src/import/mny/README.md
+++ b/backend/src/import/mny/README.md
@@ -123,6 +123,31 @@ So when a mapper is about to warn that it cannot represent something, check firs
 right answer is to *create* the row Monize needs rather than to report the mismatch. A warning
 about 3,255 rows the user cannot act on is a sign the mapping is wrong, not that the file is.
 
+### And the same gap read the other way: a row Money *does* store may be one Monize writes anyway
+
+The mirror of the rule above, and the way it goes wrong. When a trade is funded from the
+brokerage's **own** cash companion, Money already has the cash-side row -- an ordinary `TRN` in
+the companion account, paired to the trade through `TRN_XFER`. Monize writes that row itself, from
+the investment transaction's `cashAmount`, so importing Money's copy as well is one payment
+recorded twice.
+
+It presented as three rows in the cash register where Money shows one (issue #1175): the purchase,
+a transfer in and a transfer out. The two extras are Money's row plus the counterpart
+`buildCashCounterparts` synthesized for it, which for this shape lands in that row's *own*
+account -- so they cancelled, every balance reconciled, and nothing in the verification report
+could see it. `tradeCashLegRows` (`map/map-transactions.ts`) names those rows and they are not
+imported; because membership in that set is exactly "its synthesized counterpart mirrored it into
+its own account", dropping the pair cannot move a balance.
+
+Two things generalize. **A counterpart that lands in the account it came from is not a
+counterpart**, whatever the code that built it thinks. And **a pair of rows that cancel is
+invisible to every check that reconciles a total** -- the row count is the assertion that catches
+it, which is why `map/trade-cash-legs.spec.ts` asserts the count and the balance together.
+
+The rule is deliberately confined to *top-level* rows. A split **leg** in the sleeve pointing at a
+trade is a different shape: its parent has already taken the cash out, so there the synthesized
+counterpart is what stops the trade's own leg debiting the sleeve twice, and it stays.
+
 ## Traps
 
 - **Page 0 is obfuscated.** Jet XORs bytes `0x18..0x95` of the header page with a fixed mask. The

--- a/backend/src/import/mny/map/map-investments.ts
+++ b/backend/src/import/mny/map/map-investments.ts
@@ -118,7 +118,7 @@ function warningRow(
     date: row.date,
     amount: row.amount,
     payeeHandle: row.payee,
-    reference: decodeReference(row.reference, row.flags),
+    reference: decodeReference(row.reference),
     memo: row.memo,
   };
 }

--- a/backend/src/import/mny/map/map-loans.spec.ts
+++ b/backend/src/import/mny/map/map-loans.spec.ts
@@ -121,6 +121,7 @@ function transactionsFixture(
     transfersLinked: 0,
     skipped: 0,
     deferredInvestments: 0,
+    tradeCashLegs: 0,
     warnings: [],
   };
 }

--- a/backend/src/import/mny/map/map-transactions.spec.ts
+++ b/backend/src/import/mny/map/map-transactions.spec.ts
@@ -368,6 +368,33 @@ describe("mapTransactions", () => {
       });
     });
 
+    it("keeps the payment number on a loan-account row", () => {
+      // Issue #1174: the loan side of a mortgage payment is imported as an
+      // ordinary row in the loan account, and its `szId` is Money's "Pmt Num".
+      // Decoding it against `grftt & 0x80` returned null, so the Ref. num.
+      // column was empty for every payment of every loan in the file.
+      const result = mapTransactions(
+        input({
+          transactions: transactionData({
+            transactions: [
+              mnyTransaction({
+                handle: 1,
+                account: 9,
+                amount: 412.6,
+                flags: LOAN_PAYMENT_FLAGS,
+                reference: "0          14",
+              }),
+            ],
+          }),
+        }),
+      );
+
+      expect(result.transactions[0]).toMatchObject({
+        accountKey: "acct-9",
+        referenceNumber: "14",
+      });
+    });
+
     it("gives every transaction a distinct pre-generated id", () => {
       const result = mapTransactions(
         input({

--- a/backend/src/import/mny/map/map-transactions.ts
+++ b/backend/src/import/mny/map/map-transactions.ts
@@ -100,7 +100,7 @@ function warningRow(
     date: row.date,
     amount: row.amount,
     payeeHandle: row.payee,
-    reference: decodeReference(row.reference, row.flags),
+    reference: decodeReference(row.reference),
     memo: row.memo,
   };
 }
@@ -111,8 +111,16 @@ interface Indexes {
   readonly childrenByParent: ReadonlyMap<number, MnyTransaction[]>;
   readonly billTemplates: ReadonlySet<number>;
   readonly transfers: TransferIndex;
+  /**
+   * Rows that are Money's own copy of a trade's cash leg, which Monize writes
+   * from the investment transaction instead. See `tradeCashLegRows`.
+   */
+  readonly tradeCashLegs: ReadonlySet<number>;
   readonly warnings: MnyWarning[];
 }
+
+/** Everything the posting predicate reads before `tradeCashLegs` can exist. */
+type PostingIndexes = Omit<Indexes, "tradeCashLegs">;
 
 function buildIndexes(input: MapTransactionsInput): Indexes {
   const warnings: MnyWarning[] = [];
@@ -154,7 +162,7 @@ function buildIndexes(input: MapTransactionsInput): Indexes {
     ]);
   }
 
-  return {
+  const base: PostingIndexes = {
     byHandle,
     parentOfChild,
     childrenByParent,
@@ -165,19 +173,24 @@ function buildIndexes(input: MapTransactionsInput): Indexes {
     transfers: indexTransfers(input.transactions.transfers, rows),
     warnings,
   };
+
+  return { ...base, tradeCashLegs: tradeCashLegRows(rows, base, input) };
 }
 
 /**
- * Whether a row is a real posting worth importing as a banking transaction.
+ * Whether a row is a posting at all, before the trade-cash-leg rule.
  *
  * Split children, bill templates, recurrence templates (`frq != -1`),
  * loan-payment templates, scheduled instances Money never posted and genuinely
  * orphaned transfer sides are out. Scheduler-posted rows are **in**: they are
  * real postings, and excluding them emptied PR #192's loan accounts.
+ *
+ * Separate from `isImportablePosting` only because `tradeCashLegRows` has to
+ * ask this question in order to answer the other one.
  */
-function isImportablePosting(
+function isPostingRow(
   row: MnyTransaction,
-  indexes: Indexes,
+  indexes: PostingIndexes,
   input: MapTransactionsInput,
 ): boolean {
   const handle = row.handle;
@@ -194,6 +207,82 @@ function isImportablePosting(
     row.account !== null &&
     input.accountKeyByHandle.has(row.account)
   );
+}
+
+/**
+ * Whether a row is a real posting worth importing as a banking transaction:
+ * a posting that Monize is not already writing from somewhere else.
+ */
+function isImportablePosting(
+  row: MnyTransaction,
+  indexes: Indexes,
+  input: MapTransactionsInput,
+): boolean {
+  return (
+    isPostingRow(row, indexes, input) &&
+    !indexes.tradeCashLegs.has(row.handle as number)
+  );
+}
+
+/**
+ * Rows that are Money's own record of the cash half of a trade in the paired
+ * brokerage account.
+ *
+ * Money keeps an investment account's cash in a companion account and writes
+ * the cash side of a trade there as an ordinary `TRN` row, paired to the trade
+ * through `TRN_XFER` -- `act` 1 has one 2,015 times in 2,029 and `act` 3 1,090
+ * times in 1,090. Monize does not need that row: `writeInvestments` creates the
+ * sleeve transaction itself from the investment row's `cashAmount`, and links
+ * the two through `investment_transactions.transaction_id`.
+ *
+ * Importing it anyway put the same payment in the cash register three times --
+ * the purchase, a transfer in and a transfer out -- where Money shows one
+ * (issue #1175). The pair of extra rows is this row plus the counterpart
+ * `buildCashCounterparts` synthesized for it, which for these rows lands in the
+ * row's **own** account.
+ *
+ * That is also why dropping them cannot move a balance: a row belongs to this
+ * set exactly when its synthesized counterpart mirrors it into the same
+ * account, so the two always summed to zero. What changes is the row count, not
+ * the money -- whatever the investment mapper then does with the trade, whether
+ * it writes a cash leg, maps it to an action that moves none, or skips it
+ * outright.
+ *
+ * **Top-level rows only.** A split *leg* in the sleeve pointing at a trade is a
+ * different shape: its parent has already taken the cash out of the sleeve, so
+ * there the synthesized counterpart is what keeps the balance right and must
+ * stay.
+ */
+function tradeCashLegRows(
+  rows: readonly MnyTransaction[],
+  indexes: PostingIndexes,
+  input: MapTransactionsInput,
+): ReadonlySet<number> {
+  const handles = new Set<number>();
+
+  for (const row of rows) {
+    if (!isPostingRow(row, indexes, input)) {
+      continue;
+    }
+    const handle = row.handle as number;
+    const partner = indexes.transfers.partnerByHandle.get(handle);
+    const far =
+      partner === undefined ? undefined : indexes.byHandle.get(partner);
+    if (!far || far.security === null || far.account === null) {
+      continue;
+    }
+
+    const brokerageKey = input.accountKeyByHandle.get(far.account);
+    const cashKey =
+      brokerageKey === undefined
+        ? undefined
+        : input.cashKeyByAccountKey.get(brokerageKey);
+    if (cashKey !== undefined && cashKey === accountKeyOf(row, input)) {
+      handles.add(handle);
+    }
+  }
+
+  return handles;
 }
 
 /**
@@ -214,6 +303,11 @@ function isImportablePosting(
  * So the missing side is synthesized here, in the sleeve, linked to the bank
  * row both ways. The sleeve then nets out: the transfer pays cash in, the
  * trade's own leg takes it out.
+ *
+ * A near side already *in* that sleeve needs none of this, and gets none: those
+ * rows are `tradeCashLegs`, so `isImportablePosting` rejects them and `nearId`
+ * is undefined before the far side is ever looked at. A synthesized row
+ * mirroring its own account is what issue #1175 saw in the register.
  */
 function buildCashCounterparts(
   rows: readonly MnyTransaction[],
@@ -421,14 +515,21 @@ function mapOne(
     // A split parent carries no category of its own: the legs do.
     categoryHandle: splits.length > 0 ? null : row.category,
     description: row.memo,
-    referenceNumber: decodeReference(row.reference, row.flags),
+    referenceNumber: decodeReference(row.reference),
     isTransfer: linkedTransactionId !== null,
     linkedTransactionId,
     splits,
   };
 }
 
-/** Rows a real posting could not be made of, reported once each. */
+/**
+ * Rows a real posting could not be made of, reported once each.
+ *
+ * A `tradeCashLegs` row is not one of them and deliberately raises nothing: it
+ * is a perfectly usable posting that Monize writes from the trade instead, so
+ * counting it as skipped would report data loss that did not happen. Its own
+ * count travels as `MappedTransactions.tradeCashLegs`.
+ */
 function reportUnusable(
   rows: readonly MnyTransaction[],
   indexes: Indexes,
@@ -591,6 +692,7 @@ export function mapTransactions(
     referencedCategories,
     transfersLinked: countPlainTransferPairs(context) + transferSplits,
     skipped: reportUnusable(rows, indexes, input, warnings),
+    tradeCashLegs: indexes.tradeCashLegs.size,
     deferredInvestments: rows.filter(
       (row) =>
         row.security !== null &&

--- a/backend/src/import/mny/map/trade-cash-legs.spec.ts
+++ b/backend/src/import/mny/map/trade-cash-legs.spec.ts
@@ -1,0 +1,304 @@
+import { InvestmentAction } from "../../../securities/entities/investment-transaction.entity";
+import {
+  investmentData,
+  mnyAccount,
+  mnyInvestmentDetail,
+  mnySecurity,
+  mnySplit,
+  mnyTransaction,
+  mnyTransfer,
+  referenceData,
+  transactionData,
+} from "../__fixtures__/mny-row-builders";
+import { MnyTransactionData } from "../tables/read-transactions";
+import { MnyInvestmentData } from "../tables/read-investments";
+import { DEFAULT_MNY_IMPORT_OPTIONS } from "../model/mny-import-options";
+import { MNY_ACTION } from "../model/mny-model";
+import { computeExpectedBalances } from "../mny-parser.service";
+import { mapAccounts, cashKeyByAccountKey } from "./map-reference";
+import { mapSecurities } from "./map-securities";
+import { mapTransactions } from "./map-transactions";
+import { mapInvestments } from "./map-investments";
+
+/**
+ * Issue #1175: what the cash register of a brokerage account ends up holding.
+ *
+ * Money keeps an investment account's cash in a companion account and records
+ * the cash half of a trade there as an ordinary `TRN` row paired to the trade
+ * through `TRN_XFER`. Monize writes that row itself, from the investment
+ * transaction, so importing Money's copy as well produced three rows where
+ * Money shows one: the purchase, plus a transfer in and a transfer out that
+ * cancelled each other.
+ *
+ * The cancellation is why no balance check caught it, and it is also what makes
+ * the fix safe -- so these tests assert the row count **and** the balance
+ * together. Either one alone was satisfied by the defect.
+ *
+ * The two mappers are exercised together on purpose: neither can see this on
+ * its own, because the duplication is one mapper writing what the other already
+ * wrote.
+ */
+
+/** `hacct` 1 chequing, 5 the brokerage, 6 the cash companion Money pairs it with. */
+const CHEQUING = 1;
+const BROKERAGE = 5;
+const SLEEVE = 6;
+const SECURITY = 9;
+
+const SLEEVE_OPENING = 5_000;
+const PURCHASE = 2_400;
+
+function accounts() {
+  return mapAccounts(
+    referenceData({
+      accounts: [
+        mnyAccount({ handle: CHEQUING, type: 0, name: "Chequing" }),
+        mnyAccount({
+          handle: BROKERAGE,
+          type: 5,
+          name: "Brokerage",
+          relatedAccount: SLEEVE,
+        }),
+        mnyAccount({
+          handle: SLEEVE,
+          type: 0,
+          name: "Brokerage (Cash)",
+          relatedAccount: BROKERAGE,
+          openingBalance: SLEEVE_OPENING,
+        }),
+      ],
+    }),
+    DEFAULT_MNY_IMPORT_OPTIONS,
+    "USD",
+  );
+}
+
+function securities() {
+  return mapSecurities({
+    securities: [mnySecurity({ handle: SECURITY, symbol: "VOO" })],
+    currencyByHandle: new Map(),
+    baseCurrency: "USD",
+    activeHandles: new Set([SECURITY]),
+  });
+}
+
+/** The `TRN_INV` detail of the one purchase every fixture here makes. */
+function purchaseDetail(handle: number): MnyInvestmentData {
+  return investmentData({
+    securities: [mnySecurity({ handle: SECURITY, symbol: "VOO" })],
+    investmentDetails: [
+      mnyInvestmentDetail({ transaction: handle, price: 240, quantity: 10 }),
+    ],
+  });
+}
+
+/** Runs the whole banking + investment mapping the way the parser does. */
+function mapAll(
+  transactions: MnyTransactionData,
+  investmentTables: MnyInvestmentData,
+) {
+  const mappedAccounts = accounts();
+  const mappedSecurities = securities();
+
+  const banking = mapTransactions({
+    transactions,
+    accountKeyByHandle: mappedAccounts.keyByHandle,
+    currencyByHandle: mappedAccounts.currencyByHandle,
+    bills: [],
+    cashKeyByAccountKey: cashKeyByAccountKey(mappedAccounts),
+  });
+  const investments = mapInvestments({
+    transactions,
+    investments: investmentTables,
+    accounts: mappedAccounts,
+    securities: mappedSecurities,
+    bills: [],
+  });
+
+  return {
+    banking,
+    investments,
+    /** Every row that will exist in the sleeve, from both writers. */
+    sleeveRows: [
+      ...banking.transactions.filter((row) => row.accountKey === "acct-6"),
+      ...investments.transactions.filter(
+        (row) => row.cashAccountKey === "acct-6" && row.cashAmount !== 0,
+      ),
+    ],
+    balances: computeExpectedBalances(
+      mappedAccounts,
+      banking,
+      "2099-12-31",
+      investments,
+    ),
+  };
+}
+
+describe("a trade funded from the brokerage's own cash account", () => {
+  /**
+   * Money's shape: the trade in the brokerage, its cash half in the companion
+   * account, paired through `TRN_XFER`.
+   */
+  const moneyRows = transactionData({
+    transactions: [
+      mnyTransaction({
+        handle: 20,
+        account: SLEEVE,
+        amount: -PURCHASE,
+        memo: "Buy VOO",
+      }),
+      mnyTransaction({
+        handle: 21,
+        account: BROKERAGE,
+        amount: PURCHASE,
+        security: SECURITY,
+        action: MNY_ACTION.BUY,
+      }),
+    ],
+    transfers: [mnyTransfer({ from: 20, to: 21 })],
+  });
+
+  it("puts exactly one row in the cash register, the trade's own leg", () => {
+    const { banking, investments, sleeveRows } = mapAll(
+      moneyRows,
+      purchaseDetail(21),
+    );
+
+    // Money's copy of the cash leg is not imported: the investment writer
+    // creates that row, linked to the trade through `transaction_id`.
+    expect(banking.transactions).toEqual([]);
+    expect(banking.tradeCashLegs).toBe(1);
+
+    expect(sleeveRows).toHaveLength(1);
+    expect(investments.transactions).toHaveLength(1);
+    expect(investments.transactions[0]).toMatchObject({
+      accountKey: "acct-5",
+      action: InvestmentAction.BUY,
+      cashAccountKey: "acct-6",
+      cashAmount: -PURCHASE,
+      totalAmount: PURCHASE,
+    });
+  });
+
+  it("moves the cash balance exactly once", () => {
+    // The defect was invisible to this assertion alone -- the imported row and
+    // its synthesized mirror summed to zero -- which is the whole reason the
+    // row count above is asserted beside it.
+    const { balances } = mapAll(moneyRows, purchaseDetail(21));
+
+    expect(balances.get("acct-6")).toBe(SLEEVE_OPENING - PURCHASE);
+    // The brokerage side holds shares, never cash.
+    expect(balances.get("acct-5")).toBe(0);
+  });
+
+  it("reports no warning, because nothing about the file is wrong", () => {
+    const { banking, investments } = mapAll(moneyRows, purchaseDetail(21));
+
+    expect(banking.warnings).toEqual([]);
+    expect(investments.warnings).toEqual([]);
+    expect(banking.skipped).toBe(0);
+    // There is no transfer here: one movement of cash, recorded by the trade.
+    expect(banking.transfersLinked).toBe(0);
+  });
+});
+
+describe("a trade funded from an outside account", () => {
+  /**
+   * The other shape, and the one `buildCashCounterparts` exists for: the far
+   * side of the transfer is the trade itself, so Monize has to synthesize the
+   * cash arriving in the sleeve. Money shows two rows in the cash register for
+   * this -- the transfer in, then the purchase -- and so does Monize.
+   */
+  const moneyRows = transactionData({
+    transactions: [
+      mnyTransaction({ handle: 20, account: CHEQUING, amount: -PURCHASE }),
+      mnyTransaction({
+        handle: 21,
+        account: BROKERAGE,
+        amount: PURCHASE,
+        security: SECURITY,
+        action: MNY_ACTION.BUY,
+      }),
+    ],
+    transfers: [mnyTransfer({ from: 20, to: 21 })],
+  });
+
+  it("still synthesizes the cash arriving in the sleeve", () => {
+    const { banking, sleeveRows, balances } = mapAll(
+      moneyRows,
+      purchaseDetail(21),
+    );
+
+    expect(banking.tradeCashLegs).toBe(0);
+    expect(sleeveRows).toHaveLength(2);
+    expect(
+      banking.transactions.find((row) => row.accountKey === "acct-6"),
+    ).toMatchObject({ amount: PURCHASE, isTransfer: true });
+
+    // Cash in, cash out: the sleeve ends where it started and the chequing
+    // account paid for the shares.
+    expect(balances.get("acct-6")).toBe(SLEEVE_OPENING);
+    expect(balances.get("acct-1")).toBe(-PURCHASE);
+  });
+});
+
+describe("cash moved into the sleeve without a trade", () => {
+  it("imports both sides of an ordinary transfer into the cash account", () => {
+    // Neither side carries a security, so this is a plain transfer between two
+    // accounts and none of the trade-cash-leg reasoning applies to it.
+    const { banking, balances } = mapAll(
+      transactionData({
+        transactions: [
+          mnyTransaction({ handle: 20, account: CHEQUING, amount: -1_000 }),
+          mnyTransaction({ handle: 21, account: SLEEVE, amount: 1_000 }),
+        ],
+        transfers: [mnyTransfer({ from: 20, to: 21 })],
+      }),
+      investmentData(),
+    );
+
+    expect(banking.tradeCashLegs).toBe(0);
+    expect(banking.transactions).toHaveLength(2);
+    expect(banking.transfersLinked).toBe(1);
+    expect(balances.get("acct-6")).toBe(SLEEVE_OPENING + 1_000);
+  });
+});
+
+describe("a split in the sleeve with a leg paying for a trade", () => {
+  it("keeps the synthesized counterpart, which is what balances the parent", () => {
+    // A split *leg* is a different shape from a top-level row: the parent has
+    // already taken the whole amount out of the sleeve, so the counterpart put
+    // back in is what stops the trade's own leg debiting it twice. Dropping it
+    // the way a top-level row is dropped would leave the sleeve short by the
+    // purchase.
+    const { banking, balances } = mapAll(
+      transactionData({
+        transactions: [
+          mnyTransaction({ handle: 20, account: SLEEVE, amount: -2_500 }),
+          mnyTransaction({ handle: 21, account: SLEEVE, amount: -PURCHASE }),
+          mnyTransaction({ handle: 22, account: SLEEVE, amount: -100 }),
+          mnyTransaction({
+            handle: 23,
+            account: BROKERAGE,
+            amount: PURCHASE,
+            security: SECURITY,
+            action: MNY_ACTION.BUY,
+          }),
+        ],
+        splits: [
+          mnySplit({ parent: 20, child: 21, position: 0 }),
+          mnySplit({ parent: 20, child: 22, position: 1 }),
+        ],
+        transfers: [mnyTransfer({ from: 21, to: 23 })],
+      }),
+      purchaseDetail(23),
+    );
+
+    expect(banking.tradeCashLegs).toBe(0);
+    expect(banking.transactions.find((row) => row.handle === 23)).toMatchObject(
+      { accountKey: "acct-6", amount: PURCHASE },
+    );
+    // 5,000 - 2,500 (the split) + 2,400 (the counterpart) - 2,400 (the trade).
+    expect(balances.get("acct-6")).toBe(SLEEVE_OPENING - 2_500);
+  });
+});

--- a/backend/src/import/mny/mny-inspect.ts
+++ b/backend/src/import/mny/mny-inspect.ts
@@ -258,7 +258,7 @@ export function mappingSummary(tables: MnyTables): string[] {
     `  split legs:      ${signs(splitAmounts)}`,
     `  investment cash: ${signs(investmentCash)}`,
     `  accounts:        ${accounts.accounts.length} (${accounts.skipped} skipped)`,
-    `  transactions:    ${transactions.transactions.length} (${transactions.transfersLinked} transfers linked, ${transactions.skipped} skipped)`,
+    `  transactions:    ${transactions.transactions.length} (${transactions.transfersLinked} transfers linked, ${transactions.skipped} skipped, ${transactions.tradeCashLegs} cash rows written by their trade)`,
     `  securities:      ${securities.securities.length} (${securities.skipped} skipped as currencies or unusable)`,
     `  investments:     ${investments.transactions.length} (${investments.transfersPaired} share transfers paired, ${investments.skipped} skipped)`,
     "",

--- a/backend/src/import/mny/mny-parser.service.spec.ts
+++ b/backend/src/import/mny/mny-parser.service.spec.ts
@@ -64,6 +64,7 @@ describe("computeExpectedBalances", () => {
       transfersLinked: 0,
       skipped: 0,
       deferredInvestments: 0,
+      tradeCashLegs: 0,
       warnings: [],
     };
   }

--- a/backend/src/import/mny/mny-parser.service.ts
+++ b/backend/src/import/mny/mny-parser.service.ts
@@ -456,7 +456,8 @@ export class MnyParserService {
       `Parsed ${era} file: ${accounts.accounts.length} accounts, ` +
         `${transactions.transactions.length} transactions, ` +
         `${securities.securities.length} securities, ` +
-        `${investments.transactions.length} investment rows`,
+        `${investments.transactions.length} investment rows, ` +
+        `${transactions.tradeCashLegs} cash rows written by their trade`,
     );
 
     return {

--- a/backend/src/import/mny/model/mny-import-model.ts
+++ b/backend/src/import/mny/model/mny-import-model.ts
@@ -173,6 +173,14 @@ export interface MappedTransactions {
    * tables.
    */
   readonly deferredInvestments: number;
+  /**
+   * Money's own cash-sleeve rows for a trade in the paired brokerage account,
+   * which the investment writer creates from the trade itself. Not skipped and
+   * not lost: the row is written, from the other side. Reported because it is
+   * the one number that says how much of a file went through that path, and it
+   * has no other surface -- see `tradeCashLegRows` (issue #1175).
+   */
+  readonly tradeCashLegs: number;
   readonly warnings: readonly MnyWarning[];
 }
 

--- a/backend/src/import/mny/model/mny-model.spec.ts
+++ b/backend/src/import/mny/model/mny-model.spec.ts
@@ -129,9 +129,6 @@ describe("isRecurrenceTemplate", () => {
 });
 
 describe("decodeReference", () => {
-  const plain = 0;
-  const debtRow = MNY_TRANSACTION_FLAG.DEBT_ACCOUNT;
-
   // Imported whole, `szId` put "1Debit" and "0           2" in the register.
   it.each([
     ["1Debit", "Debit"],
@@ -141,7 +138,7 @@ describe("decodeReference", () => {
     ["1EComm", "EComm"],
     ["1US", "US"],
   ])("reads the text %p as %p", (raw, expected) => {
-    expect(decodeReference(raw, plain)).toBe(expected);
+    expect(decodeReference(raw)).toBe(expected);
   });
 
   it.each([
@@ -149,44 +146,45 @@ describe("decodeReference", () => {
     ["0           1", "1"],
     ["0         200", "200"],
   ])("reads the cheque number %p as %p", (raw, expected) => {
-    expect(decodeReference(raw, plain)).toBe(expected);
+    expect(decodeReference(raw)).toBe(expected);
   });
 
-  it("drops the number on a loan or mortgage row", () => {
-    // There it is Money's instalment counter, not a reference the user wrote:
-    // the bank side of the transfer carries none, and Money's loan register
-    // has no Num column to show it in.
-    expect(decodeReference("0           2", debtRow)).toBeNull();
+  it("keeps the payment number on a loan or mortgage row", () => {
+    // Issue #1174: this shape is Money's "Pmt Num" column, which its loan
+    // register does display, so dropping it left Ref. num. empty on every row
+    // of every debt account. Nothing about the account changes the decoding --
+    // the function no longer takes the flags that used to decide it.
+    expect(decodeReference("0           2")).toBe("2");
+    expect(decodeReference("0          14")).toBe("14");
     // The text kind is a real reference wherever it appears.
-    expect(decodeReference("1Debit", debtRow)).toBe("Debit");
+    expect(decodeReference("1Debit")).toBe("Debit");
   });
 
   it("keeps a value that does not fit either shape rather than losing it", () => {
     // The one that matters: a cheque number a user typed as 1042 is not the
     // text "042" behind a kind digit.
-    expect(decodeReference("1042", plain)).toBe("1042");
-    expect(decodeReference("1042", debtRow)).toBe("1042");
-    expect(decodeReference("2something", plain)).toBe("2something");
-    expect(decodeReference("0 not-a-number", plain)).toBe("0 not-a-number");
-    expect(decodeReference("7", plain)).toBe("7");
+    expect(decodeReference("1042")).toBe("1042");
+    expect(decodeReference("2something")).toBe("2something");
+    expect(decodeReference("0 not-a-number")).toBe("0 not-a-number");
+    expect(decodeReference("7")).toBe("7");
   });
 
   it("returns null for nothing at all", () => {
-    expect(decodeReference(null, plain)).toBeNull();
-    expect(decodeReference("", plain)).toBeNull();
-    expect(decodeReference("   ", plain)).toBeNull();
+    expect(decodeReference(null)).toBeNull();
+    expect(decodeReference("")).toBeNull();
+    expect(decodeReference("   ")).toBeNull();
   });
 
   it("never leaves the packed shape in what it returns", () => {
     // No committed fixture carries a single `szId` -- all three are null
     // throughout -- so the shapes above come from the two Money Plus files that
     // cannot be committed. This is the general guard: whatever the padding
-    // width, a kind digit followed by spaces never survives.
+    // width, a kind digit followed by spaces never survives, and the number
+    // behind it does.
     for (const width of [2, 5, 12, 20]) {
       const padded = `0${"7".padStart(width, " ")}`;
 
-      expect(decodeReference(padded, plain)).toBe("7");
-      expect(decodeReference(padded, debtRow)).toBeNull();
+      expect(decodeReference(padded)).toBe("7");
     }
   });
 });

--- a/backend/src/import/mny/model/mny-model.ts
+++ b/backend/src/import/mny/model/mny-model.ts
@@ -174,9 +174,13 @@ export function isUnpostedRow(flags: number): boolean {
 }
 
 /**
- * True for a row in a loan or mortgage account. Never a reason to skip a row --
- * these are ordinary postings, and treating the bit as anything else is what
- * this function exists to make obvious.
+ * True for a row in a loan or mortgage account. Never a reason to skip a row,
+ * and never a reason to drop a field either -- these are ordinary postings, and
+ * treating the bit as anything else is what this function exists to make
+ * obvious. It has no production caller: reading it as the void flag emptied
+ * every debt account's balance, and reading it as "hide the reference" emptied
+ * every debt account's Ref. num. column (issue #1174). It stays exported and
+ * tested so the bit keeps a name, not so a third reading can be built on it.
  */
 export function isDebtAccountRow(flags: number): boolean {
   return (flags & MNY_TRANSACTION_FLAG.DEBT_ACCOUNT) !== 0;
@@ -196,15 +200,23 @@ export function isDebtAccountRow(flags: number): boolean {
  * - `0` prefixes a number right-aligned in twelve characters. 1,060 rows, every
  *   one numeric, every one exactly thirteen characters long.
  *
- * A `0` number is dropped for a row in a loan or mortgage account, where it is
- * **Money's instalment counter and not a reference the user wrote**. Two files
- * agree: 657 of those 1,060 sit in debt accounts counting 1, 2, 3 up the
- * payment schedule, and all 461 in Money Plus's own `sample.mny` are the "Home
- * Loan" payment numbers, repeated across each payment's split legs. Neither
- * ever appears on the bank side of the transfer -- the partner row's `szId` is
- * null in all 642 cases -- and Money's loan register has no Num column to show
- * it in. Outside a debt account the same shape is a cheque number, sequential
- * over years against landlords and utilities, and is kept.
+ * **A `0` number in a loan or mortgage account is Money's payment number, and
+ * Money does show it.** It was dropped here for four phases on the opposite
+ * reading -- that it is an instalment counter Money's own register has no
+ * column for -- which left the Ref. num. field empty on every row of every loan
+ * and mortgage account (issue #1174, reported by a user looking at the column
+ * it is displayed in). Money's loan register calls it **Pmt Num**; the
+ * measurements behind the old reading were all correct and only the conclusion
+ * was wrong. 657 of the 1,060 numbers do sit in debt accounts counting 1, 2, 3
+ * up the payment schedule, all 461 in Money Plus's own `sample.mny` are the
+ * "Home Loan" payment numbers, and the bank side of the transfer carries none
+ * of them in any of 642 cases -- which is what a per-loan payment counter looks
+ * like, and is exactly the value the user asked to see.
+ *
+ * So the account a row sits in no longer changes what `szId` decodes to: the
+ * same shape is a cheque number outside a debt account and a payment number
+ * inside one, and both belong in Ref. num. That is why this takes no `flags`
+ * argument -- there is no branch left for one to feed.
  *
  * **Both shapes are matched strictly, and anything else is returned as-is.**
  * A bare `1042` is a cheque number a user typed, not the text `042` behind a
@@ -216,10 +228,7 @@ export function isDebtAccountRow(flags: number): boolean {
 const REFERENCE_TEXT = /^1(\D.*)$/;
 const REFERENCE_NUMBER = /^0\s+(\d+)$/;
 
-export function decodeReference(
-  raw: string | null,
-  flags: number,
-): string | null {
+export function decodeReference(raw: string | null): string | null {
   if (raw === null || raw.trim() === "") {
     return null;
   }
@@ -232,7 +241,7 @@ export function decodeReference(
 
   const number = REFERENCE_NUMBER.exec(raw);
   if (number) {
-    return isDebtAccountRow(flags) ? null : number[1];
+    return number[1];
   }
 
   return trimmed;

--- a/backend/src/import/mny/writers/write-transactions.spec.ts
+++ b/backend/src/import/mny/writers/write-transactions.spec.ts
@@ -107,6 +107,23 @@ describe("writeTransactions", () => {
     });
   });
 
+  it("carries the reference number into the column the register's Ref # reads", async () => {
+    // `transactions.reference_number` is what the register's Ref # column
+    // renders, so a value the mapper decoded has to survive this far to be the
+    // fix issue #1174 asked for. Nothing between here and the mapper asserted
+    // that the field was written at all.
+    const { manager, transactions } = doubles();
+
+    await writeTransactions(manager, "user-1", {
+      ...baseInput,
+      transactions: [transaction({ referenceNumber: "14" })],
+    });
+
+    expect(transactions.insert.mock.calls[0][0][0]).toMatchObject({
+      referenceNumber: "14",
+    });
+  });
+
   it("skips a transaction whose account was excluded from the import", async () => {
     const { manager, transactions } = doubles();
 

--- a/backend/src/transactions/register-order.spec.ts
+++ b/backend/src/transactions/register-order.spec.ts
@@ -1,0 +1,163 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { SelectQueryBuilder } from "typeorm";
+import { Transaction } from "./entities/transaction.entity";
+import {
+  applyRegisterOrder,
+  creditsBeforeDebitsDirection,
+} from "./register-order";
+
+/**
+ * The ordering itself, and the guard that stops a fifth copy of it appearing.
+ *
+ * The property under test is not "these four columns in this order" -- it is
+ * that a credit and a debit the clock cannot separate come out chronologically
+ * credit-first, whichever way the list runs. Asserting the column list alone
+ * would pass for the inverted tiebreak, which is the mistake most available
+ * here.
+ */
+
+function recordingBuilder(): {
+  builder: SelectQueryBuilder<Transaction>;
+  calls: Array<[string, string]>;
+} {
+  const calls: Array<[string, string]> = [];
+  const builder = {
+    orderBy: (column: string, direction: string) => {
+      calls.push([column, direction]);
+      return builder;
+    },
+    addOrderBy: (column: string, direction: string) => {
+      calls.push([column, direction]);
+      return builder;
+    },
+  } as unknown as SelectQueryBuilder<Transaction>;
+  return { builder, calls };
+}
+
+function orderFor(
+  direction: "ASC" | "DESC",
+  sortColumn?: string,
+): Array<[string, string]> {
+  const { builder, calls } = recordingBuilder();
+  applyRegisterOrder(builder, "t", direction, sortColumn);
+  return calls;
+}
+
+/**
+ * The register as the user reads it: rows in the order the query returns them,
+ * with the running balance walked down from the newest, exactly as
+ * `TransactionList` does it.
+ */
+function runningBalances(
+  rows: ReadonlyArray<{ id: string; amount: number }>,
+  startingBalance: number,
+): Map<string, number> {
+  const balances = new Map<string, number>();
+  let cumulative = 0;
+  for (const row of rows) {
+    balances.set(row.id, startingBalance - cumulative);
+    cumulative += row.amount;
+  }
+  return balances;
+}
+
+/** Sorts by the ordering under test, for rows that tie on date and createdAt. */
+function sortByRegisterOrder<T extends { id: string; amount: number }>(
+  rows: readonly T[],
+  direction: "ASC" | "DESC",
+): T[] {
+  const amountDirection = creditsBeforeDebitsDirection(direction);
+  return [...rows].sort((a, b) =>
+    a.amount === b.amount
+      ? a.id.localeCompare(b.id) * (direction === "DESC" ? -1 : 1)
+      : (a.amount - b.amount) * (amountDirection === "ASC" ? 1 : -1),
+  );
+}
+
+describe("applyRegisterOrder", () => {
+  it("orders by date, then created_at, then amount, then id", () => {
+    expect(orderFor("DESC")).toEqual([
+      ["t.transactionDate", "DESC"],
+      ["t.createdAt", "DESC"],
+      ["t.amount", "ASC"],
+      ["t.id", "DESC"],
+    ]);
+  });
+
+  it("runs the amount tiebreak opposite to the list, in both directions", () => {
+    // The rule is chronological -- credits first -- so a newest-first list puts
+    // them last. Hardcoding ASC would silently invert the ascending register.
+    expect(creditsBeforeDebitsDirection("DESC")).toBe("ASC");
+    expect(creditsBeforeDebitsDirection("ASC")).toBe("DESC");
+    expect(orderFor("ASC")).toEqual([
+      ["t.transactionDate", "ASC"],
+      ["t.createdAt", "ASC"],
+      ["t.amount", "DESC"],
+      ["t.id", "ASC"],
+    ]);
+  });
+
+  it("keeps the tiebreaks when the user sorts by amount or payee", () => {
+    expect(orderFor("DESC", "payeeName")[0]).toEqual(["t.payeeName", "DESC"]);
+    expect(orderFor("DESC", "payeeName").slice(1)).toEqual([
+      ["t.createdAt", "DESC"],
+      ["t.amount", "ASC"],
+      ["t.id", "DESC"],
+    ]);
+  });
+});
+
+describe("the running balance a tied credit and debit produce", () => {
+  // The reported case: an investment purchase funded by a transfer on the same
+  // day. Both rows are written by one import, so `created_at` -- which defaults
+  // to CURRENT_TIMESTAMP, one value per transaction -- cannot separate them,
+  // and the order used to fall through to a random UUID.
+  const TRANSFER_IN = { id: "aaaa-credit", amount: 2400 };
+  const PURCHASE = { id: "bbbb-debit", amount: -2400 };
+  const OPENING = 0;
+
+  it.each([["DESC" as const], ["ASC" as const]])(
+    "never dips below zero in a %s register",
+    (direction) => {
+      const rows = sortByRegisterOrder([PURCHASE, TRANSFER_IN], direction);
+      // The running balance is only ever walked newest-first.
+      const newestFirst = direction === "DESC" ? rows : [...rows].reverse();
+      const balances = runningBalances(newestFirst, OPENING);
+
+      expect(Math.min(...balances.values())).toBe(0);
+      expect(balances.get(TRANSFER_IN.id)).toBe(2400);
+      expect(balances.get(PURCHASE.id)).toBe(0);
+    },
+  );
+
+  it("dips negative when the debit is treated as the older row", () => {
+    // The defect, stated as a test: with the credit ordered second in a
+    // newest-first list, the purchase reads as having happened first and the
+    // account appears overdrawn on a day it was never short.
+    const balances = runningBalances([TRANSFER_IN, PURCHASE], OPENING);
+
+    expect(balances.get(PURCHASE.id)).toBe(-2400);
+  });
+});
+
+describe("the register ordering is written once", () => {
+  it("has no hand-rolled copy left in the transactions service", () => {
+    // Three of the four sites sum the rows on *previous* pages so page N's
+    // running balance starts from the right number. A tiebreak added to the
+    // register alone re-splits the pages under those sums.
+    //
+    // Deliberately out of scope, and why the scan is written against
+    // `addOrderBy` rather than against the column name: the payee-autofill
+    // lookup orders by `{ transactionDate, createdAt }` in `find`'s object
+    // form. It shows no balance and no page, so it has nothing to agree with.
+    const source = readFileSync(
+      join(__dirname, "transactions.service.ts"),
+      "utf8",
+    );
+
+    const applications = source.match(/applyRegisterOrder\(/g) ?? [];
+    expect(applications).toHaveLength(4);
+    expect(source).not.toMatch(/addOrderBy\(\s*["'`][^"'`]*\.createdAt/);
+  });
+});

--- a/backend/src/transactions/register-order.ts
+++ b/backend/src/transactions/register-order.ts
@@ -1,0 +1,76 @@
+import { ObjectLiteral, SelectQueryBuilder } from "typeorm";
+
+/**
+ * The order the register lists transactions in, written once.
+ *
+ * Four queries have to agree on it, and only one of them is the register: the
+ * other three sum the rows on *previous pages* so page N's running balance can
+ * start from the right number. A tiebreak added to the register alone silently
+ * re-splits the pages under those sums, and every balance from page 2 down is
+ * wrong by whichever rows crossed the boundary. That is the "a predicate that
+ * decides which row counts is written once" rule applied to an ORDER BY.
+ *
+ * ## Why `amount` is in here
+ *
+ * `created_at` defaults to `CURRENT_TIMESTAMP`, which in PostgreSQL is
+ * **transaction start time** -- one value for the whole transaction, not per
+ * statement. TypeORM leans on that default rather than sending a value
+ * (`InsertQueryBuilder` says so in a comment where the code used to be), so
+ * every row an import writes carries the *same* `created_at`. Within one date
+ * the order then fell through to `id`, which is a random UUID: the register
+ * listed same-day imported rows in an arbitrary order that changed nothing
+ * about the stored balance and everything about the running balance beside it.
+ *
+ * The visible symptom is an account that appears to go overdrawn. A purchase
+ * funded by a transfer that same day is two rows in the cash account, and if
+ * the debit is ordered as the older of the two, the running balance dips
+ * negative on a day the account was never short. It recovers on the next row,
+ * which is what makes it read as a bug in the balance rather than in the sort.
+ *
+ * So when the clock cannot separate two rows, their signs do: **credits are
+ * ordered before debits**, chronologically. Money has to arrive before it can
+ * be spent, and no data we hold says otherwise -- `.mny`, QIF and OFX all carry
+ * a date and no time.
+ *
+ * The tiebreak runs **opposite** to the list direction, which is the one part
+ * that looks wrong and is not. The rule is about chronological order, and a
+ * descending register lists newest first: putting credits earlier in time means
+ * putting them *later* in a newest-first list. Deriving it from `direction`
+ * rather than hardcoding `ASC` is what keeps an ascending register right too.
+ *
+ * It only ever changes anything when `created_at` ties, so ordinary
+ * hand-entered rows -- which are seconds apart -- are untouched.
+ */
+
+export type RegisterSortDirection = "ASC" | "DESC";
+
+/**
+ * Chronological order within a `created_at` tie is credits first, so a
+ * newest-first list needs debits first. Exported so the guard test can state
+ * the relationship rather than restate the table.
+ */
+export function creditsBeforeDebitsDirection(
+  direction: RegisterSortDirection,
+): RegisterSortDirection {
+  return direction === "DESC" ? "ASC" : "DESC";
+}
+
+/**
+ * Applies the register's full ordering to a query builder.
+ *
+ * @param sortColumn The primary column, defaulting to the transaction date.
+ *   The register also sorts by amount and payee; passing one of those leaves
+ *   the tiebreaks below it unchanged.
+ */
+export function applyRegisterOrder<T extends ObjectLiteral>(
+  queryBuilder: SelectQueryBuilder<T>,
+  alias: string,
+  direction: RegisterSortDirection,
+  sortColumn = "transactionDate",
+): SelectQueryBuilder<T> {
+  return queryBuilder
+    .orderBy(`${alias}.${sortColumn}`, direction)
+    .addOrderBy(`${alias}.createdAt`, direction)
+    .addOrderBy(`${alias}.amount`, creditsBeforeDebitsDirection(direction))
+    .addOrderBy(`${alias}.id`, direction);
+}

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -23,6 +23,7 @@ import { AccountsService } from "../accounts/accounts.service";
 import { PayeesService } from "../payees/payees.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { TransactionSplitService } from "./transaction-split.service";
+import { applyRegisterOrder } from "./register-order";
 import {
   assertVoidTransitionAllowedOnRow,
   applyVoidTransitionToMirrorLeg,
@@ -926,17 +927,17 @@ export class TransactionsService {
           "linkedSplits.transferAccount",
           "linkedSplitTransferAccount",
         )
-        .where(this.registerScope("transaction", userId, jointAccountIds))
-        .orderBy(
-          sortBy === "amount"
-            ? "transaction.amount"
-            : sortBy === "payee"
-              ? "transaction.payeeName"
-              : "transaction.transactionDate",
-          sortDirection,
-        )
-        .addOrderBy("transaction.createdAt", sortDirection)
-        .addOrderBy("transaction.id", sortDirection);
+        .where(this.registerScope("transaction", userId, jointAccountIds));
+      applyRegisterOrder(
+        queryBuilder,
+        "transaction",
+        sortDirection,
+        sortBy === "amount"
+          ? "amount"
+          : sortBy === "payee"
+            ? "payeeName"
+            : "transactionDate",
+      );
 
       if (!includeInvestmentBrokerage) {
         queryBuilder.andWhere(
@@ -1418,10 +1419,10 @@ export class TransactionsService {
       .select("t.id")
       .where("t.userId = :userId", { userId })
       .andWhere("t.accountId = :singleAccountId", { singleAccountId })
-      .orderBy("t.transactionDate", "DESC")
-      .addOrderBy("t.createdAt", "DESC")
-      .addOrderBy("t.id", "DESC")
       .limit(skip);
+    // Must stay the register's own order: these rows are the pages above the
+    // one being shown, and their sum is where its running balance starts.
+    applyRegisterOrder(previousPagesQuery, "t", "DESC");
 
     // The window is every row the register lists above this page -- voids
     // included, because they occupy a line each. What is summed out of that
@@ -1598,10 +1599,10 @@ export class TransactionsService {
       .select("t.id")
       .where("t.userId = :userId", { userId })
       .andWhere("t.accountId = :accountId", { accountId })
-      .orderBy("t.transactionDate", "DESC")
-      .addOrderBy("t.createdAt", "DESC")
-      .addOrderBy("t.id", "DESC")
       .limit(skip);
+    // Must stay the register's own order: these rows are the pages above the
+    // one being shown, and their sum is where its running balance starts.
+    applyRegisterOrder(previousPagesQuery, "t", "DESC");
 
     if (filters.startDate) {
       previousPagesQuery.andWhere("t.transactionDate >= :startDate", {
@@ -1674,10 +1675,10 @@ export class TransactionsService {
       .select("t.id")
       .where(`t.id IN (${idsSubquery.getQuery()})`)
       .setParameters(idsSubquery.getParameters())
-      .orderBy("t.transactionDate", "DESC")
-      .addOrderBy("t.createdAt", "DESC")
-      .addOrderBy("t.id", "DESC")
       .limit(skip);
+    // Must stay the register's own order: these rows are the pages above the
+    // one being shown, and their sum is where its running balance starts.
+    applyRegisterOrder(prevIdsQuery, "t", "DESC");
 
     return this.computeSplitAwareSum(m, prevIdsQuery, userId, filters);
   }

--- a/backend/test/integration/mny-import.integration.spec.ts
+++ b/backend/test/integration/mny-import.integration.spec.ts
@@ -686,6 +686,38 @@ describe("mny writers (integration)", () => {
       expect(row!.status).not.toBe("VOID");
     });
 
+    // The sibling bug, and the same shape of mistake: 0x80 also decided whether
+    // `szId` was a reference, so a loan row's payment number was dropped and the
+    // register's Ref # column was empty for every payment of every loan
+    // (issue #1174). Asserted here rather than at the mapper because Ref # reads
+    // `transactions.reference_number`, and that column is what has to hold it.
+    it("stores a loan-account row's payment number in reference_number", async () => {
+      const { input } = await setup(
+        transactionData({
+          transactions: [
+            mnyTransaction({
+              handle: 1,
+              account: 9,
+              amount: 412.6,
+              flags: 0x80,
+              // Money's packed form: kind digit `0`, then the number Money's
+              // loan register shows as Pmt Num, right-aligned.
+              reference: "0          14",
+            }),
+          ],
+        }),
+      );
+
+      await inTransaction((manager) =>
+        writeTransactions(manager, userId, input),
+      );
+
+      const row = await dataSource.getRepository(Transaction).findOne({
+        where: { userId },
+      });
+      expect(row!.referenceNumber).toBe("14");
+    });
+
     it("writes more rows than one chunk holds", async () => {
       const rows = Array.from({ length: 1200 }, (_, index) =>
         mnyTransaction({

--- a/docs/future-plans/mny-import.md
+++ b/docs/future-plans/mny-import.md
@@ -567,8 +567,10 @@ real mappers and, in the integration spec, the real INSERT path.
   `frq` decides.
 - **`TRN.szId` packs a kind digit in front of the reference** -- `1` then free text (`1Debit`),
   `0` then a number right-aligned in twelve characters (`0           2`). Imported whole it shows
-  as `1Debit` and `0 2`. The number is Money's instalment counter inside a debt account, where
-  the register has no Num column, and a cheque number everywhere else.
+  as `1Debit` and `0 2`. The number is Money's payment number inside a debt account (its loan
+  register shows it as **Pmt Num**) and a cheque number everywhere else; both are references the
+  user reads, so both are kept. Dropping the debt-account one left Ref. num. blank on every loan
+  and mortgage row until issue #1174.
 - `grftt & 0x100` -> status VOID (imported, excluded from balances by existing logic). **Not**
   `0x80`, which marks a row in a loan or mortgage account: using it voided every loan payment
   and left each debt account frozen at its opening balance.

--- a/docs/import-ms-money.md
+++ b/docs/import-ms-money.md
@@ -95,8 +95,12 @@ and import the resulting `.mny`.
 - **Loan and mortgage payments**, with the principal leg wired to the loan
   account as a transfer split. Where the payments make it unambiguous, the loan's
   funding account, payment amount and interest category are filled in too.
+  Money's **Pmt Num** arrives in the loan register's Ref. num. column.
 - **Securities and investment transactions**: buys, sells, dividends,
-  reinvestments, share transfers between accounts, and stock splits.
+  reinvestments, share transfers between accounts, and stock splits. A trade
+  paid for out of the account's own cash puts one row in the cash side, as
+  Money's does; a trade funded from another account also shows the cash
+  arriving, which is again what Money shows.
 - **Price history and exchange rates**, both additive -- importing twice, or
   importing on top of prices a quote provider already fetched, converges rather
   than duplicating.

--- a/docs/ms-money-data-model.md
+++ b/docs/ms-money-data-model.md
@@ -241,15 +241,30 @@ An investment row is identified by carrying a security, not by its action code:
 > - `0` prefixes a number right-aligned in twelve characters, so the value is
 >   always thirteen characters long. 1,060 rows, every one numeric.
 >
-> A `0` number in a loan or mortgage account is Money's instalment counter, not
-> a reference: 657 of the 1,060 sit in debt accounts counting up the payment
-> schedule, all 461 in Money Plus's own `sample.mny` are the Home Loan payment
-> numbers, the bank side of the transfer carries none of them in any of 642
-> cases, and Money's loan register has no Num column to show one in.
+> A `0` number in a loan or mortgage account is Money's **payment number**: 657
+> of the 1,060 sit in debt accounts counting up the payment schedule, all 461 in
+> Money Plus's own `sample.mny` are the Home Loan payment numbers, and the bank
+> side of the transfer carries none of them in any of 642 cases.
 >
 > Both shapes are matched strictly and anything else is passed through, so a
 > cheque number typed as `1042` stays `1042` rather than becoming the text `042`
 > behind a kind digit (`model/mny-model.ts`, `decodeReference`).
+
+> **Correction to the correction.** Those numbers were dropped for four phases,
+> on the added premise that Money's loan register has no column to show one in.
+> It does -- it is called **Pmt Num** -- so the Ref. num. field was empty on
+> every row of every loan and mortgage account until issue #1174, reported by a
+> user reading that column. Every measurement above was right; only the sentence
+> inferred from them was wrong, which is what a per-loan payment counter looks
+> like either way. `decodeReference` no longer takes `grftt` at all: the account
+> a row sits in does not change what `szId` decodes to.
+
+Neither reading of `szId` was ever checkable against the corpus -- no committed
+fixture carries a single non-null value of it. Both the packed shapes and the
+debt-account rule came from files that cannot be committed, and a claim about
+what Money *displays* cannot be measured from the file at all. Where the code
+has to assume something about Money's UI, say so in the comment and expect a
+user to be the one who settles it.
 
 ### The `act` field
 
@@ -471,6 +486,29 @@ counterpart is imported exactly once.
 Both sides exist as separate `TRN` rows with their own amounts. Because the
 pairing is exact, a `.mny` importer must never fall back to matching transfers
 by name and amount the way a QIF importer has to.
+
+### The cash counterpart of a trade, and which side Monize keeps
+
+A trade's `TRN_XFER` partner sits in one of two places, and they need opposite
+treatment:
+
+| Partner sits in | What Money is recording | What Monize does |
+|---|---|---|
+| The brokerage's own cash companion (`ACCT.hacctRel`) | The cash half of the trade | **Drops** the row. `writeInvestments` creates that sleeve transaction from the investment row's `cashAmount` and links the two through `investment_transactions.transaction_id` |
+| Any other account | Cash moving in from outside, where the investment row is *both* the arrival and the trade | Keeps the row and **synthesizes** the sleeve side Money has no row for (`buildCashCounterparts`) |
+
+Importing the first kind put three rows in the cash register where Money shows
+one -- the purchase, plus a transfer in and a transfer out that cancelled
+(issue #1175). The cancellation is why every balance still reconciled: the
+imported row and the counterpart synthesized for it landed in the same account.
+That equivalence is also what makes dropping them safe, and `tradeCashLegRows`
+(`backend/src/import/mny/map/map-transactions.ts`) is written so a row qualifies
+only when it holds.
+
+The rule applies to top-level rows only. A `TRN_SPLIT` **child** in the sleeve
+whose partner is a trade is a third shape: its parent has already moved the cash
+out of the sleeve, so the synthesized counterpart is what keeps the balance
+right there and is kept.
 
 ## LOT (tax lots)
 


### PR DESCRIPTION
## Linked discussion / issue

Closes #1175
Closes #1174
Approved in: Issues #1175 and #1174

## Summary

This PR fixes two related bugs in Money import handling:

1. **Issue #1175**: When a trade is funded from a brokerage account's own cash companion account, Money records the cash half as an ordinary transaction in the companion account paired through `TRN_XFER`. Monize was importing this row *and* synthesizing its own from the investment transaction, resulting in three rows in the cash register where Money shows one. The fix identifies these "trade cash leg" rows and skips importing them, since the investment mapper already writes the correct row.

2. **Issue #1174**: Loan and mortgage payment rows carry a payment number in `szId` that Money displays in the "Pmt Num" column. The code was incorrectly dropping this field based on the debt account flag, leaving the Ref. num. column empty for every payment. The fix removes the flag parameter from `decodeReference` so payment numbers are preserved on all rows.

3. **Register ordering**: A related issue where same-day imported rows (which share the same `created_at` timestamp) were ordered arbitrarily by UUID, causing the running balance to appear overdrawn. The fix centralizes register ordering logic in `register-order.ts` with a tiebreak that orders credits before debits chronologically, ensuring the running balance never dips negative on a day the account was never short.

### Key changes:

- **`map-transactions.ts`**: Added `tradeCashLegRows()` function to identify Money's own cash-leg rows for trades in paired brokerage accounts. These rows are excluded from import since the investment mapper writes them from the trade itself.
- **`mny-model.ts`**: Removed the `flags` parameter from `decodeReference()` so payment numbers are always preserved, not dropped for debt accounts.
- **`register-order.ts`** (new): Centralized register ordering logic with proper tiebreaks. The `amount` field is used as a tiebreak that runs opposite to the list direction, ensuring credits are ordered before debits chronologically.
- **`transactions.service.ts`**: Updated to use `applyRegisterOrder()` consistently across all four queries that must agree on ordering.
- **Tests**: Added comprehensive test suites (`trade-cash-legs.spec.ts`, `register-order.spec.ts`) that verify both row counts and balances together, ensuring the fixes are complete and prevent regressions.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (three related bugs in import and register ordering).
- [x] New behavior has tests, and the existing suite passes.
- [x] No user-facing strings added (fixes only).
- [x] No shared/core areas refactored without agreement.
- [x] The branch is rebased on the latest `main`.
- [ ] AI assistance disclosure: N/A

https://claude.ai/code/session_01UZtvTPTuAUMLTVJokW1kT9