### PR TITLE
Guard pre-login localStorage footprint against unintended expansion

### DIFF
--- a/.github/zap/rules.tsv
+++ b/.github/zap/rules.tsv
@@ -36,3 +36,13 @@
 # The root "/" returns a 307 redirect to /login with no body; redirects legitimately
 # omit Content-Type, and X-Content-Type-Options: nosniff blocks any sniffing.
 10019	IGNORE	(Content-Type Header Missing - bodiless 307 redirect, mitigated by nosniff)
+# Reports every entry present in localStorage, whatever it holds. On /login the
+# app writes two zustand persist envelopes and nothing else:
+#   auth-storage        {"state":{"isAuthenticated":false},"version":0}
+#   monize-preferences  {"state":{"preferences":null},"version":0}
+# No token, profile or PII: auth/refresh tokens are httpOnly cookies the backend
+# owns, and the profile is refetched from the API on load. That claim is about
+# the source, so frontend/src/store/persisted-storage.guard.test.ts pins the
+# pre-login footprint and fails when a store widens it or a new one appears --
+# this line cannot outlive what it was written for.
+120000	IGNORE	(Information in Browser localStorage - non-identifying zustand persist envelopes, pinned by persisted-storage.guard.test.ts)

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -822,5 +822,6 @@ Colour themes are pure CSS variable overrides in `src/app/themes.css` (`html[dat
 
 - **Zod:** Configured with `jitless: true` (`zodConfig.ts`) for CSP compliance -- no `new Function()`
 - **Auth tokens:** Stored in httpOnly cookies (backend-managed), never in JS-accessible storage
+- **localStorage is readable by any XSS, and by any scanner pointed at a public page.** A store that persists there must be listed in `src/store/persisted-storage.guard.test.ts` with the reason its contents may sit in storage, and the pre-login footprint (`auth-storage` and `monize-preferences`, both empty envelopes) is pinned there byte for byte -- the ZAP baseline's rule 120000 is silenced in `.github/zap/rules.tsv` on exactly that claim, so widening a `partialize` fails the guard rather than shipping under an IGNORE written for a smaller footprint.
 - **CSP:** Per-request nonce generated in proxy, `strict-dynamic` for script-src
 - **ESLint:** `no-new-func: error` enforced to prevent CSP violations

--- a/frontend/src/store/authStore.test.ts
+++ b/frontend/src/store/authStore.test.ts
@@ -134,15 +134,11 @@ describe('authStore', () => {
     });
   });
 
-  describe('persistence', () => {
-    it('only persists user and isAuthenticated (not token)', () => {
-      // The partialize function should exclude token
-      const store = useAuthStore;
-      // Access the persist API to check partialize config
-      const persistOptions = (store as any).persist;
-      expect(persistOptions).toBeDefined();
-    });
-  });
+  // What this store may write to localStorage lives in
+  // persisted-storage.guard.test.ts, which runs partialize over a populated
+  // state and asserts the pre-login footprint byte for byte. The test that
+  // used to sit here asserted only that a persist API existed, under a title
+  // claiming it checked the token was excluded.
 
   describe('rehydration 502 handling', () => {
     it('keeps authenticated state on 502 error and sets backend down', async () => {

--- a/frontend/src/store/persisted-storage.guard.test.ts
+++ b/frontend/src/store/persisted-storage.guard.test.ts
@@ -1,0 +1,140 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * The ZAP baseline scan reports every entry it finds in localStorage on a
+ * public page (rule 120000, INFO risk), and `.github/zap/rules.tsv` silences
+ * that rule on a single claim: everything the app writes before login is a
+ * zustand persist envelope carrying no user data, no credential and no PII.
+ *
+ * That claim is about the source, so it is checked here rather than left in a
+ * comment. The IGNORE line would otherwise outlive the footprint it was
+ * written for -- a new persisted store, or a widened `partialize`, silently
+ * ships under a rule that was silenced for something else.
+ */
+
+// Every localStorage key a zustand store owns, and why it is allowed to be
+// there. A new persisted store means a line here, which is the moment to ask
+// whether its contents belong in storage an XSS can read.
+const PERSISTED_STORE_KEYS: Record<string, string> = {
+  'auth-storage':
+    'pre-login: the isAuthenticated flag alone. The profile is refetched from the API, the token lives in an httpOnly cookie.',
+  'monize-preferences':
+    'pre-login: null until a session loads preferences; display settings only, cleared by logout().',
+  'monize:ai-chat-messages':
+    'authenticated only: written after login, removed by logout() so conversations do not cross accounts.',
+};
+
+// What an unauthenticated visitor's browser holds, verbatim. These are the two
+// entries ZAP reports on /login.
+const PRE_LOGIN_FOOTPRINT: Record<string, string> = {
+  'auth-storage': '{"state":{"isAuthenticated":false},"version":0}',
+  'monize-preferences': '{"state":{"preferences":null},"version":0}',
+};
+
+const STORE_DIR = path.join(process.cwd(), 'src', 'store');
+
+// zustand's persist config as this codebase writes it: the storage name
+// immediately followed by the localStorage-backed storage engine. The name is
+// a string literal in two stores and an exported constant in the third.
+const LOCAL_STORAGE_PERSIST_RE =
+  /name:\s*([^,\n]+),\s*\n\s*storage:\s*createJSONStorage\(\(\)\s*=>\s*localStorage\)/g;
+
+function resolveStorageName(nameExpr: string, source: string): string {
+  const literal = nameExpr.match(/^(['"])(.*)\1$/);
+  if (literal) return literal[2];
+
+  const constant = source.match(
+    new RegExp(`\\b${nameExpr.trim()}\\s*=\\s*(['"])(.*?)\\1`),
+  );
+  // An unresolvable name is a hole in the scan, so surface the expression
+  // itself and let the classification assertion fail on it.
+  return constant ? constant[2] : nameExpr.trim();
+}
+
+function readStoreSources(): { file: string; source: string }[] {
+  return fs
+    .readdirSync(STORE_DIR)
+    .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+    .map((file) => ({
+      file,
+      source: fs.readFileSync(path.join(STORE_DIR, file), 'utf8'),
+    }));
+}
+
+describe('persisted browser storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('has every localStorage-backed store classified', () => {
+    const found = new Map<string, string>();
+
+    for (const { file, source } of readStoreSources()) {
+      const matches = [...source.matchAll(LOCAL_STORAGE_PERSIST_RE)];
+
+      if (/\bpersist\(/.test(source)) {
+        // A persisted store whose config this scan cannot read is not
+        // evidence of safety -- it is a hole in the scan.
+        expect(
+          matches.length,
+          `${file} calls persist() but no "name: ... storage: createJSONStorage(() => localStorage)" pair was found. ` +
+            'Follow the existing shape, or this guard stops covering it.',
+        ).toBeGreaterThan(0);
+      }
+
+      for (const match of matches) {
+        found.set(resolveStorageName(match[1], source), file);
+      }
+    }
+
+    expect(
+      [...found.keys()].sort(),
+      'A store persisting to localStorage must be listed in PERSISTED_STORE_KEYS with the reason its contents may sit in storage that any XSS can read.',
+    ).toEqual(Object.keys(PERSISTED_STORE_KEYS).sort());
+  });
+
+  it('writes only the two non-identifying envelopes before login', async () => {
+    vi.resetModules();
+    window.localStorage.clear();
+
+    await import('./authStore');
+    await import('./preferencesStore');
+
+    const written: Record<string, string> = {};
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i)!;
+      written[key] = window.localStorage.getItem(key)!;
+    }
+
+    // Exact values, not a shape check: the claim in rules.tsv is about what a
+    // scanner reads off an unauthenticated page, so anything new in either
+    // envelope has to be looked at.
+    expect(written).toEqual(PRE_LOGIN_FOOTPRINT);
+  });
+
+  it('persists the auth flag alone, never the profile, token or delegation context', async () => {
+    const { useAuthStore } = await import('./authStore');
+    const partialize = useAuthStore.persist.getOptions().partialize!;
+
+    const persisted = partialize({
+      ...useAuthStore.getState(),
+      user: {
+        id: 'user-1',
+        email: 'someone@example.com',
+        firstName: 'Some',
+        lastName: 'One',
+        role: 'admin',
+      } as never,
+      token: 'a.jwt.token',
+      isAuthenticated: true,
+      actingAsUserId: 'owner-1',
+      availableContexts: [{ userId: 'owner-1' }] as never,
+      delegateCapabilities: { canViewTransactions: true } as never,
+      delegateSections: { transactions: true } as never,
+    });
+
+    expect(persisted).toEqual({ isAuthenticated: true });
+  });
+});


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

Adds a test guard (`persisted-storage.guard.test.ts`) that pins the exact localStorage footprint written before login to two zustand persist envelopes containing only non-identifying data (`isAuthenticated` flag and null preferences). The guard fails if:

1. A new persisted store is added without being classified in `PERSISTED_STORE_KEYS`
2. Any store's `partialize` function widens to include user profile, tokens, or delegation context
3. The pre-login footprint changes in any way

This enforces the security claim made to ZAP (OWASP scanning tool) in `.github/zap/rules.tsv` rule 120000, which silences localStorage warnings on the basis that the app writes no credentials, tokens, or PII before login. The test makes that claim verifiable and prevents silent regressions.

Also updates the existing `authStore.test.ts` persistence test (which only asserted that a persist API existed) with a comment directing readers to the new comprehensive guard.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (security guard for pre-login storage).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (N/A — no user-facing strings).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [ ] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_01TEhqPGL4FxLHmvTE7mx4wS