### PR TITLE
Extract regex escaping to shared utility, fix incomplete escape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Cross-layer rules live in `docs/`, not in this file, because they are too long t
 
 Two of these say something about a guarantee's wording that applies everywhere: any use of "atomic", "single-use", "exactly once", "retryable", "cannot", "always", "complete" or "transactional" must name the mechanism that makes it true -- the transaction, the index, the conditional `UPDATE`, the verified checksum. Three comments in this codebase claimed a lock, an atomic increment and a joint commit that the code beside them did not implement, and each was believed for as long as it existed. If the mechanism cannot be named, the wording is wrong, not merely vague.
 
-### Running the suites locally -- three ways a green branch reads as red
+### Running the suites locally -- four ways a green branch reads as red
 
 CI runs in UTC with one Playwright worker. A local run does neither, and both differences produce failures that look like regressions and are not.
 
@@ -117,6 +117,16 @@ CI runs in UTC with one Playwright worker. A local run does neither, and both di
 There is a third way, and it is the nastier one because no flag fixes it: **a test that reads the wall clock is a test about today's date.** `TZ=UTC` pins the offset, not the day. `AutoBackupService` promotes a daily artifact to weekly on the 7th, 14th, 21st and 28th and to monthly on the 1st, so on five days a month a single backup leaves two files in the folder and every assertion counting artifacts fails -- ten of them did, on `main`, with nothing having changed. A suite that is green because of the date it ran is not evidence about the code, and the failure it eventually produces points at the module rather than at the calendar.
 
 So pin the clock in the spec rather than waiting the failure out, and derive the pinned value from the constants the behaviour actually branches on (`WEEKLY_DAYS`, `MONTHLY_DAY` are exported for this) so widening one fails a named guard instead of silently re-dating ten assertions. `backend/src/backup/auto-backup.service.spec.ts` is the pattern: fake `Date` only -- faking `nextTick`/`queueMicrotask` under real `fs.promises` deadlocks rather than fails -- install the fake timers once, move the date through a single `withClockAt` helper, and let a source scan fail a second installation.
+
+The fourth is the one that hides a failure in the file you are writing rather than
+in one you did not touch: **a guard that walks the tree with `gitListFiles` cannot
+see an untracked file.** `doc-paths.spec.ts` and `source-comment-paths.spec.ts` list
+their subjects with `git ls-files` (`backend/src/common/repo-tree.util.ts`), which
+is right -- a scan must not read build output or somebody's scratch file -- and it
+means a brand-new spec or util is invisible to them until it is staged. So a run
+that is green before `git add` and red in CI on the same content is not a flake:
+the new file was simply not among the files scanned. Run those guards after staging
+(`git add -N` is enough), not before.
 
 Also: `scripts/verify-schema.sh` reproduces the "Schema vs Migrations Drift" job locally and needs nothing but Docker. Every migration has to be a no-op replayed on top of `schema.sql` (`CREATE ... IF NOT EXISTS`, `DROP ... IF EXISTS` before `CREATE POLICY`/`TRIGGER`), because that is also how the app boots: `db-init` applies `schema.sql` and `db-migrate` then replays the whole directory. A migration missing its guard does not just fail the drift check -- it aborts container start-up, and the E2E and Lighthouse jobs then report only "backend exited (1)".
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -340,6 +340,26 @@ number is data, and prefixing one stops the column adding up (issue #1134).
 Amounts here bypass `escapeCsv`, so the rule covers the text columns that can
 still hold a number, such as a cheque number written `-123`.
 
+## A partial escape is indistinguishable from a correct one
+
+Interpolating a literal into a pattern goes through `escapeRegExp`
+(`src/common/escape-regexp.util.ts`) -- never a hand-written
+`replace(/[.*+?^${}()|[\]\\]/g, "\\$&")`, and never a subset of that class.
+`repo-paths.util.ts` escaped only dots, which reads as complete because a
+repository path contains dots and nothing else interesting; it left `\` alone,
+so a prefix carrying `\d` would have interpolated as the digit class and matched
+input nobody wrote (CodeQL `js/incomplete-sanitization`, CWE-020). The class was
+already spelled out in four other files, and the fifth copy was the wrong one --
+which is the argument for one function rather than a remembered character class.
+`escape-regexp.guard.spec.ts` scans `src/` and fails on either shape.
+
+Where the pattern is built from a list, export the builder and test it against a
+prefix carrying a metacharacter. `ROOTED`'s entries contain at most a dot, so
+over its real inputs the broken escape and the correct one agree exactly; only a
+synthetic prefix can tell them apart (`buildPlainRootedPathPattern`). Do not
+escape `-`: outside a character class it is literal, and `\-` is a SyntaxError
+under the `u` flag -- so never interpolate the result *inside* a class.
+
 ## Rejection happens before the write
 
 A check capable of refusing a command belongs inside the transaction that performs it, and under the same lock when concurrency is in play. A service that mutates, commits, and returns a success-shaped value for a caller to reject afterwards has already done the thing the `409` says it did not do.

--- a/backend/src/accounts/account-name.util.ts
+++ b/backend/src/accounts/account-name.util.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from "../common/escape-regexp.util";
 import { tr } from "../i18n/translate";
 import { AccountSubType } from "./entities/account.entity";
 
@@ -62,8 +63,6 @@ export function pairHalfName(
 }
 
 function stripSuffixes(name: string, words: string[]): string {
-  const suffixes = [...new Set(words)]
-    .filter(Boolean)
-    .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const suffixes = [...new Set(words)].filter(Boolean).map(escapeRegExp);
   return name.replace(new RegExp(` - (${suffixes.join("|")})$`), "");
 }

--- a/backend/src/categories/category-name.util.ts
+++ b/backend/src/categories/category-name.util.ts
@@ -1,5 +1,6 @@
 import { EntityManager } from "typeorm";
 import { Category } from "./entities/category.entity";
+import { escapeRegExp } from "../common/escape-regexp.util";
 import { suggestClosestNames } from "../common/name-suggestions.util";
 
 /**
@@ -47,7 +48,7 @@ export const UNKNOWN_CATEGORY_LABEL = "Unknown category";
 const INPUT_SEPARATORS = ["->", ":", "/", ">"];
 
 const SEPARATOR_PATTERN = new RegExp(
-  `\\s*(?:${INPUT_SEPARATORS.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\s*`,
+  `\\s*(?:${INPUT_SEPARATORS.map(escapeRegExp).join("|")})\\s*`,
   "g",
 );
 

--- a/backend/src/common/db/prohibited-primitive-guidance.ts
+++ b/backend/src/common/db/prohibited-primitive-guidance.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from "../escape-regexp.util";
+
 /**
  * Classifier for "does this instruction text *recommend* a prohibited database
  * primitive", separated from the spec that scans the live documents so it can be
@@ -58,8 +60,8 @@ export function findProhibitedGuidance(
   typeNames: string[] = PROHIBITED_TYPE_NAMES,
 ): ProhibitedGuidanceHit[] {
   const alternatives = [
-    ...callNames.map((name) => `${escape(name)}\\(`),
-    ...typeNames.map((name) => escape(name)),
+    ...callNames.map((name) => `${escapeRegExp(name)}\\(`),
+    ...typeNames.map(escapeRegExp),
   ];
   if (alternatives.length === 0) return [];
   const pattern = new RegExp(`(?:${alternatives.join("|")})`, "g");
@@ -78,8 +80,4 @@ export function findProhibitedGuidance(
     hits.push({ token: match[0], excerpt: excerpt.trim() });
   }
   return hits;
-}
-
-function escape(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/backend/src/common/escape-regexp.guard.spec.ts
+++ b/backend/src/common/escape-regexp.guard.spec.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { globSync } from "glob";
+
+/**
+ * Regex escaping is written once, in `escape-regexp.util.ts`.
+ *
+ * The character class was spelled out in four places and got a fifth copy that
+ * escaped only dots -- which is how CodeQL's `js/incomplete-sanitization`
+ * (CWE-020) came to fire on `repo-paths.util.ts`. Both halves of that are
+ * mechanical rather than a judgement call, so this scans the source: a copy of
+ * the class is a duplicate that can drift, and a `replace` that escapes one
+ * metacharacter into a `\\`-prefixed literal is the incomplete form itself.
+ *
+ * The pattern is not "this calculation is wrong" but "this shape is the wrong
+ * shape", and the next instance will be in a file nobody thought to check.
+ */
+const SRC = join(__dirname, "..");
+
+/**
+ * The canonical metacharacter class, as source text. Written with string
+ * escapes rather than `String.raw`, because the class contains `${}` and a
+ * template literal would read that as a substitution.
+ */
+const ESCAPE_CLASS = "[.*+?^${}()|[\\]\\\\]";
+
+/**
+ * A `replace` that rewrites one character into its backslash-escaped self:
+ * `replace(/\./g, "\\.")`. That is the incomplete escape, and it reads as
+ * complete because the metacharacter it handles is the one the value contains.
+ */
+const PARTIAL_ESCAPE =
+  /\.replace\(\s*\/\\?([.*+?^$(){}|[\]])\/[a-z]*\s*,\s*"\\\\\1"/;
+
+function sourceFiles(): string[] {
+  return globSync("**/*.ts", {
+    cwd: SRC,
+    absolute: true,
+    ignore: ["**/*.spec.ts", "**/*.d.ts", "**/node_modules/**"],
+  });
+}
+
+function relative(file: string): string {
+  return file.slice(SRC.length + 1).replace(/\\/g, "/");
+}
+
+describe("regex escaping has one implementation", () => {
+  /** The helper itself is where the class is allowed to appear. */
+  const OWNER = "common/escape-regexp.util.ts";
+
+  it("the helper is the only file spelling out the metacharacter class", () => {
+    const offenders = sourceFiles()
+      .filter((file) => readFileSync(file, "utf8").includes(ESCAPE_CLASS))
+      .map(relative)
+      .filter((file) => file !== OWNER);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("no file escapes a single metacharacter by hand", () => {
+    const offenders = sourceFiles()
+      .filter((file) => PARTIAL_ESCAPE.test(readFileSync(file, "utf8")))
+      .map(relative)
+      // The helper quotes the defect it exists to prevent.
+      .filter((file) => file !== OWNER);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("the partial-escape scan recognises the shape it was written for", () => {
+    // The literal that was in `repo-paths.util.ts`, and a `%`/`_` SQL LIKE
+    // escape, which is a different job and must not be flagged.
+    expect(PARTIAL_ESCAPE.test(String.raw`p.replace(/\./g, "\\.")`)).toBe(true);
+    expect(PARTIAL_ESCAPE.test(String.raw`v.replace(/[%_]/g, "\\$&")`)).toBe(
+      false,
+    );
+  });
+
+  it("the class scan recognises the shape it was written for", () => {
+    const hand = `s.replace(/${ESCAPE_CLASS}/g, "\\\\$&")`;
+    expect(hand.includes(ESCAPE_CLASS)).toBe(true);
+    expect('s.replace(/[%_]/g, "\\\\$&")'.includes(ESCAPE_CLASS)).toBe(false);
+  });
+});

--- a/backend/src/common/escape-regexp.util.spec.ts
+++ b/backend/src/common/escape-regexp.util.spec.ts
@@ -1,0 +1,91 @@
+import { escapeRegExp } from "./escape-regexp.util";
+import {
+  buildPlainRootedPathPattern,
+  commentPathSpans,
+} from "./repo-paths.util";
+
+describe("escapeRegExp", () => {
+  it("escapes the backslash, which a dots-only escape leaves alone", () => {
+    // The original defect: `value.replace(/\./g, "\\.")` handles every dot a
+    // repository path can contain and passes `\` straight through, so the
+    // literal `c\d` becomes the digit class.
+    expect(escapeRegExp("c\\d")).toBe("c\\\\d");
+    expect(new RegExp(escapeRegExp("c\\d")).test("c5")).toBe(false);
+    expect(new RegExp(escapeRegExp("c\\d")).test("c\\d")).toBe(true);
+  });
+
+  it("escapes every regex metacharacter", () => {
+    for (const meta of [
+      ".",
+      "*",
+      "+",
+      "?",
+      "^",
+      "$",
+      "{",
+      "}",
+      "(",
+      ")",
+      "|",
+      "[",
+      "]",
+      "\\",
+    ]) {
+      const pattern = new RegExp(`^${escapeRegExp(meta)}$`);
+      expect(pattern.test(meta)).toBe(true);
+    }
+  });
+
+  it("matches the literal and nothing else", () => {
+    const pattern = new RegExp(`^${escapeRegExp("a.b*c")}$`);
+    expect(pattern.test("a.b*c")).toBe(true);
+    expect(pattern.test("axbbbc")).toBe(false);
+  });
+
+  it("leaves ordinary characters untouched", () => {
+    expect(escapeRegExp("backend/src/main.ts")).toBe("backend/src/main\\.ts");
+  });
+
+  it("does not escape `-`, which is a SyntaxError under the u flag", () => {
+    expect(escapeRegExp("a-b")).toBe("a-b");
+    expect(() => new RegExp(escapeRegExp("a-b"), "u")).not.toThrow();
+  });
+
+  it("produces a valid pattern under the u flag for every metacharacter", () => {
+    expect(
+      () => new RegExp(escapeRegExp(".*+?^${}()|[]\\/-"), "u"),
+    ).not.toThrow();
+  });
+});
+
+describe("buildPlainRootedPathPattern escapes its prefixes", () => {
+  it("reads a metacharacter in a prefix as a literal", () => {
+    // A dots-only escape leaves `\d` intact, so this prefix would match
+    // `c5/main.ts` -- a path claim nobody wrote, resolved against a file that
+    // does not exist. `a+b` is the same mistake without a backslash.
+    const pattern = buildPlainRootedPathPattern(["c\\d/", "a+b/"]);
+    expect("c5/main.ts".match(pattern)).toBeNull();
+    expect("aab/main.ts".match(pattern)).toBeNull();
+  });
+
+  it("still matches the literal prefix it was given", () => {
+    const pattern = buildPlainRootedPathPattern(["c\\d/"]);
+    expect("c\\d/main.ts".match(pattern)).toEqual(["c\\d/main.ts"]);
+  });
+
+  it("keeps the real prefixes working", () => {
+    // `.github/` carries the dot the original escape was written for.
+    expect(
+      commentPathSpans("see .github/workflows/ci.yml for the job"),
+    ).toEqual([".github/workflows/ci.yml"]);
+    expect(commentPathSpans("see backend/src/main.ts for the setup")).toEqual([
+      "backend/src/main.ts",
+    ]);
+  });
+
+  // The dot is the half the original escape did handle; asserted so a rewrite
+  // of the escaping cannot lose it while fixing the backslash.
+  it("does not read a dot in a prefix as a wildcard", () => {
+    expect(commentPathSpans("see xgithub/workflows/ci.yml")).toEqual([]);
+  });
+});

--- a/backend/src/common/escape-regexp.util.spec.ts
+++ b/backend/src/common/escape-regexp.util.spec.ts
@@ -60,9 +60,13 @@ describe("escapeRegExp", () => {
 
 describe("buildPlainRootedPathPattern escapes its prefixes", () => {
   it("reads a metacharacter in a prefix as a literal", () => {
-    // A dots-only escape leaves `\d` intact, so this prefix would match
-    // `c5/main.ts` -- a path claim nobody wrote, resolved against a file that
-    // does not exist. `a+b` is the same mistake without a backslash.
+    // A dots-only escape leaves `\d` intact, so the prefix is read as the digit
+    // class and the pattern matches c5/main.ts -- a path claim nobody wrote.
+    // That fixture is named here in plain prose rather than in a backticked
+    // span, because a backticked span is the idiom for "this file is here" and
+    // this one deliberately is not: source-comment-paths.spec.ts reads every
+    // comment in this file as a claim about the tree. `a+b/` is the same
+    // mistake without a backslash.
     const pattern = buildPlainRootedPathPattern(["c\\d/", "a+b/"]);
     expect("c5/main.ts".match(pattern)).toBeNull();
     expect("aab/main.ts".match(pattern)).toBeNull();

--- a/backend/src/common/escape-regexp.util.ts
+++ b/backend/src/common/escape-regexp.util.ts
@@ -1,0 +1,26 @@
+/**
+ * Escape a literal string for safe interpolation into a `RegExp` source.
+ *
+ * Every character with a meaning in a regular expression is neutralized,
+ * `\` included -- and the backslash is the one that gets left out. Escaping
+ * only the obvious metacharacter looks complete because it is the one the
+ * value actually contains: `value.replace(/\./g, "\\.")` handles every dot in a
+ * repository path and leaves `\` alone, so a literal `c\d` interpolates as the
+ * digit class `\d` and the pattern silently matches input nobody wrote
+ * (CWE-020, CodeQL `js/incomplete-sanitization`). An escape that is partial is
+ * indistinguishable from a correct one until the value contains the character
+ * it forgot.
+ *
+ * Use this anywhere a value -- a constant, a separator, a filename, a
+ * user-supplied word -- is concatenated into a pattern, rather than writing the
+ * character class out again: it was spelled out in five places, and the fifth
+ * copy was the incomplete one. `escape-regexp.guard.spec.ts` fails on a sixth.
+ *
+ * The set is the standard one (`.*+?^${}()|[]\`). It deliberately does not
+ * escape `-`: outside a character class `-` is literal, and `\-` is a
+ * SyntaxError under the `u` flag. Do not interpolate the result *inside* a
+ * character class.
+ */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/backend/src/common/repo-paths.util.ts
+++ b/backend/src/common/repo-paths.util.ts
@@ -1,5 +1,7 @@
 import { basename } from "path";
 
+import { escapeRegExp } from "./escape-regexp.util";
+
 /**
  * The grammar and inventory that decide whether a written reference to a file --
  * in a doc, a source comment, or a migration comment -- is a claim about this
@@ -482,12 +484,24 @@ export function extractSqlComments(sql: string): string[] {
 // Claims inside a comment.
 // ---------------------------------------------------------------------------
 
-const PLAIN_ROOTED_PATH = new RegExp(
-  `(?<![\\w./@-])(?:${ROOTED.map((p) =>
-    p.replace(/\./g, "\\.").replace(/\/$/, ""),
-  ).join("|")})/[\\w./@-]*?\\.(?:${EXTENSIONS_LONGEST_FIRST})(?![\\w])`,
-  "g",
-);
+/**
+ * The pattern that finds a rooted path in running prose, built from a list of
+ * prefixes. Exported (rather than inlined over `ROOTED`) so the escaping can be
+ * tested against a prefix carrying a metacharacter: every entry in `ROOTED`
+ * today contains at most a dot, which is exactly why an escape that handled
+ * only dots read as complete.
+ */
+export function buildPlainRootedPathPattern(prefixes: string[]): RegExp {
+  const alternatives = prefixes
+    .map((prefix) => escapeRegExp(prefix.replace(/\/$/, "")))
+    .join("|");
+  return new RegExp(
+    `(?<![\\w./@-])(?:${alternatives})/[\\w./@-]*?\\.(?:${EXTENSIONS_LONGEST_FIRST})(?![\\w])`,
+    "g",
+  );
+}
+
+const PLAIN_ROOTED_PATH = buildPlainRootedPathPattern(ROOTED);
 
 /**
  * The path claims a single comment makes. Backticked spans are the strong idiom

--- a/backend/src/import/csv-parser.ts
+++ b/backend/src/import/csv-parser.ts
@@ -9,6 +9,7 @@
  */
 
 import type { QifTransaction, QifParseResult } from "./qif-parser";
+import { escapeRegExp } from "../common/escape-regexp.util";
 import { roundToDecimals } from "../common/round.util";
 
 export interface CsvHeadersResult {
@@ -685,7 +686,7 @@ function parseDateCustom(dateStr: string, format: string): string | null {
       i += 2;
     } else {
       // Escape regex special chars for literal separator
-      regex += format[i].replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      regex += escapeRegExp(format[i]);
       i += 1;
     }
   }


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

Extracts regex escaping logic into a centralized `escapeRegExp` utility to fix an incomplete escape vulnerability (CWE-020, CodeQL `js/incomplete-sanitization`) and prevent future occurrences.

**The problem:** `repo-paths.util.ts` escaped only dots (`replace(/\./g, "\\.")`), which appeared complete because repository paths contain dots. However, it left backslashes unescaped, so a prefix containing `\d` would interpolate as the digit class and match input nobody wrote. The same character class was spelled out in four other files, and the fifth copy was the wrong one.

**The solution:** 
- Created `escape-regexp.util.ts` with a single `escapeRegExp` function that properly escapes all regex metacharacters: `[.*+?^${}()|[\]\\]`
- Replaced all hand-written escape patterns across the codebase with calls to this utility
- Exported `buildPlainRootedPathPattern` from `repo-paths.util.ts` to enable testing against synthetic prefixes carrying metacharacters
- Added `escape-regexp.guard.spec.ts` to scan the source and fail if the character class or partial-escape pattern appear elsewhere, preventing future duplicates

**Files updated:**
- `backend/src/common/escape-regexp.util.ts` (new) — the canonical implementation
- `backend/src/common/escape-regexp.util.spec.ts` (new) — unit tests for the utility and integration tests for `buildPlainRootedPathPattern`
- `backend/src/common/escape-regexp.guard.spec.ts` (new) — source-scanning tests to enforce single implementation
- `backend/src/common/repo-paths.util.ts` — uses `escapeRegExp`, exports `buildPlainRootedPathPattern`
- `backend/src/common/db/prohibited-primitive-guidance.ts` — replaced hand-written escape with `escapeRegExp`
- `backend/src/accounts/account-name.util.ts` — replaced hand-written escape with `escapeRegExp`
- `backend/src/categories/category-name.util.ts` — replaced hand-written escape with `escapeRegExp`
- `backend/src/import/csv-parser.ts` — replaced hand-written escape with `escapeRegExp`
- `backend/CLAUDE.md` — documented the pattern and rationale

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (regex escaping centralization and security fix).
- [x] New behavior has tests, and the existing suite passes.
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [ ] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_01NJi6YKRoisHx4QQ4tc8hmD