### PR TITLE
fix(transactions): allow creating a category from a split line (#1187)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -765,6 +765,32 @@ untidy: every toggle on it is one whose save cannot succeed.
 The converse is not true. An account the caller owns and has shared *out*
 carries `jointGranteeCount`, is still theirs, and stays assignable.
 
+### On a joint row, *every* picker reads the owner's list -- and creation is off
+
+A joint row belongs to the sharing owner and may only carry the owner's
+reference ids, so `TransactionForm` derives `effectiveCategories` /
+`effectivePayees` from the grant-gated reference-data endpoint. The rule is that
+**everything** downstream reads those, not the caller's own `categories`: the
+option list, the income/expense sign lookups, and the split editor. Three sites
+still read `categories`, and each failed differently and quietly -- the sign
+lookup could not resolve an owner id, so choosing an income category left the
+amount negative; `SplitEditor` was handed the caller's list, so the owner's
+split lines resolved to nothing and any pick wrote one of the caller's ids onto
+the owner's row. Split mode is blocked on the *mode button* for a joint account,
+which is not the same as being unreachable: opening a split row that already
+lives there puts the form straight into it.
+
+Creation is a separate question with a blunter answer: **do not offer it.**
+`categoriesApi.create` writes to the caller's ledger and there is no client path
+that creates on someone else's, so "+ Create" on a joint account made the
+category in the wrong place and put an id the owner does not own on the form.
+The delegation carries a `categoriesCanCreate` capability with nothing on the
+client to drive yet; until an owner-scoped create exists, withhold the creator
+(`jointSafeCategoryCreator`) rather than gate the button on a flag the code
+cannot honour. Withholding it is also what makes the rule hold everywhere at
+once -- the Category field, the transfer form's, and every split line take the
+same optional prop, so there is one decision rather than four.
+
 ## Form Patterns
 
 `useFormModal<T>` (`hooks/useFormModal.ts`) manages create/edit modal state with browser-history integration (back button closes), unsaved-changes detection via `UnsavedChangesDialog`, and form submit exposed via ref. Returns `showForm`, `editingItem`, `openCreate()`, `openEdit(item)`, `close()`, `modalProps`, `unsavedChangesDialog`.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -189,6 +189,28 @@ selectable, parents included**. A bare leaf name is ambiguous once two parents
 own the same leaf, and a picker shaped differently from the transaction form's
 reads as a second component. `CategorySwitcher` carries the regression tests.
 
+**A picker the user types into creates through `createCategoryFromInput`
+(`lib/category-create.ts`), and never inline.** It owns title casing and the
+`Parent: Child` shorthand -- create or reuse the parent, then the child under
+it -- and returns every row it created so the caller can append all of them to
+its own list, not only the leaf. Three inline copies of that parsing existed
+and the scheduled transaction form's had none of it, so `travel: hotels` became
+a child of Travel in two fields and one flat category named "Travel: Hotels" in
+the third. The guard in `src/test/ui-conventions.test.ts` fails on a second
+`categoriesApi.create` call site outside the helper and the Categories page's
+own full create form.
+
+Whether a picker *offers* to create is a property of the surface, not of the
+field: a form that can create passes the creator to **every** category picker it
+renders, its split lines included. `SplitEditor`'s lines silently discarded text
+matching no category while the Category field beside them offered "+ Create"
+(issue #1187) -- the split copy was the same `Combobox` missing
+`allowCustomValue` and `onCreateNew`. An asynchronous create addresses the row
+it came from **by id**: rows can be added, removed or reordered while the
+request is in flight, and the new category's `isIncome` comes from what the
+creator returned, since the parent's appended list has not re-rendered the
+editor yet.
+
 ### An account balance is coloured by its sign -- `balanceColor`, never by account type
 
 `balanceColor` (`lib/format.ts`) is the one rule: negative is red, everything

--- a/frontend/src/app/bills/page.test.tsx
+++ b/frontend/src/app/bills/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@/test/render';
+import { render, screen, waitFor, fireEvent, act } from '@/test/render';
 import BillsPage from './page';
 
 // Mock next/image
@@ -90,6 +90,7 @@ vi.mock('@/lib/utils', () => ({
 
 const mockGetAll = vi.fn();
 const mockGetAllCategories = vi.fn();
+const mockCreateCategory = vi.fn();
 const mockGetAllAccounts = vi.fn();
 const mockHasOverrides = vi.fn();
 const mockGetOverrides = vi.fn();
@@ -109,6 +110,7 @@ vi.mock('@/lib/scheduled-transactions', () => ({
 vi.mock('@/lib/categories', () => ({
   categoriesApi: {
     getAll: (...args: any[]) => mockGetAllCategories(...args),
+    create: (...args: any[]) => mockCreateCategory(...args),
   },
 }));
 
@@ -233,10 +235,21 @@ vi.mock('@/components/scheduled-transactions/OccurrenceDatePicker', () => ({
 }));
 
 vi.mock('@/components/scheduled-transactions/PostTransactionDialog', () => ({
-  PostTransactionDialog: ({ isOpen, onClose, onPosted }: any) => isOpen ? (
+  PostTransactionDialog: ({ isOpen, onClose, onPosted, categories, onCreateCategory }: any) => isOpen ? (
     <div data-testid="post-dialog">
       <button data-testid="post-close" onClick={onClose}>Close</button>
       <button data-testid="post-confirm" onClick={onPosted}>Confirm Post</button>
+      <span data-testid="post-category-names">
+        {(categories || []).map((c: any) => c.name).join(',')}
+      </span>
+      {onCreateCategory && (
+        <button
+          data-testid="post-create-category"
+          onClick={() => onCreateCategory('travel: hotels')}
+        >
+          Create category
+        </button>
+      )}
     </div>
   ) : null,
 }));
@@ -264,6 +277,7 @@ describe('BillsPage', () => {
     vi.useFakeTimers({ now, shouldAdvanceTime: true });
     mockGetAll.mockResolvedValue(mockScheduledTransactions);
     mockGetAllCategories.mockResolvedValue([]);
+    mockCreateCategory.mockReset();
     mockGetAllAccounts.mockResolvedValue([]);
     mockGetAllTransactions.mockResolvedValue({ data: [], total: 0 });
     mockHasOverrides.mockResolvedValue({ hasOverrides: false, count: 0 });
@@ -747,6 +761,54 @@ describe('BillsPage', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('post-dialog')).toBeInTheDocument();
+      });
+    });
+
+    // Both occurrence dialogs let the user name a category that does not exist
+    // yet; the page owns the list they read, so it owns the creation and has to
+    // add every row created -- the parent included -- or the picker shows a
+    // child whose parent is missing (issue #1187 follow-up).
+    it('creates a category for the post dialog and adds every created row to the list', async () => {
+      mockCreateCategory
+        .mockResolvedValueOnce({ id: 'parent-cat', name: 'Travel', parentId: null })
+        .mockResolvedValueOnce({ id: 'child-cat', name: 'Hotels', parentId: 'parent-cat' });
+
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('post-st-1'));
+      await waitFor(() => expect(screen.getByTestId('post-dialog')).toBeInTheDocument());
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('post-create-category'));
+      });
+
+      expect(mockCreateCategory).toHaveBeenNthCalledWith(1, { name: 'Travel' });
+      expect(mockCreateCategory).toHaveBeenNthCalledWith(2, {
+        name: 'Hotels',
+        parentId: 'parent-cat',
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('post-category-names')).toHaveTextContent('Travel,Hotels');
+      });
+    });
+
+    it('reports a failed category creation instead of silently doing nothing', async () => {
+      mockCreateCategory.mockRejectedValue(new Error('boom'));
+
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('post-st-1'));
+      await waitFor(() => expect(screen.getByTestId('post-dialog')).toBeInTheDocument());
+
+      const toast = await import('react-hot-toast');
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('post-create-category'));
+      });
+
+      await waitFor(() => {
+        expect(toast.default.error).toHaveBeenCalledWith('Failed to create category');
       });
     });
 

--- a/frontend/src/app/bills/page.tsx
+++ b/frontend/src/app/bills/page.tsx
@@ -31,6 +31,7 @@ import { SummaryCard, SummaryIcons } from '@/components/ui/SummaryCard';
 import { scheduledTransactionsApi } from '@/lib/scheduled-transactions';
 import { transactionsApi } from '@/lib/transactions';
 import { categoriesApi } from '@/lib/categories';
+import { createCategoryFromInput } from '@/lib/category-create';
 import { buildCategoryColorMap } from '@/lib/categoryUtils';
 import { accountsApi } from '@/lib/accounts';
 import { ScheduledTransaction, ScheduledTransactionOverride } from '@/types/scheduled-transaction';
@@ -80,6 +81,10 @@ export default function BillsPage() {
 function BillsContent() {
   const t = useTranslations('bills');
   const tc = useTranslations('common');
+  // The two occurrence dialogs live in the scheduled-transaction domain and
+  // their copy is in that catalog; the category toasts they raise from here
+  // read from it rather than duplicating the same two strings under `bills`.
+  const tsched = useTranslations('scheduledTransactions');
   const router = useRouter();
   const searchParams = useSearchParams();
   const postBillId = searchParams.get('postBillId');
@@ -350,6 +355,28 @@ function BillsContent() {
   const handleDatePickerClose = () => {
     setDatePicker({ isOpen: false, transaction: null, overrides: [] });
   };
+
+  // Create a category from text typed into either occurrence dialog's category
+  // picker -- the plain Category field and each split line's own. The page owns
+  // the category list both dialogs read, so it owns the creation; the created
+  // row is returned so the dialog can select it, and appended here so it
+  // appears in the picker.
+  const createCategoryFromTypedName = useCallback(
+    async (name: string): Promise<Category | null> => {
+      try {
+        const result = await createCategoryFromInput(name, categories);
+        if (!result) return null;
+        setCategories((prev) => [...prev, ...result.created]);
+        toast.success(tsched('form.toasts.categoryCreated', { name: result.displayName }));
+        return result.category;
+      } catch (error) {
+        logger.error('Failed to create category:', error);
+        toast.error(getErrorMessage(error, tsched('form.toasts.categoryCreateFailed')));
+        return null;
+      }
+    },
+    [categories, tsched],
+  );
 
   const handleOverrideEditorClose = () => {
     const wasReconcileDeepLink = overrideEditor.prefillAmount != null;
@@ -817,6 +844,7 @@ function BillsContent() {
           prefillAmount={overrideEditor.prefillAmount}
           onClose={handleOverrideEditorClose}
           onSave={handleOverrideEditorSave}
+          onCreateCategory={createCategoryFromTypedName}
         />
       )}
 
@@ -831,6 +859,7 @@ function BillsContent() {
           futureTransactions={futureTransactions}
           onClose={handlePostDialogClose}
           onPosted={handlePostDialogPosted}
+          onCreateCategory={createCategoryFromTypedName}
         />
       )}
 

--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -24,6 +24,7 @@ import { Category } from '@/types/category';
 import { accountsApi } from '@/lib/accounts';
 import { useMainAccountName } from '@/hooks/useMainAccountName';
 import { categoriesApi } from '@/lib/categories';
+import { createCategoryFromInput } from '@/lib/category-create';
 import { exchangeRatesApi, CurrencyInfo } from '@/lib/exchange-rates';
 import { getCurrencySymbol } from '@/lib/format';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
@@ -632,63 +633,27 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
     }
   };
 
-  // Convert string to title case (capitalize first letter of each word)
-  const toTitleCase = (str: string): string => {
-    return str
-      .toLowerCase()
-      .split(' ')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
-  };
-
   // Handle asset category creation - supports "Parent: Child" format
   const handleAssetCategoryCreate = async (name: string) => {
-    if (!name.trim()) return;
-
     try {
-      let categoryName = toTitleCase(name.trim());
-      let parentId: string | undefined;
-      let parentName: string | undefined;
-
-      // Check for "Parent: Child" format
-      if (categoryName.includes(':')) {
-        const parts = categoryName.split(':').map(p => p.trim());
-        if (parts.length === 2 && parts[0] && parts[1]) {
-          parentName = toTitleCase(parts[0]);
-          const childName = toTitleCase(parts[1]);
-
-          // Find existing parent category (case-insensitive, top-level only)
-          let parentCategory = categories.find(
-            c => c.name.toLowerCase() === parentName!.toLowerCase() && !c.parentId
-          );
-
-          // If parent doesn't exist, create it first
-          if (!parentCategory) {
-            const newParent = await categoriesApi.create({ name: parentName });
-            setCategories(prev => [...prev, newParent]);
-            parentCategory = newParent;
-          }
-
-          parentId = parentCategory.id;
-          parentName = parentCategory.name; // Use actual name from existing category
-          categoryName = childName;
-        }
-      }
-
-      const newCategory = await categoriesApi.create({
-        name: categoryName,
-        parentId,
+      const result = await createCategoryFromInput(name, categories, {
         isIncome: false, // Asset value changes are typically not income
       });
-      setCategories(prev => [...prev, newCategory]);
-      setSelectedAssetCategoryId(newCategory.id);
-      setAssetCategoryName(parentName ? `${parentName}: ${categoryName}` : categoryName);
-      setValue('assetCategoryId', newCategory.id, { shouldDirty: true, shouldValidate: true });
+      if (!result) return;
+      setCategories(prev => [...prev, ...result.created]);
+      setSelectedAssetCategoryId(result.category.id);
+      setAssetCategoryName(result.displayName);
+      setValue('assetCategoryId', result.category.id, { shouldDirty: true, shouldValidate: true });
 
-      if (parentId && parentName) {
-        toast.success(t('toasts.categoryCreatedNested', { parent: parentName, name: categoryName }));
+      if (result.parentName) {
+        toast.success(
+          t('toasts.categoryCreatedNested', {
+            parent: result.parentName,
+            name: result.category.name,
+          }),
+        );
       } else {
-        toast.success(t('toasts.categoryCreated', { name: categoryName }));
+        toast.success(t('toasts.categoryCreated', { name: result.category.name }));
       }
     } catch (error) {
       logger.error('Failed to create category:', error);

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
@@ -73,7 +73,9 @@ vi.mock('@/lib/categoryUtils', () => ({
 }));
 
 vi.mock('@/components/transactions/SplitEditor', () => ({
-  SplitEditor: () => <div data-testid="split-editor">SplitEditor</div>,
+  SplitEditor: ({ onCreateCategory }: any) => (
+    <div data-testid="split-editor">{onCreateCategory ? 'can-create' : 'no-create'}</div>
+  ),
   SplitRow: null,
   createEmptySplits: () => [
     { id: '1', categoryId: '', amount: 0, memo: '', splitType: 'category' },
@@ -86,13 +88,23 @@ vi.mock('@/components/transactions/SplitEditor', () => ({
 }));
 
 vi.mock('@/components/ui/Combobox', () => ({
-  Combobox: ({ placeholder, onChange, value }: any) => (
-    <input
-      placeholder={placeholder}
-      data-testid="combobox-category"
-      value={value || ''}
-      onChange={(e: any) => onChange?.(e.target.value, '')}
-    />
+  Combobox: ({ placeholder, onChange, onCreateNew, value }: any) => (
+    <>
+      <input
+        placeholder={placeholder}
+        data-testid="combobox-category"
+        value={value || ''}
+        onChange={(e: any) => onChange?.(e.target.value, '')}
+      />
+      {onCreateNew && (
+        <button
+          data-testid="combobox-category-create"
+          onClick={() => onCreateNew('vet bills')}
+        >
+          Create
+        </button>
+      )}
+    </>
   ),
 }));
 
@@ -422,6 +434,62 @@ describe('OverrideEditorDialog', () => {
   it('shows split toggle for non-transfer transactions', () => {
     render(<OverrideEditorDialog {...defaultProps} />);
     expect(screen.getByLabelText('Split this occurrence')).toBeInTheDocument();
+  });
+
+  // --- Creating a category from the dialog (issue #1187 follow-up) ---
+  describe('creating a category', () => {
+    it('offers no create option when the page cannot create categories', () => {
+      render(<OverrideEditorDialog {...defaultProps} />);
+      expect(screen.queryByTestId('combobox-category-create')).not.toBeInTheDocument();
+    });
+
+    it('selects the category the page created', async () => {
+      const onCreateCategory = vi
+        .fn()
+        .mockResolvedValue({ id: 'c-new', name: 'Vet Bills', parentId: null });
+
+      render(
+        <OverrideEditorDialog {...defaultProps} onCreateCategory={onCreateCategory} />,
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('combobox-category-create'));
+      });
+
+      expect(onCreateCategory).toHaveBeenCalledWith('vet bills');
+      expect(screen.getByTestId('combobox-category')).toHaveValue('c-new');
+    });
+
+    it('leaves the field alone when nothing was created', async () => {
+      const onCreateCategory = vi.fn().mockResolvedValue(null);
+
+      render(
+        <OverrideEditorDialog {...defaultProps} onCreateCategory={onCreateCategory} />,
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('combobox-category-create'));
+      });
+
+      expect(screen.getByTestId('combobox-category')).toHaveValue('c1');
+    });
+
+    it('passes the creator through to the split editor', () => {
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          onCreateCategory={vi.fn()}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText('Split this occurrence'));
+      expect(screen.getByTestId('split-editor')).toHaveTextContent('can-create');
+    });
+
+    it('leaves the split editor without a creator when the page has none', () => {
+      render(<OverrideEditorDialog {...defaultProps} />);
+      fireEvent.click(screen.getByLabelText('Split this occurrence'));
+      expect(screen.getByTestId('split-editor')).toHaveTextContent('no-create');
+    });
   });
 
   it('does not show split toggle for transfer transactions', () => {

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
@@ -43,6 +43,13 @@ interface OverrideEditorDialogProps {
   prefillAmount?: number | null;
   onClose: () => void;
   onSave: () => void;
+  /**
+   * Create a category from text typed into any of this dialog's category
+   * pickers -- the Category field and each split line's own -- resolving to the
+   * created category. The page owns the category list, so it owns the creation.
+   * When omitted the pickers only select from what already exists.
+   */
+  onCreateCategory?: (name: string) => Promise<Category | null | undefined>;
 }
 
 export function OverrideEditorDialog({
@@ -55,6 +62,7 @@ export function OverrideEditorDialog({
   prefillAmount,
   onClose,
   onSave,
+  onCreateCategory,
 }: OverrideEditorDialogProps) {
   const t = useTranslations('scheduledTransactions');
   const tc = useTranslations('common');
@@ -696,6 +704,7 @@ export function OverrideEditorDialog({
                 transactionAmount={amount}
                 onTransactionAmountChange={handleAmountChange}
                 currencyCode={scheduledTransaction.currencyCode}
+                onCreateCategory={onCreateCategory}
               />
             ) : (
               <div>
@@ -708,6 +717,16 @@ export function OverrideEditorDialog({
                   value={categoryId}
                   initialDisplayValue={currentCategory?.name || ''}
                   onChange={(value) => setCategoryId(value || '')}
+                  onCreateNew={
+                    onCreateCategory
+                      ? async (name) => {
+                          const created = await onCreateCategory(name);
+                          if (created) setCategoryId(created.id);
+                        }
+                      : undefined
+                  }
+                  allowCustomValue={!!onCreateCategory}
+                  valueIsId
                 />
               </div>
             )}

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
@@ -84,7 +84,9 @@ vi.mock('@/lib/categoryUtils', () => ({
 }));
 
 vi.mock('@/components/transactions/SplitEditor', () => ({
-  SplitEditor: () => <div data-testid="split-editor">SplitEditor</div>,
+  SplitEditor: ({ onCreateCategory }: any) => (
+    <div data-testid="split-editor">{onCreateCategory ? 'can-create' : 'no-create'}</div>
+  ),
   SplitRow: null,
   createEmptySplits: () => [
     { id: '1', categoryId: '', amount: 0, memo: '', splitType: 'category' },
@@ -97,13 +99,23 @@ vi.mock('@/components/transactions/SplitEditor', () => ({
 }));
 
 vi.mock('@/components/ui/Combobox', () => ({
-  Combobox: ({ placeholder, onChange, value }: any) => (
-    <input
-      placeholder={placeholder}
-      data-testid="combobox-category"
-      value={value || ''}
-      onChange={(e: any) => onChange?.(e.target.value, '')}
-    />
+  Combobox: ({ placeholder, onChange, onCreateNew, value }: any) => (
+    <>
+      <input
+        placeholder={placeholder}
+        data-testid="combobox-category"
+        value={value || ''}
+        onChange={(e: any) => onChange?.(e.target.value, '')}
+      />
+      {onCreateNew && (
+        <button
+          data-testid="combobox-category-create"
+          onClick={() => onCreateNew('vet bills')}
+        >
+          Create
+        </button>
+      )}
+    </>
   ),
 }));
 
@@ -354,6 +366,59 @@ describe('PostTransactionDialog', () => {
     render(<PostTransactionDialog {...defaultProps} />);
     expect(screen.getByText('Category')).toBeInTheDocument();
     expect(screen.getByTestId('combobox-category')).toBeInTheDocument();
+  });
+
+  // --- Creating a category from the dialog (issue #1187 follow-up) ---
+  describe('creating a category', () => {
+    it('offers no create option when the page cannot create categories', () => {
+      render(<PostTransactionDialog {...defaultProps} />);
+      expect(screen.queryByTestId('combobox-category-create')).not.toBeInTheDocument();
+    });
+
+    it('selects the category the page created', async () => {
+      const onCreateCategory = vi
+        .fn()
+        .mockResolvedValue({ id: 'c-new', name: 'Vet Bills', parentId: null });
+
+      render(
+        <PostTransactionDialog {...defaultProps} onCreateCategory={onCreateCategory} />,
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('combobox-category-create'));
+      });
+
+      expect(onCreateCategory).toHaveBeenCalledWith('vet bills');
+      expect(screen.getByTestId('combobox-category')).toHaveValue('c-new');
+    });
+
+    it('leaves the field alone when nothing was created', async () => {
+      const onCreateCategory = vi.fn().mockResolvedValue(null);
+
+      render(
+        <PostTransactionDialog {...defaultProps} onCreateCategory={onCreateCategory} />,
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('combobox-category-create'));
+      });
+
+      expect(screen.getByTestId('combobox-category')).toHaveValue('c1');
+    });
+
+    it('passes the creator through to the split editor', () => {
+      render(
+        <PostTransactionDialog {...defaultProps} onCreateCategory={vi.fn()} />,
+      );
+      fireEvent.click(screen.getByLabelText('Split this transaction'));
+      expect(screen.getByTestId('split-editor')).toHaveTextContent('can-create');
+    });
+
+    it('leaves the split editor without a creator when the page has none', () => {
+      render(<PostTransactionDialog {...defaultProps} />);
+      fireEvent.click(screen.getByLabelText('Split this transaction'));
+      expect(screen.getByTestId('split-editor')).toHaveTextContent('no-create');
+    });
   });
 
   // --- Split toggle ---

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -71,6 +71,13 @@ interface PostTransactionDialogProps {
   futureTransactions: FutureTransaction[];
   onClose: () => void;
   onPosted: () => void;
+  /**
+   * Create a category from text typed into any of this dialog's category
+   * pickers -- the Category field and each split line's own -- resolving to the
+   * created category. The page owns the category list, so it owns the creation.
+   * When omitted the pickers only select from what already exists.
+   */
+  onCreateCategory?: (name: string) => Promise<Category | null | undefined>;
 }
 
 export function PostTransactionDialog({
@@ -82,6 +89,7 @@ export function PostTransactionDialog({
   futureTransactions,
   onClose,
   onPosted,
+  onCreateCategory,
 }: PostTransactionDialogProps) {
   const t = useTranslations('scheduledTransactions');
   const tc = useTranslations('common');
@@ -1122,6 +1130,7 @@ export function PostTransactionDialog({
                 transactionAmount={amount}
                 onTransactionAmountChange={handleAmountChange}
                 currencyCode={scheduledTransaction.currencyCode}
+                onCreateCategory={onCreateCategory}
               />
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -1135,6 +1144,16 @@ export function PostTransactionDialog({
                     value={categoryId}
                     initialDisplayValue={currentCategory?.name || ''}
                     onChange={(value) => setCategoryId(value || '')}
+                    onCreateNew={
+                      onCreateCategory
+                        ? async (name) => {
+                            const created = await onCreateCategory(name);
+                            if (created) setCategoryId(created.id);
+                          }
+                        : undefined
+                    }
+                    allowCustomValue={!!onCreateCategory}
+                    valueIsId
                   />
                 </div>
                 {referenceNumberField}

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
@@ -167,6 +167,12 @@ vi.mock('@/components/ui/Combobox', () => ({
       >
         Create
       </button>
+      <button
+        data-testid={`combobox-create-nested-${label || 'unnamed'}`}
+        onClick={() => onCreateNew?.('travel: hotels')}
+      >
+        Create nested
+      </button>
       {(options || []).map((opt: any) => (
         <button
           key={opt.value}
@@ -1248,6 +1254,35 @@ describe('ScheduledTransactionForm', () => {
 
     await waitFor(() => {
       expect(mockCategoriesCreate).toHaveBeenCalledWith({ name: 'New Item' });
+    });
+  });
+
+  // This form used to create the typed text verbatim as one flat category, so
+  // "travel: hotels" became a top-level category literally named "Travel:
+  // Hotels" here while the transaction form made Hotels a child of Travel. Both
+  // now go through `createCategoryFromInput`.
+  it('creates a parent and child for "Parent: Child" typed into the category field', async () => {
+    mockCategoriesCreate
+      .mockResolvedValueOnce({ id: 'parent-cat', name: 'Travel', parentId: null })
+      .mockResolvedValueOnce({ id: 'child-cat', name: 'Hotels', parentId: 'parent-cat' });
+
+    render(<ScheduledTransactionForm />);
+
+    await waitFor(() => {
+      expect(mockCategoriesGetAll).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByTestId('combobox-create-nested-Category'));
+
+    await waitFor(() => {
+      expect(mockCategoriesCreate).toHaveBeenNthCalledWith(1, { name: 'Travel' });
+    });
+    expect(mockCategoriesCreate).toHaveBeenNthCalledWith(2, {
+      name: 'Hotels',
+      parentId: 'parent-cat',
+    });
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Category "Travel: Hotels" created');
     });
   });
 

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
@@ -24,6 +24,7 @@ import { investmentsApi } from '@/lib/investments';
 import { getLocalDateString } from '@/lib/utils';
 import { payeesApi } from '@/lib/payees';
 import { categoriesApi } from '@/lib/categories';
+import { createCategoryFromInput } from '@/lib/category-create';
 import { accountsApi } from '@/lib/accounts';
 import { tagsApi } from '@/lib/tags';
 import { ScheduledTransaction, FrequencyType, FREQUENCY_VALUES } from '@/types/scheduled-transaction';
@@ -933,19 +934,29 @@ export function ScheduledTransactionForm({
     }
   };
 
-  const handleCategoryCreate = async (name: string) => {
-    if (!name.trim()) return;
-
+  // Create a category from text typed into any of this form's category pickers
+  // -- the Category field, and each split line's own picker. Returns the
+  // created category so a split line can assign it to the row that asked; null
+  // means nothing was created (blank input, or the request failed).
+  const createCategoryFromTypedName = async (name: string): Promise<Category | null> => {
     try {
-      const newCategory = await categoriesApi.create({ name: name.trim() });
-      setCategories((prev) => [...prev, newCategory]);
-      setSelectedCategoryId(newCategory.id);
-      setValue('categoryId', newCategory.id, { shouldDirty: true, shouldValidate: true });
-      toast.success(t('form.toasts.categoryCreated', { name }));
+      const result = await createCategoryFromInput(name, categories);
+      if (!result) return null;
+      setCategories((prev) => [...prev, ...result.created]);
+      toast.success(t('form.toasts.categoryCreated', { name: result.displayName }));
+      return result.category;
     } catch (error) {
       logger.error('Failed to create category:', error);
       toast.error(getErrorMessage(error, t('form.toasts.categoryCreateFailed')));
+      return null;
     }
+  };
+
+  const handleCategoryCreate = async (name: string) => {
+    const newCategory = await createCategoryFromTypedName(name);
+    if (!newCategory) return;
+    setSelectedCategoryId(newCategory.id);
+    setValue('categoryId', newCategory.id, { shouldDirty: true, shouldValidate: true });
   };
 
   const handleTransactionAmountChange = (amount: number) => {
@@ -1637,6 +1648,7 @@ export function ScheduledTransactionForm({
               onTransactionAmountChange={handleTransactionAmountChange}
               currencyCode={watchedCurrencyCode || defaultCurrency}
               onConvertToRegular={handleConvertToRegular}
+              onCreateCategory={createCategoryFromTypedName}
             />
           </div>
 

--- a/frontend/src/components/transactions/NormalTransactionFields.tsx
+++ b/frontend/src/components/transactions/NormalTransactionFields.tsx
@@ -35,7 +35,10 @@ interface NormalTransactionFieldsProps {
   handlePayeeChange: (payeeId: string, payeeName: string) => void;
   handlePayeeCreate: (name: string) => void;
   handleCategoryChange: (categoryId: string, name: string) => void;
-  handleCategoryCreate: (name: string) => void;
+  /** Absent when the surface cannot create categories (a joint account
+   *  offers the owner's list and nothing more), which removes the
+   *  "+ Create" row from the picker. */
+  handleCategoryCreate?: (name: string) => void;
   handleAmountChange: (value: number | undefined) => void;
   handleModeChange: (mode: 'normal' | 'split' | 'transfer') => void;
   /** Quick-fill the form from a previous transaction. When undefined, the
@@ -219,7 +222,7 @@ export function NormalTransactionFields({
                 initialDisplayValue={transaction?.category?.name || ''}
                 onChange={handleCategoryChange}
                 onCreateNew={handleCategoryCreate}
-                allowCustomValue={true}
+                allowCustomValue={!!handleCategoryCreate}
                 valueIsId
                 usePortal
                 error={errors.categoryId?.message as string | undefined}

--- a/frontend/src/components/transactions/SplitEditor.test.tsx
+++ b/frontend/src/components/transactions/SplitEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/render';
+import { render, screen, fireEvent, act } from '@/test/render';
 import { SplitEditor, SplitRow, createEmptySplits, toSplitRows, toCreateSplitData } from './SplitEditor';
 
 vi.mock('@/lib/format', () => ({
@@ -2292,5 +2292,270 @@ describe('SplitEditor — foreign-currency toggle', () => {
 
     const newSplits = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
     expect(newSplits[0].amount).toBe(-40);
+  });
+});
+
+/**
+ * Issue #1187: a split line's category field silently discarded text that
+ * matched no category, while the non-split transaction form's Category field
+ * offered to create one. Both are the same Combobox; the split copy was simply
+ * missing `allowCustomValue`/`onCreateNew`, so there was nothing to click.
+ */
+describe('SplitEditor — creating a category from a split line', () => {
+  const mockOnChange = vi.fn();
+  const mockCategories = [
+    { id: 'cat-1', name: 'Groceries', parentId: null, isIncome: false },
+  ] as any[];
+
+  const newCategory = {
+    id: 'cat-new',
+    name: 'Vet Bills',
+    parentId: null,
+    isIncome: false,
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function twoSplits(): SplitRow[] {
+    return [
+      createSplitRow({ id: 'split-1', amount: -30 }),
+      createSplitRow({ id: 'split-2', amount: -20 }),
+    ];
+  }
+
+  /** The first split's category input (the mobile card layout renders first). */
+  function firstCategoryInput() {
+    return screen.getAllByPlaceholderText('Select category...')[0];
+  }
+
+  it('offers no create option when the surface cannot create categories', () => {
+    render(
+      <SplitEditor
+        splits={twoSplits()}
+        onChange={mockOnChange}
+        categories={mockCategories}
+        transactionAmount={-50}
+      />
+    );
+
+    fireEvent.change(firstCategoryInput(), { target: { value: 'Vet Bills' } });
+
+    expect(screen.queryByText('Create "Vet Bills"')).not.toBeInTheDocument();
+  });
+
+  it('offers to create a category for text matching none', () => {
+    render(
+      <SplitEditor
+        splits={twoSplits()}
+        onChange={mockOnChange}
+        categories={mockCategories}
+        transactionAmount={-50}
+        onCreateCategory={vi.fn()}
+      />
+    );
+
+    fireEvent.change(firstCategoryInput(), { target: { value: 'Vet Bills' } });
+
+    expect(screen.getByText('Create "Vet Bills"')).toBeInTheDocument();
+  });
+
+  it('offers no create option for text that already names a category', () => {
+    render(
+      <SplitEditor
+        splits={twoSplits()}
+        onChange={mockOnChange}
+        categories={mockCategories}
+        transactionAmount={-50}
+        onCreateCategory={vi.fn()}
+      />
+    );
+
+    fireEvent.change(firstCategoryInput(), { target: { value: 'Groceries' } });
+
+    expect(screen.queryByText('Create "Groceries"')).not.toBeInTheDocument();
+  });
+
+  it('assigns the created category to the row that asked', async () => {
+    const onCreateCategory = vi.fn().mockResolvedValue(newCategory);
+
+    render(
+      <SplitEditor
+        splits={twoSplits()}
+        onChange={mockOnChange}
+        categories={mockCategories}
+        transactionAmount={-50}
+        onCreateCategory={onCreateCategory}
+      />
+    );
+
+    fireEvent.change(firstCategoryInput(), { target: { value: 'Vet Bills' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create "Vet Bills"'));
+    });
+
+    expect(onCreateCategory).toHaveBeenCalledWith('Vet Bills');
+    const updated = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
+    expect(updated[0].categoryId).toBe('cat-new');
+    expect(updated[1].categoryId).toBeUndefined();
+  });
+
+  it('signs the row from the new category, which the parent has not sent back yet', async () => {
+    // The parent appends the new category to its own list, but that state
+    // update has not re-rendered this component when the create resolves --
+    // `categories` still holds only Groceries. The expense flag has to come
+    // from the category the creator returned, or a positive amount stays
+    // positive on an expense line.
+    const onCreateCategory = vi.fn().mockResolvedValue(newCategory);
+
+    render(
+      <SplitEditor
+        splits={[
+          createSplitRow({ id: 'split-1', amount: 30 }),
+          createSplitRow({ id: 'split-2', amount: -20 }),
+        ]}
+        onChange={mockOnChange}
+        categories={mockCategories}
+        transactionAmount={-50}
+        onCreateCategory={onCreateCategory}
+      />
+    );
+
+    fireEvent.change(firstCategoryInput(), { target: { value: 'Vet Bills' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create "Vet Bills"'));
+    });
+
+    const updated = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
+    expect(updated[0].categoryId).toBe('cat-new');
+    expect(updated[0].amount).toBe(-30);
+  });
+
+  it('leaves the row untouched when nothing was created', async () => {
+    const onCreateCategory = vi.fn().mockResolvedValue(null);
+
+    render(
+      <SplitEditor
+        splits={twoSplits()}
+        onChange={mockOnChange}
+        categories={mockCategories}
+        transactionAmount={-50}
+        onCreateCategory={onCreateCategory}
+      />
+    );
+
+    fireEvent.change(firstCategoryInput(), { target: { value: 'Vet Bills' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create "Vet Bills"'));
+    });
+
+    expect(onCreateCategory).toHaveBeenCalled();
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it('follows the row it was typed into when the rows move while the request is in flight', async () => {
+    // The create is asynchronous, so the split that asked for the category can
+    // have moved by the time it arrives. Addressing the row by index would put
+    // the category on whatever now sits at position 0.
+    let resolveCreate: (c: unknown) => void = () => {};
+    const onCreateCategory = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve;
+      })
+    );
+
+    const { rerender } = render(
+      <SplitEditor
+        splits={twoSplits()}
+        onChange={mockOnChange}
+        categories={mockCategories}
+        transactionAmount={-50}
+        onCreateCategory={onCreateCategory}
+      />
+    );
+
+    fireEvent.change(firstCategoryInput(), { target: { value: 'Vet Bills' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create "Vet Bills"'));
+    });
+
+    // A new split is inserted ahead of the one that asked.
+    const reordered: SplitRow[] = [
+      createSplitRow({ id: 'split-3', amount: 0 }),
+      createSplitRow({ id: 'split-1', amount: -30 }),
+      createSplitRow({ id: 'split-2', amount: -20 }),
+    ];
+    await act(async () => {
+      rerender(
+        <SplitEditor
+          splits={reordered}
+          onChange={mockOnChange}
+          categories={mockCategories}
+          transactionAmount={-50}
+          onCreateCategory={onCreateCategory}
+        />
+      );
+    });
+
+    await act(async () => {
+      resolveCreate(newCategory);
+    });
+
+    const updated = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
+    expect(updated.map((s: SplitRow) => s.categoryId)).toEqual([
+      undefined,
+      'cat-new',
+      undefined,
+    ]);
+  });
+
+  it('drops the category quietly when its row is gone by the time it arrives', async () => {
+    let resolveCreate: (c: unknown) => void = () => {};
+    const onCreateCategory = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve;
+      })
+    );
+
+    const { rerender } = render(
+      <SplitEditor
+        splits={twoSplits()}
+        onChange={mockOnChange}
+        categories={mockCategories}
+        transactionAmount={-50}
+        onCreateCategory={onCreateCategory}
+      />
+    );
+
+    fireEvent.change(firstCategoryInput(), { target: { value: 'Vet Bills' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create "Vet Bills"'));
+    });
+
+    const remaining: SplitRow[] = [
+      createSplitRow({ id: 'split-2', amount: -20 }),
+      createSplitRow({ id: 'split-4', amount: -30 }),
+    ];
+    await act(async () => {
+      rerender(
+        <SplitEditor
+          splits={remaining}
+          onChange={mockOnChange}
+          categories={mockCategories}
+          transactionAmount={-50}
+          onCreateCategory={onCreateCategory}
+        />
+      );
+    });
+
+    mockOnChange.mockClear();
+    await act(async () => {
+      resolveCreate(newCategory);
+    });
+
+    // Nothing is assigned -- and in particular nothing lands on split-2, which
+    // is what an index-based apply would have done.
+    expect(mockOnChange).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/transactions/SplitEditor.tsx
+++ b/frontend/src/components/transactions/SplitEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { Input } from '@/components/ui/Input';
 import { CurrencyInput } from '@/components/ui/CurrencyInput';
@@ -56,6 +56,14 @@ interface SplitEditorProps {
    */
   displayCurrencyCode?: string;
   displayRate?: number;
+  /**
+   * Create a category from text typed into a split line's category picker,
+   * resolving to the created category (or null/undefined when nothing was
+   * created). When provided, the picker offers the same "+ Create" row as the
+   * non-split transaction form's category field; when omitted, typed text that
+   * matches nothing is discarded, which is what every split line used to do.
+   */
+  onCreateCategory?: (name: string) => Promise<Category | null | undefined>;
 }
 
 export function SplitEditor({
@@ -73,6 +81,7 @@ export function SplitEditor({
   onConvertToRegular,
   displayCurrencyCode,
   displayRate,
+  onCreateCategory,
 }: SplitEditorProps) {
   const t = useTranslations('transactions');
   const accountOptionLabel = useAccountOptionLabel({ withCurrency: false });
@@ -153,6 +162,18 @@ export function SplitEditor({
     setLocalSplits(splits);
   }, [splits]);
 
+  // A category created from a split line is applied before the parent's own
+  // state update has re-rendered this component, so the new row is not in
+  // `categories` yet. Remember what was created here so the income/expense sign
+  // rules below can still read its `isIncome` flag on the very first apply.
+  const createdCategoriesRef = useRef<Category[]>([]);
+  const findCategory = useCallback(
+    (id: string): Category | undefined =>
+      categories.find((c) => c.id === id) ??
+      createdCategoriesRef.current.find((c) => c.id === id),
+    [categories],
+  );
+
   const splitsTotal = localSplits.reduce((sum, s) => sum + (Number(s.amount) || 0), 0);
   const remaining = Number(transactionAmount) - splitsTotal;
   // Balance is always judged in the account currency so distribution and the
@@ -215,7 +236,7 @@ export function SplitEditor({
 
     // If changing category, adjust the amount sign based on income/expense
     if (field === 'categoryId' && value) {
-      const category = categories.find(c => c.id === value);
+      const category = findCategory(value);
       if (category) {
         const currentAmount = Number(newSplits[index].amount) || 0;
         if (currentAmount !== 0) {
@@ -252,7 +273,7 @@ export function SplitEditor({
     if (field === 'amount') {
       const categoryId = newSplits[index].categoryId;
       if (categoryId) {
-        const category = categories.find(c => c.id === categoryId);
+        const category = findCategory(categoryId);
         if (category) {
           const newAmount = Number(value) || 0;
           if (newAmount !== 0) {
@@ -272,6 +293,31 @@ export function SplitEditor({
     newSplits[index] = { ...newSplits[index], [field]: value };
     setLocalSplits(newSplits);
     onChange(newSplits);
+  };
+
+  // The apply step of an asynchronous create has to run against the splits as
+  // they are when the category comes back, not as they were when the user
+  // typed: rows can be added, removed or reordered while the request is in
+  // flight. Both are read through a ref that every render refreshes.
+  const latestRef = useRef({ localSplits, handleSplitChange });
+  useEffect(() => {
+    latestRef.current = { localSplits, handleSplitChange };
+  });
+
+  // Create a category from the text typed into a split line and assign it to
+  // the row that asked. The row is addressed by its id rather than its index
+  // for the same reason.
+  const handleCategoryCreate = async (splitId: string, name: string) => {
+    if (!onCreateCategory) return;
+    const category = await onCreateCategory(name);
+    if (!category) return;
+    createdCategoriesRef.current = [...createdCategoriesRef.current, category];
+    const { localSplits: current, handleSplitChange: applyChange } = latestRef.current;
+    const index = current.findIndex((s) => s.id === splitId);
+    // The row was removed while the request was in flight: the category still
+    // exists (the user asked for it), it simply has nowhere to land.
+    if (index === -1) return;
+    applyChange(index, 'categoryId', category.id);
   };
 
   const addSplit = () => {
@@ -532,6 +578,11 @@ export function SplitEditor({
                     currencyCode={currencyCode}
                   />
                 ) : split.splitType === 'category' || !supportsTransfers ? (
+                  // Same picker as the non-split form's Category field: an id-backed
+                  // combobox offering "+ Create" for text that matches no category,
+                  // so a split line can name one that does not exist yet instead of
+                  // discarding what was typed (issue #1187). The create affordance
+                  // appears only where the surface can actually create one.
                   <Combobox
                     placeholder={t('splitEditor.selectCategory')}
                     options={categoryOptions}
@@ -540,6 +591,13 @@ export function SplitEditor({
                     onChange={(categoryId) =>
                       handleSplitChange(index, 'categoryId', categoryId || undefined)
                     }
+                    onCreateNew={
+                      onCreateCategory
+                        ? (name) => handleCategoryCreate(split.id, name)
+                        : undefined
+                    }
+                    allowCustomValue={!!onCreateCategory}
+                    valueIsId
                     disabled={disabled}
                   />
                 ) : (
@@ -694,6 +752,11 @@ export function SplitEditor({
                       currencyCode={currencyCode}
                     />
                   ) : split.splitType === 'category' || !supportsTransfers ? (
+                    // Same picker as the non-split form's Category field: an id-backed
+                    // combobox offering "+ Create" for text that matches no category,
+                    // so a split line can name one that does not exist yet instead of
+                    // discarding what was typed (issue #1187). The create affordance
+                    // appears only where the surface can actually create one.
                     <Combobox
                       placeholder={t('splitEditor.selectCategory')}
                       options={categoryOptions}
@@ -702,6 +765,13 @@ export function SplitEditor({
                       onChange={(categoryId) =>
                         handleSplitChange(index, 'categoryId', categoryId || undefined)
                       }
+                      onCreateNew={
+                        onCreateCategory
+                          ? (name) => handleCategoryCreate(split.id, name)
+                          : undefined
+                      }
+                      allowCustomValue={!!onCreateCategory}
+                      valueIsId
                       disabled={disabled}
                     />
                   ) : (

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -224,6 +224,14 @@ vi.mock('@/lib/categories', () => ({
   },
 }));
 
+const mockGetJointReferenceData = vi.fn();
+
+vi.mock('@/lib/delegation', () => ({
+  delegationApi: {
+    getJointReferenceData: (...args: any[]) => mockGetJointReferenceData(...args),
+  },
+}));
+
 const mockAccountsGetAll = vi.fn();
 
 vi.mock('@/lib/accounts', () => ({
@@ -304,7 +312,17 @@ vi.mock('@hookform/resolvers/zod', () => ({
 }));
 
 vi.mock('./SplitEditor', () => ({
-  SplitEditor: () => <div data-testid="split-editor">Split Editor</div>,
+  SplitEditor: ({ categories, onCreateCategory }: any) => (
+    <div data-testid="split-editor">
+      Split Editor
+      <span data-testid="split-editor-categories">
+        {(categories || []).map((c: any) => c.name).join(',')}
+      </span>
+      <span data-testid="split-editor-can-create">
+        {onCreateCategory ? 'yes' : 'no'}
+      </span>
+    </div>
+  ),
   createEmptySplits: () => [
     { id: 'split-1', splitType: 'category', amount: 0, categoryId: undefined, memo: '' },
     { id: 'split-2', splitType: 'category', amount: 0, categoryId: undefined, memo: '' },
@@ -450,6 +468,12 @@ describe('TransactionForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAccountsGetAll.mockResolvedValue(mockAccounts);
+    mockGetJointReferenceData.mockResolvedValue({
+      categories: [],
+      payees: [],
+      payeesCanCreate: false,
+      categoriesCanCreate: false,
+    });
     mockPayeesGetAll.mockResolvedValue(mockPayees);
     mockCategoriesGetAll.mockResolvedValue(mockCategories);
     mockGetRecent.mockResolvedValue([]);
@@ -463,6 +487,152 @@ describe('TransactionForm', () => {
   // =========================================================================
   // Existing tests (preserved)
   // =========================================================================
+
+  // =========================================================================
+  // Joint accounts: a joint row belongs to the sharing owner, so every category
+  // picker on the form offers the OWNER's list -- the split lines included.
+  // =========================================================================
+  describe('joint accounts', () => {
+    const jointAccount = {
+      ...mockAccounts[0],
+      id: 'acc-joint',
+      name: 'Shared Chequing',
+      isJoint: true,
+      ownerLabel: 'Sam',
+    } as any;
+
+    const ownerCategories = [
+      { id: 'own-cat-1', name: 'Owner Groceries', parentId: null, isIncome: false, isSystem: false, icon: null, color: null },
+    ];
+
+    beforeEach(() => {
+      mockAccountsGetAll.mockResolvedValue([...mockAccounts, jointAccount]);
+      mockGetJointReferenceData.mockResolvedValue({
+        categories: ownerCategories,
+        payees: [],
+        payeesCanCreate: false,
+        categoriesCanCreate: false,
+      });
+    });
+
+    /** A split transaction already stored in the joint account. */
+    function jointSplitTransaction() {
+      return { ...createSplitTransaction(), accountId: 'acc-joint' };
+    }
+
+    // Split mode is unreachable from the mode button on a joint account, but
+    // opening a split row that already lives there puts the form straight into
+    // it -- and the editor was handed the CALLER's categories, so the owner's
+    // split lines resolved to nothing and any pick wrote one of the caller's
+    // own ids onto the owner's row.
+    it("hands the split editor the owner's categories, not the caller's", async () => {
+      render(
+        <TransactionForm
+          transaction={jointSplitTransaction()}
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('split-editor-categories')).toHaveTextContent(
+          'Owner Groceries'
+        );
+      });
+      expect(screen.getByTestId('split-editor-categories')).not.toHaveTextContent(
+        'Groceries,'
+      );
+    });
+
+    it('offers no category creation from a joint split line', async () => {
+      render(
+        <TransactionForm
+          transaction={jointSplitTransaction()}
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('split-editor')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('split-editor-can-create')).toHaveTextContent('no');
+    });
+
+    // `categoriesApi.create` writes to the caller's own ledger, so offering
+    // "+ Create" here created the category in the wrong place and put an id the
+    // owner does not own on the form.
+    it('offers no category creation on the joint Category field', async () => {
+      render(
+        <TransactionForm
+          defaultAccountId="acc-joint"
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockGetJointReferenceData).toHaveBeenCalledWith('acc-joint');
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('combobox-create-Category')).not.toBeInTheDocument();
+      });
+    });
+
+    it("still offers category creation on the user's own account", async () => {
+      render(
+        <TransactionForm
+          defaultAccountId="acc-1"
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('combobox-create-Category')).toBeInTheDocument();
+      });
+      expect(mockGetJointReferenceData).not.toHaveBeenCalled();
+    });
+
+    it("signs the amount from the owner's category on a joint account", async () => {
+      mockGetJointReferenceData.mockResolvedValue({
+        categories: [
+          { id: 'own-inc', name: 'Owner Salary', parentId: null, isIncome: true, isSystem: false, icon: null, color: null },
+        ],
+        payees: [],
+        payeesCanCreate: false,
+        categoriesCanCreate: false,
+      });
+
+      render(
+        <TransactionForm
+          defaultAccountId="acc-joint"
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockGetJointReferenceData).toHaveBeenCalledWith('acc-joint');
+      });
+
+      const amountInput = screen.getByLabelText('Amount') as HTMLInputElement;
+      fireEvent.change(amountInput, { target: { value: '-40' } });
+      fireEvent.blur(amountInput);
+
+      // The sign lookup used the caller's own list, which cannot resolve an
+      // owner category id, so an income category never flipped the amount.
+      await act(async () => {
+        fireEvent.change(screen.getByTestId('combobox-input-Category'), {
+          target: { value: 'Owner Salary' },
+        });
+      });
+
+      await waitFor(() => {
+        expect(Number(amountInput.value)).toBeGreaterThan(0);
+      });
+    });
+  });
 
   it('fetches accounts including closed accounts on mount', async () => {
     render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -718,7 +718,10 @@ function TransactionFormFields({ transaction, duplicateFrom, defaultAccountId, d
       // "amount must be positive" check. Mirrors the mode guard in
       // handleAmountChange. Re-signs the foreign amount when entering a foreign
       // currency, so the behaviour matches account-currency entry.
-      const category = categories.find(c => c.id === categoryId);
+      // `effectiveCategories`, not `categories`: on a joint account the picker
+      // offers the OWNER's list, so the caller's own list cannot resolve the id
+      // and the income/expense sign was never applied there.
+      const category = effectiveCategories.find(c => c.id === categoryId);
       if (category && mode === 'normal') {
         resignActiveAmount(category);
       }
@@ -735,11 +738,11 @@ function TransactionFormFields({ transaction, duplicateFrom, defaultAccountId, d
   const activeSigningCategory = (): Category | undefined => {
     if (mode === 'split') {
       return splits.length > 0 && splits[0].categoryId
-        ? categories.find((c) => c.id === splits[0].categoryId)
+        ? effectiveCategories.find((c) => c.id === splits[0].categoryId)
         : undefined;
     }
     return selectedCategoryId
-      ? categories.find((c) => c.id === selectedCategoryId)
+      ? effectiveCategories.find((c) => c.id === selectedCategoryId)
       : undefined;
   };
 
@@ -967,13 +970,31 @@ function TransactionFormFields({ transaction, duplicateFrom, defaultAccountId, d
 
   // Handle creating a new category - called when user clicks "Create" in dropdown
   // Supports "Parent: Child" format to create subcategories
-  const handleCategoryCreate = async (name: string) => {
-    const newCategory = await createCategoryFromTypedName(name);
-    if (!newCategory) return;
-    setSelectedCategoryId(newCategory.id);
-    setValue('categoryId', newCategory.id, { shouldDirty: true, shouldValidate: true });
-    categoryWasAutoSetRef.current = false;
-  };
+  // A joint row belongs to the sharing owner and may only carry the owner's
+  // category ids, but `categoriesApi.create` writes to the CALLER's ledger --
+  // there is no client path that creates a category on someone else's, so the
+  // delegation's `categoriesCanCreate` capability has nothing to drive here
+  // yet. Offering "+ Create" on a joint account therefore created the category
+  // in the wrong place and put an id the owner does not own on the form. Until
+  // an owner-scoped create exists, joint accounts select from the owner's list
+  // and nothing more; withholding the creator is what removes the option from
+  // every one of this form's category pickers at once.
+  const jointSafeCategoryCreator = selectedIsJoint
+    ? undefined
+    : createCategoryFromTypedName;
+
+  // Undefined on a joint account, for the reason above -- which is what takes
+  // "+ Create" out of the Category field and the transfer form's, exactly as it
+  // does out of the split lines.
+  const handleCategoryCreate = jointSafeCategoryCreator
+    ? async (name: string) => {
+        const newCategory = await jointSafeCategoryCreator(name);
+        if (!newCategory) return;
+        setSelectedCategoryId(newCategory.id);
+        setValue('categoryId', newCategory.id, { shouldDirty: true, shouldValidate: true });
+        categoryWasAutoSetRef.current = false;
+      }
+    : undefined;
 
   // Created At override (only when editing and preference is enabled)
   const userTimezone = resolveTimezone(timezonePref);
@@ -1541,7 +1562,7 @@ function TransactionFormFields({ transaction, duplicateFrom, defaultAccountId, d
           <SplitEditor
             splits={splits}
             onChange={setSplits}
-            categories={categories}
+            categories={effectiveCategories}
             tags={tags}
             accounts={accounts}
             sourceAccountId={watchedAccountId || ''}
@@ -1555,7 +1576,7 @@ function TransactionFormFields({ transaction, duplicateFrom, defaultAccountId, d
             onConvertToRegular={handleConvertToRegular}
             displayCurrencyCode={isForeign ? entryCurrency : undefined}
             displayRate={isForeign ? (fxRate ?? undefined) : undefined}
-            onCreateCategory={createCategoryFromTypedName}
+            onCreateCategory={jointSafeCategoryCreator}
           />
         </div>
       )}

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/lib/lastTransactionDate';
 import { payeesApi } from '@/lib/payees';
 import { categoriesApi } from '@/lib/categories';
+import { createCategoryFromInput } from '@/lib/category-create';
 import { accountsApi } from '@/lib/accounts';
 import { delegationApi, JointReferenceData } from '@/lib/delegation';
 import { tagsApi } from '@/lib/tags';
@@ -946,68 +947,32 @@ function TransactionFormFields({ transaction, duplicateFrom, defaultAccountId, d
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isForeign, entryCurrency, accountCurrency, watchedDate]);
 
-  // Convert string to title case (capitalize first letter of each word)
-  const toTitleCase = (str: string): string => {
-    return str
-      .toLowerCase()
-      .split(' ')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
+  // Create a category from text typed into any of this form's category
+  // pickers -- the Category field, and each split line's own picker. Returns
+  // the created category so a split line can assign it to the row that asked;
+  // null means nothing was created (blank input, or the request failed).
+  const createCategoryFromTypedName = async (name: string): Promise<Category | null> => {
+    try {
+      const result = await createCategoryFromInput(name, categories);
+      if (!result) return null;
+      setCategories(prev => [...prev, ...result.created]);
+      toast.success(t('form.toasts.categoryCreated', { name: result.displayName }));
+      return result.category;
+    } catch (error) {
+      logger.error('Failed to create category:', error);
+      toast.error(getErrorMessage(error, t('form.toasts.categoryCreateFailed')));
+      return null;
+    }
   };
 
   // Handle creating a new category - called when user clicks "Create" in dropdown
   // Supports "Parent: Child" format to create subcategories
   const handleCategoryCreate = async (name: string) => {
-    if (!name.trim()) return;
-
-    try {
-      let categoryName = toTitleCase(name.trim());
-      let parentId: string | undefined;
-      let parentName: string | undefined;
-
-      // Check for "Parent: Child" format
-      if (categoryName.includes(':')) {
-        const parts = categoryName.split(':').map(p => p.trim());
-        if (parts.length === 2 && parts[0] && parts[1]) {
-          parentName = toTitleCase(parts[0]);
-          const childName = toTitleCase(parts[1]);
-
-          // Find existing parent category (case-insensitive, top-level only)
-          let parentCategory = categories.find(
-            c => c.name.toLowerCase() === parentName!.toLowerCase() && !c.parentId
-          );
-
-          // If parent doesn't exist, create it first
-          if (!parentCategory) {
-            const newParent = await categoriesApi.create({ name: parentName });
-            setCategories(prev => [...prev, newParent]);
-            parentCategory = newParent;
-          }
-
-          parentId = parentCategory.id;
-          parentName = parentCategory.name; // Use actual name from existing category
-          categoryName = childName;
-        }
-      }
-
-      const newCategory = await categoriesApi.create({
-        name: categoryName,
-        parentId,
-      });
-      setCategories(prev => [...prev, newCategory]);
-      setSelectedCategoryId(newCategory.id);
-      setValue('categoryId', newCategory.id, { shouldDirty: true, shouldValidate: true });
-      categoryWasAutoSetRef.current = false;
-
-      if (parentId && parentName) {
-        toast.success(t('form.toasts.categoryCreated', { name: `${parentName}: ${categoryName}` }));
-      } else {
-        toast.success(t('form.toasts.categoryCreated', { name: categoryName }));
-      }
-    } catch (error) {
-      logger.error('Failed to create category:', error);
-      toast.error(getErrorMessage(error, t('form.toasts.categoryCreateFailed')));
-    }
+    const newCategory = await createCategoryFromTypedName(name);
+    if (!newCategory) return;
+    setSelectedCategoryId(newCategory.id);
+    setValue('categoryId', newCategory.id, { shouldDirty: true, shouldValidate: true });
+    categoryWasAutoSetRef.current = false;
   };
 
   // Created At override (only when editing and preference is enabled)
@@ -1590,6 +1555,7 @@ function TransactionFormFields({ transaction, duplicateFrom, defaultAccountId, d
             onConvertToRegular={handleConvertToRegular}
             displayCurrencyCode={isForeign ? entryCurrency : undefined}
             displayRate={isForeign ? (fxRate ?? undefined) : undefined}
+            onCreateCategory={createCategoryFromTypedName}
           />
         </div>
       )}

--- a/frontend/src/components/transactions/TransferTransactionFields.tsx
+++ b/frontend/src/components/transactions/TransferTransactionFields.tsx
@@ -47,7 +47,10 @@ interface TransferTransactionFieldsProps {
   categoryOptions: Array<{ value: string; label: string }>;
   selectedCategoryId: string;
   handleCategoryChange: (categoryId: string, name: string) => void;
-  handleCategoryCreate: (name: string) => void;
+  /** Absent when the surface cannot create categories (a joint account
+   *  offers the owner's list and nothing more), which removes the
+   *  "+ Create" row from the picker. */
+  handleCategoryCreate?: (name: string) => void;
   transaction?: Transaction;
   createdAtSlot?: ReactNode;
 }
@@ -290,7 +293,7 @@ export function TransferTransactionFields({
             initialDisplayValue={transaction?.category?.name || ''}
             onChange={handleCategoryChange}
             onCreateNew={handleCategoryCreate}
-            allowCustomValue={true}
+            allowCustomValue={!!handleCategoryCreate}
             valueIsId
             error={errors.categoryId?.message as string | undefined}
           />

--- a/frontend/src/lib/category-create.test.ts
+++ b/frontend/src/lib/category-create.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import apiClient from './api';
+import { createCategoryFromInput, toTitleCase } from './category-create';
+import type { Category } from '@/types/category';
+
+vi.mock('./api', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+describe('toTitleCase', () => {
+  it('capitalizes each word and lowercases the rest', () => {
+    expect(toTitleCase('pET sUPPLIES')).toBe('Pet Supplies');
+  });
+});
+
+describe('createCategoryFromInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const cat = (over: Partial<Category>): Category =>
+    ({ id: 'x', name: 'X', parentId: null, ...over }) as Category;
+
+  it('returns null for blank input without calling the API', async () => {
+    expect(await createCategoryFromInput('   ', [])).toBeNull();
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+
+  it('title-cases a plain name', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: cat({ id: 'new', name: 'Pet Supplies' }) });
+
+    const result = await createCategoryFromInput('pet supplies', []);
+
+    expect(apiClient.post).toHaveBeenCalledWith('/categories', {
+      name: 'Pet Supplies',
+      parentId: undefined,
+    });
+    expect(result?.displayName).toBe('Pet Supplies');
+    expect(result?.created.map((c) => c.id)).toEqual(['new']);
+    expect(result?.parentName).toBeUndefined();
+  });
+
+  it('creates the parent first for "Parent: Child" when no parent exists', async () => {
+    vi.mocked(apiClient.post)
+      .mockResolvedValueOnce({ data: cat({ id: 'parent', name: 'Travel' }) })
+      .mockResolvedValueOnce({ data: cat({ id: 'child', name: 'Hotels', parentId: 'parent' }) });
+
+    const result = await createCategoryFromInput('travel: hotels', []);
+
+    expect(apiClient.post).toHaveBeenNthCalledWith(1, '/categories', { name: 'Travel' });
+    expect(apiClient.post).toHaveBeenNthCalledWith(2, '/categories', {
+      name: 'Hotels',
+      parentId: 'parent',
+    });
+    // Both rows are returned so a caller's picker shows the parent as well.
+    expect(result?.created.map((c) => c.id)).toEqual(['parent', 'child']);
+    expect(result?.category.id).toBe('child');
+    expect(result?.displayName).toBe('Travel: Hotels');
+    expect(result?.parentName).toBe('Travel');
+  });
+
+  it('reuses an existing top-level parent, matched case-insensitively, and keeps its own casing', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: cat({ id: 'child', name: 'Hotels', parentId: 'existing' }),
+    });
+    const existing = [cat({ id: 'existing', name: 'TRAVEL', parentId: null })];
+
+    const result = await createCategoryFromInput('travel: hotels', existing);
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+    expect(apiClient.post).toHaveBeenCalledWith('/categories', {
+      name: 'Hotels',
+      parentId: 'existing',
+    });
+    // The stored parent's name, not the typed casing.
+    expect(result?.parentName).toBe('TRAVEL');
+    expect(result?.displayName).toBe('TRAVEL: Hotels');
+    expect(result?.created.map((c) => c.id)).toEqual(['child']);
+  });
+
+  it('does not treat a subcategory as a possible parent', async () => {
+    vi.mocked(apiClient.post)
+      .mockResolvedValueOnce({ data: cat({ id: 'new-parent', name: 'Travel' }) })
+      .mockResolvedValueOnce({ data: cat({ id: 'child', name: 'Hotels', parentId: 'new-parent' }) });
+    // A category named Travel already exists, but it is itself a child.
+    const existing = [cat({ id: 'sub', name: 'Travel', parentId: 'other' })];
+
+    const result = await createCategoryFromInput('Travel: Hotels', existing);
+
+    expect(apiClient.post).toHaveBeenNthCalledWith(1, '/categories', { name: 'Travel' });
+    expect(result?.created.map((c) => c.id)).toEqual(['new-parent', 'child']);
+  });
+
+  it('leaves a name with more than one colon as a single flat category', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: cat({ id: 'new', name: 'A: B: C' }),
+    });
+
+    await createCategoryFromInput('a: b: c', []);
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+    expect(apiClient.post).toHaveBeenCalledWith('/categories', {
+      name: 'A: B: C',
+      parentId: undefined,
+    });
+  });
+
+  it('passes isIncome through only when the caller supplies it', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: cat({ id: 'new', name: 'Boat' }) });
+
+    await createCategoryFromInput('boat', [], { isIncome: false });
+
+    expect(apiClient.post).toHaveBeenCalledWith('/categories', {
+      name: 'Boat',
+      parentId: undefined,
+      isIncome: false,
+    });
+  });
+
+  it('propagates an API failure so the caller can report it', async () => {
+    vi.mocked(apiClient.post).mockRejectedValue(new Error('boom'));
+    await expect(createCategoryFromInput('Boat', [])).rejects.toThrow('boom');
+  });
+});

--- a/frontend/src/lib/category-create.ts
+++ b/frontend/src/lib/category-create.ts
@@ -1,0 +1,112 @@
+import { categoriesApi } from './categories';
+import { Category } from '@/types/category';
+
+/**
+ * Turning text typed into a picker into a category happens on five surfaces:
+ * the transaction form's category field and each of its split lines, the
+ * scheduled transaction form and its splits, and the asset-value category on
+ * the account form. The rules below -- title casing, and the `Parent: Child`
+ * shorthand that creates or reuses a parent -- had been written out inline
+ * three times, and the scheduled form's copy had neither, so `travel: hotels`
+ * became a child of Travel in one field and a single flat category literally
+ * named "Travel: Hotels" in another.
+ *
+ * `createCategoryFromInput` is the only place typed text becomes a category;
+ * the guard in `src/test/ui-conventions.test.ts` fails on a second
+ * `categoriesApi.create` call site outside the categories page's own full
+ * create form.
+ *
+ * It lives beside `categories.ts` rather than inside it for two reasons: that
+ * module is a typed axios wrapper (`frontend/CLAUDE.md`) and this is
+ * multi-request orchestration over it, and roughly thirty suites replace
+ * `@/lib/categories` wholesale with a mock -- a helper defined in the mocked
+ * module would vanish with it, while one that *imports* it runs against
+ * whatever `categoriesApi` the test installed.
+ */
+
+/** Capitalize the first letter of each word. */
+export function toTitleCase(str: string): string {
+  return str
+    .toLowerCase()
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+export interface CreatedCategory {
+  /** The category the user asked for -- the child, when `Parent: Child` was typed. */
+  category: Category;
+  /**
+   * Every category actually created, parent first. Callers append this to their
+   * own category list so both rows appear in the picker, not only the child.
+   */
+  created: Category[];
+  /** The parent's name when one applies, so a caller can name it in a toast. */
+  parentName?: string;
+  /** `Parent: Child` when nested, otherwise the category's own name. */
+  displayName: string;
+}
+
+export interface CreateCategoryFromInputOptions {
+  /** Passed through to the API for the created leaf category. */
+  isIncome?: boolean;
+}
+
+/**
+ * Create a category from text typed into a picker.
+ *
+ * Returns `null` for blank input -- that is "nothing to do", not a failure.
+ * API errors propagate; the caller owns the toast, because the surfaces differ
+ * in which catalog their copy lives in.
+ */
+export async function createCategoryFromInput(
+  name: string,
+  categories: Category[],
+  options: CreateCategoryFromInputOptions = {},
+): Promise<CreatedCategory | null> {
+  if (!name.trim()) return null;
+
+  let categoryName = toTitleCase(name.trim());
+  let parentId: string | undefined;
+  let parentName: string | undefined;
+  const created: Category[] = [];
+
+  // "Parent: Child" creates (or reuses) the parent, then the child under it.
+  if (categoryName.includes(':')) {
+    const parts = categoryName.split(':').map((p) => p.trim());
+    if (parts.length === 2 && parts[0] && parts[1]) {
+      const typedParentName = toTitleCase(parts[0]);
+      const childName = toTitleCase(parts[1]);
+
+      // Match an existing top-level category case-insensitively; a child
+      // category cannot itself be a parent.
+      let parentCategory = categories.find(
+        (c) => c.name.toLowerCase() === typedParentName.toLowerCase() && !c.parentId,
+      );
+
+      if (!parentCategory) {
+        parentCategory = await categoriesApi.create({ name: typedParentName });
+        created.push(parentCategory);
+      }
+
+      parentId = parentCategory.id;
+      // The existing category's own name, not the typed casing.
+      parentName = parentCategory.name;
+      categoryName = childName;
+    }
+  }
+
+  const category = await categoriesApi.create({
+    name: categoryName,
+    parentId,
+    ...(options.isIncome !== undefined ? { isIncome: options.isIncome } : {}),
+  });
+  created.push(category);
+
+  return {
+    category,
+    created,
+    parentName,
+    displayName: parentName ? `${parentName}: ${categoryName}` : categoryName,
+  };
+}

--- a/frontend/src/test/ui-conventions.test.ts
+++ b/frontend/src/test/ui-conventions.test.ts
@@ -743,3 +743,35 @@ describe("a transaction status cell is the shared StatusCellButton", () => {
     expect(DENSE_LABEL_KEY.test(wrapper)).toBe(true);
   });
 });
+
+describe("a category typed into a picker is created by one helper", () => {
+  /** The one module allowed to turn typed picker text into a category. */
+  const HELPER = "/src/lib/category-create.ts";
+  /**
+   * The Categories page's own create form is a different thing: it collects a
+   * name, parent, colour and icon from real fields, so there is no typed text
+   * to parse and no `Parent: Child` shorthand to honour.
+   */
+  const FULL_FORM = "/src/app/categories/page.tsx";
+  const CREATE_CALL = /categoriesApi\.create\(/;
+
+  it("has no second inline category-creation path", () => {
+    const offenders = productionSources()
+      .filter(([path]) => path !== HELPER && path !== FULL_FORM)
+      .filter(([, content]) => CREATE_CALL.test(content))
+      .map(([path]) => path);
+
+    // Three copies of this existed -- the transaction form, the account form's
+    // asset category, and the scheduled transaction form -- and the third had
+    // neither title casing nor the `Parent: Child` shorthand, so `travel:
+    // hotels` became a child of Travel in two fields and a single flat category
+    // named "Travel: Hotels" in the other. Use `createCategoryFromInput`.
+    expect(offenders).toEqual([]);
+  });
+
+  it("still finds the helper, so the rule cannot pass by accident", () => {
+    const helper = sources[HELPER];
+    expect(helper, `${HELPER} not found -- update HELPER in this test`).toBeTruthy();
+    expect(/export async function createCategoryFromInput\(/.test(helper)).toBe(true);
+  });
+});


### PR DESCRIPTION
A split line's category field silently discarded text that matched no
category, while the Category field on a non-split transaction offered to
create one. Both are the same Combobox; the split copy was missing
`allowCustomValue` and `onCreateNew`, so there was nothing to click.

Wiring that up needed one creator the forms could share, and there was
none: the "type a name, get a category" logic -- title casing plus the
`Parent: Child` shorthand -- was written out inline in the transaction
form and the account form's asset category, and the scheduled
transaction form's third copy had neither, so `travel: hotels` became a
child of Travel in two fields and a single flat category named
"Travel: Hotels" in the other.

- `lib/category-create.ts` is now the only place typed text becomes a
  category. It returns every row it created, parent included, so callers
  append all of them to their own list rather than only the leaf. It sits
  beside `lib/categories.ts` rather than inside it because that module is
  a typed axios wrapper and this is orchestration over it -- and because
  ~30 suites replace `@/lib/categories` with a mock, which a helper
  defined in the mocked module would vanish with.
- `SplitEditor` takes `onCreateCategory`; the transaction and scheduled
  transaction forms pass the same creator they use for their own Category
  field. The apply step addresses the row by id, since splits can be
  added, removed or reordered while the request is in flight, and reads
  the new category's income flag from what the creator returned, because
  the parent's appended list has not re-rendered the editor yet.
- The scheduled transaction form gains `Parent: Child` support as a
  result; a new case covers it, since nothing failed on that change.
- A source-scan guard in `ui-conventions.test.ts` fails on a second
  `categoriesApi.create` call site, and the rule is written up in
  `frontend/CLAUDE.md`.

Closes #1187