### PR TITLE
fix(investments): cash-row delete, funding accounts and derived-figure refresh on the account detail page

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -359,6 +359,18 @@ honest, and nothing mounted refetches on its own. `InvestmentRegisterPanel` rais
 `onDataChanged` after every write for exactly this, and `InvestmentDetailView`
 re-runs its load from it.
 
+**A sibling that fetches for itself needs the signal as a prop, not as a
+re-render.** Re-running the parent's load refreshes what the parent fetched, and
+`InvestmentValueChart` fetches its own series -- so the write reaches it as
+`refreshKey`, the same convention the header's price refresh uses. Two details it
+cannot skip: the intraday series is served from `sessionStorage`, so a re-fetch
+that trusted the cache hands back the pre-write points (drop it with
+`clearAllIntradayCache` and pass `skipCache`), and the effect must gate on the
+key it has already **acted on** rather than on running -- `loadData` changes
+identity on every range, account and currency change, and the load effect already
+covers those, so an ungated second effect fetches twice for each of them and
+again on any mount under a non-zero key.
+
 **A form's account list is a property of the form, not of the page that opened
 it.** The same `InvestmentTransactionForm` is mounted from the Investments page
 and from an account's detail page, and only the first passed `allAccounts` -- so

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -332,6 +332,44 @@ the field is non-empty. A NaN or zero close is not a usable price -- gate the
 "Latest:" placeholder on a positive `roundedMarketPrice`, never a bare
 `marketPrice != null`, so it never renders as "Latest: NaN".
 
+### Two transaction lists, two opposite delete contracts -- read the tense
+
+`InvestmentTransactionList`'s `onDelete` **asks the parent to delete**: the list
+raises a confirmation and hands back an id. `TransactionList`'s `onDeleted`
+**reports a delete it already performed** -- it owns the confirmation, the
+`transactionsApi.delete`/`deleteTransfer` call and the toast. The two are a few
+lines apart in `InvestmentRegisterPanel`, and a handler written for the first
+shape and wired to the second deleted every cash row twice: the second request
+404'd on the row the first had removed, so the user got "Transaction deleted"
+and "not found" side by side (issue #1192). Worse for a transfer, where the list
+correctly calls `deleteTransfer` and the parent then calls the plain `delete`.
+
+Reach for `onRefresh` to reload after a delete, and for `onDeleted` only when
+you need the id itself (an optimistic removal, a counterpart to drop) -- never to
+perform the delete. `ui-conventions.test.ts` scans every `<TransactionList` for
+an `onDeleted` handler that deletes, in both the named and inline forms.
+
+**The signal has to reach whatever else is derived from those rows.** The panel's
+own reload is not the page: the account detail view draws the portfolio summary,
+the allocation and the Holdings by Account list -- cash row included -- above it,
+and a cash deposit that only reloaded the register left all three at their
+pre-write figures until the page was reloaded by hand (issue #1190). Dropping the
+caches is half of it; `invalidateBalanceCaches` only makes the *next* fetch
+honest, and nothing mounted refetches on its own. `InvestmentRegisterPanel` raises
+`onDataChanged` after every write for exactly this, and `InvestmentDetailView`
+re-runs its load from it.
+
+**A form's account list is a property of the form, not of the page that opened
+it.** The same `InvestmentTransactionForm` is mounted from the Investments page
+and from an account's detail page, and only the first passed `allAccounts` -- so
+"Funds From (optional)" on the detail page offered nothing but the account's own
+linked cash, which is the one option the field exists to replace (issue #1191).
+When a surface mounts a shared form against a narrower scope, narrow the *scope*
+props (`accounts`, `defaultAccountId`) and keep supplying the wide ones. A failed
+lookup there stays `undefined`, never `[]`: the form reads undefined as "not
+supplied" and falls back, while an empty array is a claim that the user has no
+other accounts.
+
 ### A long list -- page it, or bound it and scroll with `scrollbar-slim`
 
 Two patterns, depending on where it lives:

--- a/frontend/src/app/accounts/[id]/page.test.tsx
+++ b/frontend/src/app/accounts/[id]/page.test.tsx
@@ -46,11 +46,21 @@ vi.mock('@/lib/errors', () => ({
   getErrorMessage: vi.fn((_e: unknown, fallback: string) => fallback),
 }));
 
-vi.mock('@/hooks/useNumberFormat', () => ({
-  useNumberFormat: () => ({
-    formatCurrency: (amount: number) => `$${amount.toFixed(2)}`,
-  }),
-}));
+// Only `formatCurrency` is pinned, so the assertions read `$1234.00` whatever
+// the ambient preferences say. The rest of the hook's surface comes from the
+// real one: a mock offering a subset is a fiction the moment a component this
+// page mounts reaches for another formatter -- `InvestmentValueChart` calls
+// `formatSignedPercent`, which is undefined on a hand-written object.
+vi.mock('@/hooks/useNumberFormat', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/useNumberFormat')>();
+  return {
+    ...actual,
+    useNumberFormat: () => ({
+      ...actual.useNumberFormat(),
+      formatCurrency: (amount: number) => `$${amount.toFixed(2)}`,
+    }),
+  };
+});
 
 const mockGetById = vi.fn();
 const mockGetAll = vi.fn();

--- a/frontend/src/components/accounts/investment-detail/InvestmentDetailView.test.tsx
+++ b/frontend/src/components/accounts/investment-detail/InvestmentDetailView.test.tsx
@@ -15,7 +15,9 @@ vi.mock('@/components/investments/AssetAllocationChart', () => ({
   AssetAllocationChart: () => <div data-testid="allocation" />,
 }));
 vi.mock('@/components/investments/InvestmentValueChart', () => ({
-  InvestmentValueChart: () => <div data-testid="value-chart" />,
+  InvestmentValueChart: ({ refreshKey }: { refreshKey?: number }) => (
+    <div data-testid="value-chart">{refreshKey}</div>
+  ),
 }));
 vi.mock('@/components/investments/GroupedHoldingsList', () => ({
   GroupedHoldingsList: () => <div data-testid="holdings" />,
@@ -172,6 +174,22 @@ describe('InvestmentDetailView', () => {
 
     await waitFor(() => expect(mockGetPortfolioSummary).toHaveBeenCalledTimes(2));
     expect(mockGetInvestmentPair).toHaveBeenCalledTimes(2);
+  });
+
+  // The value chart fetches its own series and has its own sessionStorage cache,
+  // so re-running this component's load says nothing to it -- the write has to
+  // reach it as a prop.
+  it('passes the write through to the value chart', async () => {
+    await renderView();
+    expect(screen.getByTestId('value-chart')).toHaveTextContent('0');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'register wrote' }));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('value-chart')).toHaveTextContent('1'),
+    );
   });
 
   it('falls back to a standalone brokerage when there is no pair', async () => {

--- a/frontend/src/components/accounts/investment-detail/InvestmentDetailView.test.tsx
+++ b/frontend/src/components/accounts/investment-detail/InvestmentDetailView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act, waitFor } from '@/test/render';
+import { render, screen, act, waitFor, fireEvent } from '@/test/render';
 import { InvestmentDetailView } from './InvestmentDetailView';
 import type { Account } from '@/types/account';
 
@@ -22,6 +22,17 @@ vi.mock('@/components/investments/GroupedHoldingsList', () => ({
 }));
 vi.mock('@/components/investments/InvestmentTransactionList', () => ({
   InvestmentTransactionList: () => <div data-testid="inv-tx-list" />,
+}));
+// The register panel raises `onDataChanged` after any write on either ledger.
+// The stub exposes that signal as a button so the wiring above it can be tested
+// without driving a whole delete or form submission through the real panel --
+// which has its own tests for when the signal is raised.
+vi.mock('@/components/investments/InvestmentRegisterPanel', () => ({
+  InvestmentRegisterPanel: ({ onDataChanged }: { onDataChanged?: () => void }) => (
+    <button type="button" onClick={onDataChanged}>
+      register wrote
+    </button>
+  ),
 }));
 vi.mock('@/components/reports/RefreshPricesButton', () => ({
   RefreshPricesButton: () => <button type="button">Refresh Prices</button>,
@@ -145,6 +156,22 @@ describe('InvestmentDetailView', () => {
     });
 
     await waitFor(() => expect(mockGetPortfolioSummary).toHaveBeenCalledTimes(2));
+  });
+
+  // Issue #1190: a cash deposit changed the cash balance the Holdings by Account
+  // list draws, and only the register below it reloaded -- the holdings, the
+  // summary card and the allocation kept their pre-write figures until the page
+  // was reloaded by hand.
+  it('re-fetches the holdings and summary when the register reports a write', async () => {
+    await renderView();
+    await waitFor(() => expect(mockGetPortfolioSummary).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'register wrote' }));
+    });
+
+    await waitFor(() => expect(mockGetPortfolioSummary).toHaveBeenCalledTimes(2));
+    expect(mockGetInvestmentPair).toHaveBeenCalledTimes(2);
   });
 
   it('falls back to a standalone brokerage when there is no pair', async () => {

--- a/frontend/src/components/accounts/investment-detail/InvestmentDetailView.tsx
+++ b/frontend/src/components/accounts/investment-detail/InvestmentDetailView.tsx
@@ -117,7 +117,11 @@ export function InvestmentDetailView({ account, refreshKey = 0 }: InvestmentDeta
           accountIds={accountIds}
           valuationComplete={summary?.valuationComplete}
         />
-        <InvestmentValueChart accountIds={accountIds} displayCurrency={currency} />
+        <InvestmentValueChart
+          accountIds={accountIds}
+          displayCurrency={currency}
+          refreshKey={writeKey}
+        />
       </div>
 
       <GroupedHoldingsList

--- a/frontend/src/components/accounts/investment-detail/InvestmentDetailView.tsx
+++ b/frontend/src/components/accounts/investment-detail/InvestmentDetailView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { format } from 'date-fns';
 import { accountsApi } from '@/lib/accounts';
 import { investmentsApi } from '@/lib/investments';
@@ -40,6 +40,15 @@ export function InvestmentDetailView({ account, refreshKey = 0 }: InvestmentDeta
   const [dividendInterestYtd, setDividendInterestYtd] = useState(0);
   const [realizedGainsYtd, setRealizedGainsYtd] = useState(0);
   const [loadedForId, setLoadedForId] = useState<string | null>(null);
+  // Bumped by the register panel after any write on either ledger. The figures
+  // above it -- the summary card, the allocation and the holdings list, cash row
+  // included -- are all derived from those rows, so a deposit that does not
+  // re-run this effect leaves them reading their pre-write values (issue #1190).
+  const [writeKey, setWriteKey] = useState(0);
+  const handleRegisterWrite = useCallback(() => setWriteKey((k) => k + 1), []);
+  // Which *account* the data on screen describes. A re-fetch triggered by a
+  // write or a price refresh is still this account's data, so it does not
+  // blank the page out from under the user.
   const isLoading = loadedForId !== account.id;
 
   useEffect(() => {
@@ -86,7 +95,7 @@ export function InvestmentDetailView({ account, refreshKey = 0 }: InvestmentDeta
     return () => {
       cancelled = true;
     };
-  }, [account, refreshKey]);
+  }, [account, refreshKey, writeKey]);
 
   const accountIds = cash ? [brokerage.id, cash.id] : [brokerage.id];
   const currency = brokerage.currencyCode;
@@ -130,6 +139,7 @@ export function InvestmentDetailView({ account, refreshKey = 0 }: InvestmentDeta
       <InvestmentRegisterPanel
         holdingsAccount={brokerage}
         cashAccount={cash}
+        onDataChanged={handleRegisterWrite}
       />
     </div>
   );

--- a/frontend/src/components/investments/InvestmentRegisterPanel.test.tsx
+++ b/frontend/src/components/investments/InvestmentRegisterPanel.test.tsx
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act, waitFor } from '@/test/render';
 import { NextIntlClientProvider } from 'next-intl';
+import toast from 'react-hot-toast';
 import { InvestmentRegisterPanel } from './InvestmentRegisterPanel';
+import { accountsApi } from '@/lib/accounts';
 import { investmentsApi } from '@/lib/investments';
 import { transactionsApi } from '@/lib/transactions';
 import { invalidateBalanceCaches } from '@/lib/apiCache';
 import type { Account } from '@/types/account';
+import { TransactionStatus, type Transaction } from '@/types/transaction';
 import investmentMessages from '@/i18n/messages/en/accountDetail-investment.json';
 import investmentsNs from '@/i18n/messages/en/investments.json';
 import transactionsNs from '@/i18n/messages/en/transactions.json';
@@ -22,7 +25,13 @@ vi.mock('@/lib/transactions', () => ({
   transactionsApi: {
     getAll: vi.fn(),
     delete: vi.fn(),
+    deleteTransfer: vi.fn(),
+    updateStatus: vi.fn(),
   },
+}));
+
+vi.mock('@/lib/accounts', () => ({
+  accountsApi: { getAll: vi.fn() },
 }));
 
 vi.mock('@/lib/apiCache', () => ({
@@ -30,10 +39,22 @@ vi.mock('@/lib/apiCache', () => ({
 }));
 
 // The forms are large trees with their own data loading; the panel's contract
-// with them is that it mounts them against the right account.
+// with them is that it mounts them against the right account, and hands the
+// brokerage form every account a trade can be funded from.
 vi.mock('./InvestmentTransactionForm', () => ({
-  InvestmentTransactionForm: ({ defaultAccountId }: { defaultAccountId?: string }) => (
-    <div data-testid="investment-form">{defaultAccountId}</div>
+  InvestmentTransactionForm: ({
+    defaultAccountId,
+    allAccounts,
+  }: {
+    defaultAccountId?: string;
+    allAccounts?: { id: string }[];
+  }) => (
+    <div data-testid="investment-form">
+      {defaultAccountId}
+      <span data-testid="form-all-accounts">
+        {allAccounts === undefined ? 'undefined' : allAccounts.map((a) => a.id).join(',')}
+      </span>
+    </div>
   ),
 }));
 vi.mock('@/components/transactions/TransactionForm', () => ({
@@ -41,11 +62,9 @@ vi.mock('@/components/transactions/TransactionForm', () => ({
     <div data-testid="cash-form">{defaultAccountId}</div>
   ),
 }));
-vi.mock('@/components/transactions/TransactionList', () => ({
-  TransactionList: ({ transactions }: { transactions: { id: string }[] }) => (
-    <div data-testid="cash-list">{transactions.map((tx) => tx.id).join(',')}</div>
-  ),
-}));
+// `TransactionList` is deliberately NOT stubbed: it owns its own delete, and the
+// bug in issue #1192 was the panel deleting a second time on top of it. A stub
+// cannot show that.
 
 const brokerage = {
   id: 'brok',
@@ -69,6 +88,49 @@ const cash = {
   isClosed: false,
 } as Account;
 
+/** An account outside the pair -- what "Funds From" is supposed to offer. */
+const chequing = {
+  id: 'chq',
+  name: 'Everyday Chequing',
+  accountType: 'CHEQUING',
+  accountSubType: null,
+  linkedAccountId: null,
+  currencyCode: 'CAD',
+  currentBalance: 2000,
+  isClosed: false,
+} as Account;
+
+const cashTransaction: Transaction = {
+  id: 'cash-tx-1',
+  userId: 'user-1',
+  accountId: 'cash',
+  account: { id: 'cash', name: 'TFSA - Cash', accountType: 'INVESTMENT' } as never,
+  transactionDate: '2026-01-05',
+  payeeId: null,
+  payeeName: 'Contribution',
+  payee: null,
+  categoryId: null,
+  category: null,
+  amount: 500,
+  currencyCode: 'CAD',
+  exchangeRate: 1,
+  originalAmount: null,
+  originalCurrencyCode: null,
+  description: 'Cash deposit',
+  referenceNumber: null,
+  status: TransactionStatus.UNRECONCILED,
+  isCleared: false,
+  isReconciled: false,
+  isVoid: false,
+  reconciledDate: null,
+  isSplit: false,
+  parentTransactionId: null,
+  isTransfer: false,
+  linkedTransactionId: null,
+  createdAt: '2026-01-05T00:00:00Z',
+  updatedAt: '2026-01-05T00:00:00Z',
+};
+
 const standalone = {
   id: 'solo',
   name: 'Self-directed',
@@ -83,6 +145,7 @@ const standalone = {
 async function renderPanel(
   holdingsAccount: Account,
   cashAccount: Account | null,
+  onDataChanged?: () => void,
 ) {
   await act(async () => {
     render(
@@ -98,9 +161,30 @@ async function renderPanel(
         <InvestmentRegisterPanel
           holdingsAccount={holdingsAccount}
           cashAccount={cashAccount}
+          onDataChanged={onDataChanged}
         />
       </NextIntlClientProvider>,
     );
+  });
+}
+
+/** Switch to the cash ledger and delete its only row, confirmation included. */
+async function deleteTheCashRow() {
+  await act(async () => {
+    fireEvent.click(screen.getByText('Cash'));
+  });
+  const rowDelete = screen
+    .getAllByRole('button')
+    .filter((b) => b.textContent === 'Delete')[0];
+  await act(async () => {
+    fireEvent.click(rowDelete);
+  });
+  const confirm = screen
+    .getAllByRole('button')
+    .filter((b) => b.textContent === 'Delete')
+    .pop()!;
+  await act(async () => {
+    fireEvent.click(confirm);
   });
 }
 
@@ -113,9 +197,15 @@ describe('InvestmentRegisterPanel', () => {
       pagination: { total: 0, page: 1, limit: 25, totalPages: 0 },
     });
     (transactionsApi.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ id: 'cash-tx-1' }],
+      data: [cashTransaction],
       pagination: { total: 1, page: 1, limit: 25, totalPages: 1 },
     });
+    (transactionsApi.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (accountsApi.getAll as ReturnType<typeof vi.fn>).mockResolvedValue([
+      brokerage,
+      cash,
+      chequing,
+    ]);
   });
 
   describe('scoping', () => {
@@ -175,7 +265,7 @@ describe('InvestmentRegisterPanel', () => {
         fireEvent.click(screen.getByText('Cash'));
       });
 
-      expect(screen.getByTestId('cash-list')).toHaveTextContent('cash-tx-1');
+      expect(screen.getByText('Contribution')).toBeInTheDocument();
     });
 
     it('offers no toggle when there is no second ledger to switch to', async () => {
@@ -228,6 +318,88 @@ describe('InvestmentRegisterPanel', () => {
         expect(investmentsApi.deleteTransaction).toHaveBeenCalledWith('tx-1');
       });
       expect(invalidateBalanceCaches).toHaveBeenCalled();
+    });
+
+    // Issue #1192. The two lists have opposite delete contracts:
+    // `InvestmentTransactionList` asks its parent to perform the delete, while
+    // `TransactionList` performs its own and only reports it afterwards. The
+    // cash register was given a handler shaped like the brokerage one, so every
+    // cash row was deleted twice -- the second request 404'd on the row the
+    // first had removed, and the user saw "not found" beside "deleted".
+    it('deletes a cash row exactly once', async () => {
+      await renderPanel(brokerage, cash);
+
+      await deleteTheCashRow();
+
+      await waitFor(() => {
+        expect(transactionsApi.delete).toHaveBeenCalledWith('cash-tx-1');
+      });
+      expect(transactionsApi.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports no error after deleting a cash row', async () => {
+      await renderPanel(brokerage, cash);
+
+      await deleteTheCashRow();
+
+      await waitFor(() => expect(transactionsApi.delete).toHaveBeenCalled());
+      await act(async () => {});
+      expect(toast.error).not.toHaveBeenCalled();
+      expect(toast.success).toHaveBeenCalled();
+    });
+
+    it('drops the balance caches after deleting a cash row', async () => {
+      await renderPanel(brokerage, cash);
+
+      await deleteTheCashRow();
+
+      await waitFor(() => expect(invalidateBalanceCaches).toHaveBeenCalled());
+    });
+
+    // Issue #1190: the figures above this panel are derived from these rows, so
+    // the view around it has to be told a write happened.
+    it('tells the surrounding view about a cash write', async () => {
+      const onDataChanged = vi.fn();
+      await renderPanel(brokerage, cash, onDataChanged);
+
+      await deleteTheCashRow();
+
+      await waitFor(() => expect(onDataChanged).toHaveBeenCalled());
+    });
+  });
+
+  // Issue #1191. The pair is not the set of accounts a trade can be funded
+  // from: a purchase is as often paid for out of a chequing account or another
+  // brokerage's cash. Given only the two accounts it had, the form's "Funds
+  // From" picker offered nothing but the linked cash account.
+  describe('the brokerage form', () => {
+    it('is handed every account, not just the pair', async () => {
+      await renderPanel(brokerage, cash);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('+ New Brokerage Transaction'));
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('form-all-accounts')).toHaveTextContent(
+          'brok,cash,chq',
+        ),
+      );
+    });
+
+    // A failed lookup is not an empty list. Passing `[]` would tell the form the
+    // user has no other accounts; leaving it undefined keeps its own fallback.
+    it('supplies no account list at all when the lookup fails', async () => {
+      (accountsApi.getAll as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('offline'),
+      );
+      await renderPanel(brokerage, cash);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('+ New Brokerage Transaction'));
+      });
+
+      expect(screen.getByTestId('form-all-accounts')).toHaveTextContent('undefined');
     });
   });
 });

--- a/frontend/src/components/investments/InvestmentRegisterPanel.tsx
+++ b/frontend/src/components/investments/InvestmentRegisterPanel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import toast from 'react-hot-toast';
+import { accountsApi } from '@/lib/accounts';
 import { investmentsApi } from '@/lib/investments';
 import { transactionsApi } from '@/lib/transactions';
 import { invalidateBalanceCaches } from '@/lib/apiCache';
@@ -35,6 +36,14 @@ interface InvestmentRegisterPanelProps {
    * ledger, which offers the brokerage register alone.
    */
   cashAccount: Account | null;
+  /**
+   * Raised after any write on either ledger, so the surrounding view can
+   * re-fetch what it derives from these rows. A cash deposit moves the cash
+   * balance the Holdings by Account list is showing, and reloading this panel
+   * alone left that figure at its pre-write value until the page was reloaded
+   * (issue #1190).
+   */
+  onDataChanged?: () => void;
 }
 
 /**
@@ -50,6 +59,7 @@ interface InvestmentRegisterPanelProps {
 export function InvestmentRegisterPanel({
   holdingsAccount,
   cashAccount,
+  onDataChanged,
 }: InvestmentRegisterPanelProps) {
   const t = useTranslations('accountDetail-investment');
   const [view, setView] = useLocalStorage<InvestmentTransactionView>(
@@ -64,6 +74,12 @@ export function InvestmentRegisterPanel({
   const [cashPage, setCashPage] = useState(1);
   const [cashTotal, setCashTotal] = useState(0);
   const [reloadKey, setReloadKey] = useState(0);
+  // Every account the user can fund a trade from, for the brokerage form's
+  // "Funds From" / "Deposit To" pickers. Undefined until it loads and after a
+  // failure, because the form reads undefined as "not supplied" and falls back
+  // to the pair -- an empty array would be a claim that the user has no other
+  // accounts. See the effect below.
+  const [allAccounts, setAllAccounts] = useState<Account[] | undefined>(undefined);
   // The key of the request the data on screen answered. Deriving the loading
   // flag from it, rather than setting one at the top of the effect, keeps the
   // payload and the request that produced it together -- and setState in an
@@ -120,13 +136,37 @@ export function InvestmentRegisterPanel({
     };
   }, [requestKey, holdingsAccountId, cashAccountId, brokeragePage, cashPage]);
 
+  // The pair alone is not the set of accounts a trade can be funded from -- a
+  // purchase is as often paid for out of a chequing account or another
+  // brokerage's cash. The Investments page hands the same form the full list;
+  // the detail page passed only the two accounts it had, so the picker offered
+  // nothing but the linked cash account (issue #1191).
+  useEffect(() => {
+    let cancelled = false;
+    accountsApi
+      .getAll()
+      .then((accounts) => {
+        if (!cancelled) setAllAccounts(accounts);
+      })
+      // A failed lookup is not an empty list: leaving this undefined keeps the
+      // form on its own fallback rather than showing an empty picker.
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const afterWrite = useCallback(() => {
     // A trade settles into the cash ledger and a cash row can carry an
     // investment split, so either side moves balances the cached account list
     // and portfolio summary are showing.
     invalidateBalanceCaches();
     reload();
-  }, [reload]);
+    // Dropped caches only make the *next* fetch honest. The holdings, the
+    // portfolio summary and the allocation beside this panel are already
+    // rendered, so they have to be told to fetch again.
+    onDataChanged?.();
+  }, [reload, onDataChanged]);
 
   const brokerageForm = useFormModal<InvestmentTransaction>();
   const cashForm = useFormModal<Transaction>();
@@ -143,17 +183,11 @@ export function InvestmentRegisterPanel({
     [afterWrite, t],
   );
 
-  const handleDeleteCash = useCallback(
-    async (id: string) => {
-      try {
-        await transactionsApi.delete(id);
-        afterWrite();
-      } catch (error) {
-        toast.error(getErrorMessage(error, t('register.deleteFailed')));
-      }
-    },
-    [afterWrite, t],
-  );
+  // There is deliberately no cash-delete handler here. `InvestmentTransactionList`
+  // asks its parent to perform the delete; `TransactionList` performs its own and
+  // only reports it afterwards, so the cash register needs `onRefresh` and
+  // nothing else. Deleting again from here 404'd on the row the list had just
+  // removed, putting a "not found" toast beside the success one (issue #1192).
 
   const accountsForForm = cashAccount
     ? [holdingsAccount, cashAccount]
@@ -210,7 +244,6 @@ export function InvestmentRegisterPanel({
           <TransactionList
             transactions={cashTx}
             onEdit={cashForm.openEdit}
-            onDelete={handleDeleteCash}
             onRefresh={afterWrite}
             isSingleAccountView
             currentPage={cashPage}
@@ -231,6 +264,7 @@ export function InvestmentRegisterPanel({
       >
         <InvestmentTransactionForm
           accounts={accountsForForm}
+          allAccounts={allAccounts}
           transaction={brokerageForm.editingItem}
           defaultAccountId={holdingsAccount.id}
           onSuccess={() => {

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -726,6 +726,90 @@ describe('InvestmentValueChart', () => {
     });
   });
 
+  // Issue #1190. The chart fetches on mount and on a range or currency change,
+  // so a write elsewhere on the page -- a cash deposit, a trade -- moved today's
+  // point with nothing to tell the chart. `refreshKey` is that signal.
+  describe('refreshKey', () => {
+    it('re-fetches a daily range when the key is bumped', async () => {
+      const { rerender } = render(<InvestmentValueChart refreshKey={0} />);
+      await screen.findByText('Portfolio Value Over Time');
+      const before = vi.mocked(netWorthApi.getInvestmentsDaily).mock.calls.length;
+
+      await act(async () => {
+        rerender(<InvestmentValueChart refreshKey={1} />);
+      });
+
+      await waitFor(() => {
+        expect(
+          vi.mocked(netWorthApi.getInvestmentsDaily).mock.calls.length,
+        ).toBeGreaterThan(before);
+      });
+    });
+
+    // The intraday series is served from sessionStorage, so a re-fetch that
+    // trusted the cache would hand back the pre-write points.
+    it('drops the intraday cache and re-fetches when the key is bumped', async () => {
+      dateRangeState.dateRange = '1d';
+      vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
+        points: [{ timestamp: '2024-01-02T15:00:00.000Z', value: 9000 }],
+        interval: '1m',
+        currency: 'CAD',
+        range: '1d',
+        fetchedAt: '2024-01-02T15:00:00.000Z',
+        skippedSymbols: [],
+        failedSymbols: [],
+        fallbackToDaily: false,
+      });
+
+      const { rerender } = render(<InvestmentValueChart refreshKey={0} />);
+      await screen.findByText('Portfolio Value Over Time');
+      await waitFor(() =>
+        expect(window.sessionStorage.getItem('monize-intraday|1d||CAD')).toBeTruthy(),
+      );
+      const before = vi.mocked(investmentsApi.getIntradayValue).mock.calls.length;
+
+      await act(async () => {
+        rerender(<InvestmentValueChart refreshKey={1} />);
+      });
+
+      await waitFor(() => {
+        expect(
+          vi.mocked(investmentsApi.getIntradayValue).mock.calls.length,
+        ).toBeGreaterThan(before);
+      });
+    });
+
+    // Mounting under a key that is already non-zero is not a write: the initial
+    // fetch belongs to the load effect, and firing here as well would double
+    // every request the chart makes on an account switch.
+    it('does not fetch twice when mounted under a non-zero key', async () => {
+      render(<InvestmentValueChart refreshKey={4} />);
+      await screen.findByText('Portfolio Value Over Time');
+
+      await waitFor(() =>
+        expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledTimes(1),
+      );
+    });
+
+    // A range change already re-fetches through the load effect. Were the
+    // write-refresh effect to depend on the loader it would fetch again for the
+    // same change.
+    it('does not fetch twice when only the range changes', async () => {
+      const { rerender } = render(<InvestmentValueChart refreshKey={2} />);
+      await screen.findByText('Portfolio Value Over Time');
+      dateRangeState.dateRange = '3m';
+      dateRangeState.resolvedRange = { start: '2023-10-01', end: '2024-01-01' };
+
+      await act(async () => {
+        rerender(<InvestmentValueChart refreshKey={2} titleSuffix="RRSP" />);
+      });
+
+      await waitFor(() =>
+        expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledTimes(2),
+      );
+    });
+  });
+
   it('uses monthly API for 5y range (not in DAILY_RANGES)', async () => {
     dateRangeState.dateRange = '5y';
     dateRangeState.resolvedRange = { start: '2019-01-01', end: '2024-01-01' };

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -57,9 +57,19 @@ interface InvestmentValueChartProps {
   accountIds?: string[];
   displayCurrency?: string | null;
   titleSuffix?: string;
+  /**
+   * Bumped by the surrounding view when a write changed the rows this series is
+   * computed from. The chart otherwise fetches on mount and on a range or
+   * currency change only, so a cash deposit or a trade moved today's point and
+   * left the line -- and the Highest / Lowest / Change figures beside it -- at
+   * their pre-write values (issue #1190). A bump also drops the intraday
+   * sessionStorage entry, which would serve the pre-write points back to a
+   * re-fetch that trusted it.
+   */
+  refreshKey?: number;
 }
 
-export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix }: InvestmentValueChartProps) {
+export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix, refreshKey = 0 }: InvestmentValueChartProps) {
   const t = useTranslations('investments');
   const tc = useTranslations('common');
   const { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatSignedPercent } = useNumberFormat();
@@ -331,6 +341,23 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
       window.removeEventListener(INVESTMENT_CHART_REFRESH_EVENT, handler);
     };
   }, [isIntraday, loadData]);
+
+  // Re-fetch when the surrounding view reports a write.
+  //
+  // The key this chart has already acted on is what gates the fetch, not the
+  // effect running: `loadData` changes identity on every range, account and
+  // currency change, and the effect above already re-fetches for each of those.
+  // Without the comparison this effect would fetch a second time for all of
+  // them, and once more on any mount under an already-nonzero key.
+  const actedOnRefreshKey = useRef(refreshKey);
+  useEffect(() => {
+    if (actedOnRefreshKey.current === refreshKey) return;
+    actedOnRefreshKey.current = refreshKey;
+    // The daily and monthly endpoints are uncached, so re-asking is enough; the
+    // intraday one is served from sessionStorage until it is dropped.
+    if (isIntraday) clearAllIntradayCache();
+    void loadData({ skipCache: true });
+  }, [refreshKey, isIntraday, loadData]);
 
   // On 1D / 1W / MTD the change is reported against the close of the trading
   // day before the window rather than against the first point drawn, unless the

--- a/frontend/src/components/transactions/TransactionList.test.tsx
+++ b/frontend/src/components/transactions/TransactionList.test.tsx
@@ -80,7 +80,7 @@ describe('TransactionList', () => {
       <TransactionList
         transactions={[]}
         onEdit={mockOnEdit}
-        onDelete={mockOnDelete}
+        onDeleted={mockOnDelete}
         onRefresh={mockOnRefresh}
       />
     );
@@ -105,7 +105,7 @@ describe('TransactionList', () => {
       <TransactionList
         transactions={transactions}
         onEdit={mockOnEdit}
-        onDelete={mockOnDelete}
+        onDeleted={mockOnDelete}
         onRefresh={mockOnRefresh}
       />
     );
@@ -171,7 +171,7 @@ describe('TransactionList', () => {
       <TransactionList
         transactions={[transaction]}
         onEdit={mockOnEdit}
-        onDelete={mockOnDelete}
+        onDeleted={mockOnDelete}
         onRefresh={mockOnRefresh}
       />
     );
@@ -1336,7 +1336,7 @@ describe('TransactionList', () => {
         <TransactionList
           transactions={[tx]}
           onEdit={mockOnEdit}
-          onDelete={mockOnDelete}
+          onDeleted={mockOnDelete}
           onRefresh={mockOnRefresh}
         />
       );
@@ -1356,7 +1356,7 @@ describe('TransactionList', () => {
         <TransactionList
           transactions={[tx]}
           onEdit={mockOnEdit}
-          onDelete={mockOnDelete}
+          onDeleted={mockOnDelete}
           onRefresh={mockOnRefresh}
         />
       );
@@ -1387,7 +1387,7 @@ describe('TransactionList', () => {
         <TransactionList
           transactions={[transferTx]}
           onEdit={mockOnEdit}
-          onDelete={mockOnDelete}
+          onDeleted={mockOnDelete}
           onRefresh={mockOnRefresh}
         />
       );
@@ -1410,7 +1410,7 @@ describe('TransactionList', () => {
         <TransactionList
           transactions={[tx]}
           onEdit={mockOnEdit}
-          onDelete={mockOnDelete}
+          onDeleted={mockOnDelete}
           onRefresh={mockOnRefresh}
         />
       );
@@ -1444,7 +1444,7 @@ describe('TransactionList', () => {
         <TransactionList
           transactions={[transferTx]}
           onEdit={mockOnEdit}
-          onDelete={mockOnDelete}
+          onDeleted={mockOnDelete}
           onRefresh={mockOnRefresh}
         />
       );
@@ -1467,7 +1467,7 @@ describe('TransactionList', () => {
         <TransactionList
           transactions={[tx]}
           onEdit={mockOnEdit}
-          onDelete={mockOnDelete}
+          onDeleted={mockOnDelete}
           onRefresh={mockOnRefresh}
         />
       );
@@ -1486,7 +1486,7 @@ describe('TransactionList', () => {
       });
     });
 
-    it('calls onDelete and onRefresh after successful deletion', async () => {
+    it('calls onDeleted and onRefresh after successful deletion', async () => {
       const { transactionsApi } = await import('@/lib/transactions');
       vi.mocked(transactionsApi.delete).mockResolvedValueOnce(undefined);
 
@@ -1496,7 +1496,7 @@ describe('TransactionList', () => {
         <TransactionList
           transactions={[tx]}
           onEdit={mockOnEdit}
-          onDelete={mockOnDelete}
+          onDeleted={mockOnDelete}
           onRefresh={mockOnRefresh}
         />
       );
@@ -2373,7 +2373,7 @@ describe('TransactionList', () => {
         <TransactionList
           transactions={[investmentTx]}
           onEdit={mockOnEdit}
-          onDelete={mockOnDelete}
+          onDeleted={mockOnDelete}
           onRefresh={mockOnRefresh}
         />
       );

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -22,7 +22,17 @@ interface TransactionListProps {
   onEdit?: (transaction: Transaction) => void;
   onDuplicate?: (transaction: Transaction) => void;
   onScheduleRecurring?: (transaction: Transaction) => void;
-  onDelete?: (id: string) => void;
+  /**
+   * Notification that the row has **already been deleted** -- this list owns the
+   * confirmation, the `transactionsApi.delete`/`deleteTransfer` call and the
+   * toast, and calls this afterwards with the id it removed. It is not a request
+   * to perform the delete: a handler that deletes again issues a second request
+   * for a row that no longer exists, so the user gets the success toast and a
+   * "not found" error side by side (issue #1192). Past tense is the whole
+   * contract -- reach for `onRefresh` to reload, and this only when the caller
+   * needs the id (an optimistic removal, a counterpart to drop).
+   */
+  onDeleted?: (id: string) => void;
   onRefresh?: () => void;
   onTransactionUpdate?: (transaction: Transaction) => void;
   onPayeeClick?: (payeeId: string) => void;
@@ -77,7 +87,7 @@ export function TransactionList({
   onEdit,
   onDuplicate,
   onScheduleRecurring,
-  onDelete,
+  onDeleted,
   onRefresh,
   onTransactionUpdate,
   onPayeeClick,
@@ -248,14 +258,14 @@ export function TransactionList({
         await transactionsApi.delete(transaction.id);
         toast.success(t('list.delete.success'));
       }
-      onDelete?.(transaction.id);
+      onDeleted?.(transaction.id);
       onRefresh?.();
     } catch (error) {
       toast.error(getErrorMessage(error, t('list.delete.error')));
     } finally {
       setDeletingId(null);
     }
-  }, [deleteConfirm.transaction, onDelete, onRefresh, t]);
+  }, [deleteConfirm.transaction, onDeleted, onRefresh, t]);
 
   const handleDeleteCancel = useCallback(() => {
     setDeleteConfirm({ isOpen: false, transaction: null });

--- a/frontend/src/test/ui-conventions.test.ts
+++ b/frontend/src/test/ui-conventions.test.ts
@@ -775,3 +775,89 @@ describe("a category typed into a picker is created by one helper", () => {
     expect(/export async function createCategoryFromInput\(/.test(helper)).toBe(true);
   });
 });
+
+describe("TransactionList performs its own delete", () => {
+  /** The list that owns the confirmation, the API call and the toast. */
+  const LIST = "/src/components/transactions/TransactionList.tsx";
+  /** Every way a caller could delete the row a second time. */
+  const DELETES =
+    /(?:transactionsApi\.(?:delete|deleteTransfer)|investmentsApi\.deleteTransaction)\(/;
+
+  /**
+   * The expression a file hands to `<TransactionList onDeleted={...}>`, resolved
+   * to the callback's own source where it is passed by name. Brace-matched
+   * rather than regex-terminated, because the handler is usually a `useCallback`
+   * whose body contains braces of its own.
+   */
+  function deletedHandlerSources(content: string): string[] {
+    const bodies: string[] = [];
+    const prop = /onDeleted=\{/g;
+    while (prop.exec(content) !== null) {
+      const expression = braceMatched(content, prop.lastIndex - 1);
+      const identifier = expression.trim();
+      bodies.push(
+        /^[A-Za-z_$][\w$]*$/.test(identifier)
+          ? definitionOf(content, identifier)
+          : expression,
+      );
+    }
+    return bodies;
+  }
+
+  /** The text between `{` at `open` and its matching `}`. */
+  function braceMatched(content: string, open: number): string {
+    let depth = 0;
+    for (let i = open; i < content.length; i++) {
+      if (content[i] === "{") depth++;
+      else if (content[i] === "}" && --depth === 0)
+        return content.slice(open + 1, i);
+    }
+    return content.slice(open + 1);
+  }
+
+  /**
+   * The initialiser of `const <name> = ...`, taken to the `;` at nesting depth
+   * zero. Returns the empty string when the name is not defined in this file --
+   * an imported handler is out of reach of a source scan, and saying so by
+   * finding nothing is better than guessing.
+   */
+  function definitionOf(content: string, name: string): string {
+    const start = content.search(
+      new RegExp(`\\bconst\\s+${name}\\s*=`),
+    );
+    if (start < 0) return "";
+    let depth = 0;
+    for (let i = start; i < content.length; i++) {
+      const c = content[i];
+      if (c === "(" || c === "{" || c === "[") depth++;
+      else if (c === ")" || c === "}" || c === "]") depth--;
+      else if (c === ";" && depth === 0) return content.slice(start, i);
+    }
+    return content.slice(start);
+  }
+
+  it("is never asked to delete a row twice", () => {
+    const offenders = productionSources()
+      .filter(([, content]) => content.includes("<TransactionList"))
+      .filter(([, content]) => deletedHandlerSources(content).some((body) => DELETES.test(body)))
+      .map(([path]) => path);
+
+    // `onDeleted` reports a delete this list has already performed; it is not a
+    // request to perform one. The investment register panel gave it a handler
+    // shaped like `InvestmentTransactionList`'s -- whose `onDelete` *is* the
+    // performer -- so every cash row was deleted twice and the 404 from the
+    // second attempt landed beside the success toast (issue #1192). Reach for
+    // `onRefresh` to reload after a delete.
+    expect(offenders).toEqual([]);
+  });
+
+  it("still owns the delete, so the rule cannot pass by accident", () => {
+    // Were the contract to flip -- the list asking its parent to delete -- the
+    // check above would be policing the opposite of the truth. This fails first
+    // and says what to update.
+    const list = sources[LIST];
+    expect(list, `${LIST} not found -- update LIST in this test`).toBeTruthy();
+    expect(DELETES.test(list)).toBe(true);
+    expect(/onDeleted\?\.\(/.test(list)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Linked discussion / issue

Closes #1192
Closes #1191
Closes #1190

Approved in: the three issues above, each labelled `approved-to-build`.

## Summary

Four fixes on the investment account detail page — three reported defects in the register panel below the holdings, plus the one surface the third one left stale.

**#1192 — deleting a cash transaction reported an error beside the success toast.** The two lists in that panel have opposite delete contracts: `InvestmentTransactionList` asks its parent to perform the delete, while `TransactionList` performs its own (confirmation, API call, toast) and only reports it afterwards. The cash register was given a handler shaped like the brokerage one, so every row was deleted twice and the second request 404'd on the row the first had removed. Worse for a transfer, where the list correctly calls `deleteTransfer` and the parent then called the plain `delete`.

The handler is gone; the cash list reloads through `onRefresh` alone, as the Investments page's copy already did.

**#1191 — "Funds From (optional)" offered only the account's own linked cash.** `InvestmentTransactionForm` falls back to its `accounts` prop when `allAccounts` is absent, and the detail page passed only the two accounts of the pair — so the one option the field exists to replace was the only one in it. The panel now loads `accountsApi.getAll()` and supplies it: same source, same filter, and the same behaviour as the Investments page's copy of the modal rather than a second implementation. A failed lookup stays `undefined` rather than becoming `[]`, which would claim the user has no other accounts.

**#1190 — a cash write left the figures above the register at their pre-write values.** Dropping the balance caches only makes the *next* fetch honest, and nothing already mounted refetches on its own. The panel now raises `onDataChanged` after every write on either ledger and `InvestmentDetailView` re-runs its load from it, covering the summary card, the allocation chart, the YTD income panel and Holdings by Account — including the cash row the issue names.

**#1190, second half — the portfolio value chart.** `InvestmentValueChart` fetches its own series, so re-running the view's load said nothing to it. It now takes the same write counter as `refreshKey`. Two details the re-fetch has to get right: the intraday series is served from `sessionStorage`, so a re-fetch that trusted the cache would hand back exactly the points the write invalidated (the bump drops it and asks with `skipCache`); and the effect gates on the key it has already *acted on* rather than on running, because `loadData` changes identity on every range, account and currency change — all already covered by the load effect above it.

### Guards, not just fixes

- `TransactionList.onDelete` is renamed `onDeleted`, so the tense states the contract, and a source scan in `src/test/ui-conventions.test.ts` fails on any `<TransactionList` handed an `onDeleted` handler that itself deletes, in both the named and the inline form.
- Every regression test was checked against the code it guards, not merely written beside the fix: the #1190/#1192 tests fail against the original handlers, the two chart tests fail without the prop, and the two double-fetch tests fail if the acted-on guard is removed.
- The three rules are written into `frontend/CLAUDE.md` so the next change inherits them.

### Also in this PR

`src/app/accounts/[id]/page.test.tsx` mocked `useNumberFormat` with `formatCurrency` alone, so `InvestmentValueChart`'s `formatSignedPercent` was `undefined`. It had been passing only because the failing render landed outside `act`; the extra state update from the #1191 fix flushed it into the test. The mock now spreads the real hook.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [ ] This PR addresses a **single concern** (large work is split into a series). — **No:** it carries three issues. They were requested together and share one component (the investment register panel) and one root surface, so splitting them would have produced three PRs touching the same two files. Happy to split if you would rather review them separately.
- [x] New behavior has tests, and the existing suite passes. — 681 files / 13380 tests green; `tsc --noEmit` and `eslint` clean.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — Vacuous here: no catalog string was added or changed, so the pseudo-locale needed no regeneration.
- [ ] No shared/core areas were refactored without prior agreement. — **One, deliberately:** `TransactionList`'s `onDelete` prop is renamed `onDeleted`. That component is shared, but the misleading name *is* the defect in #1192, and a rename is what makes every stale call site a compile error. It had exactly one production caller (the one that was wrong); the rest of the diff there is its own test file.
- [x] The branch is rebased on the latest `main`.

## AI assistance disclosure

Written with Claude Code, driven by @kenlasko. Each fix was reproduced against the original code before the change and each regression test was confirmed to fail without it; the full frontend suite, typecheck and lint were run on the pushed commit.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)