### PR TITLE
fix(investments): show the running balance in the account detail page's cash register

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -382,6 +382,21 @@ lookup there stays `undefined`, never `[]`: the form reads undefined as "not
 supplied" and falls back, while an empty array is a claim that the user has no
 other accounts.
 
+### Asking for the Balance column and supplying the balance are one decision
+
+`<TransactionList isSingleAccountView>` draws the Balance column, and the number
+in it is the backend's `startingBalance` run down the page -- the list derives
+nothing on its own, so the column arrives empty without it. `InvestmentRegisterPanel`
+read the rows off `transactionsApi.getAll` and dropped the `startingBalance` that
+came with them, so the account detail page's cash register showed "-" on every row
+while the Investments page's copy of the same register was right (issue #1188).
+
+Take both from the same response and adopt them in the same block: a starting
+balance is computed for one page of one account and means nothing beside another
+page's rows, and a failed reload that keeps the rows has to keep the balance too.
+`ui-conventions.test.ts` fails any `<TransactionList>` that sets
+`isSingleAccountView` without passing `startingBalance`.
+
 ### A long list -- page it, or bound it and scroll with `scrollbar-slim`
 
 Two patterns, depending on where it lives:

--- a/frontend/src/components/investments/InvestmentRegisterPanel.test.tsx
+++ b/frontend/src/components/investments/InvestmentRegisterPanel.test.tsx
@@ -168,11 +168,15 @@ async function renderPanel(
   });
 }
 
-/** Switch to the cash ledger and delete its only row, confirmation included. */
-async function deleteTheCashRow() {
+/** Put the cash ledger on screen. */
+async function switchToCash() {
   await act(async () => {
     fireEvent.click(screen.getByText('Cash'));
   });
+}
+
+/** Delete the cash register's only row, confirmation included. */
+async function deleteFirstCashRow() {
   const rowDelete = screen
     .getAllByRole('button')
     .filter((b) => b.textContent === 'Delete')[0];
@@ -186,6 +190,12 @@ async function deleteTheCashRow() {
   await act(async () => {
     fireEvent.click(confirm);
   });
+}
+
+/** Switch to the cash ledger and delete its only row. */
+async function deleteTheCashRow() {
+  await switchToCash();
+  await deleteFirstCashRow();
 }
 
 describe('InvestmentRegisterPanel', () => {
@@ -272,6 +282,84 @@ describe('InvestmentRegisterPanel', () => {
       await renderPanel(brokerage, null);
 
       expect(screen.queryByText('Cash')).not.toBeInTheDocument();
+    });
+  });
+
+  // Issue #1188. The register draws a Balance column for a single-account view,
+  // and the number in it is the backend's starting balance run down the page.
+  // The panel read the rows off the response and dropped the starting balance
+  // beside them, so every row's balance cell rendered the empty marker.
+  describe('the running balance', () => {
+    it('shows the balance the rows run from', async () => {
+      (transactionsApi.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [cashTransaction],
+        pagination: { total: 1, page: 1, limit: 25, totalPages: 1 },
+        startingBalance: 3500,
+      });
+
+      await renderPanel(brokerage, cash);
+      await switchToCash();
+
+      expect(screen.getByText('Balance')).toBeInTheDocument();
+      expect(screen.getByText('$3,500.00')).toBeInTheDocument();
+    });
+
+    // The starting balance is computed for one page of one account and means
+    // nothing beside another page's rows, so it is adopted from the same
+    // response as the rows rather than lagging a request behind them.
+    it('moves the balance with the rows it was computed for', async () => {
+      (transactionsApi.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [cashTransaction],
+        pagination: { total: 1, page: 1, limit: 25, totalPages: 1 },
+        startingBalance: 3500,
+      });
+
+      await renderPanel(brokerage, cash);
+      await switchToCash();
+
+      // The write's reload answers with the register as it now stands.
+      (transactionsApi.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [
+          {
+            ...cashTransaction,
+            id: 'cash-tx-2',
+            payeeName: 'Withdrawal',
+            amount: -750,
+          },
+        ],
+        pagination: { total: 1, page: 1, limit: 25, totalPages: 1 },
+        startingBalance: 2750,
+      });
+      await deleteFirstCashRow();
+
+      await waitFor(() => {
+        expect(screen.getByText('Withdrawal')).toBeInTheDocument();
+        expect(screen.getByText('$2,750.00')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('$3,500.00')).not.toBeInTheDocument();
+    });
+
+    // A failed reload is not a register with no starting balance: the rows on
+    // screen stay, so the balances beside them have to stay too rather than
+    // collapsing to the empty marker under unchanged rows.
+    it('keeps the balance when a reload fails', async () => {
+      (transactionsApi.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [cashTransaction],
+        pagination: { total: 1, page: 1, limit: 25, totalPages: 1 },
+        startingBalance: 3500,
+      });
+
+      await renderPanel(brokerage, cash);
+      await switchToCash();
+
+      (transactionsApi.getAll as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('network'),
+      );
+      await deleteFirstCashRow();
+      await act(async () => {});
+
+      expect(screen.getByText('Contribution')).toBeInTheDocument();
+      expect(screen.getByText('$3,500.00')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/investments/InvestmentRegisterPanel.tsx
+++ b/frontend/src/components/investments/InvestmentRegisterPanel.tsx
@@ -73,6 +73,13 @@ export function InvestmentRegisterPanel({
   const [cashTx, setCashTx] = useState<Transaction[]>([]);
   const [cashPage, setCashPage] = useState(1);
   const [cashTotal, setCashTotal] = useState(0);
+  // The balance the page's first row runs from. It is part of the same
+  // payload as the rows and is only meaningful beside them, so it is adopted
+  // in the same block -- a starting balance from one page against another
+  // page's rows is a running balance for transactions nobody is looking at.
+  const [cashStartingBalance, setCashStartingBalance] = useState<
+    number | undefined
+  >(undefined);
   const [reloadKey, setReloadKey] = useState(0);
   // Every account the user can fund a trade from, for the brokerage form's
   // "Funds From" / "Deposit To" pickers. Undefined until it loads and after a
@@ -128,6 +135,7 @@ export function InvestmentRegisterPanel({
       if (cash) {
         setCashTx(cash.data);
         setCashTotal(cash.pagination?.total ?? cash.data.length);
+        setCashStartingBalance(cash.startingBalance);
       }
       setLoadedKey(requestKey);
     })();
@@ -251,6 +259,7 @@ export function InvestmentRegisterPanel({
             totalItems={cashTotal}
             pageSize={PAGE_SIZE}
             onPageChange={setCashPage}
+            startingBalance={cashStartingBalance}
           />
         </div>
       )}

--- a/frontend/src/test/ui-conventions.test.ts
+++ b/frontend/src/test/ui-conventions.test.ts
@@ -776,6 +776,58 @@ describe("a category typed into a picker is created by one helper", () => {
   });
 });
 
+describe("a register that draws a Balance column is given the balance", () => {
+  /** The list that renders the column and computes the running balances. */
+  const LIST = "/src/components/transactions/TransactionList.tsx";
+
+  /** The attribute text of every `<TransactionList ...>` opening tag in a file. */
+  function transactionListTags(content: string): string[] {
+    const tags: string[] = [];
+    const open = /<TransactionList[\s>]/g;
+    let match: RegExpExecArray | null;
+    while ((match = open.exec(content)) !== null) {
+      let depth = 0;
+      for (let i = match.index; i < content.length; i++) {
+        if (content[i] === "{") depth++;
+        else if (content[i] === "}") depth--;
+        else if (content[i] === ">" && depth === 0) {
+          tags.push(content.slice(match.index, i));
+          break;
+        }
+      }
+    }
+    return tags;
+  }
+
+  it("supplies startingBalance wherever isSingleAccountView is set", () => {
+    const offenders = productionSources()
+      .flatMap(([path, content]) =>
+        transactionListTags(content).map((tag) => [path, tag] as const),
+      )
+      .filter(([, tag]) => /\bisSingleAccountView\b/.test(tag))
+      .filter(([, tag]) => !/\bstartingBalance\b/.test(tag))
+      .map(([path]) => path);
+
+    // `isSingleAccountView` alone draws the Balance column, and the number in
+    // it comes from the backend's `startingBalance` run down the page. The
+    // investment register panel read the rows off the response and dropped that
+    // field, so the column it had just asked for rendered "-" on every row
+    // (issue #1188). The two are one decision: ask for the column, supply the
+    // balance, and take both from the same response.
+    expect(offenders).toEqual([]);
+  });
+
+  it("still needs the balance to draw the column, so the rule cannot pass by accident", () => {
+    // Were the list to start deriving the running balance itself, this check
+    // would be demanding a prop nothing reads. This fails first and says so.
+    const list = sources[LIST];
+    expect(list, `${LIST} not found -- update LIST in this test`).toBeTruthy();
+    expect(/isSingleAccountView \|\| startingBalance !== undefined/.test(list)).toBe(
+      true,
+    );
+  });
+});
+
 describe("TransactionList performs its own delete", () => {
   /** The list that owns the confirmation, the API call and the toast. */
   const LIST = "/src/components/transactions/TransactionList.tsx";


### PR DESCRIPTION
## Linked discussion / issue

Closes #1188
Approved in: https://github.com/kenlasko/monize/issues/1188 (labelled `approved-to-build`)

## Summary

The investment account detail page's Cash transactions section drew a Balance column with `-` in every row.

`InvestmentRegisterPanel` renders the cash ledger through `TransactionList` with `isSingleAccountView`, which turns the Balance column on — but it never read `startingBalance` off the `transactionsApi.getAll` response that carried the rows. `TransactionList` derives nothing on its own: `Number(undefined)` is `NaN`, so the running-balance map came back empty and every cell fell through to the `-` marker. The Investments page passes the field (`frontend/src/app/investments/page.tsx`), which is why the same register reads correctly there — and likely why the reporter saw the column populate after navigating through portfolio views.

The fix adopts the starting balance in the same block that adopts the rows. It is computed for one page of one account and means nothing beside another page's rows, so the pair is kept together, and a failed reload leaves both untouched rather than dropping the balances under rows that are still on screen.

The mistake is mechanical — a prop the column depends on, omitted at one of three call sites — so it is now a source scan rather than a paragraph: `ui-conventions.test.ts` fails any `<TransactionList>` that sets `isSingleAccountView` without supplying `startingBalance`, with a companion assertion that fails first if the list ever starts deriving the balance itself. `frontend/CLAUDE.md` records the rule.

Files changed:

- `frontend/src/components/investments/InvestmentRegisterPanel.tsx` — hold `cashStartingBalance`, set it beside the rows, pass it to `TransactionList`.
- `frontend/src/components/investments/InvestmentRegisterPanel.test.tsx` — three cases against the real `TransactionList` (deliberately unstubbed in this file since #1192): the balance renders, it moves with the rows a reload returned, and it survives a failed reload.
- `frontend/src/test/ui-conventions.test.ts` — the guard.
- `frontend/CLAUDE.md` — the rule.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

Notes on the checklist:

- No user-facing strings were added or changed, so no catalog was touched and i18n parity is unaffected.
- `TransactionList` itself is unchanged; only a call site supplies a prop it already accepts.
- Rebased onto `7fffbca9`. Verified locally: the changed file's suite is 17/17, `src/components/investments` + `src/components/transactions` + `src/test/ui-conventions.test.ts` are 1474/1474, `tsc --noEmit` and ESLint clean. Reverting the one-line prop turns the three new tests and the new guard red.

## AI assistance disclosure

Written with Claude Code. The diagnosis, the fix, the tests and the guard were produced by the assistant and verified by running the suites above, including checking that each new test and the new scan fails against the unfixed code.