### PR TITLE
Give Bills and Deposits the row density every other table has

### DIFF
--- a/frontend/src/app/bills/page.test.tsx
+++ b/frontend/src/app/bills/page.test.tsx
@@ -475,6 +475,19 @@ describe('BillsPage', () => {
       expect(toggle.parentElement?.lastElementChild).toBe(toggle);
     });
 
+    it('is the plain toggle every other table draws, not a filled chip', async () => {
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());
+
+      // It sits among the filter chips but is not one of them, so it carries no
+      // resting fill -- only the hover the borderless `sm` button has. Matched
+      // on whole class names, since `hover:bg-gray-100` contains the other.
+      const classes = screen.getByTitle('Toggle row density').className.split(/\s+/);
+      expect(classes).not.toContain('bg-gray-100');
+      expect(classes).not.toContain('dark:bg-gray-700');
+      expect(classes).toContain('hover:bg-gray-100');
+    });
+
     it('stays visible below sm, where the type chips do not', async () => {
       render(<BillsPage />);
       await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());

--- a/frontend/src/app/bills/page.test.tsx
+++ b/frontend/src/app/bills/page.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@/test/render';
 import BillsPage from './page';
+import { useDensityStore } from '@/store/densityStore';
 
 // Mock next/image
 vi.mock('next/image', () => ({
@@ -447,6 +448,85 @@ describe('BillsPage', () => {
       fireEvent.click(screen.getByText('Calendar'));
       // Filter tabs hidden in calendar view
       expect(screen.queryByText('All (6)')).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Issue #1203: the Bills list had no density control at all. It sits at the
+   * far right of the bar the List/Calendar tabs and the All/Bills/Deposits
+   * chips already share, so every control that shapes the list is on one line.
+   */
+  describe('Density toggle', () => {
+    beforeEach(() => {
+      useDensityStore.setState({ densities: {} });
+    });
+
+    it('sits at the far right of the bar holding the view tabs and filter chips', async () => {
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());
+
+      const bar = screen.getByText('List').closest('nav')!.parentElement!;
+      const toggle = screen.getByTitle('Toggle row density');
+
+      expect(bar).toContainElement(toggle);
+      expect(bar).toContainElement(screen.getByText('All (6)'));
+      // Last child of the bar, and last within that child: nothing sits right of it.
+      expect(bar.lastElementChild).toContainElement(toggle);
+      expect(toggle.parentElement?.lastElementChild).toBe(toggle);
+    });
+
+    it('stays visible below sm, where the type chips do not', async () => {
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());
+
+      // The chips are in their own `hidden sm:flex` group; the toggle is not,
+      // because a phone is where tightening the rows matters most.
+      expect(screen.getByText('All (6)').parentElement?.className).toContain('hidden');
+      expect(screen.getByTitle('Toggle row density').parentElement?.className).not.toContain('hidden');
+    });
+
+    it('is absent in calendar view, which has no rows to tighten', async () => {
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByText('Calendar'));
+      expect(screen.queryByTitle('Toggle row density')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('List'));
+      expect(screen.getByTitle('Toggle row density')).toBeInTheDocument();
+    });
+
+    it('cycles normal to compact to dense and back', async () => {
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());
+
+      const toggle = screen.getByTitle('Toggle row density');
+      expect(toggle).toHaveTextContent('Normal');
+
+      fireEvent.click(toggle);
+      expect(toggle).toHaveTextContent('Compact');
+      fireEvent.click(toggle);
+      expect(toggle).toHaveTextContent('Dense');
+      fireEvent.click(toggle);
+      expect(toggle).toHaveTextContent('Normal');
+    });
+
+    it('writes to the bills view, not the transactions register', async () => {
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTitle('Toggle row density'));
+
+      expect(useDensityStore.getState().densities.bills).toBe('compact');
+      expect(useDensityStore.getState().densities.transactions).toBeUndefined();
+    });
+
+    it('reads the level the store already holds for bills', async () => {
+      useDensityStore.setState({ densities: { bills: 'dense' } });
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());
+
+      expect(screen.getByTitle('Toggle row density')).toHaveTextContent('Dense');
     });
   });
 

--- a/frontend/src/app/bills/page.tsx
+++ b/frontend/src/app/bills/page.tsx
@@ -24,6 +24,7 @@ import { BillsFilterPanel } from '@/components/scheduled-transactions/BillsFilte
 import { OverrideEditorDialog } from '@/components/scheduled-transactions/OverrideEditorDialog';
 import { OccurrenceDatePicker } from '@/components/scheduled-transactions/OccurrenceDatePicker';
 import { PostTransactionDialog } from '@/components/scheduled-transactions/PostTransactionDialog';
+import { DensityToggle } from '@/components/ui/DensityToggle';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
@@ -695,22 +696,30 @@ function BillsContent() {
               </button>
             </nav>
             {viewMode === 'list' && (
-              <div className="hidden sm:flex pr-4 gap-2">
-                {(['all', 'bills', 'deposits'] as const).map((type) => (
-                  <button
-                    key={type}
-                    onClick={() => setFilterType(type)}
-                    className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
-                      filterType === type
-                        ? 'bg-blue-600 text-white'
-                        : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-                    }`}
-                  >
-                    {type === 'all' ? t('viewTabs.filterAll', { count: scheduledTransactions.length }) :
-                     type === 'bills' ? t('viewTabs.filterBills', { count: scheduledTransactions.filter((st) => scheduledKind(st) === 'bill').length }) :
-                     t('viewTabs.filterDeposits', { count: scheduledTransactions.filter((st) => scheduledKind(st) === 'deposit').length })}
-                  </button>
-                ))}
+              <div className="flex items-center pr-4 gap-2">
+                <div className="hidden sm:flex gap-2">
+                  {(['all', 'bills', 'deposits'] as const).map((type) => (
+                    <button
+                      key={type}
+                      onClick={() => setFilterType(type)}
+                      className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                        filterType === type
+                          ? 'bg-blue-600 text-white'
+                          : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                      }`}
+                    >
+                      {type === 'all' ? t('viewTabs.filterAll', { count: scheduledTransactions.length }) :
+                       type === 'bills' ? t('viewTabs.filterBills', { count: scheduledTransactions.filter((st) => scheduledKind(st) === 'bill').length }) :
+                       t('viewTabs.filterDeposits', { count: scheduledTransactions.filter((st) => scheduledKind(st) === 'deposit').length })}
+                    </button>
+                  ))}
+                </div>
+                {/* Density belongs to the list, so it sits with the list's own
+                    controls and is absent from the calendar. `chip` because the
+                    neighbours here are filter chips, not plain toolbar buttons.
+                    It stays visible below `sm`, where the type chips do not:
+                    the rows are still there to tighten. */}
+                <DensityToggle view="bills" size="chip" />
               </div>
             )}
             {viewMode === 'calendar' && (

--- a/frontend/src/app/bills/page.tsx
+++ b/frontend/src/app/bills/page.tsx
@@ -715,11 +715,13 @@ function BillsContent() {
                   ))}
                 </div>
                 {/* Density belongs to the list, so it sits with the list's own
-                    controls and is absent from the calendar. `chip` because the
-                    neighbours here are filter chips, not plain toolbar buttons.
-                    It stays visible below `sm`, where the type chips do not:
-                    the rows are still there to tighten. */}
-                <DensityToggle view="bills" size="chip" />
+                    controls and is absent from the calendar. `sm` -- the plain
+                    borderless button every other table's toggle is, rather than
+                    a filled chip: it is not a fourth filter beside All/Bills/
+                    Deposits and must not read as one. It stays visible below
+                    `sm`, where the type chips do not: the rows are still there
+                    to tighten. */}
+                <DensityToggle view="bills" />
               </div>
             )}
             {viewMode === 'calendar' && (

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionList.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionList.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@/test/render';
 import { ScheduledTransactionList } from './ScheduledTransactionList';
 import toast from 'react-hot-toast';
+import { useDensityStore } from '@/store/densityStore';
 
 vi.mock('react-hot-toast', () => ({
   default: {
@@ -1087,5 +1088,121 @@ describe('ScheduledTransactionList - foreign currency', () => {
   it('shows no second line for an ordinary schedule', () => {
     render(<ScheduledTransactionList transactions={[createTransaction()]} />);
     expect(screen.queryByText(/USD/)).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Issue #1203: the list had no density control at all, so every bill occupied
+ * roughly three lines and nothing could be done about it. It reads its level
+ * from the one store like every other table, which means two things worth
+ * pinning: the padding that reaches the DOM comes from the shared scale, and
+ * the level is written to the `bills` bucket rather than sharing the
+ * register's.
+ */
+describe('ScheduledTransactionList - row density', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDensityStore.setState({ densities: {} });
+  });
+
+  it.each([
+    ['normal', 'px-3 sm:px-6 py-4'],
+    ['compact', 'px-4 py-2'],
+    ['dense', 'px-3 py-1'],
+  ] as const)('uses the default scale at %s density', (level, expected) => {
+    useDensityStore.setState({ densities: { bills: level } });
+    render(<ScheduledTransactionList transactions={[createTransaction()]} />);
+
+    const cell = screen.getByText('Netflix').closest('td');
+    for (const cls of expected.split(' ')) {
+      expect(cell?.className, `${level}: ${cls}`).toContain(cls);
+    }
+  });
+
+  it('cycles the level through the shared toggle', () => {
+    render(<ScheduledTransactionList transactions={[createTransaction()]} />);
+
+    const toggle = screen.getByTitle('Toggle row density');
+    expect(toggle).toHaveTextContent('Normal');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveTextContent('Compact');
+    fireEvent.click(toggle);
+    expect(toggle).toHaveTextContent('Dense');
+    fireEvent.click(toggle);
+    expect(toggle).toHaveTextContent('Normal');
+  });
+
+  it('remembers the level under its own bills view, not the transactions register', () => {
+    render(<ScheduledTransactionList transactions={[createTransaction()]} />);
+
+    fireEvent.click(screen.getByTitle('Toggle row density'));
+
+    expect(useDensityStore.getState().densities.bills).toBe('compact');
+    expect(useDensityStore.getState().densities.transactions).toBeUndefined();
+  });
+
+  it('reads a level another surface already stored for bills', () => {
+    useDensityStore.setState({ densities: { bills: 'dense' } });
+    render(<ScheduledTransactionList transactions={[createTransaction()]} />);
+
+    expect(screen.getByTitle('Toggle row density')).toHaveTextContent('Dense');
+  });
+
+  it('puts the payee beside the name at dense instead of under it', () => {
+    useDensityStore.setState({ densities: { bills: 'dense' } });
+    render(
+      <ScheduledTransactionList
+        transactions={[createTransaction({ payeeName: 'Netflix Inc' })]}
+      />,
+    );
+
+    // Same parent, laid out as a row: the three-line row the issue reported is
+    // one line at dense, and the payee is still on screen rather than dropped.
+    const name = screen.getByText('Netflix');
+    const payee = screen.getByText('Netflix Inc');
+    expect(payee.parentElement).toBe(name.parentElement);
+    expect(name.parentElement?.className).toContain('flex');
+  });
+
+  it('stacks the payee under the name at normal', () => {
+    render(
+      <ScheduledTransactionList
+        transactions={[createTransaction({ payeeName: 'Netflix Inc' })]}
+      />,
+    );
+
+    expect(screen.getByText('Netflix').parentElement?.className).not.toContain('flex');
+  });
+
+  it('stripes alternating rows once the padding between them is gone', () => {
+    useDensityStore.setState({ densities: { bills: 'compact' } });
+    render(
+      <ScheduledTransactionList
+        transactions={[
+          createTransaction({ id: 's1', name: 'First' }),
+          createTransaction({ id: 's2', name: 'Second' }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('First').closest('tr')?.className).toContain('bg-white');
+    expect(screen.getByText('Second').closest('tr')?.className).toContain('bg-gray-50');
+  });
+
+  it('leaves an overdue row its own ground rather than striping it', () => {
+    useDensityStore.setState({ densities: { bills: 'compact' } });
+    render(
+      <ScheduledTransactionList
+        transactions={[
+          createTransaction({ id: 's1', name: 'First' }),
+          createTransaction({ id: 's2', name: 'Second', nextDueDate: pastDate(3) }),
+        ]}
+      />,
+    );
+
+    const overdue = screen.getByText('Second').closest('tr')!;
+    expect(overdue.className).toContain('bg-red-50');
+    expect(overdue.className).not.toContain('bg-gray-50');
   });
 });

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionList.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionList.test.tsx
@@ -1093,11 +1093,10 @@ describe('ScheduledTransactionList - foreign currency', () => {
 
 /**
  * Issue #1203: the list had no density control at all, so every bill occupied
- * roughly three lines and nothing could be done about it. It reads its level
- * from the one store like every other table, which means two things worth
- * pinning: the padding that reaches the DOM comes from the shared scale, and
- * the level is written to the `bills` bucket rather than sharing the
- * register's.
+ * roughly three lines and nothing could be done about it. The control itself
+ * lives on the Bills page, beside the List/Calendar and All/Bills/Deposits
+ * selectors (its tests are there); what belongs here is that the level the
+ * store holds for `bills` is what reaches the DOM.
  */
 describe('ScheduledTransactionList - row density', () => {
   beforeEach(() => {
@@ -1117,36 +1116,6 @@ describe('ScheduledTransactionList - row density', () => {
     for (const cls of expected.split(' ')) {
       expect(cell?.className, `${level}: ${cls}`).toContain(cls);
     }
-  });
-
-  it('cycles the level through the shared toggle', () => {
-    render(<ScheduledTransactionList transactions={[createTransaction()]} />);
-
-    const toggle = screen.getByTitle('Toggle row density');
-    expect(toggle).toHaveTextContent('Normal');
-
-    fireEvent.click(toggle);
-    expect(toggle).toHaveTextContent('Compact');
-    fireEvent.click(toggle);
-    expect(toggle).toHaveTextContent('Dense');
-    fireEvent.click(toggle);
-    expect(toggle).toHaveTextContent('Normal');
-  });
-
-  it('remembers the level under its own bills view, not the transactions register', () => {
-    render(<ScheduledTransactionList transactions={[createTransaction()]} />);
-
-    fireEvent.click(screen.getByTitle('Toggle row density'));
-
-    expect(useDensityStore.getState().densities.bills).toBe('compact');
-    expect(useDensityStore.getState().densities.transactions).toBeUndefined();
-  });
-
-  it('reads a level another surface already stored for bills', () => {
-    useDensityStore.setState({ densities: { bills: 'dense' } });
-    render(<ScheduledTransactionList transactions={[createTransaction()]} />);
-
-    expect(screen.getByTitle('Toggle row density')).toHaveTextContent('Dense');
   });
 
   it('puts the payee beside the name at dense instead of under it', () => {

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionList.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionList.tsx
@@ -25,7 +25,6 @@ import {
 } from '@/hooks/useHighlightTarget';
 import { useTableDensity, type DensityLevel } from '@/hooks/useTableDensity';
 import { useDensityPreference } from '@/store/densityStore';
-import { DensityToggleBar } from '@/components/ui/DensityToggle';
 
 interface ScheduledActionLabels {
   post: string;
@@ -598,59 +597,56 @@ export function ScheduledTransactionList({
   }
 
   return (
-    <div>
-      <DensityToggleBar view="bills" />
-      <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-          <thead className="bg-gray-50 dark:bg-gray-800">
-            <tr>
-              <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
-                {t('list.columns.namePayee')}
-              </th>
-              <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell`}>
-                {t('list.columns.account')}
-              </th>
-              <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell`}>
-                {t('list.columns.category')}
-              </th>
-              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
-                {t('list.columns.amount')}
-              </th>
-              <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell`}>
-                {t('list.columns.schedule')}
-              </th>
-              <th className={`${headerPadding} text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell`}>
-                {t('list.columns.auto')}
-              </th>
-              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden min-[480px]:table-cell sticky right-0 bg-gray-50 dark:bg-gray-800`}>
-                {t('list.columns.actions')}
-              </th>
-            </tr>
-          </thead>
-          <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
-            {transactions.map((transaction, index) => (
-              <ScheduledTransactionRow
-                key={transaction.id}
-                transaction={transaction}
-                isProcessing={actionInProgress === transaction.id}
-                density={density}
-                cellPadding={cellPadding}
-                index={index}
-                formatDate={formatDate}
-                formatAmount={formatAmount}
-                getDueDateStatus={getDueDateStatus}
-                getRowHandlers={getRowHandlers}
-                onPost={onPost}
-                onOpenConfirm={openConfirm}
-                onEdit={onEdit}
-                onEditOccurrence={onEditOccurrence}
-                categoryColorMap={categoryColorMap}
-                isHighlighted={!!highlightId && transaction.id === highlightId}
-              />
-            ))}
-          </tbody>
-        </table>
-      </div>
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead className="bg-gray-50 dark:bg-gray-800">
+          <tr>
+            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
+              {t('list.columns.namePayee')}
+            </th>
+            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell`}>
+              {t('list.columns.account')}
+            </th>
+            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell`}>
+              {t('list.columns.category')}
+            </th>
+            <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
+              {t('list.columns.amount')}
+            </th>
+            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell`}>
+              {t('list.columns.schedule')}
+            </th>
+            <th className={`${headerPadding} text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell`}>
+              {t('list.columns.auto')}
+            </th>
+            <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden min-[480px]:table-cell sticky right-0 bg-gray-50 dark:bg-gray-800`}>
+              {t('list.columns.actions')}
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+          {transactions.map((transaction, index) => (
+            <ScheduledTransactionRow
+              key={transaction.id}
+              transaction={transaction}
+              isProcessing={actionInProgress === transaction.id}
+              density={density}
+              cellPadding={cellPadding}
+              index={index}
+              formatDate={formatDate}
+              formatAmount={formatAmount}
+              getDueDateStatus={getDueDateStatus}
+              getRowHandlers={getRowHandlers}
+              onPost={onPost}
+              onOpenConfirm={openConfirm}
+              onEdit={onEdit}
+              onEditOccurrence={onEditOccurrence}
+              categoryColorMap={categoryColorMap}
+              isHighlighted={!!highlightId && transaction.id === highlightId}
+            />
+          ))}
+        </tbody>
+      </table>
 
       {/* Long-press action sheet */}
       <RowActionSheet

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionList.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionList.tsx
@@ -23,6 +23,9 @@ import {
   HIGHLIGHT_FLASH_CELL,
   useScrollIntoViewWhen,
 } from '@/hooks/useHighlightTarget';
+import { useTableDensity, type DensityLevel } from '@/hooks/useTableDensity';
+import { useDensityPreference } from '@/store/densityStore';
+import { DensityToggleBar } from '@/components/ui/DensityToggle';
 
 interface ScheduledActionLabels {
   post: string;
@@ -149,6 +152,10 @@ interface ConfirmState {
 interface ScheduledTransactionRowProps {
   transaction: ScheduledTransaction;
   isProcessing: boolean;
+  density: DensityLevel;
+  cellPadding: string;
+  /** Row position, for the striping that carries a row across a dense table. */
+  index: number;
   formatDate: (date: string) => string;
   formatAmount: (amount: number | null | undefined, currencyCode?: string) => JSX.Element;
   getDueDateStatus: (nextDueDate: string | undefined | null) => { label: string; className: string } | null;
@@ -164,6 +171,9 @@ interface ScheduledTransactionRowProps {
 const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
   transaction,
   isProcessing,
+  density,
+  cellPadding,
+  index,
   formatDate,
   formatAmount,
   getDueDateStatus,
@@ -195,19 +205,34 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
   const effectiveDueDate = transaction.nextOverride?.overrideDate || transaction.nextDueDate || '';
   const dueDateStatus = effectiveDueDate ? getDueDateStatus(effectiveDueDate) : null;
   const payee = transaction.payeeName || transaction.payee?.name;
+  const isOverdue = dueDateStatus?.label === t('list.dueDateStatus.overdue');
+  // One expression, used by the row and by the sticky actions cell that has to
+  // sit on the same ground as the row it belongs to.
+  const rowBackground = isOverdue
+    ? 'bg-red-50 dark:bg-red-900/10'
+    : density !== 'normal' && index % 2 === 1
+      ? 'bg-gray-50 dark:bg-table-stripe-dark'
+      : 'bg-white dark:bg-gray-900';
+  const badgePadding = density === 'dense' ? 'px-1.5 py-0.5' : 'px-2 py-0.5';
+  // At dense a row is one line: the secondary line each of these cells carries
+  // sits beside its primary rather than under it. Nothing is dropped -- the
+  // payee, the frequency and the occurrence count are all still on screen.
+  const stackedLines = density === 'dense' ? 'flex items-baseline gap-1.5 flex-wrap' : '';
 
   return (
     <tr
       ref={rowRef}
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${!transaction.isActive ? 'opacity-50' : ''} ${dueDateStatus?.label === t('list.dueDateStatus.overdue') ? 'bg-red-50 dark:bg-red-900/10' : 'bg-white dark:bg-gray-900'} ${isHighlighted ? HIGHLIGHT_FLASH : ''}`}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${!transaction.isActive ? 'opacity-50' : ''} ${rowBackground} ${isHighlighted ? HIGHLIGHT_FLASH : ''}`}
       {...getRowHandlers(transaction)}
     >
       {/* Name / Payee */}
-      <td className="px-4 py-3">
-        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{transaction.name}</div>
-        {payee && payee !== transaction.name && (
-          <div className="text-xs text-gray-500 dark:text-gray-400">{payee}</div>
-        )}
+      <td className={cellPadding}>
+        <div className={stackedLines}>
+          <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{transaction.name}</div>
+          {payee && payee !== transaction.name && (
+            <div className="text-xs text-gray-500 dark:text-gray-400">{payee}</div>
+          )}
+        </div>
         {/* Mobile-only: show schedule info under name */}
         <div className="sm:hidden mt-0.5">
           <div className="text-xs text-gray-500 dark:text-gray-400">
@@ -223,15 +248,15 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
       </td>
 
       {/* Account */}
-      <td className="px-4 py-3 hidden sm:table-cell">
+      <td className={`${cellPadding} hidden sm:table-cell`}>
         <div className="text-sm text-gray-900 dark:text-gray-100">{transaction.account?.name}</div>
       </td>
 
       {/* Category */}
-      <td className="px-4 py-3 hidden md:table-cell">
+      <td className={`${cellPadding} hidden md:table-cell`}>
         {transaction.isInvestment ? (
           <span
-            className="inline-flex text-xs font-medium rounded-full px-2 py-0.5 bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200"
+            className={`inline-flex text-xs font-medium rounded-full ${badgePadding} bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200`}
             title={
               transaction.investmentSecurity
                 ? `${transaction.investmentAction || ''} ${transaction.investmentSecurity.symbol || transaction.investmentSecurity.name}`.trim()
@@ -244,21 +269,21 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
           </span>
         ) : transaction.isTransfer ? (
           <span
-            className="inline-flex text-xs font-medium rounded-full px-2 py-0.5 bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+            className={`inline-flex text-xs font-medium rounded-full ${badgePadding} bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200`}
             title={`Transfer to ${transaction.transferAccount?.name || 'account'}`}
           >
             Transfer
           </span>
         ) : transaction.isSplit ? (
           <span
-            className="inline-flex text-xs font-medium rounded-full px-2 py-0.5 bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+            className={`inline-flex text-xs font-medium rounded-full ${badgePadding} bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200`}
             title={transaction.splits?.map(s => s.category?.name || 'Uncategorized').join(', ')}
           >
             Split ({transaction.splits?.length || 0})
           </span>
         ) : transaction.category ? (
           <span
-            className="inline-flex text-xs font-medium rounded-full px-2 py-0.5"
+            className={`inline-flex text-xs font-medium rounded-full ${badgePadding}`}
             style={{
               backgroundColor: categoryColor
                 ? `color-mix(in srgb, ${categoryColor} 15%, var(--category-bg-base, #e5e7eb))`
@@ -276,7 +301,7 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
       </td>
 
       {/* Amount */}
-      <td className="px-4 py-3 whitespace-nowrap text-sm font-medium text-right">
+      <td className={`${cellPadding} whitespace-nowrap text-sm font-medium text-right`}>
         {(() => {
           const baseAmount = scheduledOccurrenceAmount(transaction, false);
           const overrideAmount = transaction.nextOverride
@@ -325,52 +350,54 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
       </td>
 
       {/* Schedule (Frequency + Next Due + Remaining) */}
-      <td className="px-4 py-3 hidden sm:table-cell">
-        <div className="text-sm text-gray-900 dark:text-gray-100">
-          {/* Show override date if it differs from the original next due date */}
-          {transaction.nextOverride?.overrideDate &&
-           transaction.nextDueDate &&
-           transaction.nextOverride.overrideDate !== String(transaction.nextDueDate).split('T')[0] ? (
-            <span className="inline-flex flex-col align-middle">
-              <span className="text-xs text-gray-400 dark:text-gray-500 line-through leading-tight">
-                {formatDate(transaction.nextDueDate)}
+      <td className={`${cellPadding} hidden sm:table-cell`}>
+        <div className={stackedLines}>
+          <div className="text-sm text-gray-900 dark:text-gray-100">
+            {/* Show override date if it differs from the original next due date */}
+            {transaction.nextOverride?.overrideDate &&
+             transaction.nextDueDate &&
+             transaction.nextOverride.overrideDate !== String(transaction.nextDueDate).split('T')[0] ? (
+              <span className="inline-flex flex-col align-middle">
+                <span className="text-xs text-gray-400 dark:text-gray-500 line-through leading-tight">
+                  {formatDate(transaction.nextDueDate)}
+                </span>
+                <span className="leading-tight" title="Date modified for this occurrence">
+                  {formatDate(transaction.nextOverride.overrideDate)}
+                </span>
               </span>
-              <span className="leading-tight" title="Date modified for this occurrence">
-                {formatDate(transaction.nextOverride.overrideDate)}
+            ) : (
+              transaction.nextDueDate ? formatDate(transaction.nextDueDate) : '\u2014'
+            )}
+            {dueDateStatus && (
+              <span
+                className={`ml-1.5 inline-flex text-xs font-medium rounded-full px-1.5 py-0.5 ${dueDateStatus.className}`}
+              >
+                {dueDateStatus.label}
               </span>
-            </span>
-          ) : (
-            transaction.nextDueDate ? formatDate(transaction.nextDueDate) : '\u2014'
-          )}
-          {dueDateStatus && (
-            <span
-              className={`ml-1.5 inline-flex text-xs font-medium rounded-full px-1.5 py-0.5 ${dueDateStatus.className}`}
-            >
-              {dueDateStatus.label}
-            </span>
-          )}
-        </div>
-        <div className="text-xs text-gray-500 dark:text-gray-400">
-          {t(`frequency.${transaction.frequency}`)}
-          {transaction.occurrencesRemaining !== null && (
-            <span className="ml-1">{'\u00b7'} {t('list.occurrencesRemaining', { count: transaction.occurrencesRemaining })}</span>
-          )}
-          {transaction.overrideCount !== undefined && transaction.overrideCount > 0 && (
-            <span
-              className="ml-1.5 inline-flex text-xs font-medium rounded-full px-1.5 py-0.5 bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200"
-              title={t('list.modifiedTitle', { count: transaction.overrideCount })}
-            >
-              {t('list.modifiedBadge', { count: transaction.overrideCount })}
-            </span>
-          )}
+            )}
+          </div>
+          <div className="text-xs text-gray-500 dark:text-gray-400">
+            {t(`frequency.${transaction.frequency}`)}
+            {transaction.occurrencesRemaining !== null && (
+              <span className="ml-1">{'\u00b7'} {t('list.occurrencesRemaining', { count: transaction.occurrencesRemaining })}</span>
+            )}
+            {transaction.overrideCount !== undefined && transaction.overrideCount > 0 && (
+              <span
+                className="ml-1.5 inline-flex text-xs font-medium rounded-full px-1.5 py-0.5 bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+                title={t('list.modifiedTitle', { count: transaction.overrideCount })}
+              >
+                {t('list.modifiedBadge', { count: transaction.overrideCount })}
+              </span>
+            )}
+          </div>
         </div>
       </td>
 
       {/* Auto-post */}
-      <td className="px-4 py-3 text-center hidden md:table-cell">
+      <td className={`${cellPadding} text-center hidden md:table-cell`}>
         {transaction.autoPost ? (
           <span
-            className="inline-flex items-center text-xs font-medium rounded-full px-2 py-0.5 bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+            className={`inline-flex items-center text-xs font-medium rounded-full ${badgePadding} bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200`}
             title={t('list.autoPostTitle')}
           >
             {t('list.autoPostBadge')}
@@ -381,8 +408,10 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
       </td>
 
       {/* Actions */}
-      <td className={`px-4 py-3 whitespace-nowrap text-right hidden min-[480px]:table-cell sticky right-0 ${dueDateStatus?.label === t('list.dueDateStatus.overdue') ? 'bg-red-50 dark:bg-red-900/10' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800 ${isHighlighted ? HIGHLIGHT_FLASH_CELL : ''}`} onClick={(e) => e.stopPropagation()}>
-        <RowActions actions={actions} density="compact" />
+      <td className={`${cellPadding} whitespace-nowrap text-right hidden min-[480px]:table-cell sticky right-0 ${rowBackground} group-hover:bg-gray-100 dark:group-hover:bg-gray-800 ${isHighlighted ? HIGHLIGHT_FLASH_CELL : ''}`} onClick={(e) => e.stopPropagation()}>
+        {/* Icon-only from `compact` up: five verbs as text labels would widen
+            the cell past the data it sits beside. Dense still tightens them. */}
+        <RowActions actions={actions} density={density === 'dense' ? 'dense' : 'compact'} />
       </td>
     </tr>
   );
@@ -411,6 +440,8 @@ export function ScheduledTransactionList({
   const t = useTranslations('scheduledTransactions');
   const { formatDate } = useDateFormat();
   const { formatCurrency } = useNumberFormat();
+  const { density } = useDensityPreference('bills');
+  const { cellPadding, headerPadding } = useTableDensity(density);
   const [actionInProgress, setActionInProgress] = useState<string | null>(null);
   const [confirmState, setConfirmState] = useState<ConfirmState>({
     isOpen: false,
@@ -567,53 +598,59 @@ export function ScheduledTransactionList({
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-        <thead className="bg-gray-50 dark:bg-gray-800">
-          <tr>
-            <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-              {t('list.columns.namePayee')}
-            </th>
-            <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell">
-              {t('list.columns.account')}
-            </th>
-            <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell">
-              {t('list.columns.category')}
-            </th>
-            <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-              {t('list.columns.amount')}
-            </th>
-            <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell">
-              {t('list.columns.schedule')}
-            </th>
-            <th className="px-4 py-2 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell">
-              {t('list.columns.auto')}
-            </th>
-            <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden min-[480px]:table-cell sticky right-0 bg-gray-50 dark:bg-gray-800">
-              {t('list.columns.actions')}
-            </th>
-          </tr>
-        </thead>
-        <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
-          {transactions.map((transaction) => (
-            <ScheduledTransactionRow
-              key={transaction.id}
-              transaction={transaction}
-              isProcessing={actionInProgress === transaction.id}
-              formatDate={formatDate}
-              formatAmount={formatAmount}
-              getDueDateStatus={getDueDateStatus}
-              getRowHandlers={getRowHandlers}
-              onPost={onPost}
-              onOpenConfirm={openConfirm}
-              onEdit={onEdit}
-              onEditOccurrence={onEditOccurrence}
-              categoryColorMap={categoryColorMap}
-              isHighlighted={!!highlightId && transaction.id === highlightId}
-            />
-          ))}
-        </tbody>
-      </table>
+    <div>
+      <DensityToggleBar view="bills" />
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
+                {t('list.columns.namePayee')}
+              </th>
+              <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell`}>
+                {t('list.columns.account')}
+              </th>
+              <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell`}>
+                {t('list.columns.category')}
+              </th>
+              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
+                {t('list.columns.amount')}
+              </th>
+              <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell`}>
+                {t('list.columns.schedule')}
+              </th>
+              <th className={`${headerPadding} text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell`}>
+                {t('list.columns.auto')}
+              </th>
+              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden min-[480px]:table-cell sticky right-0 bg-gray-50 dark:bg-gray-800`}>
+                {t('list.columns.actions')}
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+            {transactions.map((transaction, index) => (
+              <ScheduledTransactionRow
+                key={transaction.id}
+                transaction={transaction}
+                isProcessing={actionInProgress === transaction.id}
+                density={density}
+                cellPadding={cellPadding}
+                index={index}
+                formatDate={formatDate}
+                formatAmount={formatAmount}
+                getDueDateStatus={getDueDateStatus}
+                getRowHandlers={getRowHandlers}
+                onPost={onPost}
+                onOpenConfirm={openConfirm}
+                onEdit={onEdit}
+                onEditOccurrence={onEditOccurrence}
+                categoryColorMap={categoryColorMap}
+                isHighlighted={!!highlightId && transaction.id === highlightId}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
 
       {/* Long-press action sheet */}
       <RowActionSheet

--- a/frontend/src/store/densityStore.ts
+++ b/frontend/src/store/densityStore.ts
@@ -38,6 +38,7 @@ export const DENSITY_STORAGE_KEY = 'monize-density';
  */
 export type DensityView =
   | 'transactions'
+  | 'bills'
   | 'accounts'
   | 'investments'
   | 'securities'
@@ -55,6 +56,7 @@ export type DensityView =
 
 export const DENSITY_VIEWS: readonly DensityView[] = [
   'transactions',
+  'bills',
   'accounts',
   'investments',
   'securities',


### PR DESCRIPTION
## Linked discussion / issue

Closes #1203
Approved in: https://github.com/kenlasko/monize/issues/1203

## Summary

The Bills & Deposits list was the one table never wired into the density work from #1193. It hardcoded `px-4 py-3` cells, `px-4 py-2` headers and a fixed `density="compact"` for its row actions, and drew no toggle — so every entry took about three lines and nothing could be done about it.

It now reads `useDensityPreference('bills')` and takes its padding from `useTableDensity`'s default scale, like the eleven tables that already do. There is no new copy of the button and **no new catalog strings**: `DensityToggle` and `common.density.*` cover it, which is the point of having consolidated them. `bills` is its own view in the store, so tightening the register does not tighten this list and vice versa.

The toggle sits at the far right of the bar that already holds the List/Calendar tabs and the All/Bills/Deposits chips, so every control that shapes the list is on one line. It renders only in list mode (the calendar has no rows to tighten) and sits outside the type chips' `hidden sm:flex` group, so a phone keeps the control — a narrow screen is where the three-line row is worst. It draws as the plain borderless `sm` button every other table's toggle is, not as a filled chip, so it does not read as a fourth filter beside the type chips.

Padding alone would not reach one line, because two cells stack a secondary line under their primary: the payee under the schedule name, the frequency and occurrence count under the next due date. At dense those pairs sit beside each other instead of under, so nothing leaves the screen — the row is one line and the payee is still on it. Badges lose a step of horizontal padding at dense, and rows stripe at compact and dense, which is what keeps a row readable across once the gap between rows is gone. An overdue row keeps its red ground rather than being striped: that colour is the one thing on the row carrying meaning. The sticky actions cell now takes the row's background from the same expression the row does, rather than repeating the overdue test.

Row actions stay icon-only at normal deliberately. `RowActions` renders text labels at that level, and five verbs — post, skip, edit occurrence, edit schedule, delete — would widen that cell past the data beside it; dense still tightens the icons.

**Files:** `store/densityStore.ts` (adds `bills` to the `DensityView` union), `components/scheduled-transactions/ScheduledTransactionList.tsx`, `app/bills/page.tsx`, plus tests.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

Notes on two of those:

- **i18n** — no strings were added or changed. The toggle reads `common.density.*`, which every locale already carries; parity is untouched and the pseudo-locale needed no regeneration.
- **Tests** — the padding reaching the DOM is pinned at all three levels, and the dense one-line layout and the striping each carry a case; on the page, the toggle's placement, its plain (non-chip) styling, its absence in calendar view, its visibility below `sm`, its cycling, and its writing to the `bills` bucket rather than the register's. Each new test was confirmed to fail against the tree before its change: 8 of 10 in the list suite, all 6 page-placement tests, and the styling test against `size="chip"`. Full frontend suite green (693 files, 13,571 tests), plus `type-check`, `lint`, and the `density-preference` and `ui-conventions` guard scans.

## AI assistance disclosure

Written with Claude Code. The implementation, the tests and the commit messages are AI-authored; the placement and styling of the toggle were corrected twice on human review, and those corrections are pinned by tests rather than left to prose.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyX4DC5QaHy9Vyvq25pQSM)_