### PR TITLE
Label a .mny import's investment cash legs with the activity

### DIFF
--- a/backend/src/import/import-investment-processor.service.spec.ts
+++ b/backend/src/import/import-investment-processor.service.spec.ts
@@ -929,10 +929,45 @@ describe("ImportInvestmentProcessorService", () => {
       const cashTx = saveCalls.find(
         (call: any) => call[0]?.payeeName && call[0]?.payeeName.includes("Buy"),
       );
+      // Exact, not `toContain`: the assertions here were loose enough that
+      // swapping the label's hard-coded `$` for the security's real currency
+      // broke nothing (issue #1204).
       expect(cashTx).toBeDefined();
-      expect(cashTx[0].payeeName).toContain("TST");
-      expect(cashTx[0].payeeName).toContain("10");
-      expect(cashTx[0].payeeName).toContain("$100.00");
+      expect(cashTx[0].payeeName).toBe("Buy: TST 10 @ $100.00");
+    });
+
+    it("quotes the label in the security's currency, not a hard-coded dollar", async () => {
+      // The amount beside it is converted out of that currency two lines
+      // later; labelling a EUR-priced trade with `$` contradicts the row.
+      const securityMap = new Map<string, string | null>();
+      securityMap.set("Test Stock", "sec-1");
+      const ctx = makeContext({ securityMap });
+      exchangeRateService.getRateForDate.mockResolvedValue(1.1);
+
+      managerOf(ctx).findOne.mockImplementation((entity: any, opts: any) => {
+        if (entity === Security && opts?.where?.id === "sec-1") {
+          return Promise.resolve({
+            id: "sec-1",
+            symbol: "TST",
+            currencyCode: "EUR",
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      await service.processTransaction(ctx, {
+        action: "Buy",
+        security: "Test Stock",
+        quantity: 10,
+        price: 100,
+        commission: 0,
+        date: "2025-01-15",
+      });
+
+      const cashTx = managerOf(ctx).save.mock.calls.find(
+        (call: any) => call[0]?.payeeName,
+      );
+      expect(cashTx[0].payeeName).toBe("Buy: TST 10 @ €100.00");
     });
   });
 

--- a/backend/src/import/import-investment-processor.service.ts
+++ b/backend/src/import/import-investment-processor.service.ts
@@ -22,6 +22,10 @@ import {
   isQuantityOnlyAction,
   SHARE_MOVING_ACTIONS,
 } from "../securities/investment-replay.util";
+import {
+  formatInvestmentActionLabel,
+  formatInvestmentCashPayeeName,
+} from "../securities/investment-cash-payee.util";
 
 @Injectable()
 export class ImportInvestmentProcessorService {
@@ -518,27 +522,18 @@ export class ImportInvestmentProcessorService {
       }
     }
 
-    const formatAction = (act: string) => {
-      return act
-        .split("_")
-        .map(
-          (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
-        )
-        .join(" ");
-    };
-    const actionLabel = formatAction(action);
-
-    let payeeName: string;
-    if (
-      baseInvestmentAction(action) === InvestmentAction.BUY ||
-      baseInvestmentAction(action) === InvestmentAction.SELL
-    ) {
-      payeeName = `${actionLabel}: ${securitySymbol} ${quantity} @ $${price.toFixed(2)}`;
-    } else if (action === InvestmentAction.INTEREST) {
-      payeeName = `${actionLabel}: $${totalAmount.toFixed(2)}`;
-    } else {
-      payeeName = `${actionLabel}: ${securitySymbol} $${totalAmount.toFixed(2)}`;
-    }
+    // The label is rendered in the security's currency, because the price and
+    // total it quotes are denominated there -- this used to hard-code a `$`
+    // over an amount the very next block converts out of that currency.
+    const payeeName = formatInvestmentCashPayeeName({
+      action,
+      symbol: securitySymbol,
+      quantity,
+      price,
+      totalAmount,
+      currencyCode: securityCurrency ?? cashAccountCurrency,
+    });
+    const actionLabel = formatInvestmentActionLabel(action);
 
     const isCrossAccountTransfer = cashAccountId !== ctx.accountId;
 

--- a/backend/src/import/mny/README.md
+++ b/backend/src/import/mny/README.md
@@ -123,6 +123,23 @@ So when a mapper is about to warn that it cannot represent something, check firs
 right answer is to *create* the row Monize needs rather than to report the mismatch. A warning
 about 3,255 rows the user cannot act on is a sign the mapping is wrong, not that the file is.
 
+### A row Monize writes itself has to say why it exists
+
+Because Monize writes the trade's cash leg rather than importing Money's, the columns on that row
+are Monize's to fill -- and `payee` was left empty. Money records no payee on a trade, so every
+imported cash leg rendered as a bare `-` in the register: the one column that could say why the
+money moved, on rows that exist only to say a trade settled (issue #1204).
+
+The leg now carries the same activity label a natively entered and a QIF-imported trade already
+store (`Buy: VOO 10 @ $100.00`), built by `backend/src/securities/investment-cash-payee.util.ts` --
+the one implementation of that label, quoted in the row's own currency. Money's payee still wins
+when the file recorded one; the label is the fallback, never an override, so nothing the user
+entered is replaced by generated text.
+
+The general rule: when the importer synthesizes a row Money has no copy of, ask what each column
+would have held had a person entered it. An empty column on a row nobody wrote reads as missing
+data rather than as a row that never had any.
+
 ### And the same gap read the other way: a row Money *does* store may be one Monize writes anyway
 
 The mirror of the rule above, and the way it goes wrong. When a trade is funded from the

--- a/backend/src/import/mny/writers/write-investments.spec.ts
+++ b/backend/src/import/mny/writers/write-investments.spec.ts
@@ -349,6 +349,73 @@ describe("writeInvestments", () => {
     expect(investments.insert.mock.calls[0][0][0].description).toBe("VOO");
   });
 
+  it("labels the cash leg with the activity when Money recorded no payee", async () => {
+    // Issue #1204: Money files carry no payee on a trade, so every imported
+    // cash leg rendered as a bare "-" in the register -- the one column that
+    // could say why the money moved. The label is the same one a natively
+    // entered and a QIF-imported trade already store.
+    const { manager, transactions } = doubles();
+
+    await writeInvestments(manager, "user-1", {
+      ...baseInput,
+      transactions: [investment()],
+    });
+
+    expect(transactions.insert.mock.calls[0][0][0]).toMatchObject({
+      payeeId: null,
+      payeeName: "Buy: VOO 10 @ $100.00",
+    });
+  });
+
+  it("quotes the label in the row's own currency", async () => {
+    const { manager, transactions } = doubles();
+
+    await writeInvestments(manager, "user-1", {
+      ...baseInput,
+      transactions: [investment({ currencyCode: "EUR" })],
+    });
+
+    expect(transactions.insert.mock.calls[0][0][0].payeeName).toBe(
+      "Buy: VOO 10 @ €100.00",
+    );
+  });
+
+  it("labels an income leg with its total rather than a unit price", async () => {
+    const { manager, transactions } = doubles();
+
+    await writeInvestments(manager, "user-1", {
+      ...baseInput,
+      transactions: [
+        investment({
+          action: InvestmentAction.DIVIDEND,
+          quantity: null,
+          price: null,
+          commission: 0,
+          totalAmount: 42.5,
+          cashAmount: 42.5,
+        }),
+      ],
+    });
+
+    expect(transactions.insert.mock.calls[0][0][0].payeeName).toBe(
+      "Dividend: VOO $42.50",
+    );
+  });
+
+  it("says Unknown when the security handle resolves to nothing", async () => {
+    const { manager, transactions } = doubles();
+
+    await writeInvestments(manager, "user-1", {
+      ...baseInput,
+      symbolByHandle: new Map<number, string>(),
+      transactions: [investment()],
+    });
+
+    expect(transactions.insert.mock.calls[0][0][0].payeeName).toBe(
+      "Buy: Unknown 10 @ $100.00",
+    );
+  });
+
   it("carries Money's own payee and category onto the cash leg", async () => {
     const { manager, transactions } = doubles();
 
@@ -360,10 +427,30 @@ describe("writeInvestments", () => {
       transactions: [investment({ payeeHandle: 4, categoryHandle: 9 })],
     });
 
+    // The synthesized label is a fallback, never an override: a payee the
+    // user recorded in Money is not replaced by generated text.
     expect(transactions.insert.mock.calls[0][0][0]).toMatchObject({
       payeeId: "payee-4",
       payeeName: "Broker",
       categoryId: "category-9",
+    });
+  });
+
+  it("labels the leg rather than linking half a payee", async () => {
+    // A handle that resolves to an id but no name (or the reverse) is not a
+    // payee: writing one half leaves the register showing whichever survived.
+    const { manager, transactions } = doubles();
+
+    await writeInvestments(manager, "user-1", {
+      ...baseInput,
+      payeeIdByHandle: new Map([[4, "payee-4"]]),
+      payeeNameByHandle: new Map<number, string>(),
+      transactions: [investment({ payeeHandle: 4 })],
+    });
+
+    expect(transactions.insert.mock.calls[0][0][0]).toMatchObject({
+      payeeId: null,
+      payeeName: "Buy: VOO 10 @ $100.00",
     });
   });
 

--- a/backend/src/import/mny/writers/write-investments.ts
+++ b/backend/src/import/mny/writers/write-investments.ts
@@ -4,6 +4,7 @@ import { Security } from "../../../securities/entities/security.entity";
 import { InvestmentTransaction } from "../../../securities/entities/investment-transaction.entity";
 import { Transaction } from "../../../transactions/entities/transaction.entity";
 import { roundMoney } from "../../../common/round.util";
+import { formatInvestmentCashPayeeName } from "../../../securities/investment-cash-payee.util";
 import {
   MappedInvestmentTransaction,
   MappedSecurity,
@@ -107,7 +108,8 @@ export interface WriteInvestmentsInput {
   readonly categoryIdByHandle: ReadonlyMap<number, string>;
   readonly payeeIdByHandle: ReadonlyMap<number, string>;
   readonly payeeNameByHandle: ReadonlyMap<number, string>;
-  /** `SEC.hsec` -> symbol, used as the cash leg's description of last resort. */
+  /** `SEC.hsec` -> symbol, for the cash leg's payee label and its
+   * description of last resort. */
   readonly symbolByHandle: ReadonlyMap<number, string>;
   readonly onProgress?: (processed: number, total: number) => Promise<void>;
 }
@@ -131,8 +133,14 @@ export interface WrittenInvestments {
  * so mirroring the leg there would invent a balance the Money file never had and
  * make the verification report disagree with itself.
  *
- * The cash leg's payee and category are Money's own. Nothing is synthesized --
- * a generated payee name would be untranslatable English written into user data.
+ * The cash leg's category is Money's own, and so is its payee when the file
+ * recorded one. When it did not -- which is the ordinary case for a trade --
+ * the payee falls back to the activity label every other producer writes
+ * (`formatInvestmentCashPayeeName`), because the alternative is the register
+ * rendering a bare "-" against a row whose whole purpose is to say a trade
+ * settled (issue #1204). It is the same English string a natively entered or
+ * QIF-imported trade already stores, so this is consistency with the existing
+ * surfaces rather than a new class of generated user data.
  */
 export async function writeInvestments(
   manager: EntityManager,
@@ -173,13 +181,37 @@ export async function writeInvestments(
           ? randomUUID()
           : null;
 
-      const description =
-        transaction.description ??
-        input.symbolByHandle.get(transaction.securityHandle) ??
-        null;
+      const symbol =
+        input.symbolByHandle.get(transaction.securityHandle) ?? null;
+      const description = transaction.description ?? symbol ?? null;
+
+      // Money's payee, id and name together -- a name with no id, or an id
+      // with no name, is half a payee and the register would show whichever
+      // half survived.
+      const moneyPayeeId =
+        transaction.payeeHandle === null
+          ? null
+          : (input.payeeIdByHandle.get(transaction.payeeHandle) ?? null);
+      const moneyPayeeName =
+        transaction.payeeHandle === null
+          ? null
+          : (input.payeeNameByHandle.get(transaction.payeeHandle) ?? null);
+      const hasMoneyPayee = moneyPayeeId !== null && moneyPayeeName !== null;
 
       if (cashTransactionId !== null) {
         affectedAccountIds.add(cashAccountId as string);
+        // Rendered in the row's own currency: this writer denominates the
+        // cash amount, the total and the price in `transaction.currencyCode`
+        // with `exchangeRate: 1`, so quoting the label in any other currency
+        // would disagree with the amount stored beside it.
+        const activityPayeeName = formatInvestmentCashPayeeName({
+          action: transaction.action,
+          symbol,
+          quantity: transaction.quantity,
+          price: transaction.price,
+          totalAmount: transaction.totalAmount,
+          currencyCode: transaction.currencyCode,
+        });
         cashRows.push({
           id: cashTransactionId,
           userId,
@@ -189,14 +221,12 @@ export async function writeInvestments(
           currencyCode: transaction.currencyCode,
           exchangeRate: 1,
           status: transaction.status,
-          payeeId:
-            transaction.payeeHandle === null
-              ? null
-              : (input.payeeIdByHandle.get(transaction.payeeHandle) ?? null),
-          payeeName:
-            transaction.payeeHandle === null
-              ? null
-              : (input.payeeNameByHandle.get(transaction.payeeHandle) ?? null),
+          // Money's payee wins when there is one -- it is what the user
+          // recorded. The synthesized label is the fallback, not an override,
+          // so nothing the file carried is replaced by generated text; and it
+          // is an unlinked name, exactly as the native and QIF paths write it.
+          payeeId: hasMoneyPayee ? moneyPayeeId : null,
+          payeeName: hasMoneyPayee ? moneyPayeeName : activityPayeeName,
           categoryId:
             transaction.categoryHandle === null
               ? null

--- a/backend/src/securities/investment-cash-payee.guard.spec.ts
+++ b/backend/src/securities/investment-cash-payee.guard.spec.ts
@@ -1,0 +1,93 @@
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative } from "path";
+
+const SRC_ROOT = join(__dirname, "..");
+
+/** The file that owns the label. Everything else has to call it. */
+const OWNER = "securities/investment-cash-payee.util.ts";
+
+/**
+ * The three writers of an investment cash leg. Each must reach the label
+ * through the util rather than assembling one, and the list is asserted in
+ * both directions so a fourth producer is a decision somebody made here.
+ */
+const PRODUCERS = [
+  "securities/investment-transactions.service.ts",
+  "import/import-investment-processor.service.ts",
+  "import/mny/writers/write-investments.ts",
+];
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "node_modules" || entry === "dist") continue;
+      out.push(...sourceFiles(full));
+      continue;
+    }
+    if (!entry.endsWith(".ts")) continue;
+    if (entry.endsWith(".spec.ts")) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+function rel(file: string): string {
+  return relative(SRC_ROOT, file).split("\\").join("/");
+}
+
+/**
+ * A cash leg's payee label is the only thing on that row saying why the money
+ * moved, and it was written out twice and omitted once. The QIF copy hard-coded
+ * a `$` over an amount it had just converted out of the security's currency,
+ * and the `.mny` writer wrote no label at all, so every imported trade's cash
+ * leg rendered as "-" in the register (issue #1204).
+ *
+ * Each copy was internally consistent -- the same reason the duplicated share
+ * replay survived -- so this is a scan rather than a paragraph.
+ */
+describe("the investment cash payee label is written once", () => {
+  const files = sourceFiles(SRC_ROOT);
+
+  it("finds source files to scan", () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it("has no second title-caser folding an investment action into prose", () => {
+    // Narrow on purpose: the subject has to be an action. Title-casing some
+    // other snake_case value (a security type, say) is not this mistake.
+    const handRolled = /\b\w*[Aa]ction\w*\s*\.split\("_"\)/;
+    const offenders = files
+      .filter((file) => rel(file) !== OWNER)
+      .filter((file) => handRolled.test(readFileSync(file, "utf8")))
+      .map(rel);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("has no payee label built with a hard-coded currency symbol", () => {
+    // `$${x.toFixed(2)}` is what the QIF importer wrote beside a converted
+    // amount: right for a USD file and wrong for every other one.
+    // Bounded to the assignment itself: a log line that happens to print a
+    // payee beside a dollar amount is not this defect.
+    const hardCoded = /payeeName\s*[:=][^;]{0,300}\$\$\{[^}]*toFixed\(/;
+    const offenders = files
+      .filter((file) => hardCoded.test(readFileSync(file, "utf8")))
+      .map(rel);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("routes every cash-leg producer through the util, and names no others", () => {
+    const callers = files
+      .filter((file) => rel(file) !== OWNER)
+      .filter((file) =>
+        readFileSync(file, "utf8").includes("formatInvestmentCashPayeeName"),
+      )
+      .map(rel)
+      .sort();
+
+    expect(callers).toEqual([...PRODUCERS].sort());
+  });
+});

--- a/backend/src/securities/investment-cash-payee.util.spec.ts
+++ b/backend/src/securities/investment-cash-payee.util.spec.ts
@@ -1,0 +1,210 @@
+import { InvestmentAction } from "./entities/investment-transaction.entity";
+import {
+  formatInvestmentActionLabel,
+  formatInvestmentCashPayeeName,
+} from "./investment-cash-payee.util";
+
+/**
+ * Exact strings, not `stringContaining`. The three producers of this label had
+ * drifted into two different formats and one absence, and every assertion any
+ * of them carried was a `toContain` -- which is why swapping a hard-coded `$`
+ * for the row's real currency broke nothing anywhere.
+ */
+describe("formatInvestmentCashPayeeName", () => {
+  const buy = {
+    action: InvestmentAction.BUY,
+    symbol: "VOO",
+    quantity: 10,
+    price: 150,
+    totalAmount: 1500,
+  };
+
+  it("labels a buy with the symbol, quantity and unit price", () => {
+    expect(formatInvestmentCashPayeeName({ ...buy, currencyCode: "USD" })).toBe(
+      "Buy: VOO 10 @ $150.00",
+    );
+  });
+
+  it("quotes the price in the currency it was given, not a hard-coded dollar", () => {
+    expect(formatInvestmentCashPayeeName({ ...buy, currencyCode: "EUR" })).toBe(
+      "Buy: VOO 10 @ €150.00",
+    );
+    expect(formatInvestmentCashPayeeName({ ...buy, currencyCode: "CAD" })).toBe(
+      "Buy: VOO 10 @ CA$150.00",
+    );
+  });
+
+  it("renders the figures bare rather than throwing when the code is unusable", () => {
+    // A `.mny` account can carry an empty currency code, and `Intl` answers a
+    // malformed one with a RangeError -- aborting an import over a label.
+    for (const currencyCode of ["", null, undefined, "US"]) {
+      expect(formatInvestmentCashPayeeName({ ...buy, currencyCode })).toBe(
+        "Buy: VOO 10 @ 150.00",
+      );
+    }
+  });
+
+  it("drops a quantity's trailing zeros but keeps its stored 4dp", () => {
+    expect(
+      formatInvestmentCashPayeeName({
+        ...buy,
+        quantity: 10.5,
+        currencyCode: "USD",
+      }),
+    ).toBe("Buy: VOO 10.5 @ $150.00");
+    expect(
+      formatInvestmentCashPayeeName({
+        ...buy,
+        quantity: 0.19855,
+        currencyCode: "USD",
+      }),
+    ).toBe("Buy: VOO 0.1986 @ $150.00");
+  });
+
+  it("shows sub-cent unit prices to 4dp", () => {
+    expect(
+      formatInvestmentCashPayeeName({
+        ...buy,
+        price: 0.0125,
+        currencyCode: "USD",
+      }),
+    ).toBe("Buy: VOO 10 @ $0.0125");
+  });
+
+  it("groups thousands", () => {
+    expect(
+      formatInvestmentCashPayeeName({
+        ...buy,
+        price: 12345.6,
+        currencyCode: "USD",
+      }),
+    ).toBe("Buy: VOO 10 @ $12,345.60");
+  });
+
+  it("keeps the raw action's own name while following its base action's shape", () => {
+    // REDEEM's base is SELL, so it reads like a sell without being called one.
+    expect(
+      formatInvestmentCashPayeeName({
+        ...buy,
+        action: InvestmentAction.REDEEM,
+        currencyCode: "USD",
+      }),
+    ).toBe("Redeem: VOO 10 @ $150.00");
+    expect(
+      formatInvestmentCashPayeeName({
+        action: InvestmentAction.CAPITAL_GAIN_LONG,
+        symbol: "VOO",
+        quantity: null,
+        price: null,
+        totalAmount: 42,
+        currencyCode: "USD",
+      }),
+    ).toBe("Capital Gain Long: VOO $42.00");
+  });
+
+  it("describes an income action with its total", () => {
+    expect(
+      formatInvestmentCashPayeeName({
+        action: InvestmentAction.DIVIDEND,
+        symbol: "VOO",
+        quantity: null,
+        price: null,
+        totalAmount: 42.5,
+        currencyCode: "USD",
+      }),
+    ).toBe("Dividend: VOO $42.50");
+  });
+
+  it("omits the symbol from an interest line, which has no security", () => {
+    expect(
+      formatInvestmentCashPayeeName({
+        action: InvestmentAction.INTEREST,
+        symbol: null,
+        quantity: null,
+        price: null,
+        totalAmount: 3.21,
+        currencyCode: "USD",
+      }),
+    ).toBe("Interest: $3.21");
+  });
+
+  it("says Unknown for a trade or income line with no resolvable security", () => {
+    expect(
+      formatInvestmentCashPayeeName({
+        ...buy,
+        symbol: null,
+        currencyCode: "USD",
+      }),
+    ).toBe("Buy: Unknown 10 @ $150.00");
+  });
+
+  it("leaves no double space when an other-action line has no symbol", () => {
+    expect(
+      formatInvestmentCashPayeeName({
+        action: InvestmentAction.TRANSFER_IN,
+        symbol: null,
+        quantity: null,
+        price: null,
+        totalAmount: 8,
+        currencyCode: "USD",
+      }),
+    ).toBe("Transfer In: $8.00");
+    expect(
+      formatInvestmentCashPayeeName({
+        action: InvestmentAction.TRANSFER_IN,
+        symbol: "VOO",
+        quantity: null,
+        price: null,
+        totalAmount: 8,
+        currencyCode: "USD",
+      }),
+    ).toBe("Transfer In: VOO $8.00");
+  });
+
+  it("describes the size of the activity, never its direction", () => {
+    // The register's amount column carries the sign. A cash leg reading
+    // "Buy: VOO 10 @ $-150.00" describes nothing that happened.
+    expect(
+      formatInvestmentCashPayeeName({
+        ...buy,
+        price: -150,
+        totalAmount: -1500,
+        currencyCode: "USD",
+      }),
+    ).toBe("Buy: VOO 10 @ $150.00");
+    expect(
+      formatInvestmentCashPayeeName({
+        action: InvestmentAction.DIVIDEND,
+        symbol: "VOO",
+        quantity: null,
+        price: null,
+        totalAmount: -42.5,
+        currencyCode: "USD",
+      }),
+    ).toBe("Dividend: VOO $42.50");
+  });
+
+  it("survives the nulls a partially recorded row can carry", () => {
+    expect(
+      formatInvestmentCashPayeeName({
+        action: InvestmentAction.BUY,
+        symbol: null,
+        quantity: null,
+        price: null,
+        totalAmount: 0,
+        currencyCode: "USD",
+      }),
+    ).toBe("Buy: Unknown 0 @ $0.00");
+  });
+});
+
+describe("formatInvestmentActionLabel", () => {
+  it("title-cases a snake_case action", () => {
+    expect(formatInvestmentActionLabel(InvestmentAction.CAPITAL_GAIN)).toBe(
+      "Capital Gain",
+    );
+    expect(
+      formatInvestmentActionLabel(InvestmentAction.REINVEST_CAPITAL_GAIN_SHORT),
+    ).toBe("Reinvest Capital Gain Short");
+  });
+});

--- a/backend/src/securities/investment-cash-payee.util.ts
+++ b/backend/src/securities/investment-cash-payee.util.ts
@@ -1,0 +1,105 @@
+import { InvestmentAction } from "./entities/investment-transaction.entity";
+import { baseInvestmentAction } from "./investment-replay.util";
+
+/**
+ * The one place a cash leg's payee label is built from an investment action.
+ *
+ * A trade's cash movement lands in the cash sleeve as a plain transaction, and
+ * the register's Payee column is the only thing on that row that can say why
+ * the money moved -- Money itself labels the line with the activity. Three
+ * producers create those rows (native create, QIF import, .mny import) and the
+ * label was written out twice and omitted once: the QIF copy hard-coded a `$`
+ * over an amount it had just carefully converted, and the .mny writer wrote no
+ * label at all, so every imported trade's cash leg rendered as "-" (issue
+ * #1204). Same family as `applyActionToQuantity`: one fold, one implementation.
+ *
+ * `investment-cash-payee.guard.spec.ts` fails when a fourth copy appears.
+ */
+export interface InvestmentCashPayeeInput {
+  /** The raw action, not its base: a redemption reads "Redeem", not "Sell". */
+  readonly action: InvestmentAction;
+  readonly symbol: string | null;
+  readonly quantity: number | null;
+  readonly price: number | null;
+  /**
+   * The size of the activity. Signed input is fine -- the label describes what
+   * happened and the register's amount column carries the direction, so a Buy
+   * must not read "Buy: VOO $-1,500.00".
+   */
+  readonly totalAmount: number;
+  /**
+   * The currency the price and total are denominated in. A blank or malformed
+   * code renders the figures without a symbol rather than throwing: `.mny`
+   * accounts can carry an empty code, and `Intl` raises `RangeError` on one,
+   * which would abort a whole import over a label.
+   */
+  readonly currencyCode?: string | null;
+}
+
+const CURRENCY_CODE = /^[A-Za-z]{3}$/;
+
+function formatAmount(value: number, currencyCode: string | null): string {
+  const options: Intl.NumberFormatOptions =
+    currencyCode && CURRENCY_CODE.test(currencyCode)
+      ? {
+          style: "currency",
+          currency: currencyCode.toUpperCase(),
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 4,
+        }
+      : { minimumFractionDigits: 2, maximumFractionDigits: 4 };
+  return value.toLocaleString("en-US", options);
+}
+
+/** Trailing zeros dropped, but never more than the 4dp the column stores. */
+function formatQuantity(value: number): string {
+  return Number(value.toFixed(4)).toString();
+}
+
+/** `CAPITAL_GAIN` -> `Capital Gain`. Exported for warning copy that has to
+ * name the activity outside a payee label. */
+export function formatInvestmentActionLabel(action: string): string {
+  return action
+    .split("_")
+    .map((word) =>
+      word ? word.charAt(0).toUpperCase() + word.slice(1).toLowerCase() : word,
+    )
+    .join(" ");
+}
+
+export function formatInvestmentCashPayeeName(
+  input: InvestmentCashPayeeInput,
+): string {
+  const currencyCode = input.currencyCode ?? null;
+  const total = Math.abs(input.totalAmount);
+  const actionLabel = formatInvestmentActionLabel(input.action);
+
+  // The label keeps the raw action's name; only the shape of the line follows
+  // the base action, so REDEEM reads like a SELL without being called one.
+  switch (baseInvestmentAction(input.action)) {
+    case InvestmentAction.BUY:
+    case InvestmentAction.SELL:
+      return `${actionLabel}: ${input.symbol || "Unknown"} ${formatQuantity(
+        input.quantity || 0,
+      )} @ ${formatAmount(Math.abs(input.price || 0), currencyCode)}`;
+
+    case InvestmentAction.DIVIDEND:
+    case InvestmentAction.CAPITAL_GAIN:
+      return `${actionLabel}: ${input.symbol || "Unknown"} ${formatAmount(
+        total,
+        currencyCode,
+      )}`;
+
+    case InvestmentAction.INTEREST:
+      return `${actionLabel}: ${formatAmount(total, currencyCode)}`;
+
+    default: {
+      // No `${symbol || ""} ` interpolation: an action with no security left a
+      // double space in the middle of the label.
+      const parts = [input.symbol, formatAmount(total, currencyCode)].filter(
+        (part): part is string => Boolean(part),
+      );
+      return `${actionLabel}: ${parts.join(" ")}`;
+    }
+  }
+}

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -4097,7 +4097,7 @@ describe("InvestmentTransactionsService", () => {
     });
   });
 
-  describe("formatCashTransactionPayeeName (via create)", () => {
+  describe("formatInvestmentCashPayeeName (via create)", () => {
     beforeEach(() => {
       accountsService.findOne.mockImplementation((uid: string, aid: string) => {
         if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
@@ -4132,7 +4132,10 @@ describe("InvestmentTransactionsService", () => {
 
       expect(transactionRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          payeeName: expect.stringContaining("Buy:"),
+          // Exact, because the shared formatter is what the .mny and QIF
+          // importers now write too, and a `toContain` cannot see a format
+          // drift between the three (issue #1204).
+          payeeName: "Buy: AAPL 10 @ $150.25",
         }),
       );
       expect(transactionRepository.create).toHaveBeenCalledWith(

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -18,6 +18,7 @@ import {
 } from "../common/db/locks";
 import { applyVoidTransitionToMirrorLeg } from "../transactions/void-status-transition.util";
 import { investmentRowHasEffect } from "./investment-row-effects.util";
+import { formatInvestmentCashPayeeName } from "./investment-cash-payee.util";
 import {
   InvestmentTransaction,
   InvestmentAction,
@@ -535,57 +536,6 @@ export class InvestmentTransactionsService {
     return Number(rate);
   }
 
-  private formatCashTransactionPayeeName(
-    action: InvestmentAction,
-    symbol: string | null,
-    quantity: number | null,
-    price: number | null,
-    totalAmount: number,
-    currencyCode: string = "USD",
-  ): string {
-    const formatPrice = (value: number) => {
-      return value.toLocaleString("en-US", {
-        style: "currency",
-        currency: currencyCode,
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 4,
-      });
-    };
-
-    const formatQuantity = (value: number) => {
-      return Number(value.toFixed(4)).toString();
-    };
-
-    const formatAction = (act: string) => {
-      return act
-        .split("_")
-        .map(
-          (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
-        )
-        .join(" ");
-    };
-
-    const actionLabel = formatAction(action);
-
-    // The label keeps the raw action's name (a redemption reads "Redeem", not
-    // "Sell"); only the shape of the line follows the base action.
-    switch (baseInvestmentAction(action)) {
-      case InvestmentAction.BUY:
-      case InvestmentAction.SELL:
-        return `${actionLabel}: ${symbol || "Unknown"} ${formatQuantity(quantity || 0)} @ ${formatPrice(price || 0)}`;
-
-      case InvestmentAction.DIVIDEND:
-      case InvestmentAction.CAPITAL_GAIN:
-        return `${actionLabel}: ${symbol || "Unknown"} ${formatPrice(totalAmount)}`;
-
-      case InvestmentAction.INTEREST:
-        return `${actionLabel}: ${formatPrice(totalAmount)}`;
-
-      default:
-        return `${actionLabel}: ${symbol || ""} ${formatPrice(totalAmount)}`;
-    }
-  }
-
   private async createCashTransactionInTransaction(
     manager: EntityManager,
     userId: string,
@@ -606,14 +556,14 @@ export class InvestmentTransactionsService {
 
     // Payee name is rendered in the security's currency because the values
     // being displayed (price per share, totalAmount) are denominated there.
-    const payeeName = this.formatCashTransactionPayeeName(
-      investmentTransaction.action,
+    const payeeName = formatInvestmentCashPayeeName({
+      action: investmentTransaction.action,
       symbol,
-      investmentTransaction.quantity,
-      investmentTransaction.price,
-      Math.abs(investmentTransaction.totalAmount),
-      sourceCurrency,
-    );
+      quantity: investmentTransaction.quantity,
+      price: investmentTransaction.price,
+      totalAmount: investmentTransaction.totalAmount,
+      currencyCode: sourceCurrency,
+    });
 
     // A stored rate is validated positive on the way in, and is absent only for
     // a same-currency posting -- so `??` rather than `||`, which would also have


### PR DESCRIPTION
## Linked discussion / issue

Closes #1204 (partially — see *Scope* below)
Approved in: https://github.com/kenlasko/monize/issues/1204 (labelled `approved-to-build`; the Payee half scoped by @kenlasko's [comment](https://github.com/kenlasko/monize/issues/1204#issuecomment-5327720175))

## Summary

The Payee column on an investment account's cash ledger showed a bare `-` for every transaction that came in through a `.mny` import. Natively entered and QIF-imported trades have carried an activity label there all along (`Buy: VOO 10 @ $100.00`); `writeInvestments` wrote the cash leg's `payeeName` from Money's payee handle and nothing else, and Money records no payee on a trade — so in practice the field was always `null` on the one column that could say why the money moved.

The label already existed **twice**, and the two copies disagreed for the same trade:

| | native | QIF import |
|---|---|---|
| price | `Intl` currency, in the security's currency | hard-coded `$` + `toFixed(2)` — over an amount it converts *out of* that currency two lines later |
| quantity | normalized to the 4dp the column stores | raw interpolation |
| `INTEREST` branch | keyed on the base action | keyed on the raw action, so a refinement fell through to the symbol branch |

So rather than adding a third copy, this consolidates to one — `backend/src/securities/investment-cash-payee.util.ts` — called by all three producers, with the richer native semantics as the canonical shape. Same family as `applyActionToQuantity`: one fold, one implementation.

Two latent bugs fold in:

- A blank or malformed currency code now renders the figures bare instead of raising `RangeError` out of `Intl`. A `.mny` account can carry an empty code (`map-investments.ts` defaults to `""`), and the native formatter would have aborted a whole import over a label.
- An other-action line with no security no longer leaves a double space mid-label.

On the `.mny` side, Money's own payee still wins when the file recorded one — the synthesized label is a fallback, never an override, so nothing the user entered is replaced by generated text. `payeeId` and `payeeName` travel together, so a handle resolving to only one of them falls back rather than linking half a payee.

**A green suite after a behaviour change is a finding.** Both behaviour changes — the QIF label's currency and the new `.mny` label — left every existing test passing, because every assertion any of the three producers carried was a `toContain`. They are now exact strings, plus a source-scanning guard (`investment-cash-payee.guard.spec.ts`) that fails on a second action title-caser, on a payee label built with a hard-coded currency symbol, and on a fourth producer that does not call the util. I verified the guard fails on both of the original mistakes by re-introducing them.

### Scope

This is the Payee half of #1204 only. The issue also asks about the Category tooltip and about editing/navigating to the investment side from a cash row (including Money's rule that sells cannot be edited from the cash side) — untouched here, and worth its own issue and PR.

Already-imported data keeps its blank payee until re-import: the fix applies at import time. A backfill is feasible (cash legs reachable from `investment_transactions.transaction_id` with both payee columns null are exactly the affected set, since native and QIF always write a name) but belongs in TypeScript rather than SQL, so it does not reimplement the currency formatting this PR just consolidated. Happy to add it as a follow-up if you want it.

### Verification

- `TZ=UTC npm run test:unit` — 486 suites, 13,055 passing, 2 skipped
- `npm run typecheck` and `npx eslint src/` clean

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — no catalog change: the label is stored data on the transaction row, exactly as the native and QIF paths already write it, not a rendered string. Worth a look if you would rather it were localized at display time, but that would be a change to all three producers and to existing rows.
- [ ] No shared/core areas were refactored without prior agreement. — **flagging this one.** Fixing the `.mny` path meant either a third copy of the label or one shared implementation, and I took the second. That deletes `InvestmentTransactionsService.formatCashTransactionPayeeName` and changes what the QIF importer emits for a non-USD security. Say the word if you would rather I left the two existing producers alone and only added the `.mny` call.
- [x] The branch is rebased on the latest `main` (`4d049888`).
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written by Claude Code, on @kenlasko's instruction to fix the Payee field for `.mny` imports.

---
_Generated by [Claude Code](https://claude.ai/code/session_018GBh3baQ51zNoo8Uz6Vk4Q)_