### PR TITLE
Exclude accounts from Account Balances before they existed

### DIFF
--- a/backend/src/accounts/account-balances-report.service.spec.ts
+++ b/backend/src/accounts/account-balances-report.service.spec.ts
@@ -32,6 +32,7 @@ interface Fixture {
     close_price: string;
   }>;
   securities?: Array<{ id: string; currency_code: string }>;
+  firstActivity?: Array<{ id: string; first_activity: string | null }>;
   rates?: Array<{
     from_currency: string;
     to_currency: string;
@@ -39,6 +40,17 @@ interface Fixture {
     rate: string;
   }>;
 }
+
+/**
+ * The holdings replay, told apart from the inception read beside it.
+ *
+ * Both name `investment_transactions`, so matching on the table alone finds
+ * whichever call the scheduler ran first -- and the assertions that no replay
+ * happened at all would pass for the wrong reason. The select list is what
+ * identifies the replay.
+ */
+const isReplayQuery = (sql: string): boolean =>
+  sql.includes("security_id, action");
 
 describe("AccountBalancesReportService", () => {
   let service: AccountBalancesReportService;
@@ -50,13 +62,18 @@ describe("AccountBalancesReportService", () => {
       if (sql.includes("FROM accounts\n") && sql.includes("account_sub_type")) {
         return fixture.accounts ?? [];
       }
+      // Checked before the ledger and investment reads: this one names both
+      // tables, so an earlier arm would swallow it.
+      if (sql.includes("AS first_activity")) {
+        return fixture.firstActivity ?? [];
+      }
       if (
         sql.includes("opening_balance") &&
         sql.includes("LEFT JOIN transactions")
       ) {
         return fixture.balances ?? [];
       }
-      if (sql.includes("FROM investment_transactions")) {
+      if (isReplayQuery(sql)) {
         return fixture.investmentTransactions ?? [];
       }
       if (sql.includes("FROM security_prices")) {
@@ -235,7 +252,7 @@ describe("AccountBalancesReportService", () => {
       );
       expect(ledgerCall[1][1]).toBe("2027-06-30");
       const replayCall = query.mock.calls.find(([sql]: [string]) =>
-        sql.includes("FROM investment_transactions"),
+        isReplayQuery(sql),
       );
       expect(replayCall[1][1]).toBe("2027-06-30");
 
@@ -331,6 +348,206 @@ describe("AccountBalancesReportService", () => {
     expect(result.accounts[0].balance).toBe(0);
   });
 
+  /**
+   * A balance is a fact about something that exists, so a date before the
+   * account came into existence has no balance to report -- not an opening
+   * balance carried backwards, which is the sum the account *started* at.
+   *
+   * Inception is `date_acquired` for an asset that carries one, and otherwise
+   * the first movement on either ledger.
+   */
+  describe("a date before the account existed", () => {
+    const asset = {
+      id: "acc-asset",
+      currency_code: "CAD",
+      account_type: "ASSET",
+      account_sub_type: null,
+      date_acquired: "2024-06-15",
+    };
+
+    it("reports an asset as absent before the day it was acquired", async () => {
+      program({
+        accounts: [asset],
+        balances: [{ id: "acc-asset", balance: "450000" }],
+      });
+      const result = await service.getBalancesAsOf("user-1", "2024-06-14");
+      expect(result.accounts[0]).toMatchObject({
+        accountId: "acc-asset",
+        existsAsOf: false,
+        balance: 0,
+      });
+    });
+
+    // The day itself is the day it started existing, not the day before it did.
+    it("reports the asset from its acquisition date onwards", async () => {
+      program({
+        accounts: [asset],
+        balances: [{ id: "acc-asset", balance: "450000" }],
+      });
+      for (const date of ["2024-06-15", "2026-03-01"]) {
+        const result = await service.getBalancesAsOf("user-1", date);
+        expect(result.accounts[0]).toMatchObject({
+          existsAsOf: true,
+          balance: 450000,
+        });
+      }
+    });
+
+    // The field says when the asset started existing. A transaction filed
+    // earlier is what the user has already corrected by setting it.
+    it("lets the acquisition date win over an earlier transaction", async () => {
+      program({
+        accounts: [asset],
+        balances: [{ id: "acc-asset", balance: "450000" }],
+        firstActivity: [{ id: "acc-asset", first_activity: "2020-01-01" }],
+      });
+      const result = await service.getBalancesAsOf("user-1", "2024-06-14");
+      expect(result.accounts[0]).toMatchObject({
+        existsAsOf: false,
+        balance: 0,
+      });
+    });
+
+    // `date_acquired` is an asset field; the account form offers it nowhere
+    // else, and net worth zeroes on it only for an ASSET. A stray value on
+    // another type must not hide a chequing account from its own history.
+    it("ignores an acquisition date on an account that is not an asset", async () => {
+      program({
+        accounts: [{ ...cheque, date_acquired: "2024-06-15" }],
+        balances: [{ id: "acc-1", balance: "5000" }],
+      });
+      const result = await service.getBalancesAsOf("user-1", "2020-01-01");
+      expect(result.accounts[0]).toMatchObject({
+        existsAsOf: true,
+        balance: 5000,
+      });
+    });
+
+    // The opening balance is what the account started at, so before the first
+    // transaction there is nothing to start from yet.
+    it("withholds an opening balance from dates before the first transaction", async () => {
+      program({
+        accounts: [cheque],
+        balances: [{ id: "acc-1", balance: "2500" }],
+        firstActivity: [{ id: "acc-1", first_activity: "2023-04-10" }],
+      });
+      const result = await service.getBalancesAsOf("user-1", "2023-04-09");
+      expect(result.accounts[0]).toMatchObject({
+        existsAsOf: false,
+        balance: 0,
+      });
+    });
+
+    it("reports the opening balance from the first transaction's own date", async () => {
+      program({
+        accounts: [cheque],
+        balances: [{ id: "acc-1", balance: "2500" }],
+        firstActivity: [{ id: "acc-1", first_activity: "2023-04-10" }],
+      });
+      const result = await service.getBalancesAsOf("user-1", "2023-04-10");
+      expect(result.accounts[0]).toMatchObject({
+        existsAsOf: true,
+        balance: 2500,
+      });
+    });
+
+    // Nothing dates this account's inception, and `created_at` is when the row
+    // was typed in rather than when the account came to exist -- so an account
+    // imported today would otherwise vanish from its own history.
+    it("reports an account with no acquisition date and no movements at every date", async () => {
+      program({
+        accounts: [cheque],
+        balances: [{ id: "acc-1", balance: "2500" }],
+        firstActivity: [{ id: "acc-1", first_activity: null }],
+      });
+      const result = await service.getBalancesAsOf("user-1", "1999-01-01");
+      expect(result.accounts[0]).toMatchObject({
+        existsAsOf: true,
+        balance: 2500,
+      });
+    });
+
+    // A brokerage's movements are trades, not ledger rows, so the inception
+    // read has to look at both tables or the account reports as timeless.
+    it("dates a brokerage from its investment transactions", async () => {
+      program({
+        accounts: [brokerage],
+        balances: [{ id: "acc-b", balance: "0" }],
+        firstActivity: [{ id: "acc-b", first_activity: "2025-02-03" }],
+      });
+      const result = await service.getBalancesAsOf("user-1", "2025-02-02");
+      expect(result.accounts[0]).toMatchObject({
+        existsAsOf: false,
+        balance: 0,
+      });
+    });
+
+    // The row is in `accounts` as the query runs, so the account exists now
+    // whatever its ledger says about next week. Today is the fixture's
+    // 2026-08-18.
+    it("reports an account whose only movement is still ahead of it", async () => {
+      program({
+        accounts: [cheque],
+        balances: [{ id: "acc-1", balance: "500" }],
+        firstActivity: [{ id: "acc-1", first_activity: "2026-09-01" }],
+      });
+      const result = await service.getBalancesAsOf("user-1", "2026-08-18");
+      expect(result.accounts[0]).toMatchObject({
+        existsAsOf: true,
+        balance: 500,
+      });
+    });
+
+    // Capped at today, not waived: nothing says the account was there in 2010.
+    it("still withholds that account from a date before today", async () => {
+      program({
+        accounts: [cheque],
+        balances: [{ id: "acc-1", balance: "500" }],
+        firstActivity: [{ id: "acc-1", first_activity: "2026-09-01" }],
+      });
+      const result = await service.getBalancesAsOf("user-1", "2026-08-17");
+      expect(result.accounts[0]).toMatchObject({
+        existsAsOf: false,
+        balance: 0,
+      });
+    });
+
+    // The user's own statement about an asset they do not own yet, so it is
+    // honoured as written rather than capped.
+    it("honours an acquisition date that has not arrived", async () => {
+      program({
+        accounts: [{ ...asset, date_acquired: "2027-01-01" }],
+        balances: [{ id: "acc-asset", balance: "450000" }],
+      });
+      const result = await service.getBalancesAsOf("user-1", "2026-08-18");
+      expect(result.accounts[0]).toMatchObject({
+        existsAsOf: false,
+        balance: 0,
+      });
+    });
+
+    it("asks both ledgers for the first movement, unbounded by the report's date", async () => {
+      program({
+        accounts: [cheque],
+        balances: [{ id: "acc-1", balance: "1" }],
+      });
+      await service.getBalancesAsOf("user-1", "2026-03-01");
+
+      const inceptionCall = query.mock.calls.find(([sql]: [string]) =>
+        sql.includes("AS first_activity"),
+      );
+      expect(inceptionCall[0]).toContain("FROM transactions t");
+      expect(inceptionCall[0]).toContain("FROM investment_transactions it");
+      expect(inceptionCall[0]).toContain("t.parent_transaction_id IS NULL");
+      expect(inceptionCall[0]).toContain("t.status != 'VOID'");
+      expect(inceptionCall[0]).toContain("it.status != 'VOID'");
+      // A window ending at the report's date cannot tell "before the first
+      // movement" from "has never had one".
+      expect(inceptionCall[0]).not.toContain("$4");
+      expect(inceptionCall[1]).toEqual(["user-1", [], null]);
+    });
+  });
+
   it("does not report a market value for an account that holds no securities", async () => {
     program({ accounts: [cheque], balances: [{ id: "acc-1", balance: "10" }] });
     const result = await service.getBalancesAsOf("user-1", "2026-06-30");
@@ -343,11 +560,9 @@ describe("AccountBalancesReportService", () => {
       fxComplete: true,
     });
     // No holdings accounts, so no replay and no price lookup at all.
-    expect(
-      query.mock.calls.some(([sql]: [string]) =>
-        sql.includes("investment_transactions"),
-      ),
-    ).toBe(false);
+    expect(query.mock.calls.some(([sql]: [string]) => isReplayQuery(sql))).toBe(
+      false,
+    );
   });
 
   it("values a holding at the last close on or before the date", async () => {
@@ -507,7 +722,7 @@ describe("AccountBalancesReportService", () => {
     });
     await service.getBalancesAsOf("user-1", "2026-03-01");
     const replayCall = query.mock.calls.find(([sql]: [string]) =>
-      sql.includes("FROM investment_transactions"),
+      isReplayQuery(sql),
     );
     expect(replayCall[0]).toContain("status != 'VOID'");
     expect(replayCall[0]).toContain("transaction_date <= $2");
@@ -719,11 +934,9 @@ describe("AccountBalancesReportService", () => {
       balance: 5000,
       marketValue: null,
     });
-    expect(
-      query.mock.calls.some(([sql]: [string]) =>
-        sql.includes("investment_transactions"),
-      ),
-    ).toBe(false);
+    expect(query.mock.calls.some(([sql]: [string]) => isReplayQuery(sql))).toBe(
+      false,
+    );
   });
 
   it("values a standalone investment account, which carries its own holdings", async () => {
@@ -778,7 +991,7 @@ describe("AccountBalancesReportService", () => {
     expect(query).not.toHaveBeenCalled();
   });
 
-  it("restricts both reads to the accounts a delegate may see", async () => {
+  it("restricts every read to the accounts a delegate may see", async () => {
     program({ accounts: [cheque], balances: [{ id: "acc-1", balance: "1" }] });
     await service.getBalancesAsOf("user-1", "2026-03-01", [], ["acc-1"]);
 
@@ -791,6 +1004,10 @@ describe("AccountBalancesReportService", () => {
       sql.includes("LEFT JOIN transactions"),
     );
     expect(ledgerCall[1][3]).toEqual(["acc-1"]);
+    const inceptionCall = query.mock.calls.find(([sql]: [string]) =>
+      sql.includes("AS first_activity"),
+    );
+    expect(inceptionCall[1][2]).toEqual(["acc-1"]);
   });
 
   it("widens the ownership predicate to the authorized joint accounts only", async () => {

--- a/backend/src/accounts/account-balances-report.service.ts
+++ b/backend/src/accounts/account-balances-report.service.ts
@@ -33,6 +33,24 @@ export interface AccountBalanceAsOf {
   pricesComplete: boolean;
   fxComplete: boolean;
   valuationComplete: boolean;
+  /**
+   * Whether the account existed at `asOfDate`.
+   *
+   * An account's inception is the first date it has anything to report: an
+   * asset's `date_acquired` when it has one, otherwise its earliest non-VOID
+   * ledger or investment movement. Before that date the account is not a thing
+   * with a balance -- an asset bought in 2024 was not worth its purchase price
+   * in 2019, and an opening balance is the sum the account *started* at, not a
+   * figure it carried backwards forever.
+   *
+   * `false` therefore means "did not exist yet", and `balance` is 0 rather than
+   * the opening balance the ledger sum would otherwise carry. An account with
+   * no acquisition date and no transactions at all has nothing dating its
+   * inception, so it is `true` at every date: nothing here guesses one from
+   * `created_at`, which records when the row was typed in rather than when the
+   * account came to exist.
+   */
+  existsAsOf: boolean;
 }
 
 export interface AccountBalancesAsOfResponse {
@@ -134,8 +152,10 @@ export class AccountBalancesReportService {
       currency_code: string;
       account_type: string;
       account_sub_type: string | null;
+      date_acquired: string | null;
     }> = await this.scopedQuery(
-      `SELECT id, currency_code, account_type, account_sub_type
+      `SELECT id, currency_code, account_type, account_sub_type,
+              date_acquired::text AS date_acquired
          FROM accounts
         WHERE (user_id = $1 OR id = ANY($2::UUID[]))
           AND ($3::UUID[] IS NULL OR id = ANY($3::UUID[]))`,
@@ -144,12 +164,10 @@ export class AccountBalancesReportService {
 
     if (accounts.length === 0) return empty;
 
-    const ledgerBalances = await this.ledgerBalances(
-      userId,
-      asOfDate,
-      jointAccountIds,
-      restriction,
-    );
+    const [ledgerBalances, firstActivity] = await Promise.all([
+      this.ledgerBalances(userId, asOfDate, jointAccountIds, restriction),
+      this.firstActivityDates(userId, jointAccountIds, restriction),
+    ]);
 
     // One rate read serves both jobs: pricing a foreign holding into its own
     // account's currency, and presenting every account in the user's. Reading
@@ -184,6 +202,14 @@ export class AccountBalancesReportService {
         asOfDate,
       ),
       accounts: accounts.map((a) => {
+        const existsAsOf = this.existedOn(
+          a,
+          firstActivity.get(a.id) ?? null,
+          asOfDate,
+        );
+        // Before its inception the account held nothing, so the opening balance
+        // the ledger sum would otherwise carry does not travel back with it.
+        const balance = existsAsOf ? (ledgerBalances.get(a.id) ?? 0) : 0;
         const valuation = marketValues.get(a.id);
         // A row that holds no securities has no market value to report -- that
         // is "does not apply", which is why the completeness flag stays true
@@ -192,7 +218,7 @@ export class AccountBalancesReportService {
           return {
             accountId: a.id,
             currencyCode: a.currency_code,
-            balance: ledgerBalances.get(a.id) ?? 0,
+            balance,
             marketValue: null,
             knownMarketValueSubtotal: 0,
             unpricedHoldingsCount: 0,
@@ -200,13 +226,15 @@ export class AccountBalancesReportService {
             pricesComplete: true,
             fxComplete: true,
             valuationComplete: true,
+            existsAsOf,
           };
         }
         return {
           accountId: a.id,
           currencyCode: a.currency_code,
-          balance: ledgerBalances.get(a.id) ?? 0,
+          balance,
           ...valuation,
+          existsAsOf,
         };
       }),
     };
@@ -238,6 +266,84 @@ export class AccountBalancesReportService {
     );
 
     return new Map(rows.map((r) => [r.id, roundMoney(Number(r.balance))]));
+  }
+
+  /**
+   * The earliest date each account has any movement on record, over both
+   * ledgers -- ordinary transactions and investment transactions.
+   *
+   * Deliberately unbounded by `asOfDate`: the question it answers is whether
+   * the report's date falls *before* the account's first movement, which a
+   * window ending at that date cannot tell from "this account has never had
+   * one". `LEAST` ignores NULLs, so it is null only when both ledgers are
+   * empty.
+   */
+  private async firstActivityDates(
+    userId: string,
+    jointAccountIds: string[],
+    restriction: string[] | null,
+  ): Promise<Map<string, string>> {
+    const rows: Array<{ id: string; first_activity: string | null }> =
+      await this.scopedQuery(
+        `SELECT a.id,
+                LEAST(
+                  (SELECT MIN(t.transaction_date)
+                     FROM transactions t
+                    WHERE t.account_id = a.id
+                      AND (t.status IS NULL OR t.status != 'VOID')
+                      AND t.parent_transaction_id IS NULL),
+                  (SELECT MIN(it.transaction_date)
+                     FROM investment_transactions it
+                    WHERE it.account_id = a.id
+                      AND it.status != 'VOID')
+                )::text AS first_activity
+           FROM accounts a
+          WHERE (a.user_id = $1 OR a.id = ANY($2::UUID[]))
+            AND ($3::UUID[] IS NULL OR a.id = ANY($3::UUID[]))`,
+        [userId, jointAccountIds, restriction],
+      );
+
+    const dates = new Map<string, string>();
+    for (const row of rows) {
+      if (row.first_activity)
+        dates.set(row.id, row.first_activity.slice(0, 10));
+    }
+    return dates;
+  }
+
+  /**
+   * Whether the account was a thing with a balance at `asOfDate`.
+   *
+   * Its inception is `date_acquired` for an asset that carries one -- the date
+   * the user says they came to own it, which is the same date net worth zeroes
+   * an asset before -- and otherwise its first movement on either ledger. An
+   * acquisition date wins over an earlier transaction rather than being
+   * minimised with it: the field's whole job is to say when the asset started
+   * existing, and the two disagreeing is a correction the user has already made.
+   * A *future* acquisition date is honoured as written, because it is the user's
+   * own statement about an asset they do not own yet.
+   *
+   * A first movement in the future is not, and it is capped at today. The row is
+   * in `accounts` as this query runs, so the account demonstrably exists now
+   * whatever its ledger says about next week -- and without the cap an account
+   * funded with an opening balance whose only entry is an upcoming bill
+   * disappears from today's own balance sheet.
+   *
+   * With neither, nothing dates the account's inception and it is reported at
+   * every date. `created_at` is not a candidate -- it records when the row was
+   * typed in, so an account imported today would vanish from its own history.
+   */
+  private existedOn(
+    account: { account_type: string; date_acquired: string | null },
+    firstActivity: string | null,
+    asOfDate: string,
+  ): boolean {
+    if (account.account_type === "ASSET" && account.date_acquired) {
+      return asOfDate >= account.date_acquired.slice(0, 10);
+    }
+    if (firstActivity === null) return true;
+    const today = todayYMD();
+    return asOfDate >= (firstActivity < today ? firstActivity : today);
   }
 
   /**

--- a/docs/specs/account-balances-as-of.md
+++ b/docs/specs/account-balances-as-of.md
@@ -65,6 +65,33 @@ nowhere since, from a single observation. A security outside the window is
 **unpriced** for `d`, which makes the account's total null (section 4), not
 smaller.
 
+**Inception** -- the first date the account is a thing with a balance:
+`date_acquired` when the account is an `ASSET` that carries one, and otherwise
+the earliest non-VOID, non-child movement on either ledger (`transactions` and
+`investment_transactions`). An acquisition date **wins** over an earlier
+transaction rather than being minimised with it: the field's job is to say when
+the asset started existing, and the two disagreeing is a correction the user has
+already made, and a *future* acquisition date is honoured as written because it
+is the user's own statement about an asset they do not own yet.
+
+A first movement in the future is **capped at today**. The account's row is in
+`accounts` as the query runs, so it demonstrably exists now whatever its ledger
+says about next week; without the cap, an account funded with an opening balance
+whose only entry is an upcoming bill disappears from today's own balance sheet.
+The cap is not a waiver -- that account is still absent from any date before
+today, because nothing says it was there.
+
+An account with neither has no inception and is reported at every
+date -- `created_at` is not a candidate, because it records when the row was
+typed in, so an account imported today would vanish from its own history.
+
+Before its inception an account is **absent**, not worth zero: `existsAsOf` is
+`false` and `balance` is 0 rather than the opening balance the ledger sum would
+otherwise carry back with it. The opening balance is the sum the account
+*started* at, and an asset bought in 2024 was not worth its purchase price in
+2019. The client drops those rows from the report entirely -- an empty row is a
+measured zero, and this is not a measurement.
+
 **The market date is `min(d, today)`.** The ledger runs ahead -- a transaction
 can be dated next year -- and prices and rates cannot, so a future `d` reads the
 market at today, the same clamp `ExchangeRateService.getRateForDate` applies and
@@ -94,12 +121,24 @@ Per the contract, a total is `null` unless every component is known.
 
 `balance` is never `null`: a ledger sum over rows the database holds is always
 known, and an account with no transactions before `d` sits at its opening
-balance.
+balance -- unless `d` predates its inception, where it is 0 (section 3).
+
+An account before its inception holds no positions either, because the replay is
+bounded by `d` and the inception read covers the same investment rows -- so a
+holdings account reports `marketValue: 0`, complete, exactly as an emptied one
+does.
 
 `valuationComplete` means *every component of every figure this row reports is
 known*. A consumer reads it as `=== false`, never `!`, so a response from a
 backend that predates the field reads as "no information" rather than
-"incomplete".
+"incomplete". `existsAsOf` is read the same way and for the same reason: absent
+means "no information", which is not "did not exist" -- hiding every account
+during a rolling deploy is the worse reading of a missing field.
+
+An investment pair is one entity with two ledgers, and they can come into
+existence on different days (a cash sleeve funded before the first trade
+settles). The client therefore drops an entity only when **every** member
+account is `existsAsOf: false`.
 
 ## 5. Shape
 
@@ -120,6 +159,8 @@ interface AccountBalanceAsOf {
   pricesComplete: boolean;
   fxComplete: boolean;
   valuationComplete: boolean;
+  /** False when asOfDate predates the account's inception (section 3). */
+  existsAsOf: boolean;
 }
 
 interface AccountBalancesAsOfResponse {
@@ -145,6 +186,13 @@ payload without the date that produced it cannot be told from the previous one
 | same, but no close on or before the date | 2026-01-04 | 0 | `null` |
 | same, last close 2025-09-30 (outside the window) | 2026-03-01 | 0 | `null` |
 | BUY 10 @ 20 USD in a CAD account, no USD->CAD rate | any | 0 | `null` |
+| opening 100, first transaction 2026-01-10 | 2026-01-09 | 0 (absent) | n/a |
+| same | 2026-01-10 | 150 | n/a |
+| opening 100, no transactions, no acquisition date | 1999-01-01 | 100 | n/a |
+| opening 500, only movement dated next month | today | 500 | n/a |
+| same | yesterday | 0 (absent) | n/a |
+| ASSET, `date_acquired` 2024-06-15, opening 450000 | 2024-06-14 | 0 (absent) | n/a |
+| same | 2024-06-15 | 450000 | n/a |
 
 ## 7. Display currency
 
@@ -204,7 +252,20 @@ The backend spec must cover, at minimum:
    omits a currency it has no accepted rate for.
 11. A future date sums the ledger to that date while reading prices and rates at
    today, and its positions are valued rather than reported unpriced.
+12. Inception (section 3): an asset is `existsAsOf: false` with `balance: 0`
+   before `date_acquired` and reported from that day onwards; the acquisition
+   date wins over an earlier transaction; `date_acquired` on a non-`ASSET`
+   account is ignored; an account with a later first transaction withholds its
+   opening balance until that day; an account with neither is reported at every
+   date; a brokerage is dated from its investment transactions; a first movement
+   still ahead of today is capped at today (reported today, absent yesterday)
+   while a future acquisition date is not; and the inception read is unbounded
+   by `d` and restricted for a delegate.
 
 The client tests must cover the filters, the grouping keys, the sort orders, the
 default-date change in section 2, conversion at the payload's rates, and an
-omitted currency leaving the totals marked partial.
+omitted currency leaving the totals marked partial -- plus, for section 3: an
+`existsAsOf: false` account leaving both the rows and the totals, its group
+heading going with it, a pair surviving on one live member, a row with the field
+absent still rendering, and the empty state naming the date rather than the
+filters.

--- a/frontend/src/components/reports/AccountBalancesReport.test.tsx
+++ b/frontend/src/components/reports/AccountBalancesReport.test.tsx
@@ -759,11 +759,11 @@ describe("AccountBalancesReport", () => {
     await waitFor(() => {
       expect(screen.getByText("Total Assets")).toBeInTheDocument();
     });
-    await act(async () => { fireEvent.click(screen.getByTitle("Chart view")); });
+    await act(async () => { fireEvent.click(chartViewButton()); });
     await waitFor(() => {
       expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
     });
-    await act(async () => { fireEvent.click(screen.getByTitle("Table view")); });
+    await act(async () => { fireEvent.click(tableViewButton()); });
     await waitFor(() => {
       expect(screen.queryByTestId("pie-chart")).not.toBeInTheDocument();
     });
@@ -776,7 +776,7 @@ describe("AccountBalancesReport", () => {
     await waitFor(() => {
       expect(screen.getByText("Total Assets")).toBeInTheDocument();
     });
-    await act(async () => { fireEvent.click(screen.getByTitle("Chart view")); });
+    await act(async () => { fireEvent.click(chartViewButton()); });
     await waitFor(() => {
       expect(screen.getByText("No data to display.")).toBeInTheDocument();
     });
@@ -985,6 +985,21 @@ describe("AccountBalancesReport", () => {
     });
   });
 });
+
+/**
+ * The view toggle, found by the titles `ChartViewToggle` gives it.
+ *
+ * The report used to hand-roll this pair of buttons under its own "Chart
+ * view"/"Table view" copy, which is how they came to stand short of every
+ * field beside them; the shared component names them from `common`.
+ */
+function chartViewButton(): HTMLElement {
+  return screen.getByTitle("Pie Chart");
+}
+
+function tableViewButton(): HTMLElement {
+  return screen.getByTitle("Table");
+}
 
 /** The account rows the table is rendering, in order. */
 function rowButtons(): HTMLElement[] {

--- a/frontend/src/components/reports/AccountBalancesReport.test.tsx
+++ b/frontend/src/components/reports/AccountBalancesReport.test.tsx
@@ -160,6 +160,7 @@ function balance(accountId: string, value: number, overrides: Record<string, unk
     pricesComplete: true,
     fxComplete: true,
     valuationComplete: true,
+    existsAsOf: true,
     ...overrides,
   };
 }
@@ -848,6 +849,128 @@ describe("AccountBalancesReport", () => {
     render(<AccountBalancesReport />);
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "EXOTIC_TYPE" })).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * A balance is a fact about something that exists. An asset bought in 2024
+   * was not worth its purchase price in 2019, and an opening balance is the sum
+   * an account *started* at rather than one it carried backwards forever -- so
+   * the server marks those rows and the report leaves them out entirely, rather
+   * than drawing them at zero.
+   */
+  describe("an account that did not exist on the chosen date", () => {
+    it("leaves it out of the rows and out of the totals", async () => {
+      mockGetAll.mockResolvedValue([
+        acc(),
+        acc({ id: "acc-2", name: "Lake House", accountType: "ASSET" }),
+      ]);
+      mockGetBalancesAsOf.mockResolvedValue(
+        balancesFor([
+          balance("acc-1", 5000),
+          balance("acc-2", 0, { existsAsOf: false }),
+        ]),
+      );
+      render(<AccountBalancesReport />);
+      await waitFor(() => {
+        expect(screen.getByText("Total Assets")).toBeInTheDocument();
+      });
+      expect(rowNames()).toEqual(["Chequing"]);
+      expect(screen.queryByText("Lake House")).not.toBeInTheDocument();
+      expect(
+        within(screen.getByTestId("summary-assets")).getByText("$5000.00"),
+      ).toBeInTheDocument();
+    });
+
+    // Not "worth nothing" -- a zero row is a measured zero, and this is not a
+    // measurement. It must not appear even as an empty group.
+    it("does not draw it as a zero row when its own type is the only group", async () => {
+      mockGetAll.mockResolvedValue([
+        acc({ id: "acc-2", name: "Lake House", accountType: "ASSET" }),
+      ]);
+      mockGetBalancesAsOf.mockResolvedValue(
+        balancesFor([balance("acc-2", 450000, { existsAsOf: false })]),
+      );
+      render(<AccountBalancesReport />);
+      await waitFor(() => {
+        expect(screen.getByText("Total Assets")).toBeInTheDocument();
+      });
+      expect(rowNames()).toEqual([]);
+      expect(screen.queryByText("$450000.00")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { name: "Asset" }),
+      ).not.toBeInTheDocument();
+    });
+
+    // The filters are not what emptied the report, and saying they were sends
+    // the user to undo a filter they never set.
+    it("says the accounts postdate the day, rather than blaming the filters", async () => {
+      mockGetAll.mockResolvedValue([acc()]);
+      mockGetBalancesAsOf.mockResolvedValue(
+        balancesFor([balance("acc-1", 5000, { existsAsOf: false })]),
+      );
+      render(<AccountBalancesReport />);
+      await waitFor(() => {
+        expect(
+          screen.getByText(`None of your accounts existed on date(${TODAY}).`),
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText("No accounts match the current filters."),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("No accounts found.")).not.toBeInTheDocument();
+    });
+
+    // An investment pair is one entity with two ledgers, and the cash sleeve
+    // can be funded before the first trade settles. One live member is enough
+    // to have something to report.
+    it("keeps a pair whose brokerage half is not yet trading", async () => {
+      mockGetAll.mockResolvedValue([
+        acc({
+          id: "acc-brokerage",
+          name: "Investments - Brokerage",
+          accountType: "INVESTMENT",
+          accountSubType: "INVESTMENT_BROKERAGE",
+          linkedAccountId: "acc-cash",
+        }),
+        acc({
+          id: "acc-cash",
+          name: "Investments - Cash",
+          accountType: "INVESTMENT",
+          accountSubType: "INVESTMENT_CASH",
+          linkedAccountId: "acc-brokerage",
+        }),
+      ]);
+      mockGetBalancesAsOf.mockResolvedValue(
+        balancesFor([
+          balance("acc-brokerage", 0, {
+            marketValue: 0,
+            existsAsOf: false,
+          }),
+          balance("acc-cash", 5000),
+        ]),
+      );
+      render(<AccountBalancesReport />);
+      await waitFor(() => {
+        expect(screen.getByText("Investments")).toBeInTheDocument();
+      });
+      const row = screen.getByText("Investments").closest("button")!;
+      expect(within(row).getByText("$5000.00")).toBeInTheDocument();
+    });
+
+    // Absent means "no information", not "did not exist": during a rolling
+    // deploy a page can be handed a response from a backend predating the
+    // field, and hiding every account would be the worse reading of it.
+    it("shows an account whose row carries no existence field at all", async () => {
+      mockGetAll.mockResolvedValue([acc()]);
+      mockGetBalancesAsOf.mockResolvedValue(
+        balancesFor([balance("acc-1", 5000, { existsAsOf: undefined })]),
+      );
+      render(<AccountBalancesReport />);
+      await waitFor(() => {
+        expect(screen.getByText("Total Assets")).toBeInTheDocument();
+      });
+      expect(rowNames()).toEqual(["Chequing"]);
     });
   });
 

--- a/frontend/src/components/reports/AccountBalancesReport.tsx
+++ b/frontend/src/components/reports/AccountBalancesReport.tsx
@@ -165,9 +165,40 @@ export function AccountBalancesReport() {
     [accounts, mainAccountName, portfolio, ledgerBalances],
   );
 
+  /**
+   * Accounts the payload says had not come into existence at the measured date
+   * -- an asset before the day it was acquired, an account before its first
+   * movement. A balance is a fact about something that exists, so these are not
+   * rows worth zero: they are not rows.
+   */
+  const notYetOpened = useMemo(() => {
+    const ids = new Set<string>();
+    for (const row of response?.balances.accounts ?? []) {
+      // `=== false`, never `!`: a backend that predates the field sends nothing,
+      // and absent means "no information", not "did not exist".
+      if (row.existsAsOf === false) ids.add(row.accountId);
+    }
+    return ids;
+  }, [response]);
+
+  /**
+   * An investment pair is one entity with two ledgers, and they can come into
+   * existence on different days -- the cash sleeve funded before the first
+   * trade settles. So the entity is dropped only when *every* ledger behind it
+   * predates its own inception; one live member is enough to have something to
+   * report.
+   */
+  const openedAccounts = useMemo(
+    () =>
+      logicalAccounts.filter((entry) =>
+        entry.memberIds.some((id) => !notYetOpened.has(id)),
+      ),
+    [logicalAccounts, notYetOpened],
+  );
+
   const visibleAccounts = useMemo(
-    () => logicalAccounts.filter((entry) => matchesFilters(entry.primary, filters)),
-    [logicalAccounts, filters],
+    () => openedAccounts.filter((entry) => matchesFilters(entry.primary, filters)),
+    [openedAccounts, filters],
   );
 
   const institutionNames = useMemo(() => {
@@ -722,7 +753,13 @@ export function AccountBalancesReport() {
               <p className="text-gray-500 dark:text-gray-400">
                 {accounts.length === 0
                   ? t('accountBalances.noAccounts')
-                  : t('accountBalances.noAccountsForFilters')}
+                  : openedAccounts.length === 0
+                    ? /* Every account the user has postdates the chosen day, so
+                         the filters are not what emptied the report. */
+                      t('accountBalances.noAccountsOnDate', {
+                        date: formatDate(measuredDate),
+                      })
+                    : t('accountBalances.noAccountsForFilters')}
               </p>
             </div>
           )}

--- a/frontend/src/components/reports/DuplicateTransactionReport.test.tsx
+++ b/frontend/src/components/reports/DuplicateTransactionReport.test.tsx
@@ -21,6 +21,8 @@ vi.mock('@/hooks/useDateRange', () => ({
 
 vi.mock('@/lib/utils', () => ({
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
+  // ExportDropdown (rendered by this report) imports `cn` for className merging.
+  cn: (...inputs: any[]) => inputs.flat(Infinity).filter(Boolean).join(' '),
 }));
 
 vi.mock('@/components/ui/DateRangeSelector', () => ({

--- a/frontend/src/components/reports/account-balances/AccountBalancesControls.test.tsx
+++ b/frontend/src/components/reports/account-balances/AccountBalancesControls.test.tsx
@@ -20,7 +20,11 @@ vi.mock('@/components/ui/MultiSelect', () => ({
 }));
 
 vi.mock('@/components/ui/ExportDropdown', () => ({
-  ExportDropdown: () => <div data-testid="export-dropdown" />,
+  ExportDropdown: ({ className }: any) => (
+    <button data-testid="export-dropdown" className={className}>
+      Export
+    </button>
+  ),
 }));
 
 function renderControls() {
@@ -49,6 +53,11 @@ function renderControls() {
 /** The sort-direction toggle, found by the label it carries in either state. */
 function directionToggle(): HTMLElement {
   return screen.getByTitle(/Sorted (highest|lowest) first/);
+}
+
+/** The table/chart view toggle's "Table" button, from `ChartViewToggle`. */
+function tableViewButton(): HTMLElement {
+  return screen.getByTitle('Table');
 }
 
 describe('AccountBalancesControls layout', () => {
@@ -119,14 +128,73 @@ describe('AccountBalancesControls layout', () => {
       'A control sized in rem cannot fit copy it has not seen; let the grid size it.',
     ).toEqual([]);
 
-    // Both bands are grids that start at one column and widen with the
+    // The two bands that hold the actual controls (the date/group/sort row and
+    // the filters row) are grids that start at one column and widen with the
     // viewport, so a narrow screen stacks rather than squeezing.
     const grids = [...container.querySelectorAll<HTMLElement>('.grid')];
     expect(grids.length).toBeGreaterThanOrEqual(2);
-    for (const grid of grids) {
+    const fieldGrids = grids.filter((grid) => grid.className.includes('sm:grid-cols-2'));
+    expect(fieldGrids.length).toBeGreaterThanOrEqual(2);
+    for (const grid of fieldGrids) {
       expect(grid.className).toContain('grid-cols-1');
       expect(grid.className).toMatch(/sm:grid-cols-2/);
     }
+  });
+
+  /**
+   * The outermost grid is structural -- it places the fields band and the
+   * actions column side by side rather than sizing repeated same-shape
+   * controls -- so it earns its own assertion instead of being swept into the
+   * field-sizing one above. It still starts single-column (stacked, actions
+   * below the fields on a narrow screen) and widens at a breakpoint, which is
+   * what makes `align-items: stretch` -- grid's default -- give the actions
+   * column the fields band's own row height with no number written down
+   * anywhere for it.
+   */
+  it('splits into fields and actions only once there is room for both', () => {
+    const { container } = renderControls();
+    const outer = container.querySelector<HTMLElement>('.grid')!;
+    expect(outer.className).toContain('grid-cols-1');
+    expect(outer.className).toContain('items-stretch');
+    expect(outer.className).toMatch(/lg:grid-cols-\[.*\]/);
+    // Not the field-sizing breakpoint -- this grid has exactly two cells and
+    // widens once, not once per extra control.
+    expect(outer.className).not.toMatch(/sm:grid-cols-2/);
+  });
+
+  /**
+   * The view toggle and the export button sit on the same row as the labelled
+   * fields (the date, group-by, sort-by), and used to be a hand-rolled pair of
+   * icon buttons centred against that row -- shorter than every field beside
+   * them, because nothing reserved the label space above them the way `Select`
+   * does above its own input. `ChartViewToggle`/`ExportDropdown` now sit in a
+   * column shaped exactly like the sort-direction toggle's: same spacer, same
+   * `items-stretch` row, so what is left to stretch into is the field height.
+   */
+  it('gives the view toggle and export button the height of the fields beside them', () => {
+    renderControls();
+    const tableButton = tableViewButton();
+    const exportButton = screen.getByTestId('export-dropdown');
+
+    // Both controls share one stretched row, inside a column that reserves a
+    // label spacer above them -- the same shape the sort-direction toggle uses.
+    // `ChartViewToggle` wraps its own buttons in a `flex gap-2` div, so the
+    // shared row is one level up from the button itself.
+    const row = tableButton.parentElement!.parentElement!;
+    expect(row).toBe(exportButton.parentElement);
+    expect(row.className).toContain('items-stretch');
+
+    const column = row.parentElement!;
+    const spacer = column.firstElementChild!;
+    expect(spacer).not.toBe(row);
+    expect(spacer.getAttribute('aria-hidden')).toBe('true');
+    expect(spacer.className).toContain('mb-1');
+    expect(spacer.className).toContain('text-sm');
+
+    // The export button is told to fill that stretched height; a plain toggle
+    // button already does via ChartViewToggle's own `p-2` sizing plus the
+    // stretched flex row.
+    expect(exportButton.className).toContain('h-full');
   });
 
   it('renders every filter the report offers', () => {

--- a/frontend/src/components/reports/account-balances/AccountBalancesControls.tsx
+++ b/frontend/src/components/reports/account-balances/AccountBalancesControls.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 import { DateInput } from '@/components/ui/DateInput';
 import { Select } from '@/components/ui/Select';
 import { MultiSelect, type MultiSelectOption } from '@/components/ui/MultiSelect';
+import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import {
   GROUP_BY_OPTIONS,
@@ -39,6 +40,25 @@ interface Props {
 }
 
 const SCOPES: BalanceScope[] = ['all', 'assets', 'liabilities'];
+
+/**
+ * The space a `Select` gives its label, reserved above a control that has none.
+ *
+ * A button standing beside a labelled field is the height of the *field*, not
+ * of the field plus its label. Reserving the label's own space above it means
+ * what is left to stretch into is exactly the input's height, with no magic
+ * number that a font or padding change would silently invalidate --
+ * `self-stretch` alone measures from the top of the label and stands a label
+ * taller. Both the sort-direction toggle and the view/export group need it, so
+ * the rule lives in one place rather than being written out twice.
+ */
+function LabelSpacer() {
+  return (
+    <span aria-hidden="true" className="mb-1 block text-sm font-medium">
+      {'\u00a0'}
+    </span>
+  );
+}
 
 /**
  * The report's toolbar: the date the balances are measured at, what is
@@ -83,8 +103,18 @@ export function AccountBalancesControls({
           longest option's length in every language -- one the translations
           break. The grid gives each control an equal share of the full row and
           drops to fewer columns before any of them gets narrow. */}
-      <div className="flex flex-wrap items-end gap-4">
-        <div className="grid min-w-0 flex-1 grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {/* The fields and the actions column are two cells of one CSS grid row,
+          not two flex items -- `align-items: stretch` is grid's default, so
+          both cells are pulled to the row's own height (the fields' 66px:
+          label + gap + input) with no explicit number written down anywhere.
+          A flex row with `items-end` only lines up bottoms; it does not equalize
+          height, which is how the view toggle and export button ended up a
+          visibly shorter 36px sitting flush against the same baseline -- close
+          enough to pass a glance, wrong on measurement. Below `lg` the two
+          cells stack into their own rows (nothing to stretch against, and
+          nothing beside them to look mismatched against either). */}
+      <div className="grid grid-cols-1 items-stretch gap-4 lg:grid-cols-[minmax(0,1fr)_auto]">
+        <div className="grid min-w-0 grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           <DateInput
             label={t('accountBalances.asOfDate')}
             value={asOfDate}
@@ -113,9 +143,7 @@ export function AccountBalancesControls({
               />
             </div>
             <div className="flex flex-col">
-              <span aria-hidden="true" className="mb-1 block text-sm font-medium">
-                {'\u00a0'}
-              </span>
+              <LabelSpacer />
               <button
                 type="button"
                 onClick={onSortDirectionToggle}
@@ -136,36 +164,27 @@ export function AccountBalancesControls({
             </div>
           </div>
         </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <button
-            type="button"
-            onClick={() => onViewModeChange('table')}
-            className={`p-2 rounded-md transition-colors ${
-              viewMode === 'table'
-                ? 'bg-blue-600 text-white'
-                : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
-            }`}
-            title={t('accountBalances.tableView')}
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
-            </svg>
-          </button>
-          <button
-            type="button"
-            onClick={() => onViewModeChange('chart')}
-            className={`p-2 rounded-md transition-colors ${
-              viewMode === 'chart'
-                ? 'bg-blue-600 text-white'
-                : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
-            }`}
-            title={t('accountBalances.chartView')}
-          >
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M11 2v20c-5.07-.5-9-4.79-9-10s3.93-9.5 9-10zm2.03 0v8.99H22c-.47-4.74-4.24-8.52-8.97-8.99zm0 11.01V22c4.74-.47 8.5-4.25 8.97-8.99h-8.97z" />
-            </svg>
-          </button>
-          <ExportDropdown onExportPdf={onExportPdf} onExportCsv={onExportCsv} />
+        {/* The view toggle and the export button are controls on a row of
+            labelled fields, so they take the fields' height the same way the
+            sort-direction button does: the label's space is reserved above
+            them, and what is left is stretched into. They were previously a
+            hand-rolled pair of icon buttons centred against the row, which
+            stood short of every field beside them -- `ChartViewToggle` is the
+            component 19 other surfaces use for exactly this. */}
+        <div className="flex flex-col">
+          <LabelSpacer />
+          <div className="flex flex-1 items-stretch gap-2">
+            <ChartViewToggle
+              value={viewMode === 'chart' ? 'pie' : 'table'}
+              onChange={(view) => onViewModeChange(view === 'pie' ? 'chart' : 'table')}
+              options={['table', 'pie']}
+            />
+            <ExportDropdown
+              onExportPdf={onExportPdf}
+              onExportCsv={onExportCsv}
+              className="h-full"
+            />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/ui/ExportDropdown.tsx
+++ b/frontend/src/components/ui/ExportDropdown.tsx
@@ -4,14 +4,28 @@ import { useState, useRef, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import toast from 'react-hot-toast';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { cn } from '@/lib/utils';
 
 interface ExportDropdownProps {
   onExportCsv?: () => void;
   onExportPdf: () => void;
   disabled?: boolean;
+  /**
+   * Extra classes for the trigger button, for a caller that has to size it --
+   * a toolbar standing it beside labelled fields needs `h-full`, and the
+   * button's own padding cannot know that. Layout only; the colours, the
+   * spacing and the disabled treatment stay here so every export button reads
+   * the same.
+   */
+  className?: string;
 }
 
-export function ExportDropdown({ onExportCsv, onExportPdf, disabled }: ExportDropdownProps) {
+export function ExportDropdown({
+  onExportCsv,
+  onExportPdf,
+  disabled,
+  className,
+}: ExportDropdownProps) {
   const t = useTranslations('common');
   const [isOpen, setIsOpen] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
@@ -45,7 +59,10 @@ export function ExportDropdown({ onExportCsv, onExportPdf, disabled }: ExportDro
       <button
         onClick={handleExportPdf}
         disabled={disabled || isExporting}
-        className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 disabled:opacity-50"
+        className={cn(
+          'px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 disabled:opacity-50',
+          className,
+        )}
         title={t('exportDropdown.exportPdf')}
       >
         <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -61,7 +78,10 @@ export function ExportDropdown({ onExportCsv, onExportPdf, disabled }: ExportDro
       <button
         onClick={() => setIsOpen(!isOpen)}
         disabled={disabled || isExporting}
-        className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 disabled:opacity-50"
+        className={cn(
+          'px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 disabled:opacity-50',
+          className,
+        )}
         title={t('exportDropdown.exportReport')}
       >
         <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/i18n/messages/de/reports.json
+++ b/frontend/src/i18n/messages/de/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Gesamte Aktiva",
     "totalLiabilities": "Gesamte Verbindlichkeiten",
     "netWorth": "Reinvermögen",
-    "tableView": "Tabellenansicht",
-    "chartView": "Diagrammansicht",
     "noData": "Keine Daten vorhanden.",
     "noAccounts": "Keine Konten gefunden.",
     "closed": "Geschlossen",
@@ -193,6 +191,7 @@
     "groupAll": "Alle Konten",
     "colGroup": "Gruppe",
     "noAccountsForFilters": "Keine Konten entsprechen den aktuellen Filtern.",
+    "noAccountsOnDate": "Am {date} existierte keines Ihrer Konten.",
     "accountTypes": {
       "CHEQUING": "Girokonto",
       "SAVINGS": "Sparkonto",

--- a/frontend/src/i18n/messages/en/reports.json
+++ b/frontend/src/i18n/messages/en/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Total Assets",
     "totalLiabilities": "Total Liabilities",
     "netWorth": "Net Worth",
-    "tableView": "Table view",
-    "chartView": "Chart view",
     "noData": "No data to display.",
     "noAccounts": "No accounts found.",
     "closed": "Closed",

--- a/frontend/src/i18n/messages/en/reports.json
+++ b/frontend/src/i18n/messages/en/reports.json
@@ -193,6 +193,7 @@
     "groupAll": "All accounts",
     "colGroup": "Group",
     "noAccountsForFilters": "No accounts match the current filters.",
+    "noAccountsOnDate": "None of your accounts existed on {date}.",
     "accountTypes": {
       "CHEQUING": "Chequing",
       "SAVINGS": "Savings",

--- a/frontend/src/i18n/messages/es/reports.json
+++ b/frontend/src/i18n/messages/es/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Total de activos",
     "totalLiabilities": "Total de pasivos",
     "netWorth": "Patrimonio neto",
-    "tableView": "Vista de tabla",
-    "chartView": "Vista de gráfico",
     "noData": "No hay datos para mostrar.",
     "noAccounts": "No se encontraron cuentas.",
     "closed": "Cerrada",
@@ -193,6 +191,7 @@
     "groupAll": "Todas las cuentas",
     "colGroup": "Grupo",
     "noAccountsForFilters": "Ninguna cuenta coincide con los filtros actuales.",
+    "noAccountsOnDate": "Ninguna de tus cuentas existía el {date}.",
     "accountTypes": {
       "CHEQUING": "Cuenta corriente",
       "SAVINGS": "Cuenta de ahorros",

--- a/frontend/src/i18n/messages/fr/reports.json
+++ b/frontend/src/i18n/messages/fr/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Total des actifs",
     "totalLiabilities": "Total des passifs",
     "netWorth": "Valeur nette",
-    "tableView": "Vue tableau",
-    "chartView": "Vue graphique",
     "noData": "Aucune donnée à afficher.",
     "noAccounts": "Aucun compte trouvé.",
     "closed": "Clôturé",
@@ -193,6 +191,7 @@
     "groupAll": "Tous les comptes",
     "colGroup": "Groupe",
     "noAccountsForFilters": "Aucun compte ne correspond aux filtres actuels.",
+    "noAccountsOnDate": "Aucun de vos comptes n'existait le {date}.",
     "accountTypes": {
       "CHEQUING": "Chèque",
       "SAVINGS": "Épargne",

--- a/frontend/src/i18n/messages/hi/reports.json
+++ b/frontend/src/i18n/messages/hi/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "कुल संपत्ति",
     "totalLiabilities": "कुल देनदारियाँ",
     "netWorth": "निवल मूल्य",
-    "tableView": "तालिका दृश्य",
-    "chartView": "चित्र दृश्य",
     "noData": "प्रदर्शित करने के लिए कोई डेटा नहीं।",
     "noAccounts": "कोई खाता नहीं मिला।",
     "closed": "बंद",
@@ -193,6 +191,7 @@
     "groupAll": "सभी खाते",
     "colGroup": "समूह",
     "noAccountsForFilters": "वर्तमान फ़िल्टर से कोई खाता मेल नहीं खाता।",
+    "noAccountsOnDate": "{date} को आपका कोई भी खाता मौजूद नहीं था।",
     "accountTypes": {
       "CHEQUING": "चेकिंग",
       "SAVINGS": "बचत",

--- a/frontend/src/i18n/messages/id/reports.json
+++ b/frontend/src/i18n/messages/id/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Total Aset",
     "totalLiabilities": "Total Liabilitas",
     "netWorth": "Nilai Bersih",
-    "tableView": "Tampilan tabel",
-    "chartView": "Tampilan grafik",
     "noData": "Tidak ada data untuk ditampilkan.",
     "noAccounts": "Tidak ada akun ditemukan.",
     "closed": "Ditutup",
@@ -193,6 +191,7 @@
     "groupAll": "Semua akun",
     "colGroup": "Grup",
     "noAccountsForFilters": "Tidak ada akun yang cocok dengan filter saat ini.",
+    "noAccountsOnDate": "Belum ada akun Anda yang berdiri pada {date}.",
     "accountTypes": {
       "CHEQUING": "Rekening Koran",
       "SAVINGS": "Tabungan",

--- a/frontend/src/i18n/messages/it/reports.json
+++ b/frontend/src/i18n/messages/it/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Totale attività",
     "totalLiabilities": "Totale passività",
     "netWorth": "Patrimonio netto",
-    "tableView": "Vista tabella",
-    "chartView": "Vista grafico",
     "noData": "Nessun dato da visualizzare.",
     "noAccounts": "Nessun conto trovato.",
     "closed": "Chiuso",
@@ -193,6 +191,7 @@
     "groupAll": "Tutti i conti",
     "colGroup": "Gruppo",
     "noAccountsForFilters": "Nessun conto corrisponde ai filtri attuali.",
+    "noAccountsOnDate": "Nessuno dei tuoi conti esisteva il {date}.",
     "accountTypes": {
       "CHEQUING": "Conto corrente",
       "SAVINGS": "Conto di risparmio",

--- a/frontend/src/i18n/messages/ja/reports.json
+++ b/frontend/src/i18n/messages/ja/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "総資産",
     "totalLiabilities": "総負債",
     "netWorth": "純資産",
-    "tableView": "表形式",
-    "chartView": "グラフ形式",
     "noData": "表示するデータがありません。",
     "noAccounts": "口座が見つかりません。",
     "closed": "閉鎖済み",
@@ -193,6 +191,7 @@
     "groupAll": "すべての口座",
     "colGroup": "グループ",
     "noAccountsForFilters": "現在のフィルターに一致する口座はありません。",
+    "noAccountsOnDate": "{date} 時点では、いずれの口座もまだ存在していません。",
     "accountTypes": {
       "CHEQUING": "当座預金",
       "SAVINGS": "普通預金",

--- a/frontend/src/i18n/messages/ko/reports.json
+++ b/frontend/src/i18n/messages/ko/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "총 자산",
     "totalLiabilities": "총 부채",
     "netWorth": "순자산가액",
-    "tableView": "표 보기",
-    "chartView": "차트 보기",
     "noData": "표시할 데이터가 없습니다.",
     "noAccounts": "계정을 찾을 수 없습니다.",
     "closed": "마감됨",
@@ -193,6 +191,7 @@
     "groupAll": "모든 계정",
     "colGroup": "그룹",
     "noAccountsForFilters": "현재 필터와 일치하는 계정이 없습니다.",
+    "noAccountsOnDate": "{date} 시점에는 존재하는 계정이 없습니다.",
     "accountTypes": {
       "CHEQUING": "당좌예금",
       "SAVINGS": "저축예금",

--- a/frontend/src/i18n/messages/nl/reports.json
+++ b/frontend/src/i18n/messages/nl/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Totale activa",
     "totalLiabilities": "Totale passiva",
     "netWorth": "Nettowaarde",
-    "tableView": "Tabelweergave",
-    "chartView": "Grafiekweergave",
     "noData": "Geen gegevens om weer te geven.",
     "noAccounts": "Geen rekeningen gevonden.",
     "closed": "Gesloten",
@@ -193,6 +191,7 @@
     "groupAll": "Alle rekeningen",
     "colGroup": "Groep",
     "noAccountsForFilters": "Geen rekeningen komen overeen met de huidige filters.",
+    "noAccountsOnDate": "Geen van uw rekeningen bestond op {date}.",
     "accountTypes": {
       "CHEQUING": "Betaalrekening",
       "SAVINGS": "Spaarrekening",

--- a/frontend/src/i18n/messages/pl/reports.json
+++ b/frontend/src/i18n/messages/pl/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Aktywa razem",
     "totalLiabilities": "Zobowiązania razem",
     "netWorth": "Wartość netto",
-    "tableView": "Widok tabeli",
-    "chartView": "Widok wykresu",
     "noData": "Brak danych do wyświetlenia.",
     "noAccounts": "Nie znaleziono kont.",
     "closed": "Zamknięte",
@@ -193,6 +191,7 @@
     "groupAll": "Wszystkie konta",
     "colGroup": "Grupa",
     "noAccountsForFilters": "Żadne konto nie pasuje do bieżących filtrów.",
+    "noAccountsOnDate": "Żadne z Twoich kont nie istniało w dniu {date}.",
     "accountTypes": {
       "CHEQUING": "Rachunek bieżący",
       "SAVINGS": "Oszczędności",

--- a/frontend/src/i18n/messages/pt-BR/reports.json
+++ b/frontend/src/i18n/messages/pt-BR/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Total de Ativos",
     "totalLiabilities": "Total de Passivos",
     "netWorth": "Patrimônio Líquido",
-    "tableView": "Vista de tabela",
-    "chartView": "Vista de gráfico",
     "noData": "Sem dados para apresentar.",
     "noAccounts": "Nenhuma conta encontrada.",
     "closed": "Fechada",
@@ -193,6 +191,7 @@
     "groupAll": "Todas as contas",
     "colGroup": "Grupo",
     "noAccountsForFilters": "Nenhuma conta corresponde aos filtros atuais.",
+    "noAccountsOnDate": "Nenhuma das suas contas existia em {date}.",
     "accountTypes": {
       "CHEQUING": "Conta Corrente",
       "SAVINGS": "Poupança",

--- a/frontend/src/i18n/messages/pt/reports.json
+++ b/frontend/src/i18n/messages/pt/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Total de Ativos",
     "totalLiabilities": "Total de Passivos",
     "netWorth": "Valor Líquido",
-    "tableView": "Vista de tabela",
-    "chartView": "Vista de gráfico",
     "noData": "Sem dados para apresentar.",
     "noAccounts": "Nenhuma conta encontrada.",
     "closed": "Fechada",
@@ -193,6 +191,7 @@
     "groupAll": "Todas as contas",
     "colGroup": "Grupo",
     "noAccountsForFilters": "Nenhuma conta corresponde aos filtros atuais.",
+    "noAccountsOnDate": "Nenhuma das suas contas existia em {date}.",
     "accountTypes": {
       "CHEQUING": "Conta à Ordem",
       "SAVINGS": "Poupança",

--- a/frontend/src/i18n/messages/ru/reports.json
+++ b/frontend/src/i18n/messages/ru/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Всего активов",
     "totalLiabilities": "Всего обязательств",
     "netWorth": "Чистая стоимость",
-    "tableView": "Таблица",
-    "chartView": "График",
     "noData": "Нет данных для отображения.",
     "noAccounts": "Счета не найдены.",
     "closed": "Закрыт",
@@ -193,6 +191,7 @@
     "groupAll": "Все счета",
     "colGroup": "Группа",
     "noAccountsForFilters": "Ни один счёт не подходит под текущие фильтры.",
+    "noAccountsOnDate": "На {date} ни одного вашего счёта ещё не существовало.",
     "accountTypes": {
       "CHEQUING": "Текущий",
       "SAVINGS": "Сберегательный",

--- a/frontend/src/i18n/messages/tr/reports.json
+++ b/frontend/src/i18n/messages/tr/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Toplam Varlıklar",
     "totalLiabilities": "Toplam Yükümlülükler",
     "netWorth": "Net Değer",
-    "tableView": "Tablo görünümü",
-    "chartView": "Grafik görünümü",
     "noData": "Gösterilecek veri yok.",
     "noAccounts": "Hesap bulunamadı.",
     "closed": "Kapalı",
@@ -193,6 +191,7 @@
     "groupAll": "Tüm hesaplar",
     "colGroup": "Grup",
     "noAccountsForFilters": "Geçerli filtrelerle eşleşen hesap yok.",
+    "noAccountsOnDate": "{date} tarihinde hesaplarınızın hiçbiri mevcut değildi.",
     "accountTypes": {
       "CHEQUING": "Çek Hesabı",
       "SAVINGS": "Tasarruf",

--- a/frontend/src/i18n/messages/uk/reports.json
+++ b/frontend/src/i18n/messages/uk/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Усього активів",
     "totalLiabilities": "Усього пасивів",
     "netWorth": "Чистий капітал",
-    "tableView": "Таблиця",
-    "chartView": "Діаграма",
     "noData": "Немає даних для відображення.",
     "noAccounts": "Рахунків не знайдено.",
     "closed": "Закрито",
@@ -193,6 +191,7 @@
     "groupAll": "Усі рахунки",
     "colGroup": "Група",
     "noAccountsForFilters": "Жоден рахунок не відповідає поточним фільтрам.",
+    "noAccountsOnDate": "На {date} жодного вашого рахунку ще не існувало.",
     "accountTypes": {
       "CHEQUING": "Поточний",
       "SAVINGS": "Ощадний",

--- a/frontend/src/i18n/messages/vi/reports.json
+++ b/frontend/src/i18n/messages/vi/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "Tổng tài sản",
     "totalLiabilities": "Tổng nợ",
     "netWorth": "Giá trị ròng",
-    "tableView": "Chế độ bảng",
-    "chartView": "Chế độ biểu đồ",
     "noData": "Không có dữ liệu để hiển thị.",
     "noAccounts": "Không tìm thấy tài khoản.",
     "closed": "Đã đóng",
@@ -193,6 +191,7 @@
     "groupAll": "Tất cả tài khoản",
     "colGroup": "Nhóm",
     "noAccountsForFilters": "Không có tài khoản nào khớp với bộ lọc hiện tại.",
+    "noAccountsOnDate": "Không có tài khoản nào của bạn tồn tại vào {date}.",
     "accountTypes": {
       "CHEQUING": "Tài khoản hàng ngày",
       "SAVINGS": "Tiết kiệm",

--- a/frontend/src/i18n/messages/xx/reports.json
+++ b/frontend/src/i18n/messages/xx/reports.json
@@ -193,6 +193,7 @@
     "groupAll": "[XX-All accounts-XX]",
     "colGroup": "[XX-Group-XX]",
     "noAccountsForFilters": "[XX-No accounts match the current filters.-XX]",
+    "noAccountsOnDate": "[XX-None of your accounts existed on {date}.-XX]",
     "accountTypes": {
       "CHEQUING": "[XX-Chequing-XX]",
       "SAVINGS": "[XX-Savings-XX]",

--- a/frontend/src/i18n/messages/xx/reports.json
+++ b/frontend/src/i18n/messages/xx/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "[XX-Total Assets-XX]",
     "totalLiabilities": "[XX-Total Liabilities-XX]",
     "netWorth": "[XX-Net Worth-XX]",
-    "tableView": "[XX-Table view-XX]",
-    "chartView": "[XX-Chart view-XX]",
     "noData": "[XX-No data to display.-XX]",
     "noAccounts": "[XX-No accounts found.-XX]",
     "closed": "[XX-Closed-XX]",

--- a/frontend/src/i18n/messages/zh-CN/reports.json
+++ b/frontend/src/i18n/messages/zh-CN/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "总资产",
     "totalLiabilities": "总负债",
     "netWorth": "资产净值",
-    "tableView": "表格视图",
-    "chartView": "图表视图",
     "noData": "无数据可显示。",
     "noAccounts": "未找到账户。",
     "closed": "已关闭",
@@ -193,6 +191,7 @@
     "groupAll": "所有账户",
     "colGroup": "分组",
     "noAccountsForFilters": "没有账户符合当前筛选条件。",
+    "noAccountsOnDate": "{date} 时您的账户均不存在。",
     "accountTypes": {
       "CHEQUING": "支票账户",
       "SAVINGS": "储蓄账户",

--- a/frontend/src/i18n/messages/zh-TW/reports.json
+++ b/frontend/src/i18n/messages/zh-TW/reports.json
@@ -142,8 +142,6 @@
     "totalAssets": "總資產",
     "totalLiabilities": "總負債",
     "netWorth": "資產淨值",
-    "tableView": "表格檢視",
-    "chartView": "圖表檢視",
     "noData": "無資料可顯示。",
     "noAccounts": "找不到科目。",
     "closed": "已關閉",
@@ -193,6 +191,7 @@
     "groupAll": "所有科目",
     "colGroup": "分組",
     "noAccountsForFilters": "沒有科目符合目前的篩選條件。",
+    "noAccountsOnDate": "{date} 時您的科目均不存在。",
     "accountTypes": {
       "CHEQUING": "活期存款",
       "SAVINGS": "儲蓄存款",

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -327,6 +327,16 @@ export interface AccountBalanceAsOf {
   fxComplete: boolean;
   /** Read as `=== false`: an older backend sends no field, which is not "incomplete". */
   valuationComplete: boolean;
+  /**
+   * Whether the account existed at the as-of date.
+   *
+   * Its inception is an asset's acquisition date, or otherwise its first
+   * movement on either ledger; before that the account is not a thing with a
+   * balance, so it is left out of the report rather than shown at its opening
+   * balance. Read as `=== false`, never `!`: a backend that predates the field
+   * sends nothing, and absent means "no information", not "did not exist".
+   */
+  existsAsOf: boolean;
 }
 
 export interface AccountBalancesAsOfResponse {


### PR DESCRIPTION
## Linked discussion / issue

Closes #1198
Approved in: https://github.com/kenlasko/monize/issues/1198

## Summary

The point-in-time Account Balances report (issue #1198) could report a date before an account existed. An asset with "Date Acquired" set was shown at full value years before it was bought, and an account's opening balance -- the sum it *started* at -- was carried backwards past its first transaction to any earlier date.

The report now carries an account's inception: `date_acquired` for an asset that has one (the same date net worth already zeroes an asset before), otherwise its earliest non-VOID, non-child movement across `transactions` and `investment_transactions`. Before that date the row reports `existsAsOf: false` with `balance: 0`, and the client drops it from the rows, the groups, the chart and every total -- a zero row is a measured zero, and this is not a measurement.

Three decisions worth naming:

- An acquisition date wins over an earlier transaction rather than being minimised with it, and a *future* acquisition date is honoured as written -- both are the user's own statement about the asset.
- A first movement in the future is capped at today: the account's row is in `accounts` as the query runs, so it exists now whatever its ledger says about next week. The cap is not a waiver -- the account is still absent from earlier dates.
- An account with neither an acquisition date nor a movement has nothing dating its inception and is reported at every date; `created_at` is not a candidate, since it records when the row was typed in rather than when the account came to exist.

An investment pair (brokerage + linked cash) is one entity with two ledgers that can start on different days, so the client drops an entity only when every member is absent. `existsAsOf` is read as `=== false`, never `!`, so a response from a backend predating the field still renders.

`docs/specs/account-balances-as-of.md` sections 3-6 and 8 carry the definition, the numerical examples and the test obligations.

While in the toolbar, also fixed a real (not just cosmetic) height mismatch: the view toggle and Export button measured 36px against the fields' 42px, hidden by the outer row's `items-end` only lining up bottoms. Confirmed with a live render and pixel measurements. Root cause: the fields grid and the actions column were flex siblings under `items-end`, which never equalizes height, whereas the working sort-direction toggle only worked because it sits inside the fields' own CSS grid row where grid's default `align-items: stretch` does the equalizing for free. Restructured the outer container as a two-cell CSS grid so the same mechanism now applies to both, with no hardcoded height anywhere. Also replaced the hand-rolled table/chart icon-button pair with `ChartViewToggle`, the shared component 19 other report toolbars already use.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written with Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbuPKxEeP2fK1kzrYoNzU7)_