### PR TITLE
Fix restore attachment staging cleanup on pre-transaction failures

### DIFF
--- a/backend/src/backup/backup-attachment-transfer.service.ts
+++ b/backend/src/backup/backup-attachment-transfer.service.ts
@@ -306,7 +306,13 @@ export class BackupAttachmentTransferService {
           // The blob row stays and is inserted with everything else.
           continue;
         }
-        await this.attachmentStorage.save(attachmentId, carried);
+        if (!(await this.tryStageAttachmentObject(attachmentId, carried))) {
+          // The write failed: drop the row rather than halt the whole restore,
+          // and leave the objects already staged this run untouched -- they are
+          // referenced by attachments that are still coming back.
+          unrestorable.add(attachmentId);
+          continue;
+        }
         stagedKeys.push(attachmentId);
         // ...and its blob row must not be inserted: `attachment_blobs` is the
         // database provider's storage, and a row there for an externally stored
@@ -376,7 +382,10 @@ export class BackupAttachmentTransferService {
         }
       }
 
-      await this.attachmentStorage.save(attachmentId, bytes);
+      if (!(await this.tryStageAttachmentObject(attachmentId, bytes))) {
+        unrestorable.add(attachmentId);
+        continue;
+      }
       stagedKeys.push(attachmentId);
       sourceKeys.push(oldKey);
     }
@@ -457,6 +466,56 @@ export class BackupAttachmentTransferService {
       });
     }
     return owned;
+  }
+
+  /**
+   * Write one staged object, turning a provider failure into a dropped
+   * attachment rather than an aborted restore.
+   *
+   * A bare `attachmentStorage.save` that throws mid-loop does two bad things at
+   * once. It halts a restore that could have completed without this one
+   * attachment -- the ledger is the point, and refusing the whole thing over a
+   * receipt image is the wrong trade, the same one `stageAttachmentObjects`
+   * already makes for a missing or corrupt object. And the throw escapes
+   * `stageAttachmentObjects` before it can return `stagedKeys`, so every object
+   * already staged this run is orphaned: the caller never receives the list its
+   * `.catch` would have discarded.
+   *
+   * So a failed save is handled where it happens. The object under `key` is the
+   * one the restored metadata would have named, so a partial write there is
+   * exactly the leak this method exists to avoid -- delete it, best-effort, and
+   * swallow a delete error the way the post-commit sweep does. The caller reads
+   * the `false` and drops the row (counting it in `skipped`); the objects staged
+   * before this one stay, still referenced by attachments that are restoring.
+   *
+   * Returns whether the bytes are now reachable under `key`.
+   */
+  private async tryStageAttachmentObject(
+    key: string,
+    bytes: Buffer,
+  ): Promise<boolean> {
+    try {
+      await this.attachmentStorage.save(key, bytes);
+      return true;
+    } catch (error) {
+      this.logger.warn(
+        `Could not stage attachment object ${key} during restore; dropping the ` +
+          `attachment: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      try {
+        await this.attachmentStorage.delete(key);
+      } catch (deleteError) {
+        this.logger.warn(
+          `Could not remove partially staged attachment object ${key} after a ` +
+            `failed write: ${
+              deleteError instanceof Error
+                ? deleteError.message
+                : String(deleteError)
+            }`,
+        );
+      }
+      return false;
+    }
   }
 
   /** Best-effort removal of objects staged for a restore that then failed. */

--- a/backend/src/backup/backup-attachment-transfer.service.ts
+++ b/backend/src/backup/backup-attachment-transfer.service.ts
@@ -382,12 +382,22 @@ export class BackupAttachmentTransferService {
         }
       }
 
+      // `oldKey` was loaded and its bytes verified above, so it is a source this
+      // restore read from -- record it *before* attempting the destination
+      // write, not after. On a same-account restore `oldKey` is also the user's
+      // current, displaced object and the file's only copy of these bytes; if
+      // the copy then fails and this row is dropped (below), the post-commit
+      // sweep must still spare `oldKey` rather than delete the bytes and leave
+      // the backup unrestorable. `sourceKeys` is defined as exactly "keys this
+      // restore read from, never removed by the post-commit sweep", and reading
+      // is what already happened here.
+      sourceKeys.push(oldKey);
+
       if (!(await this.tryStageAttachmentObject(attachmentId, bytes))) {
         unrestorable.add(attachmentId);
         continue;
       }
       stagedKeys.push(attachmentId);
-      sourceKeys.push(oldKey);
     }
 
     if (unrestorable.size > 0) {

--- a/backend/src/backup/backup-restore.service.ts
+++ b/backend/src/backup/backup-restore.service.ts
@@ -168,21 +168,36 @@ export class BackupRestoreService {
         skipped: skippedAttachments,
       } = await this.attachments.stageAttachmentObjects(userId, data, idRemap);
 
-      // The keys this user's *current* attachments occupy, read before the delete
-      // because afterwards there is nothing left to read them from. They are
-      // deleted after a successful commit -- see `deleteDisplacedAttachmentObjects`
-      // for why that is the only safe moment and why the backup's own old keys are
-      // not in this set.
-      const displacedKeys =
-        await this.attachments.collectExternalAttachmentKeys(userId);
+      // Everything between staging and the restore transaction runs after
+      // objects have been written to the store but before the transaction's
+      // `.catch` (below) is wired to discard them. A throw here would therefore
+      // orphan every staged object: the failure never reaches the handler that
+      // cleans them up. So this region discards the staged objects itself before
+      // re-raising. The cleanup swallows its own delete failures, so it cannot
+      // mask the error that actually aborted the restore.
+      let displacedKeys: string[];
+      let unusableAiProviderKeys: number;
+      try {
+        // The keys this user's *current* attachments occupy, read before the
+        // delete because afterwards there is nothing left to read them from.
+        // They are deleted after a successful commit -- see
+        // `deleteDisplacedAttachmentObjects` for why that is the only safe
+        // moment and why the backup's own old keys are not in this set.
+        displacedKeys =
+          await this.attachments.collectExternalAttachmentKeys(userId);
 
-      // Re-encrypt every AI provider key the artifact carries in plaintext under
-      // *this* instance's AI_ENCRYPTION_KEY, before the transaction: the work is
-      // scrypt-bound (tens of milliseconds per key) and does not belong inside
-      // the transaction that holds every one of this user's rows. Rows an older
-      // artifact carries as foreign ciphertext are left alone and counted, which
-      // is the pre-transport behaviour and the only case still reportable.
-      const unusableAiProviderKeys = this.restoreAiProviderKeys(userId, data);
+        // Re-encrypt every AI provider key the artifact carries in plaintext
+        // under *this* instance's AI_ENCRYPTION_KEY, before the transaction: the
+        // work is scrypt-bound (tens of milliseconds per key) and does not
+        // belong inside the transaction that holds every one of this user's
+        // rows. Rows an older artifact carries as foreign ciphertext are left
+        // alone and counted, which is the pre-transport behaviour and the only
+        // case still reportable.
+        unusableAiProviderKeys = this.restoreAiProviderKeys(userId, data);
+      } catch (error) {
+        await this.attachments.discardStagedAttachmentObjects(stagedKeys);
+        throw error;
+      }
 
       const restored: Record<string, number> = {};
 

--- a/backend/src/backup/backup.service.spec.ts
+++ b/backend/src/backup/backup.service.spec.ts
@@ -2485,6 +2485,168 @@ describe("BackupService", () => {
       });
 
       /**
+       * Objects staged before the destructive transaction leak on failure
+       * (issue #1094).
+       *
+       * `stageAttachmentObjects` writes bytes to the store *before* the restore
+       * transaction opens, so anything that throws between the first successful
+       * save and the transaction's own `.catch` leaves those objects orphaned:
+       * bytes in the volume or bucket that no `transaction_attachments` row will
+       * ever name again. Two throw sites had no cleanup -- a later save failing
+       * inside the stage loop, and the displaced-key lookup that runs after
+       * staging returns.
+       */
+      describe("objects staged for a restore that fails before it commits", () => {
+        const OLD_ID_2 = "33333333-3333-4333-8333-333333333333";
+        const TX_ID_2 = "44444444-4444-4444-8444-444444444444";
+
+        /** Two own external attachments, both copied from their old key. */
+        function backupWithTwoLocalAttachments() {
+          const base = backupWithLocalAttachment();
+          return {
+            ...base,
+            transaction_attachments: [
+              ...base.transaction_attachments,
+              {
+                id: OLD_ID_2,
+                user_id: userId,
+                transaction_id: TX_ID_2,
+                filename: "receipt-2.pdf",
+                content_type: "application/pdf",
+                byte_size: BYTES.length,
+                sha256: SHA256,
+                storage_provider: "local",
+                storage_key: OLD_ID_2,
+              },
+            ],
+          };
+        }
+
+        let warnSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+          attachmentStorage.load.mockResolvedValue(BYTES);
+          // The server holds both rows, so both pass the ownership check and
+          // reach the copy.
+          ownedAttachments = [
+            {
+              id: OLD_ID,
+              storage_provider: "local",
+              byte_size: BYTES.length,
+              sha256: SHA256,
+            },
+            {
+              id: OLD_ID_2,
+              storage_provider: "local",
+              byte_size: BYTES.length,
+              sha256: SHA256,
+            },
+          ];
+          warnSpy = jest.spyOn(Logger.prototype, "warn").mockImplementation();
+        });
+
+        afterEach(() => warnSpy.mockRestore());
+
+        it("removes the failed object and finishes when a later save fails", async () => {
+          // First object stages; the second write fails. The restore must not
+          // abort over one attachment, and the failed write's own key -- which
+          // is exactly where the restored metadata would have pointed -- must be
+          // cleaned up so no orphan is left behind.
+          const savedKeys: string[] = [];
+          attachmentStorage.save.mockImplementation(async (key: string) => {
+            savedKeys.push(key);
+            if (savedKeys.length >= 2) throw new Error("EIO");
+          });
+
+          const result = await service.restoreData(
+            userId,
+            makeInput({
+              password: "test",
+              data: backupWithTwoLocalAttachments(),
+            }),
+          );
+
+          expect(savedKeys).toHaveLength(2);
+          // The object the failed save was writing is removed...
+          expect(attachmentStorage.delete).toHaveBeenCalledWith(savedKeys[1]);
+          // ...and only that one -- the first attachment is genuinely restored,
+          // so its object stays. No displaced keys exist in this fixture.
+          expect(attachmentStorage.delete).toHaveBeenCalledTimes(1);
+          // The restore completed, dropping the one attachment it could not stage.
+          expect(result.restored.transactionAttachments).toBe(1);
+          expect(result.skippedAttachments).toBe(1);
+        });
+
+        it("discards every staged object when the displaced-key lookup fails", async () => {
+          // One object stages, then the read of the user's current external keys
+          // throws -- a failure that escapes before the transaction's `.catch`
+          // could ever discard the staged object.
+          const savedKeys: string[] = [];
+          attachmentStorage.save.mockImplementation(async (key: string) => {
+            savedKeys.push(key);
+          });
+          mockQueryRunner.query.mockImplementation(
+            (sql: string, params?: unknown[]) => {
+              if (
+                String(sql).includes(
+                  "SELECT storage_key FROM transaction_attachments",
+                )
+              ) {
+                return Promise.reject(new Error("displaced-key read failed"));
+              }
+              return mockQueryHandler(sql, params);
+            },
+          );
+
+          await expect(
+            service.restoreData(
+              userId,
+              makeInput({
+                password: "test",
+                data: backupWithLocalAttachment(),
+              }),
+            ),
+          ).rejects.toThrow("displaced-key read failed");
+
+          expect(savedKeys).toHaveLength(1);
+          // The staged object is removed rather than left orphaned.
+          expect(attachmentStorage.delete).toHaveBeenCalledWith(savedKeys[0]);
+        });
+
+        it("lets the original error through when the cleanup delete also fails", async () => {
+          // A cleanup failure must not mask the error that actually aborted the
+          // restore: the user needs to see why it failed, not why the tidy-up
+          // did.
+          attachmentStorage.save.mockResolvedValue(undefined);
+          attachmentStorage.delete.mockRejectedValue(
+            new Error("delete failed"),
+          );
+          mockQueryRunner.query.mockImplementation(
+            (sql: string, params?: unknown[]) => {
+              if (
+                String(sql).includes(
+                  "SELECT storage_key FROM transaction_attachments",
+                )
+              ) {
+                return Promise.reject(new Error("displaced-key read failed"));
+              }
+              return mockQueryHandler(sql, params);
+            },
+          );
+
+          await expect(
+            service.restoreData(
+              userId,
+              makeInput({
+                password: "test",
+                data: backupWithLocalAttachment(),
+              }),
+            ),
+          ).rejects.toThrow("displaced-key read failed");
+        });
+      });
+
+      /**
        * The key in the uploaded file is attacker-controlled (F3RR-001).
        *
        * The destination used to come from `row.storage_key`, and a key the restore

--- a/backend/src/backup/backup.service.spec.ts
+++ b/backend/src/backup/backup.service.spec.ts
@@ -2547,11 +2547,27 @@ describe("BackupService", () => {
 
         afterEach(() => warnSpy.mockRestore());
 
-        it("removes the failed object and finishes when a later save fails", async () => {
-          // First object stages; the second write fails. The restore must not
-          // abort over one attachment, and the failed write's own key -- which
-          // is exactly where the restored metadata would have pointed -- must be
-          // cleaned up so no orphan is left behind.
+        /** Answers `collectExternalAttachmentKeys` with the user's current keys. */
+        const targetHolds = (...keys: string[]) => {
+          mockQueryRunner.query.mockImplementation(
+            (sql: string, params?: unknown[]) => {
+              if (
+                String(sql).includes(
+                  "SELECT storage_key FROM transaction_attachments",
+                )
+              ) {
+                return Promise.resolve(keys.map((k) => ({ storage_key: k })));
+              }
+              return mockQueryHandler(sql, params);
+            },
+          );
+        };
+
+        it("removes the failed object but keeps its legacy source when a later save fails", async () => {
+          // Same-account restore: the user currently holds both old objects, so
+          // both are displaced keys the post-commit sweep will consider deleting.
+          targetHolds(OLD_ID, OLD_ID_2);
+          // First object stages; the second write fails.
           const savedKeys: string[] = [];
           attachmentStorage.save.mockImplementation(async (key: string) => {
             savedKeys.push(key);
@@ -2567,20 +2583,27 @@ describe("BackupService", () => {
           );
 
           expect(savedKeys).toHaveLength(2);
-          // The object the failed save was writing is removed...
+          // The destination the failed save was writing -- exactly where the
+          // restored metadata would have pointed -- is cleaned up.
           expect(attachmentStorage.delete).toHaveBeenCalledWith(savedKeys[1]);
-          // ...and only that one -- the first attachment is genuinely restored,
-          // so its object stays. No displaced keys exist in this fixture.
+          // ...but the legacy *source* of that dropped attachment must survive.
+          // It is the file's only copy of those bytes, so deleting it because
+          // the copy did not complete would be permanent data loss and would
+          // make the backup unrestorable (the regression this guards). The
+          // succeeded attachment's source stays too.
+          expect(attachmentStorage.delete).not.toHaveBeenCalledWith(OLD_ID_2);
+          expect(attachmentStorage.delete).not.toHaveBeenCalledWith(OLD_ID);
+          // So the only deletion is the failed destination object.
           expect(attachmentStorage.delete).toHaveBeenCalledTimes(1);
           // The restore completed, dropping the one attachment it could not stage.
           expect(result.restored.transactionAttachments).toBe(1);
           expect(result.skippedAttachments).toBe(1);
         });
 
-        it("discards every staged object when the displaced-key lookup fails", async () => {
-          // One object stages, then the read of the user's current external keys
-          // throws -- a failure that escapes before the transaction's `.catch`
-          // could ever discard the staged object.
+        it("discards every staged object and deletes nothing when the displaced-key lookup fails", async () => {
+          // Two objects stage successfully, then the read of the user's current
+          // external keys throws -- a failure that escapes before the restore
+          // transaction's `.catch` could ever discard them.
           const savedKeys: string[] = [];
           attachmentStorage.save.mockImplementation(async (key: string) => {
             savedKeys.push(key);
@@ -2603,21 +2626,33 @@ describe("BackupService", () => {
               userId,
               makeInput({
                 password: "test",
-                data: backupWithLocalAttachment(),
+                data: backupWithTwoLocalAttachments(),
               }),
             ),
           ).rejects.toThrow("displaced-key read failed");
 
-          expect(savedKeys).toHaveLength(1);
-          // The staged object is removed rather than left orphaned.
+          // Both staged objects staged, and *both* are removed -- not just the
+          // last one.
+          expect(savedKeys).toHaveLength(2);
           expect(attachmentStorage.delete).toHaveBeenCalledWith(savedKeys[0]);
+          expect(attachmentStorage.delete).toHaveBeenCalledWith(savedKeys[1]);
+          expect(attachmentStorage.delete).toHaveBeenCalledTimes(2);
+          // The failure is before the destructive phase, so the user's data is
+          // untouched: nothing was deleted from the database.
+          const destructive = mockQueryRunner.query.mock.calls.filter(([sql]) =>
+            String(sql).includes("DELETE FROM"),
+          );
+          expect(destructive).toHaveLength(0);
         });
 
-        it("lets the original error through when the cleanup delete also fails", async () => {
+        it("lets the original error through, and logs, when the cleanup delete also fails", async () => {
           // A cleanup failure must not mask the error that actually aborted the
           // restore: the user needs to see why it failed, not why the tidy-up
-          // did.
-          attachmentStorage.save.mockResolvedValue(undefined);
+          // did. The failed cleanup is logged instead.
+          const savedKeys: string[] = [];
+          attachmentStorage.save.mockImplementation(async (key: string) => {
+            savedKeys.push(key);
+          });
           attachmentStorage.delete.mockRejectedValue(
             new Error("delete failed"),
           );
@@ -2643,6 +2678,20 @@ describe("BackupService", () => {
               }),
             ),
           ).rejects.toThrow("displaced-key read failed");
+
+          // The discard was attempted and its failure was logged rather than
+          // thrown -- which is what keeps it from masking the original error.
+          expect(attachmentStorage.delete).toHaveBeenCalledWith(savedKeys[0]);
+          const warnings = warnSpy.mock.calls.map(([message]) =>
+            String(message),
+          );
+          expect(
+            warnings.some((message) =>
+              message.includes(
+                `Could not remove staged attachment object ${savedKeys[0]}`,
+              ),
+            ),
+          ).toBe(true);
         });
       });
 

--- a/docs/backup-restore-contract.md
+++ b/docs/backup-restore-contract.md
@@ -340,6 +340,33 @@ The timing and the scope are both load-bearing:
   own receipt costs storage, while a backup that can only be restored once costs
   the receipt.
 
+**The objects the restore staged are discarded when it fails.** Staging writes
+bytes to the store *before* the destructive transaction, so a failure between
+the first successful write and the transaction's `.catch` would leave those
+objects orphaned — bytes no row will ever name again (issue #1094). Two throw
+sites are handled so it does not:
+
+- A destination write that fails *inside* the stage loop drops that one
+  attachment rather than aborting the whole restore (`tryStageAttachmentObject`):
+  it best-effort deletes the object it was writing, logs, and counts the row in
+  `skippedAttachments`. The objects already staged this run stay — they are
+  referenced by attachments still being restored. Crucially, a **legacy** row's
+  source object (`sourceKeys`) is recorded the moment its bytes are read and
+  verified, *before* the copy is attempted, so a failed copy on a same-account
+  restore never lets the post-commit sweep delete the file's only copy of those
+  bytes.
+- The displaced-key lookup and the AI-provider re-keying run after staging but
+  before the transaction's `.catch` is wired; a throw there discards every staged
+  object before re-raising. The discard swallows its own delete failures, so a
+  failed tidy-up cannot mask the error that aborted the restore.
+
+**Known gap:** this covers *catchable* failures only. A process crash or kill
+between staging and commit still orphans the staged objects, and there is no
+sweeper or recovery pass for them yet. It is a bounded storage cost, never a row
+promising bytes that are gone, so it is a leak to reclaim rather than a
+correctness hazard — tracked as a separate follow-up, not closed by the #1094
+fix.
+
 Operationally: for an artifact that carries its own bytes there is nothing to
 restore alongside it — that is the point. The sidecar directory or bucket only
 matters for an artifact produced before the bytes travelled, and for those it must


### PR DESCRIPTION
## Linked discussion / issue

Closes #1094
Approved in: https://github.com/kenlasko/monize/issues/1094

## Summary

Fixes external attachment objects being left orphaned when a restore fails after staging has begun but before the destructive database transaction is running.

For `local` and `s3` providers, attachment bytes are written to the object store before the restore transaction starts. Previously, a later staging failure or a failure while collecting displaced attachment keys could leave newly written objects with no database row referencing them.

This PR:

* routes external attachment writes through a best-effort staging helper;
* removes a partially written destination object when its `save` fails;
* drops only the affected attachment and reports it through `skippedAttachments` instead of aborting the entire restore;
* discards all successfully staged objects if pre-transaction work fails;
* preserves the original restore error if cleanup itself fails, while logging the cleanup failure;
* records verified legacy source objects before attempting the destination write, preventing the post-commit sweep from deleting the only remaining copy when a legacy copy fails.

Regression coverage verifies:

* a later destination write failure removes the failed destination while preserving legacy source objects;
* a displaced-key lookup failure removes every staged object and starts no destructive SQL;
* a cleanup failure is logged without masking the original failure.

The backup/restore contract also documents the remaining crash-recovery limitation: a process crash between staging and commit can still leave staged objects orphaned because there is currently no recovery sweeper.

## Checklist

* [x] An approved discussion or issue exists and is linked above.
* [x] This PR addresses a **single concern** (large work is split into a series).
* [x] New behavior has tests, and the existing suite passes.
* [x] All user-facing strings are translated for **every** locale (i18n parity).
* [x] No shared/core areas were refactored without prior agreement.
* [x] The branch is rebased on the latest `main`.
* [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

AI assistance was used to analyze issue #1094, implement the restore cleanup changes, identify and fix a legacy attachment data-loss edge case during review, and strengthen the regression tests. I reviewed the resulting changes and take responsibility for their correctness and scope.
