### PR TITLE
Fix override price updates to preserve investment total (#1148)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -314,14 +314,23 @@ price *or quantity* -- an override that set only the shares must not have them
 rescaled) or when the user has edited any field, keeping the base-schedule DCA
 refresh only for a price that is a creation-time snapshot.
 
-The two guards differ **because their fill precedence differs**, and the guard
-protects whichever field that precedence would clobber. The override editor's
-fill is quantity-first (it keeps the shares and recomputes the total), so it must
-not run once the user has typed a **total** -- but a quantity-only edit is safe
-and is left to auto-fill. The post dialog's refresh is total-first (it preserves
-the scheduled total and rescales the shares), so it must not run once the user
-has typed anything, because a typed **quantity** is what its precedence would
-overwrite. The fetch being asynchronous is what makes this matter: it can resolve
+Both fills are **total-first** (issue #1148): they preserve the amount invested
+and re-derive the share count, so the override editor's "use latest close" button,
+its keystroke path (`handleInvestmentPriceChange`), and the post dialog's refresh
+all book the same quantity and total for the same price -- the button used to be
+quantity-first and was the odd one out. The two guards **still differ**, not
+because the precedence differs but because the state each fill runs against does,
+and the guard protects the field the fill would clobber in that state. The
+override editor auto-fills only on an occurrence with no stored price, where the
+price field is empty and no total has been computed yet: with no total present the
+total-first fill degrades to deriving the total from the shares, which preserves a
+quantity-only edit -- so it blocks only once the user has typed a **total**
+(`userEditedTotal`), the one state where a total is present and the fill would
+rescale the quantity beside it. The post dialog's refresh carries the scheduled
+total, so a total is always present and the fill always rescales the shares --
+which is why it must block once the user has typed **anything**
+(`userEditedInvestment`), a typed quantity included. The fetch being asynchronous
+is what makes this matter: it can resolve
 *after* the dialog opens, and a value typed in the meantime (price still blank,
 so an "is the field empty" check alone lets the fill through) is the user's own
 instruction. The defect all of this prevents is a silent re-price: reopening an

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
@@ -767,10 +767,41 @@ describe('OverrideEditorDialog', () => {
       expect(Number(qtyInput.value)).toBeCloseTo(8.100446, 5);
     });
 
-    // Issue #1148: the button and the keystroke path must agree. Typing the same
-    // price the "use latest close" test clicks must book the same quantity and
-    // total -- both total-first now, so the divergence is gone.
+    // Issue #1148: the two affordances must agree. This runs BOTH paths from the
+    // same starting state (qty=10, price=100, total=1000) -- clicking "use latest
+    // close" and typing the same price -- and asserts they book the same quantity
+    // and total. Before the fix the button was quantity-first (10 / 1,234.5) and
+    // typing was total-first (8.1 / 1,000), so this comparison would have failed.
     it('books the same quantity and total whether the price is typed or applied', async () => {
+      const readFields = () => ({
+        qty: Number(
+          (screen.getByLabelText('Quantity (shares)') as HTMLInputElement).value,
+        ),
+        total: (screen.getByLabelText('Total Price') as HTMLInputElement).value.replace(
+          /,/g,
+          '',
+        ),
+      });
+
+      // Path A -- the button. A stored price (100) differing from the market close
+      // (123.45) is what makes "use latest close" appear.
+      mockGetSecurityPrices.mockResolvedValue([
+        { closePrice: '123.45', priceDate: '2025-02-20' },
+      ]);
+      const applied = render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Use latest close')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Use latest close'));
+      const appliedFields = readFields();
+      applied.unmount();
+
+      // Path B -- typing the same price into the same starting state.
       mockGetSecurityPrices.mockResolvedValue([]);
       render(
         <OverrideEditorDialog
@@ -778,18 +809,17 @@ describe('OverrideEditorDialog', () => {
           scheduledTransaction={investmentTransaction}
         />,
       );
-      const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
-      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
-      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
-      // Starting state: qty=10, price=100, total=1000 (seeded from the schedule).
-      expect(totalInput.value.replace(/,/g, '')).toBe('1000');
+      fireEvent.change(screen.getByLabelText('Price per share'), {
+        target: { value: '123.45' },
+      });
+      const typedFields = readFields();
 
-      fireEvent.change(priceInput, { target: { value: '123.45' } });
-
-      // Same figures the "use latest close" test asserts: total preserved,
-      // quantity re-derived.
-      expect(totalInput.value.replace(/,/g, '')).toBe('1000');
-      expect(Number(qtyInput.value)).toBeCloseTo(8.100446, 5);
+      // Same intent -> same booking, and concretely total-first: total held at
+      // 1000, quantity 1000 / 123.45 = 8.10044552.
+      expect(typedFields.total).toBe(appliedFields.total);
+      expect(typedFields.qty).toBeCloseTo(appliedFields.qty, 6);
+      expect(typedFields.total).toBe('1000');
+      expect(typedFields.qty).toBeCloseTo(8.100446, 5);
     });
 
     it('fills Price from the latest close when the schedule stored none', async () => {
@@ -923,10 +953,12 @@ describe('OverrideEditorDialog', () => {
       // slow connection the user enters a quantity and a total while
       // getSecurityPrices is still pending; the price field is still blank, so
       // the auto-fill gate's `investmentPrice === ''` holds. Without the
-      // userEditedTotal guard the arriving close fired writePrice, whose
-      // quantity-first branch re-derived the total to 10 * 123.45 = 1,234.5 --
-      // booking ~30% more money than the user entered. A deferred promise
-      // reproduces the timing. (No stored price, so the auto-fill is armed.)
+      // userEditedTotal guard the arriving close fired writePrice, and its
+      // total-first branch would keep the typed total (950) but re-derive the
+      // quantity from it -- 950 / 123.45 = ~7.6954 -- silently changing the 10
+      // shares the user entered. The guard blocks the fill entirely, so both the
+      // typed total and the typed quantity stand. A deferred promise reproduces
+      // the timing. (No stored price, so the auto-fill is armed.)
       let resolvePrices: (v: any) => void = () => {};
       mockGetSecurityPrices.mockReturnValue(
         new Promise((resolve) => {
@@ -964,10 +996,12 @@ describe('OverrideEditorDialog', () => {
     });
 
     it('auto-fills the price after a quantity-only edit, keeping the quantity', async () => {
-      // A quantity-only edit is safe to auto-fill: the fill is quantity-first, so
-      // the shares are preserved and the total simply follows. Blocking it (as an
-      // any-edit guard did) left the price empty and forced a manual click,
-      // diverging from ScheduledTransactionForm on identical input.
+      // A quantity-only edit is safe to auto-fill: the fill is total-first, but
+      // with no total on the field yet it falls into the fallback branch that
+      // derives the total from the shares, so the shares are preserved and the
+      // total simply follows. Blocking it (as an any-edit guard did) left the
+      // price empty and forced a manual click, diverging from
+      // ScheduledTransactionForm on identical input.
       let resolvePrices: (v: any) => void = () => {};
       mockGetSecurityPrices.mockReturnValue(
         new Promise((resolve) => {

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
@@ -738,6 +738,10 @@ describe('OverrideEditorDialog', () => {
       );
     });
 
+    // Total-first (issue #1148): "use latest close" now keeps the scheduled total
+    // and re-derives the quantity, exactly as typing the same price does. It used
+    // to keep the quantity (10) and recompute the total to 1,234.5 -- the divergent
+    // behaviour the issue is closing.
     it('applies the latest close only when the user asks for it', async () => {
       mockGetSecurityPrices.mockResolvedValue([
         { closePrice: '123.45', priceDate: '2025-02-20' },
@@ -755,9 +759,37 @@ describe('OverrideEditorDialog', () => {
 
       const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
       expect(Number(priceInput.value)).toBeCloseTo(123.45, 6);
-      // The total follows the applied price, not the old one.
+      // The scheduled total stands; the quantity follows the applied price.
       const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
-      expect(totalInput.value).toBe('1,234.5');
+      expect(totalInput.value.replace(/,/g, '')).toBe('1000');
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      // 1000 / 123.45 = 8.10044552 shares.
+      expect(Number(qtyInput.value)).toBeCloseTo(8.100446, 5);
+    });
+
+    // Issue #1148: the button and the keystroke path must agree. Typing the same
+    // price the "use latest close" test clicks must book the same quantity and
+    // total -- both total-first now, so the divergence is gone.
+    it('books the same quantity and total whether the price is typed or applied', async () => {
+      mockGetSecurityPrices.mockResolvedValue([]);
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      // Starting state: qty=10, price=100, total=1000 (seeded from the schedule).
+      expect(totalInput.value.replace(/,/g, '')).toBe('1000');
+
+      fireEvent.change(priceInput, { target: { value: '123.45' } });
+
+      // Same figures the "use latest close" test asserts: total preserved,
+      // quantity re-derived.
+      expect(totalInput.value.replace(/,/g, '')).toBe('1000');
+      expect(Number(qtyInput.value)).toBeCloseTo(8.100446, 5);
     });
 
     it('fills Price from the latest close when the schedule stored none', async () => {

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
@@ -103,11 +103,13 @@ export function OverrideEditorDialog({
   const [priceFromOccurrence, setPriceFromOccurrence] = useState(false);
   const [priceCameFromMarket, setPriceCameFromMarket] = useState(false);
   // True once the user types into the Total field after the dialog opens. The
-  // latest close is fetched asynchronously and the auto-fill is quantity-first
-  // (writePrice keeps the shares and recomputes the total), so it would clobber a
-  // total the user typed while the fetch was still in flight. A quantity-only
-  // edit is safe to auto-fill -- the shares are preserved and the total follows --
-  // so only a typed total blocks it; a typed price already blocks via the
+  // latest close is fetched asynchronously and the auto-fill is total-first
+  // (writePrice preserves the total and re-derives the quantity, issue #1148), so
+  // a total the user typed while the fetch was in flight is present when the close
+  // lands and would have the quantity rescaled beside it. A quantity-only edit is
+  // safe to auto-fill -- with no total on the field the total-first fill degrades
+  // to deriving the total from the shares, so the quantity is preserved -- so only
+  // a typed total blocks it; a typed price already blocks via the
   // `investmentPrice === ''` gate.
   const [userEditedTotal, setUserEditedTotal] = useState(false);
 
@@ -268,13 +270,14 @@ export function OverrideEditorDialog({
    * "use latest close" button -- so the value always came from the market and
    * `priceCameFromMarket` is set unconditionally.
    *
-   * Precedence here is quantity-first: a stated quantity keeps its shares and
-   * the total follows, because clicking "use latest close" means "re-price the
-   * shares I am buying". Only when no quantity is entered does a stated total
-   * derive the quantity, so the click never leaves an inconsistent
-   * price/total/empty-quantity triple. This deliberately differs from the
-   * keystroke path (`handleInvestmentPriceChange`, total-first); reconciling the
-   * two is a product decision tracked separately, not a claim made here.
+   * Precedence here is total-first (issue #1148), matching the keystroke path
+   * (`handleInvestmentPriceChange`) and the posting dialog's market refresh: a
+   * stated total keeps the amount invested and the share count follows, so
+   * clicking "use latest close" and typing the same price book the same quantity
+   * and total. Only when no total is present does a stated quantity derive the
+   * total -- the auto-fill's own case, where the price field is empty so no total
+   * has been computed yet, which keeps a quantity-only edit safe to auto-fill.
+   * Either way the click never leaves an inconsistent price/total/quantity triple.
    *
    * Once a market price is written, the field no longer holds the stored
    * instruction, so `hasStoredPrice` drops -- the provenance note must not
@@ -285,13 +288,15 @@ export function OverrideEditorDialog({
     setInvestmentPrice(rounded);
     setPriceCameFromMarket(true);
     setHasStoredPrice(false);
-    if (investmentQuantity !== '' && Number(investmentQuantity) > 0) {
-      setInvestmentTotalValue(
-        totalFromQuantity(Number(investmentQuantity), rounded, investmentSign, investmentCommission),
-      );
-    } else if (investmentTotalValue !== '') {
+    if (investmentTotalValue !== '') {
+      // Total-first: preserve the amount invested, re-derive the quantity.
       setInvestmentQuantity(
         quantityFromTotal(Number(investmentTotalValue), rounded, investmentSign, investmentCommission),
+      );
+    } else if (investmentQuantity !== '' && Number(investmentQuantity) > 0) {
+      // No total to preserve (the auto-fill case) -- derive it from the quantity.
+      setInvestmentTotalValue(
+        totalFromQuantity(Number(investmentQuantity), rounded, investmentSign, investmentCommission),
       );
     }
   };
@@ -305,12 +310,14 @@ export function OverrideEditorDialog({
   // pattern to avoid violating react-hooks/set-state-in-effect.
   //
   // `!userEditedTotal` is the second half of that guard: the fetch is
-  // asynchronous, and the fill is quantity-first (writePrice keeps the shares and
-  // recomputes the total), so a total the user typed while it was in flight would
-  // be silently re-derived from the arriving close -- the typed-before-fetch race
-  // PostTransactionDialog guards on its side. A quantity-only edit does not block
-  // it: the shares are preserved and the total simply follows, so filling the
-  // price is safe and matches ScheduledTransactionForm on identical input.
+  // asynchronous, and the fill is total-first (writePrice preserves the total and
+  // re-derives the quantity, issue #1148). A total the user typed while the fetch
+  // was in flight is present when the close lands, so the fill would rescale the
+  // quantity beside it -- the typed-before-fetch race PostTransactionDialog guards
+  // on its side. A quantity-only edit does not block it: with no total on the
+  // field the total-first fill degrades to deriving the total from the shares, so
+  // the typed quantity is preserved and filling the price matches
+  // ScheduledTransactionForm on identical input.
   const [lastSeenMarketPrice, setLastSeenMarketPrice] = useState<number | null>(null);
   if (isOpen && marketPrice !== lastSeenMarketPrice) {
     setLastSeenMarketPrice(marketPrice);


### PR DESCRIPTION
## Linked discussion / issue

Closes #1148
Approved in: https://github.com/kenlasko/monize/issues/1148

## Summary

Make investment price updates in `OverrideEditorDialog` consistently **total-first**.

Previously, applying **Use latest close** preserved the share quantity and recomputed the total, while typing the same price preserved the total and recomputed the quantity. This meant the same price could book a different investment depending on how it was entered.

This PR changes `writePrice` to preserve the investment total and re-derive the quantity, matching the manual price-entry path and `PostTransactionDialog`.

It also:

* updates the related documentation and comments to describe the total-first invariant;
* updates the existing latest-close regression test;
* adds a parity regression test that runs both the button and typed-price paths from the same starting state and verifies they produce the same quantity and total.

No user-facing strings were added or changed.

## Checklist

* [x] An approved discussion or issue exists and is linked above.
* [x] This PR addresses a **single concern** (large work is split into a series).
* [x] New behavior has tests, and the existing suite passes.
* [x] All user-facing strings are translated for **every** locale (i18n parity). No user-facing strings were changed.
* [x] No shared/core areas were refactored without prior agreement.
* [x] The branch is rebased on the latest `main`.
* [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Claude Code was used to implement the change, update tests and documentation, and run verification. ChatGPT was used for code review and follow-up review. I reviewed the resulting changes and own their correctness.
