### PR TITLE
Guard raw SQL column names against schema.sql

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -127,6 +127,31 @@ transactionDate: string;
 
 **Raw selects bypass both transformers.** `getRawOne`/`getRawMany` return driver values, not entity-hydrated ones, so a DATE column comes back as a JS `Date` and a numeric as a string -- regardless of the transformer on the entity. Select a DATE as text in SQL (`TO_CHAR(col, 'YYYY-MM-DD')`) and pass a numeric through `Number()` before it reaches a DTO that declares `string`/`number`. `main.ts` installs a global DATE string parser, which hides the DATE half of this in the running server but not in tests, jobs, or any other process -- so do not rely on it. `payee-detail.service.ts` is the worked example; its `test/payee-detail.e2e-spec.ts` is what caught it, because a unit spec with mocked query builders cannot.
 
+**A hand-written column name is checked by nobody -- so a scan checks it.** A
+mocked `manager.query` records the string and resolves, which makes every raw
+statement's column names untested by construction. `AutoBackupService`'s claim
+ended `RETURNING id`, `auto_backup_settings` has no `id` (its primary key is
+`user_id`), and the spec beside it asserted
+`expect(sql).toContain("RETURNING id")` -- so the mistake was not merely
+uncaught, it was pinned. In production every hourly sweep raised
+`column "id" does not exist` (42703) and no user's automatic backup ran.
+`src/common/db/raw-sql-columns.spec.ts` now checks every `RETURNING` list,
+`INSERT` column list and `UPDATE ... SET` target in `src/` against
+`database/schema.sql`, with the grammar in `raw-sql-columns.ts` unit-tested
+separately. Assert the *column*, not the substring: a mock cannot tell a real
+column from a plausible one.
+
+**A per-user loop in a cron isolates each user, including the steps before the
+work starts.** The auto-backup sweep's `try` began *below* the claim, so an
+error while deciding whether to run -- the maintenance pre-check, the claim's
+own `UPDATE` -- left the whole handler and every remaining user was skipped,
+with nothing recorded as failed. Wrap the entire per-user body, record the
+failure on the row so the surface that shows a last-run status tells the truth,
+and record it through a path that cannot itself throw (the outcome write is a
+database call, and whatever broke the work can break the recording of it).
+`enrollManagedUsers` in the same file already had the rule; the loop below it
+did not.
+
 ## DTO Conventions
 
 ### An optional field with a format validator needs `@ValidateIf`, not just `@IsOptional`

--- a/backend/src/backup/auto-backup.service.spec.ts
+++ b/backend/src/backup/auto-backup.service.spec.ts
@@ -28,6 +28,11 @@ import {
   userMaintenanceProvider,
   type UserMaintenanceMock,
 } from "../test-helpers/job-claim-testing";
+import {
+  columnProblem,
+  parseSchemaColumns,
+  statementClaims,
+} from "../common/db/raw-sql-columns";
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
@@ -154,8 +159,11 @@ describe("AutoBackupService", () => {
     // `UPDATE ... RETURNING`, which the pg driver answers as
     // `[rows, rowCount]`. Winning by default preserves the behaviour every test
     // written before the claim existed expects; the loser path is asserted
-    // explicitly below.
-    scoped.manager.query.mockResolvedValue([[{ id: "settings-1" }], 1]);
+    // explicitly below. The returned row carries `user_id` because that is what
+    // the statement returns and what the table has -- a fixture keyed `id`
+    // described a column `auto_backup_settings` does not define, which is the
+    // shape the outage was in.
+    scoped.manager.query.mockResolvedValue([[{ user_id: userId }], 1]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -1470,8 +1478,127 @@ describe("AutoBackupService", () => {
         )!;
         expect(sql).toContain("next_backup_at <= $3");
         expect(sql).toContain("enabled = true");
-        expect(sql).toContain("RETURNING id");
         expect(params).toHaveLength(3);
+      });
+
+      it("returns a column this table actually has", async () => {
+        // The regression: the claim ended `RETURNING id`, and
+        // `auto_backup_settings` has no `id` -- `user_id` is its primary key.
+        // Postgres raised 42703 out of `claimDueBackup`, which runs before the
+        // per-user `try`, so the whole sweep aborted on the first due user and
+        // nothing was even recorded as failed.
+        //
+        // This assertion is deliberately not `toContain("RETURNING user_id")`:
+        // the previous one was `toContain("RETURNING id")`, and a mocked
+        // `manager.query` cannot tell a real column from a plausible one. The
+        // column is checked against `database/schema.sql`, and the tree-wide
+        // version of the same check is
+        // `backend/src/common/db/raw-sql-columns.spec.ts`.
+        const schema = parseSchemaColumns(
+          readFileSync(
+            join(__dirname, "..", "..", "..", "database", "schema.sql"),
+            "utf8",
+          ),
+        );
+        mockSettingsRepo.find.mockResolvedValue([dueSettings()]);
+        await service.handleAutoBackupCron();
+        const claimSql = String(
+          scoped.manager.query.mock.calls.find((call) =>
+            String(call[0]).includes("UPDATE auto_backup_settings"),
+          )![0],
+        );
+        const claims = statementClaims(claimSql).flatMap(
+          (statement) => statement.claims,
+        );
+        expect(claims).toContainEqual({
+          table: "auto_backup_settings",
+          column: "user_id",
+          clause: "RETURNING",
+        });
+        expect(
+          claims
+            .map((claim) => columnProblem(claim, schema))
+            .filter((problem) => problem !== null),
+        ).toEqual([]);
+      });
+
+      it("runs the users after one whose claim throws", async () => {
+        // The regression this pairs with: `RETURNING id` raised 42703 from
+        // inside `claimDueBackup`, which sat *outside* the per-user try, so the
+        // throw left `handleAutoBackupCron` entirely. Every user after the
+        // first due one was skipped, hour after hour, and none of them was even
+        // recorded as failed -- the settings page showed the last successful
+        // run from before the deploy.
+        mockSettingsRepo.find.mockResolvedValue([
+          dueSettings(),
+          createSettings({
+            userId: otherUserId,
+            folderPath: root,
+            enabled: true,
+            nextBackupAt: new Date(Date.now() - 3600000),
+          }),
+        ]);
+        scoped.manager.query
+          .mockRejectedValueOnce(new Error('column "id" does not exist'))
+          .mockResolvedValue([[{ user_id: otherUserId }], 1]);
+
+        await service.handleAutoBackupCron();
+
+        expect(await listBackups(folderFor())).toHaveLength(0);
+        expect(await listBackups(folderFor(otherUserId))).toHaveLength(1);
+        // And the user whose window failed is told so, rather than being left
+        // showing the last run that worked.
+        expect(updateBuilder.set).toHaveBeenCalledWith(
+          expect.objectContaining({
+            lastBackupStatus: "failed",
+            lastBackupError: expect.stringContaining("does not exist"),
+          }),
+        );
+      });
+
+      it("runs the users after one whose maintenance pre-check throws", async () => {
+        // The pre-check was outside the try as well, and it reads two other
+        // tables -- so the same one-user-ends-the-sweep failure was reachable
+        // without any backup being attempted at all.
+        mockSettingsRepo.find.mockResolvedValue([
+          dueSettings(),
+          createSettings({
+            userId: otherUserId,
+            folderPath: root,
+            enabled: true,
+            nextBackupAt: new Date(Date.now() - 3600000),
+          }),
+        ]);
+        maintenance.isUnderMaintenance
+          .mockRejectedValueOnce(new Error("db down"))
+          .mockResolvedValue(false);
+
+        await service.handleAutoBackupCron();
+
+        expect(await listBackups(folderFor(otherUserId))).toHaveLength(1);
+      });
+
+      it("continues when recording the failure fails too", async () => {
+        // The outcome write is a database call, so whatever broke the backup can
+        // break the recording of it. Throwing from the recorder would put the
+        // sweep back where it started.
+        mockSettingsRepo.find.mockResolvedValue([
+          dueSettings(),
+          createSettings({
+            userId: otherUserId,
+            folderPath: root,
+            enabled: true,
+            nextBackupAt: new Date(Date.now() - 3600000),
+          }),
+        ]);
+        scoped.manager.query
+          .mockRejectedValueOnce(new Error("claim failed"))
+          .mockResolvedValue([[{ user_id: otherUserId }], 1]);
+        updateBuilder.execute.mockRejectedValueOnce(new Error("write failed"));
+
+        await expect(service.handleAutoBackupCron()).resolves.toBeUndefined();
+
+        expect(await listBackups(folderFor(otherUserId))).toHaveLength(1);
       });
 
       it("exports nothing when another replica claimed the window", async () => {

--- a/backend/src/backup/auto-backup.service.ts
+++ b/backend/src/backup/auto-backup.service.ts
@@ -727,6 +727,13 @@ export class AutoBackupService {
    * fact. Advancing *before* the export also means a crash mid-backup skips this
    * window rather than retrying forever, which is the behaviour the failure path
    * already had.
+   *
+   * `RETURNING user_id` because that column is this table's primary key -- there
+   * is no `id`. `RETURNING id` parses fine in a mocked-`query` unit test and
+   * fails at runtime with `column "id" does not exist` (42703), which took the
+   * claim, and therefore every automatic backup, down for every user. The
+   * columns any raw SQL in `src/` names are now checked against
+   * `database/schema.sql` by `backend/src/common/db/raw-sql-columns.spec.ts`.
    */
   private async claimDueBackup(
     settings: AutoBackupSettings,
@@ -742,7 +749,7 @@ export class AutoBackupService {
               AND enabled = true
               AND next_backup_at IS NOT NULL
               AND next_backup_at <= $3
-            RETURNING id`,
+            RETURNING user_id`,
           [nextBackupAt, settings.userId, now],
         ),
       ),
@@ -802,99 +809,140 @@ export class AutoBackupService {
     this.logger.log(`Auto-backup cron: ${dueSettings.length} backup(s) due`);
 
     for (const settings of dueSettings) {
-      const nextBackupAt = this.calculateNextBackupAt(
-        settings.frequency as AutoBackupFrequency,
-        settings.backupTime,
-        settings.timezone,
-        now,
-      );
-
-      // Do not start a backup of a dataset that is already mid-replacement. A
-      // `.mny` import with "start fresh" commits its wipe and then writes rows
-      // for minutes, so an hourly backup landing in that window would export the
-      // empty dataset, save it as today's file, and enforce retention --
-      // rotating the last good backup out to make room for one containing
-      // nothing. Skipping without claiming leaves `next_backup_at` in the past,
-      // so the next hour retries (audit DR-04-02).
-      //
-      // This is a pre-check and only a pre-check: `isUnderMaintenance` is
-      // documented as a hint, and maintenance can still begin between this read
-      // and the export snapshot below. It narrows the window rather than closing
-      // it; closing it needs backup admission and maintenance acquisition to
-      // share one lease, which is the outstanding HIGH item in the PR
-      // description.
-      //
-      // Runs under the user's context like the claim and the outcome write: it
-      // reaches `import_jobs` and `job_claims` through `withScopedDb`, which
-      // throws without an ambient identity. The `withSystemContext` fan-out
-      // above covers only the cross-user settings read.
-      const underMaintenance = await withUserContext(settings.userId, () =>
-        this.maintenance.isUnderMaintenance(settings.userId),
-      );
-      if (underMaintenance) {
-        this.logger.log(
-          `Auto-backup deferred for user ${settings.userId}: their data is being replaced`,
-        );
-        continue;
-      }
-
-      const claimed = await this.claimDueBackup(settings, now, nextBackupAt);
-      if (!claimed) {
-        // Either another replica took this window, or the user disabled or
-        // rescheduled the backup after this sweep read its snapshot. Both mean
-        // "not ours to run".
-        continue;
-      }
-
+      // Everything about one user, including the steps *before* the claim,
+      // happens inside this try. It used to start below the claim, so an error
+      // raised while deciding whether to run -- the maintenance pre-check, or
+      // the claim's own UPDATE -- escaped the loop and ended the sweep for
+      // every user after this one, with nothing recorded as failed either. That
+      // is precisely how `RETURNING id` against a table with no `id` column
+      // turned one bad statement into "no automatic backups at all". The same
+      // rule is already written out in `enrollManagedUsers` below: one user's
+      // row failing must not stop the others.
       try {
-        settings.folderPath = this.resolveFolderPath(settings.folderPath);
-        const userFolder = await this.resolveUserFolder(
-          settings.userId,
-          settings.folderPath,
-        );
-        const timezone = settings.timezone || "UTC";
-        // RLS (task C2): the export reads this user's entire dataset, and the
-        // settings write below is that user's row -- both under a user context.
-        const { filename, report } = await withUserContext(
-          settings.userId,
-          () => this.exportToFile(settings.userId, userFolder, timezone),
-        );
-        // Promotion and retention run only for a complete artifact; a partial is
-        // written but never allowed to displace a complete copy (F3R7-001).
-        await this.applyBackupOutcome(
-          settings,
-          userFolder,
-          filename,
-          report,
-          timezone,
-        );
-
-        // applyBackupOutcome set lastBackupStatus/Error to reflect a complete
-        // ("success") or incomplete ("partial") artifact; record exactly that,
-        // never a hardcoded success, so a partial backup is not persisted as a
-        // full one (F3R7-001). The write is the targeted outcome UPDATE, not a
-        // whole-row save, so it cannot revert a concurrent settings edit.
-        await this.recordBackupOutcome(
-          settings.userId,
-          now,
-          report.complete ? "success" : "partial",
-          settings.lastBackupError,
-        );
-
-        this.logger.log(
-          `Auto-backup ${report.complete ? "completed" : "written (partial)"} for user ${settings.userId}: ${filename}`,
-        );
+        await this.runDueBackup(settings, now);
       } catch (error) {
         this.logger.error(
           `Auto-backup failed for user ${settings.userId}: ${error.message}`,
         );
-        await this.recordBackupOutcome(
-          settings.userId,
-          now,
-          "failed",
-          String(error.message).slice(0, 1024),
-        );
+        await this.recordFailureQuietly(settings.userId, now, error);
       }
+    }
+  }
+
+  /**
+   * One user's window: decide whether to run it, claim it, export it, record it.
+   *
+   * Throws rather than swallowing, so `handleAutoBackupCron` -- which owns the
+   * "one user must not take out the sweep" rule -- is the only place that
+   * decides what a failure means.
+   */
+  private async runDueBackup(
+    settings: AutoBackupSettings,
+    now: Date,
+  ): Promise<void> {
+    const nextBackupAt = this.calculateNextBackupAt(
+      settings.frequency as AutoBackupFrequency,
+      settings.backupTime,
+      settings.timezone,
+      now,
+    );
+
+    // Do not start a backup of a dataset that is already mid-replacement. A
+    // `.mny` import with "start fresh" commits its wipe and then writes rows
+    // for minutes, so an hourly backup landing in that window would export the
+    // empty dataset, save it as today's file, and enforce retention --
+    // rotating the last good backup out to make room for one containing
+    // nothing. Skipping without claiming leaves `next_backup_at` in the past,
+    // so the next hour retries (audit DR-04-02).
+    //
+    // This is a pre-check and only a pre-check: `isUnderMaintenance` is
+    // documented as a hint, and maintenance can still begin between this read
+    // and the export snapshot below. It narrows the window rather than closing
+    // it; closing it needs backup admission and maintenance acquisition to
+    // share one lease, which is the outstanding HIGH item in the PR
+    // description.
+    //
+    // Runs under the user's context like the claim and the outcome write: it
+    // reaches `import_jobs` and `job_claims` through `withScopedDb`, which
+    // throws without an ambient identity. The `withSystemContext` fan-out
+    // above covers only the cross-user settings read.
+    const underMaintenance = await withUserContext(settings.userId, () =>
+      this.maintenance.isUnderMaintenance(settings.userId),
+    );
+    if (underMaintenance) {
+      this.logger.log(
+        `Auto-backup deferred for user ${settings.userId}: their data is being replaced`,
+      );
+      return;
+    }
+
+    const claimed = await this.claimDueBackup(settings, now, nextBackupAt);
+    if (!claimed) {
+      // Either another replica took this window, or the user disabled or
+      // rescheduled the backup after this sweep read its snapshot. Both mean
+      // "not ours to run".
+      return;
+    }
+
+    settings.folderPath = this.resolveFolderPath(settings.folderPath);
+    const userFolder = await this.resolveUserFolder(
+      settings.userId,
+      settings.folderPath,
+    );
+    const timezone = settings.timezone || "UTC";
+    // RLS (task C2): the export reads this user's entire dataset, and the
+    // settings write below is that user's row -- both under a user context.
+    const { filename, report } = await withUserContext(settings.userId, () =>
+      this.exportToFile(settings.userId, userFolder, timezone),
+    );
+    // Promotion and retention run only for a complete artifact; a partial is
+    // written but never allowed to displace a complete copy (F3R7-001).
+    await this.applyBackupOutcome(
+      settings,
+      userFolder,
+      filename,
+      report,
+      timezone,
+    );
+
+    // applyBackupOutcome set lastBackupStatus/Error to reflect a complete
+    // ("success") or incomplete ("partial") artifact; record exactly that,
+    // never a hardcoded success, so a partial backup is not persisted as a
+    // full one (F3R7-001). The write is the targeted outcome UPDATE, not a
+    // whole-row save, so it cannot revert a concurrent settings edit.
+    await this.recordBackupOutcome(
+      settings.userId,
+      now,
+      report.complete ? "success" : "partial",
+      settings.lastBackupError,
+    );
+
+    this.logger.log(
+      `Auto-backup ${report.complete ? "completed" : "written (partial)"} for user ${settings.userId}: ${filename}`,
+    );
+  }
+
+  /**
+   * Record a failed window without letting the recording become the failure.
+   *
+   * The outcome write is itself a database call, so the errors most likely to
+   * bring the export down -- the connection, the pool, a broken statement --
+   * are exactly the ones that can also break the write recording them. Throwing
+   * here would put the sweep back where it started: one user's failure ending
+   * everybody else's backups.
+   */
+  private async recordFailureQuietly(
+    userId: string,
+    at: Date,
+    cause: unknown,
+  ): Promise<void> {
+    const message = String((cause as Error)?.message ?? cause).slice(0, 1024);
+    try {
+      await this.recordBackupOutcome(userId, at, "failed", message);
+    } catch (error) {
+      this.logger.error(
+        `Auto-backup could not record the failure for user ${userId}: ${error.message}`,
+      );
     }
   }
 

--- a/backend/src/common/db/raw-sql-columns.spec.ts
+++ b/backend/src/common/db/raw-sql-columns.spec.ts
@@ -1,0 +1,300 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { globSync } from "glob";
+
+import {
+  ColumnClaim,
+  columnProblem,
+  extractStringLiterals,
+  parseSchemaColumns,
+  splitTopLevel,
+  statementClaims,
+  stripOutputLabel,
+} from "./raw-sql-columns";
+
+/**
+ * Every column named by raw SQL in `src/` exists in `database/schema.sql`.
+ *
+ * The regression: `AutoBackupService.claimDueBackup` ended its claim with
+ * `RETURNING id`, and `auto_backup_settings` has no `id` -- `user_id` is its
+ * primary key. Its unit tests asserted the string (`expect(sql).toContain(
+ * "RETURNING id")`) against a mocked `manager.query`, so the mistake was not
+ * merely uncaught, it was pinned in place. In production every hourly sweep
+ * threw `column "id" does not exist` (42703) out of the claim, which sits
+ * before the per-user `try`, so no user's backup ran and none was recorded as
+ * failed either.
+ *
+ * A mocked query cannot demonstrate a property of the schema, the same way a
+ * mocked filesystem cannot demonstrate a property of a directory
+ * (`backend/CLAUDE.md`). This scan can: it reads the schema and the source, and
+ * needs no database.
+ *
+ * It is deliberately a scan rather than a case for that one query -- the class
+ * is "a hand-written column name in a hand-written statement", and there are
+ * ~50 such statements across imports, sweepers, job claims and seeders. The
+ * grammar lives in `raw-sql-columns.ts` and is unit-tested below, so widening
+ * it is a reviewed change rather than a silent one.
+ */
+const SRC = join(__dirname, "..", "..");
+const SCHEMA_PATH = join(SRC, "..", "..", "database", "schema.sql");
+
+function sourceFiles(): string[] {
+  return globSync("**/*.ts", {
+    cwd: SRC,
+    absolute: true,
+    ignore: ["**/*.spec.ts", "**/*.d.ts", "**/node_modules/**"],
+  });
+}
+
+const relative = (file: string): string =>
+  file.slice(SRC.length + 1).replace(/\\/g, "/");
+
+type FoundClaim = ColumnClaim & { file: string };
+
+function scanTree(): FoundClaim[] {
+  const found: FoundClaim[] = [];
+  for (const file of sourceFiles()) {
+    const source = readFileSync(file, "utf8");
+    // Cheap pre-filter: only files that write SQL can make a claim.
+    if (!/\b(?:UPDATE|INSERT\s+INTO|DELETE\s+FROM)\s/i.test(source)) continue;
+    for (const literal of extractStringLiterals(source)) {
+      for (const statement of statementClaims(literal)) {
+        for (const claim of statement.claims) {
+          found.push({ file: relative(file), ...claim });
+        }
+      }
+    }
+  }
+  return found;
+}
+
+describe("raw SQL column names", () => {
+  const schema = parseSchemaColumns(readFileSync(SCHEMA_PATH, "utf8"));
+  const claims = scanTree();
+
+  describe("the scan sees what it claims to see", () => {
+    // Anti-vacuity. A grammar that quietly matched nothing would make the
+    // assertion below trivially green -- which is exactly how the original
+    // mistake survived its own test.
+    it("parses the schema into tables and columns", () => {
+      expect(schema.size).toBeGreaterThan(50);
+      expect([...(schema.get("auto_backup_settings") ?? [])]).toEqual(
+        expect.arrayContaining(["user_id", "enabled", "next_backup_at"]),
+      );
+      // The table the regression was on genuinely has no `id`.
+      expect(schema.get("auto_backup_settings")?.has("id")).toBe(false);
+      expect(schema.get("transactions")?.has("id")).toBe(true);
+    });
+
+    it("finds the statements the tree is known to contain", () => {
+      expect(claims.length).toBeGreaterThan(100);
+      const files = new Set(claims.map((claim) => claim.file));
+      // One of each shape the scanner is meant to reach: a cron claim, a job
+      // lease, a sweeper, and a seeder's INSERT column lists.
+      expect(files).toContain("backup/auto-backup.service.ts");
+      expect(files).toContain("common/jobs/job-claim.service.ts");
+      expect(files).toContain(
+        "attachments/attachment-orphan-sweeper.service.ts",
+      );
+      expect(files).toContain("database/demo-seed.service.ts");
+    });
+
+    it("reads the auto-backup claim's RETURNING column", () => {
+      // The exact claim the outage was in, checked as a claim rather than as a
+      // substring of the SQL.
+      expect(claims).toContainEqual({
+        file: "backup/auto-backup.service.ts",
+        table: "auto_backup_settings",
+        column: "user_id",
+        clause: "RETURNING",
+      });
+    });
+  });
+
+  it("names only columns that exist in database/schema.sql", () => {
+    const problems = claims
+      .map((claim) => {
+        const problem = columnProblem(claim, schema);
+        return problem ? `${claim.file}: ${problem}` : null;
+      })
+      .filter((problem): problem is string => problem !== null);
+    expect(problems).toEqual([]);
+  });
+});
+
+describe("raw SQL column grammar", () => {
+  const schema = parseSchemaColumns(
+    `CREATE TABLE auto_backup_settings (
+       user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+       enabled BOOLEAN NOT NULL DEFAULT false,
+       next_backup_at TIMESTAMP,
+       CONSTRAINT abs_check CHECK (enabled IS NOT NULL)
+     );
+     CREATE TABLE IF NOT EXISTS users (
+       id UUID PRIMARY KEY,
+       failed_login_attempts INT NOT NULL DEFAULT 0,
+       locked_until TIMESTAMP
+     );`,
+  );
+
+  const problemsIn = (sql: string): string[] =>
+    statementClaims(sql).flatMap((statement) =>
+      statement.claims
+        .map((claim) => columnProblem(claim, schema))
+        .filter((problem): problem is string => problem !== null),
+    );
+
+  it("parses columns and skips table constraints", () => {
+    expect([...(schema.get("auto_backup_settings") ?? [])]).toEqual([
+      "user_id",
+      "enabled",
+      "next_backup_at",
+    ]);
+    // `REFERENCES users(id)` is inside the column entry, not a column of its
+    // own -- a paren-blind comma split would have invented `id` here, and this
+    // whole guard would then have passed the regression.
+    expect(schema.get("auto_backup_settings")?.has("id")).toBe(false);
+  });
+
+  it("fails the exact statement that broke automatic backups", () => {
+    expect(
+      problemsIn(
+        `UPDATE auto_backup_settings
+            SET next_backup_at = $1
+          WHERE user_id = $2 AND enabled = true
+          RETURNING id`,
+      ),
+    ).toEqual([
+      expect.stringContaining("RETURNING id on auto_backup_settings"),
+    ]);
+  });
+
+  it("passes the fixed statement", () => {
+    expect(
+      problemsIn(
+        `UPDATE auto_backup_settings
+            SET next_backup_at = $1
+          WHERE user_id = $2
+          RETURNING user_id`,
+      ),
+    ).toEqual([]);
+  });
+
+  it("checks SET targets and INSERT column lists too", () => {
+    expect(
+      problemsIn("UPDATE auto_backup_settings SET last_backup_at = $1"),
+    ).toEqual([expect.stringContaining("SET last_backup_at")]);
+    expect(
+      problemsIn("INSERT INTO users (id, nickname) VALUES ($1, $2)"),
+    ).toEqual([expect.stringContaining("INSERT nickname")]);
+    expect(
+      problemsIn("INSERT INTO users (id, locked_until) VALUES ($1, $2)"),
+    ).toEqual([]);
+  });
+
+  it("does not read the table's own alias as a foreign qualifier", () => {
+    expect(
+      problemsIn(
+        `UPDATE users u SET locked_until = NULL
+          WHERE u.id = $1
+          RETURNING u.failed_login_attempts AS attempts, u.nickname AS nick`,
+      ),
+    ).toEqual([expect.stringContaining("RETURNING nickname")]);
+  });
+
+  it("does not read SET as an alias", () => {
+    // `UPDATE t SET x` would otherwise alias the table `set`, and every
+    // qualified column would then be skipped as another relation's.
+    expect(
+      problemsIn("UPDATE auto_backup_settings SET enabled = true RETURNING id"),
+    ).toHaveLength(1);
+  });
+
+  it("makes no claim it cannot resolve", () => {
+    // A CTE or joined qualifier, an expression, a star, and an interpolated
+    // fragment each yield nothing rather than a guess: a guard with false
+    // positives gets disabled, and then it guards nothing.
+    expect(
+      problemsIn(
+        `WITH prev AS (SELECT id, locked_until FROM users)
+         UPDATE users u SET locked_until = NULL FROM prev
+          WHERE u.id = prev.id
+          RETURNING prev.locked_until AS old_locked_until,
+                    COUNT(*) AS total, *`,
+      ),
+    ).toEqual([]);
+    expect(problemsIn("UPDATE users SET  interp  = $1 RETURNING id")).toEqual(
+      [],
+    );
+  });
+
+  it("attributes each statement's columns to its own table", () => {
+    // One string, two statements: the second's RETURNING must not be checked
+    // against the first's table.
+    expect(
+      problemsIn(
+        `INSERT INTO users (id) VALUES ($1) RETURNING id;
+         UPDATE auto_backup_settings SET enabled = true RETURNING user_id`,
+      ),
+    ).toEqual([]);
+  });
+
+  it("says nothing about a table the schema does not define", () => {
+    // A temporary table, a `pg_catalog` relation or a CTE target is not a claim
+    // about the application schema; the table inventory is guarded elsewhere.
+    expect(problemsIn("UPDATE pg_temp_scratch SET whatever = 1")).toEqual([]);
+  });
+
+  describe("literal extraction", () => {
+    it("reads template, single- and double-quoted SQL", () => {
+      const source = [
+        "const a = `UPDATE users SET locked_until = NULL`;",
+        `const b = 'DELETE FROM users';`,
+        `const c = "INSERT INTO users (id) VALUES ($1)";`,
+      ].join("\n");
+      expect(extractStringLiterals(source)).toEqual([
+        "UPDATE users SET locked_until = NULL",
+        "DELETE FROM users",
+        "INSERT INTO users (id) VALUES ($1)",
+      ]);
+    });
+
+    it("skips comments, so SQL quoted in a doc comment is not scanned", () => {
+      const source = [
+        "// UPDATE users SET nope = 1",
+        "/* RETURNING nope */",
+        "const a = `UPDATE users SET locked_until = NULL`;",
+      ].join("\n");
+      expect(extractStringLiterals(source)).toEqual([
+        "UPDATE users SET locked_until = NULL",
+      ]);
+    });
+
+    it("replaces an interpolation rather than splicing its code in", () => {
+      const source =
+        "const a = `UPDATE users SET locked_until = NULL ${cond ? `AND x` : ''} RETURNING id`;";
+      const [literal] = extractStringLiterals(source);
+      expect(literal).toContain("interp");
+      expect(literal).not.toContain("cond");
+      expect(literal).toContain("RETURNING id");
+    });
+  });
+
+  describe("clause splitting", () => {
+    it("splits on top-level commas only", () => {
+      expect(splitTopLevel("a, b, coalesce(c, d) AS e")).toEqual([
+        "a",
+        "b",
+        "coalesce(c, d) AS e",
+      ]);
+    });
+
+    it("strips an output label without eating a qualifier", () => {
+      expect(stripOutputLabel("u.failed_login_attempts AS attempts")).toBe(
+        "u.failed_login_attempts",
+      );
+      expect(stripOutputLabel("u.locked_until")).toBe("u.locked_until");
+      expect(stripOutputLabel("data_committed")).toBe("data_committed");
+    });
+  });
+});

--- a/backend/src/common/db/raw-sql-columns.ts
+++ b/backend/src/common/db/raw-sql-columns.ts
@@ -1,0 +1,395 @@
+/**
+ * The grammar that decides whether a column name written in raw SQL inside
+ * `src/` is a real column of the table the statement targets.
+ *
+ * A mocked `manager.query` cannot demonstrate a property of the schema: it
+ * records the string and resolves. So `RETURNING id` against
+ * `auto_backup_settings` -- whose primary key is `user_id`, and which has no
+ * `id` at all -- passed its unit tests, shipped, and took every automatic
+ * backup down for every user with `column "id" does not exist` (42703). The
+ * claim runs before the per-user `try`, so the first failure aborted the whole
+ * sweep.
+ *
+ * Extracted from the spec so the grammar itself is unit-tested rather than only
+ * exercised over whatever the tree happens to contain today -- the same reason
+ * `repo-paths.util.ts` sits beside `doc-paths.spec.ts`.
+ *
+ * What is checked, per raw DML statement, against `database/schema.sql`:
+ *
+ *  - the `RETURNING` list,
+ *  - an `INSERT`'s parenthesised column list,
+ *  - an `UPDATE`'s `SET` assignment targets.
+ *
+ * What is deliberately *not* checked: anything the scanner cannot resolve
+ * unambiguously -- an expression, a `*`, a name qualified by something other
+ * than the target table or its alias (a CTE or a joined relation), or an item
+ * carrying a `${...}` interpolation. Those yield no claim rather than a guess,
+ * because a guard that reports false positives gets disabled and then reports
+ * nothing at all. `WHERE` clauses are out of scope for the same reason: they
+ * reference joined and correlated relations freely.
+ */
+
+/** A column reference a statement makes, with enough context to explain it. */
+export interface ColumnClaim {
+  table: string;
+  column: string;
+  /** Which clause it came from, for the failure message. */
+  clause: "RETURNING" | "INSERT" | "SET";
+}
+
+/** A DML statement found in a SQL string, reduced to the claims it makes. */
+export interface StatementClaims {
+  table: string;
+  claims: ColumnClaim[];
+}
+
+const IDENT = "[A-Za-z_][A-Za-z0-9_$]*";
+
+/**
+ * Words that may follow a table name in DML and are therefore never an alias.
+ * `SET` is the one that matters -- `UPDATE auto_backup_settings SET ...` would
+ * otherwise be read as table `auto_backup_settings` aliased `SET`, and every
+ * unqualified column would still resolve, but a `SET`-qualified one would be
+ * skipped as "some other relation": the guard passing by not looking.
+ */
+const NOT_AN_ALIAS = new Set([
+  "set",
+  "where",
+  "values",
+  "returning",
+  "using",
+  "from",
+  "select",
+  "on",
+  "default",
+  "overriding",
+]);
+
+/** A `${...}` interpolation, replaced by a marker the scanner can recognise. */
+export const INTERPOLATION = " interp ";
+
+// ---------------------------------------------------------------------------
+// database/schema.sql -> table -> columns
+// ---------------------------------------------------------------------------
+
+/**
+ * Entries in a `CREATE TABLE` body that declare a constraint rather than a
+ * column. `PRIMARY`, `UNIQUE` and `FOREIGN` also begin *column* modifiers, but
+ * only ever after the column name, so matching them as the entry's first word
+ * is exact.
+ */
+const CONSTRAINT_KEYWORDS = new Set([
+  "constraint",
+  "primary",
+  "foreign",
+  "unique",
+  "check",
+  "exclude",
+  "like",
+]);
+
+/** Split on commas that are not inside parentheses. */
+export function splitTopLevel(text: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of text) {
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  parts.push(current);
+  return parts.map((part) => part.trim()).filter(Boolean);
+}
+
+/** From the index of an opening `(`, the index of its matching `)`, or -1. */
+function matchParen(text: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === "(") depth++;
+    else if (text[i] === ")" && --depth === 0) return i;
+  }
+  return -1;
+}
+
+/**
+ * Table name -> its column names, from `database/schema.sql`.
+ *
+ * Comments are stripped first so a commented-out column is not read as one.
+ * Both `CREATE TABLE x` and `CREATE TABLE IF NOT EXISTS x` are matched, because
+ * migrations replay onto the schema and use the guarded form.
+ */
+export function parseSchemaColumns(
+  schemaSql: string,
+): Map<string, Set<string>> {
+  const sql = schemaSql.replace(/--[^\n]*/g, "");
+  const tables = new Map<string, Set<string>>();
+  const create = new RegExp(
+    `CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?"?(${IDENT})"?\\s*\\(`,
+    "gi",
+  );
+  for (const match of sql.matchAll(create)) {
+    const open = match.index + match[0].length - 1;
+    const close = matchParen(sql, open);
+    if (close < 0) continue;
+    const columns = new Set<string>();
+    for (const entry of splitTopLevel(sql.slice(open + 1, close))) {
+      const first = new RegExp(`^"?(${IDENT})"?`).exec(entry);
+      if (!first) continue;
+      if (CONSTRAINT_KEYWORDS.has(first[1].toLowerCase())) continue;
+      columns.add(first[1].toLowerCase());
+    }
+    tables.set(match[1].toLowerCase(), columns);
+  }
+  return tables;
+}
+
+// ---------------------------------------------------------------------------
+// TypeScript source -> the SQL strings in it
+// ---------------------------------------------------------------------------
+
+/**
+ * Every string and template literal in a TypeScript source, with `${...}`
+ * interpolations replaced by a marker.
+ *
+ * Written as a character scanner rather than a regex because a SQL statement in
+ * this codebase is a multi-line template literal, frequently with an
+ * interpolated fragment in its `WHERE`. Comments are skipped so the SQL quoted
+ * *inside* a doc comment -- and this file is full of it -- is never scanned as
+ * code.
+ */
+export function extractStringLiterals(source: string): string[] {
+  const literals: string[] = [];
+  const n = source.length;
+  let i = 0;
+  while (i < n) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (ch === "/" && next === "/") {
+      while (i < n && source[i] !== "\n") i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      const end = source.indexOf("*/", i + 2);
+      i = end < 0 ? n : end + 2;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      let j = i + 1;
+      let text = "";
+      while (j < n && source[j] !== ch && source[j] !== "\n") {
+        if (source[j] === "\\") {
+          j += 2;
+          text += " ";
+          continue;
+        }
+        text += source[j];
+        j++;
+      }
+      literals.push(text);
+      i = j + 1;
+      continue;
+    }
+    if (ch === "`") {
+      let j = i + 1;
+      let text = "";
+      while (j < n && source[j] !== "`") {
+        if (source[j] === "\\") {
+          j += 2;
+          text += " ";
+          continue;
+        }
+        if (source[j] === "$" && source[j + 1] === "{") {
+          // Skip the interpolation body, tracking nesting so an object literal
+          // or a nested template inside it does not end the scan early.
+          let depth = 1;
+          j += 2;
+          while (j < n && depth > 0) {
+            if (source[j] === "{") depth++;
+            else if (source[j] === "}") depth--;
+            else if (source[j] === "`") {
+              j++;
+              while (j < n && source[j] !== "`")
+                j += source[j] === "\\" ? 2 : 1;
+            }
+            j++;
+          }
+          text += INTERPOLATION;
+          continue;
+        }
+        text += source[j];
+        j++;
+      }
+      literals.push(text);
+      i = j + 1;
+      continue;
+    }
+    i++;
+  }
+  return literals;
+}
+
+// ---------------------------------------------------------------------------
+// SQL string -> the column claims it makes
+// ---------------------------------------------------------------------------
+
+/** The identifier a claim can be checked from, or null when it cannot be. */
+function resolveColumn(
+  item: string,
+  table: string,
+  alias: string | null,
+): string | null {
+  const text = item.trim();
+  if (!text || text.includes(INTERPOLATION.trim())) return null;
+  const qualified = new RegExp(`^(?:"?(${IDENT})"?\\.)?"?(${IDENT})"?$`).exec(
+    text,
+  );
+  if (!qualified) return null; // an expression, a `*`, a literal, a cast
+  const qualifier = qualified[1]?.toLowerCase();
+  if (qualifier && qualifier !== table && qualifier !== alias) return null;
+  return qualified[2].toLowerCase();
+}
+
+/**
+ * Strip a `RETURNING expr AS name` / `expr name` output label, but only when
+ * what remains is itself a (possibly qualified) identifier -- otherwise
+ * `u.locked_until` would lose its qualifier to the "alias" branch and be
+ * checked as a column named `u`.
+ */
+export function stripOutputLabel(item: string): string {
+  const text = item.trim();
+  const aliased = new RegExp(
+    `^([\\s\\S]+?)\\s+(?:AS\\s+)?"?${IDENT}"?$`,
+    "i",
+  ).exec(text);
+  const bare = new RegExp(`^(?:"?${IDENT}"?\\.)?"?${IDENT}"?$`);
+  if (aliased && bare.test(aliased[1].trim())) return aliased[1].trim();
+  return text;
+}
+
+/** Text of a clause: from `start` up to the first top-level stop word. */
+function clauseText(sql: string, start: number, stops: RegExp): string {
+  const rest = sql.slice(start);
+  let depth = 0;
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i] === "(") depth++;
+    else if (rest[i] === ")") depth--;
+    else if (rest[i] === ";" && depth === 0) return rest.slice(0, i);
+    if (depth !== 0) continue;
+    stops.lastIndex = i;
+    if (stops.test(rest)) return rest.slice(0, i);
+  }
+  return rest;
+}
+
+const DML = new RegExp(
+  `\\b(UPDATE|INSERT\\s+INTO|DELETE\\s+FROM)\\s+(?:ONLY\\s+)?"?(${IDENT})"?` +
+    `(?:\\s+(?:AS\\s+)?"?(${IDENT})"?)?`,
+  "gi",
+);
+
+/** Sticky, so `clauseText` can ask "does a stop word start exactly here?". */
+const SET_STOPS = /\b(?:FROM|WHERE|RETURNING)\b/giy;
+const RETURNING_STOPS = /\bINTO\b/giy;
+
+/**
+ * The column claims every DML statement in one SQL string makes.
+ *
+ * A string with no DML verb yields nothing, so the scan is safe to run over
+ * every literal in the tree rather than over a hand-maintained list of files.
+ */
+export function statementClaims(sql: string): StatementClaims[] {
+  const statements: StatementClaims[] = [];
+  const matches = [...sql.matchAll(DML)];
+  for (const [index, match] of matches.entries()) {
+    const verb = match[1].replace(/\s+/g, " ").toUpperCase();
+    const table = match[2].toLowerCase();
+    const aliasWord = match[3]?.toLowerCase() ?? null;
+    const alias = aliasWord && !NOT_AN_ALIAS.has(aliasWord) ? aliasWord : null;
+    const claims: ColumnClaim[] = [];
+    // The statement ends where the next DML verb begins, so one string holding
+    // two statements does not attribute the second's columns to the first.
+    const nextMatch = matches[index + 1];
+    const body = sql.slice(match.index, nextMatch?.index ?? sql.length);
+    const afterTable = match[0].length;
+
+    if (verb === "INSERT INTO") {
+      const open = body.slice(afterTable).search(/\S/) + afterTable;
+      if (body[open] === "(") {
+        const close = matchParen(body, open);
+        if (close > 0) {
+          const columns = splitTopLevel(body.slice(open + 1, close)).map(
+            (item) => resolveColumn(item, table, alias),
+          );
+          // All or nothing: `INSERT INTO t SELECT ...` and any list the scanner
+          // cannot fully resolve must not contribute half a claim.
+          if (
+            columns.length > 0 &&
+            columns.every((column) => column !== null)
+          ) {
+            for (const column of columns) {
+              claims.push({
+                table,
+                column: column as string,
+                clause: "INSERT",
+              });
+            }
+          }
+        }
+      }
+    }
+
+    if (verb === "UPDATE") {
+      const set = /\bSET\b/i.exec(body);
+      if (set) {
+        const text = clauseText(body, set.index + set[0].length, SET_STOPS);
+        for (const assignment of splitTopLevel(text)) {
+          if (assignment.startsWith("(")) continue; // SET (a, b) = (...)
+          const column = resolveColumn(assignment.split("=")[0], table, alias);
+          if (column) claims.push({ table, column, clause: "SET" });
+        }
+      }
+    }
+
+    const returning = /\bRETURNING\b/i.exec(body);
+    if (returning) {
+      const text = clauseText(
+        body,
+        returning.index + returning[0].length,
+        RETURNING_STOPS,
+      );
+      for (const item of splitTopLevel(text)) {
+        const column = resolveColumn(stripOutputLabel(item), table, alias);
+        if (column) claims.push({ table, column, clause: "RETURNING" });
+      }
+    }
+
+    if (claims.length > 0) statements.push({ table, claims });
+  }
+  return statements;
+}
+
+/**
+ * A claim that names a column the schema does not have, described. `null` when
+ * the claim holds, and when the table itself is unknown to `schema.sql` -- a
+ * CTE, a temporary table or a `pg_catalog` relation is not a claim about the
+ * application schema, and the table inventory is guarded elsewhere
+ * (`rls-exempt-tables.spec.ts`, `restore-plan.spec.ts`).
+ */
+export function columnProblem(
+  claim: ColumnClaim,
+  schema: Map<string, Set<string>>,
+): string | null {
+  const columns = schema.get(claim.table);
+  if (!columns) return null;
+  if (columns.has(claim.column)) return null;
+  return (
+    `${claim.clause} ${claim.column} on ${claim.table}: no such column ` +
+    `(database/schema.sql has ${[...columns].sort().join(", ")})`
+  );
+}


### PR DESCRIPTION
## Linked discussion / issue

Closes #[issue number]
Approved in: [discussion/issue link]

## Summary

Adds a compile-time guard that validates every hand-written column name in raw SQL statements (`RETURNING`, `INSERT` column lists, `UPDATE SET` targets) against `database/schema.sql`. This prevents the class of defect that took automatic backups down for all users: `AutoBackupService.claimDueBackup` ended with `RETURNING id`, but `auto_backup_settings` has no `id` column (its primary key is `user_id`). The mocked `manager.query` in unit tests recorded the string and resolved, so the mistake shipped and failed at runtime with `column "id" does not exist` (42703).

The guard is implemented as:
- **`raw-sql-columns.ts`**: A grammar that extracts column claims from SQL strings, parses the schema, and validates claims against it. Deliberately conservative — it makes no claim it cannot resolve unambiguously (expressions, `*`, interpolations, qualified names outside the target table), so false positives cannot disable the guard.
- **`raw-sql-columns.spec.ts`**: Tree-wide scan that runs the grammar over every string literal in `src/`, checking all claims against the actual schema. Catches the regression and any future occurrence.

Also refactors `AutoBackupService.handleAutoBackupCron` to wrap each user's window (including the maintenance pre-check and the claim itself) in a try-catch, so one user's failure does not abort the sweep for all subsequent users. Records the failure to the settings row so the user sees it in the UI rather than the last successful run from before the deploy.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (the regression and its structural cause).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (no new user-facing strings).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_01HMLTEwrEmMDqeMV7FyiPe6