### PR TITLE
Document and enforce critical system invariants

### DIFF
--- a/backend/src/action-history/action-history.service.ts
+++ b/backend/src/action-history/action-history.service.ts
@@ -10,6 +10,7 @@ import { Cron } from "@nestjs/schedule";
 import { ActionHistory } from "./entities/action-history.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
+import { assertReconciledRowsMutable } from "../transactions/reconciled-lock.util";
 import { Account } from "../accounts/entities/account.entity";
 import { Category } from "../categories/entities/category.entity";
 import { Payee } from "../payees/entities/payee.entity";
@@ -546,6 +547,7 @@ export class ActionHistoryService {
 
     const transaction = await manager.findOne(Transaction, {
       where: { id: action.entityId, userId: action.userId },
+      lock: { mode: "pessimistic_write" },
     });
     if (!transaction) {
       throw new ConflictException(
@@ -555,6 +557,13 @@ export class ActionHistoryService {
         ),
       );
     }
+
+    // INV-RECONCILE-001: undo/redo of an edit rewrites this row's stored fields
+    // (redo reaches here too, via `executeRedo` inverting the action), so a
+    // reconciled locked row refuses -- an undo is no more allowed to alter it
+    // than the original edit was. Runs after the row lock above and before the
+    // write below, so a refusal reverses nothing.
+    await assertReconciledRowsMutable(manager, action.userId, [transaction]);
 
     const before = action.beforeData;
 

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1040,6 +1040,30 @@ describe("AuthController", () => {
         message: "Logged out successfully",
       });
     });
+
+    /**
+     * INV-AUTH-004: a logout reports only what it achieved. If the family revoke
+     * fails, the session is still live server-side, so presenting a completed
+     * logout to the user is a lie -- they believe they signed out and did not.
+     * The handler awaits the revoke before clearing cookies and returning
+     * success, with no try/catch, so a rejection must propagate and neither the
+     * success body nor the cookie-clearing may run. A future refactor that
+     * wrapped the revoke to "log and continue" would make this test fail.
+     */
+    it("does not report a completed logout when the revoke fails", async () => {
+      authService.revokeRefreshToken.mockRejectedValue(
+        new Error("revoke failed"),
+      );
+      const res = mockRes();
+      const expressReq = { cookies: { refresh_token: "rt-123" } } as any;
+
+      await expect(controller.logout(expressReq, res as any)).rejects.toThrow(
+        "revoke failed",
+      );
+
+      expect(res.json).not.toHaveBeenCalled();
+      expect(res.clearCookie).not.toHaveBeenCalled();
+    });
   });
 
   describe("oidcStatus", () => {

--- a/backend/src/common/invariant-catalog-parity.spec.ts
+++ b/backend/src/common/invariant-catalog-parity.spec.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * The invariant catalog and the verification matrix must name the same set of
+ * invariants.
+ *
+ * `docs/system-invariants.md` defines the IDs (its Index table) and
+ * `docs/verification-contract.md` says, per ID, which kind of test each one
+ * needs (its matrix). The two drift silently: an invariant added to the catalog
+ * with no matrix row has no stated required-test kind, and a matrix row with no
+ * catalog entry describes a claim nothing defines. That is exactly what happened
+ * when INV-RECONCILE-001 was catalogued and enforced while the matrix had no row
+ * for it -- prose could not catch it, so this scan does.
+ *
+ * Both documents write their IDs as the first cell of a table row (`| INV-... |`
+ * in the Index, `| INV-... <description> |` in the matrix), so the same
+ * line-anchored match reads both.
+ */
+const DOCS = join(__dirname, "..", "..", "..", "docs");
+
+function tableRowInvariantIds(file: string): Set<string> {
+  const text = readFileSync(join(DOCS, file), "utf8");
+  const ids = new Set<string>();
+  for (const line of text.split("\n")) {
+    const match = /^\|\s*(INV-[A-Z]+-\d+)\b/.exec(line);
+    if (match) ids.add(match[1]);
+  }
+  return ids;
+}
+
+describe("the invariant catalog and the verification matrix cover the same IDs", () => {
+  const catalog = tableRowInvariantIds("system-invariants.md");
+  const matrix = tableRowInvariantIds("verification-contract.md");
+
+  it("reads a plausible number of invariants from each document", () => {
+    // A parsing regression (a reformatted table) would empty one set and make
+    // the parity checks below pass vacuously; anchor them against reality.
+    expect(catalog.size).toBeGreaterThan(20);
+    expect(matrix.size).toBeGreaterThan(20);
+  });
+
+  it("gives every catalogued invariant a verification-matrix row", () => {
+    const missing = [...catalog].filter((id) => !matrix.has(id)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  it("backs every verification-matrix row with a catalogued invariant", () => {
+    const extra = [...matrix].filter((id) => !catalog.has(id)).sort();
+    expect(extra).toEqual([]);
+  });
+});

--- a/backend/src/common/invariant-catalog-parity.spec.ts
+++ b/backend/src/common/invariant-catalog-parity.spec.ts
@@ -16,28 +16,55 @@ import { join } from "path";
  * Both documents write their IDs as the first cell of a table row (`| INV-... |`
  * in the Index, `| INV-... <description> |` in the matrix), so the same
  * line-anchored match reads both.
+ *
+ * The IDs are collected as a **list**, not a set, so a duplicated row is visible.
+ * Set equality alone would pass a document that carried the same ID twice -- and
+ * a duplicate matrix row is worse than a missing one, because the two copies can
+ * disagree about the required-test classification and nothing says which the
+ * reader should believe. So each document is first checked for duplicate rows,
+ * then the de-duplicated sets are compared for one-to-one coverage.
  */
 const DOCS = join(__dirname, "..", "..", "..", "docs");
 
-function tableRowInvariantIds(file: string): Set<string> {
+function tableRowInvariantIdList(file: string): string[] {
   const text = readFileSync(join(DOCS, file), "utf8");
-  const ids = new Set<string>();
+  const ids: string[] = [];
   for (const line of text.split("\n")) {
     const match = /^\|\s*(INV-[A-Z]+-\d+)\b/.exec(line);
-    if (match) ids.add(match[1]);
+    if (match) ids.push(match[1]);
   }
   return ids;
 }
 
+function duplicates(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const repeated = new Set<string>();
+  for (const id of ids) {
+    if (seen.has(id)) repeated.add(id);
+    else seen.add(id);
+  }
+  return [...repeated].sort();
+}
+
 describe("the invariant catalog and the verification matrix cover the same IDs", () => {
-  const catalog = tableRowInvariantIds("system-invariants.md");
-  const matrix = tableRowInvariantIds("verification-contract.md");
+  const catalogList = tableRowInvariantIdList("system-invariants.md");
+  const matrixList = tableRowInvariantIdList("verification-contract.md");
+  const catalog = new Set(catalogList);
+  const matrix = new Set(matrixList);
 
   it("reads a plausible number of invariants from each document", () => {
-    // A parsing regression (a reformatted table) would empty one set and make
+    // A parsing regression (a reformatted table) would empty one list and make
     // the parity checks below pass vacuously; anchor them against reality.
     expect(catalog.size).toBeGreaterThan(20);
     expect(matrix.size).toBeGreaterThan(20);
+  });
+
+  it("has no invariant catalogued twice", () => {
+    expect(duplicates(catalogList)).toEqual([]);
+  });
+
+  it("has no invariant in the verification matrix twice", () => {
+    expect(duplicates(matrixList)).toEqual([]);
   });
 
   it("gives every catalogued invariant a verification-matrix row", () => {

--- a/backend/src/currencies/currencies.service.spec.ts
+++ b/backend/src/currencies/currencies.service.spec.ts
@@ -626,6 +626,35 @@ describe("CurrenciesService", () => {
       expect(mockCurrencyRepo.remove).toHaveBeenCalledWith(userCurrency);
     });
 
+    /**
+     * INV-CURRENCY-001, authorization clause: a shared custom currency row is
+     * deleted only by its creator. A non-creator who activated the code may
+     * deactivate it (remove their own preference), but must never take the row
+     * itself -- even when the global count has since hit zero. The old gate
+     * (`createdByUserId !== null`) checked "is this custom" instead of "am I the
+     * creator", so this exact call deleted another user's currency.
+     */
+    it("does not delete another user's custom currency, even when globally unreferenced", async () => {
+      const othersCurrency = {
+        ...mockCurrency,
+        createdByUserId: "other-user",
+      };
+      mockCurrencyRepo.findOne!.mockResolvedValue(othersCurrency);
+      answering({ inUseByUser: false, inUseGlobally: false });
+      mockPrefRepo.delete!.mockResolvedValue(undefined);
+      mockCurrencyRepo.remove!.mockResolvedValue(undefined);
+
+      await service.remove(userId, "CAD");
+
+      // Deactivation still happens...
+      expect(mockPrefRepo.delete).toHaveBeenCalledWith({
+        userId,
+        currencyCode: "CAD",
+      });
+      // ...but the creator's row is left standing.
+      expect(mockCurrencyRepo.remove).not.toHaveBeenCalled();
+    });
+
     it("does not delete system currency row even when preference is removed", async () => {
       mockCurrencyRepo.findOne!.mockResolvedValue(mockCurrency);
       mockDataSource.query.mockResolvedValue([{ inUse: false }]);

--- a/backend/src/currencies/currencies.service.ts
+++ b/backend/src/currencies/currencies.service.ts
@@ -395,8 +395,17 @@ export class CurrenciesService implements OnApplicationBootstrap {
       currencyCode: upperCode,
     });
 
-    // A user-created currency nothing points at any more is cleaned up. The
-    // preference row above is deleted as of this transaction, so a remaining
+    // The currency row itself is cleaned up only by its **creator**, and only
+    // when nothing anywhere still points at it (INV-CURRENCY-001). Deactivation
+    // above is every activator's own action, so a non-creator reaches here too
+    // -- but `createdByUserId !== null` ("is this a custom currency") was the
+    // wrong gate: it let user B, who had merely activated user A's custom
+    // currency, delete A's shared row out from under them once the global count
+    // hit zero. The row belongs to A; B removing their activation leaves it for
+    // A to keep or clean up. `=== userId` is the creator check, and because
+    // `userId` is never null it still skips system currencies exactly as before.
+    //
+    // The preference row above is deleted as of this transaction, so a remaining
     // reference is somebody else's -- and the check has to be able to see
     // somebody else's rows, which is what makes it a SECURITY DEFINER function
     // rather than a query here.
@@ -406,7 +415,7 @@ export class CurrenciesService implements OnApplicationBootstrap {
     // deleted: it reported zero for a code another user had activated, and the
     // ON DELETE CASCADE on `user_currency_preferences.currency_code` then took
     // that user's activation with it.
-    if (currency.createdByUserId !== null) {
+    if (currency.createdByUserId === userId) {
       if (!(await this.isInUseGlobally(manager, upperCode))) {
         await manager.getRepository(Currency).remove(currency);
       }

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -17,6 +17,7 @@ import {
   LockedInvestmentTransactionRow,
 } from "../common/db/locks";
 import { applyVoidTransitionToMirrorLeg } from "../transactions/void-status-transition.util";
+import { assertReconciledRowsMutable } from "../transactions/reconciled-lock.util";
 import { investmentRowHasEffect } from "./investment-row-effects.util";
 import { formatInvestmentCashPayeeName } from "./investment-cash-payee.util";
 import {
@@ -2474,14 +2475,10 @@ export class InvestmentTransactionsService {
       );
     }
 
-    await manager.update(TransactionSplit, splitId, {
-      amount: newSplitAmount,
-    });
-
-    // Locked: the delta below reverses `oldParentAmount`, so it has to be the
-    // version this write replaces. Two concurrent edits to the same parent's
-    // splits would otherwise each apply a delta derived from the same stale
-    // amount (audit P4-003).
+    // Locked first, before any write: the delta below reverses `oldParentAmount`,
+    // so it has to be the version this write replaces. Two concurrent edits to
+    // the same parent's splits would otherwise each apply a delta derived from
+    // the same stale amount (audit P4-003).
     const parentTransaction = await lockTransactionRow(
       manager,
       split.transactionId,
@@ -2496,6 +2493,18 @@ export class InvestmentTransactionsService {
         ),
       );
     }
+
+    // INV-RECONCILE-001: editing an embedded investment row rewrites this split's
+    // amount and the parent transaction's total, so a reconciled locked parent
+    // refuses the change -- "not its fields, not its splits". Runs after the row
+    // lock and before the first write, so the refusal reverses nothing. Editing
+    // the split amount used to happen before the parent was even loaded, which is
+    // why this had to move above that write rather than beside it.
+    await assertReconciledRowsMutable(manager, userId, [parentTransaction]);
+
+    await manager.update(TransactionSplit, splitId, {
+      amount: newSplitAmount,
+    });
 
     const siblingSplits = await manager.find(TransactionSplit, {
       where: { transactionId: split.transactionId },

--- a/backend/src/transactions/reconciled-lock.guard.spec.ts
+++ b/backend/src/transactions/reconciled-lock.guard.spec.ts
@@ -17,7 +17,20 @@ const TX_ROOT = __dirname;
  * The list may grow. Removing an entry means the route no longer writes to a
  * transaction, which is a change worth arguing for in the diff.
  */
-const ENFORCEMENT_SITES: { file: string; fn: string; why: string }[] = [
+/**
+ * `beforeWrite` marks a site that receives an ambient `EntityManager` rather
+ * than opening its own `withScopedDb` -- a nested handler whose transaction is
+ * opened by its caller. For those the "inside the transaction" check cannot look
+ * for `withScopedDb`, so it instead asserts the assertion appears before the
+ * named first write of the method. A site without `beforeWrite` opens its own
+ * `withScopedDb` and is checked against that.
+ */
+const ENFORCEMENT_SITES: {
+  file: string;
+  fn: string;
+  why: string;
+  beforeWrite?: string;
+}[] = [
   {
     file: "transactions.service.ts",
     fn: "async update(",
@@ -72,6 +85,18 @@ const ENFORCEMENT_SITES: { file: string; fn: string; why: string }[] = [
     file: "transaction-split.service.ts",
     fn: "async removeSplit(",
     why: "DELETE /transactions/:id/splits/:splitId",
+  },
+  {
+    file: "../action-history/action-history.service.ts",
+    fn: "private async undoTransactionUpdate(",
+    why: "undo/redo of a transaction edit restores prior field values onto the row",
+    beforeWrite: "manager.update(Transaction",
+  },
+  {
+    file: "../securities/investment-transactions.service.ts",
+    fn: "private async updateEmbeddedSplitParent(",
+    why: "editing an embedded investment rewrites the split amount and the parent's total",
+    beforeWrite: "manager.update(TransactionSplit",
   },
 ];
 
@@ -150,10 +175,17 @@ describe("the strict reconciled lock is asked on every write path", () => {
     // cannot undo a committed row (docs/financial-calculation-contract.md
     // section 7). `withScopedDb` opening before the call is the observable form
     // of that in this codebase.
-    const outside = ENFORCEMENT_SITES.filter(({ file, fn }) => {
+    const outside = ENFORCEMENT_SITES.filter(({ file, fn, beforeWrite }) => {
       const body = methodBody(sources.get(file)!, fn)!;
-      const scoped = body.indexOf("withScopedDb");
       const assertion = body.search(ASSERTION);
+      if (beforeWrite) {
+        // A nested handler: its transaction is the caller's, so "inside the
+        // transaction" is proven by the assertion preceding this method's first
+        // write rather than by a local `withScopedDb`.
+        const write = body.indexOf(beforeWrite);
+        return write === -1 || assertion === -1 || assertion > write;
+      }
+      const scoped = body.indexOf("withScopedDb");
       return scoped === -1 || assertion < scoped;
     }).map(({ file, fn }) => `${file} ${fn}`);
     expect(outside).toEqual([]);

--- a/backend/test/integration/balance-delta-recompute.integration.spec.ts
+++ b/backend/test/integration/balance-delta-recompute.integration.spec.ts
@@ -1,0 +1,222 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+import { AccountsService } from "@/accounts/accounts.service";
+import { AccountsModule } from "@/accounts/accounts.module";
+import { Account } from "@/accounts/entities/account.entity";
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { withUserContext } from "@/common/db/with-context";
+import { withScopedDb } from "@/common/db/scoped-db";
+import { createTestAccount } from "../helpers/test-factories";
+
+/**
+ * INV-BALANCE-001 -- two-connection proof (audit P4-005).
+ *
+ * Mechanism under test: `lockAccountsForBalanceWrite`
+ * (`backend/src/common/db/locks.ts`), a `SELECT ... FOR UPDATE` that
+ * `AccountsService.recalculateCurrentBalance` takes as the *first* statement of
+ * its transaction, before it reads the ledger it will write back.
+ *
+ * The invariant: a balance delta committing concurrently with an absolute
+ * recompute must NOT be silently discarded. `current_balance` after both is
+ * `opening_balance + SUM(every non-void, non-child ledger row)` -- the delta's
+ * new row included.
+ *
+ * Why the two protocols do not compose unaided: under READ COMMITTED the
+ * recompute's ledger `SELECT` and its account `UPDATE` are separate statement
+ * snapshots. A delta (a new transaction plus `current_balance += amount`) that
+ * commits between them is overwritten by an absolute total that never saw its
+ * ledger row -- the money moved, then un-moved itself, with both writers
+ * reporting success.
+ *
+ * ---------------------------------------------------------------------------
+ * The interleaving is forced, not hoped for. `Promise.all` alone reproduces a
+ * lost update only on the unlucky scheduling, so removing the lock would leave
+ * the test flaky-green rather than reliably red. Instead the delta transaction
+ * grabs the account row lock (via its `current_balance += d` UPDATE) and is held
+ * open while the recompute runs, so the ordering is pinned:
+ *
+ *   1. Delta: `UPDATE accounts SET current_balance += d` -- takes & holds the
+ *      account row lock. Its ledger row is NOT inserted yet.
+ *   2. Recompute starts. WITHOUT the lock its ledger `SELECT` runs immediately
+ *      and reads the *stale* sum (the delta row does not exist), then its
+ *      `UPDATE accounts` blocks on the delta's row lock. WITH the lock its very
+ *      first statement (`FOR UPDATE`) blocks -- before it can read the ledger.
+ *   3. Once the recompute backend is observed blocked, the delta inserts the
+ *      ledger row backing its `+d` and commits, releasing the row lock.
+ *   4. WITHOUT the lock the recompute now writes its stale total (opening + S),
+ *      silently discarding `d`. WITH the lock the recompute only now acquires
+ *      `FOR UPDATE`, reads the ledger on a fresh snapshot that includes the
+ *      delta row, and writes opening + S + d.
+ *
+ * So with the mechanism present the final balance reflects BOTH writers in
+ * either scheduling; with it neutralized this exact ordering deterministically
+ * loses `d`.
+ */
+describe("balance delta vs. absolute recompute (integration, INV-BALANCE-001)", () => {
+  let module: TestingModule;
+  let service: AccountsService;
+  let dataSource: DataSource;
+  let userId: string;
+  let accountId: string;
+
+  const OPENING = 1000;
+  // Seeded ledger rows summing to S = 300, so the seeded current_balance is
+  // opening + S = 1300 and consistent before the race.
+  const SEED_ROWS = [500, -200];
+  const S = SEED_ROWS.reduce((sum, amount) => sum + amount, 0);
+  // The concurrent atomic delta (a new transaction of +250).
+  const DELTA = 250;
+  const EXPECTED_FINAL = OPENING + S + DELTA; // 1550
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([AccountsModule]);
+    service = module.get(AccountsService);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "transaction_splits",
+      "transactions",
+      "accounts",
+      "categories",
+      "payees",
+      "scheduled_transaction_splits",
+      "scheduled_transaction_overrides",
+      "scheduled_transactions",
+      "investment_transactions",
+      "monthly_account_balances",
+      "users",
+    ]);
+
+    const user = await createTestUserDirect(dataSource);
+    userId = user.id;
+
+    const account = await createTestAccount(dataSource, userId, {
+      name: "Chequing",
+      openingBalance: OPENING,
+      currentBalance: OPENING + S,
+    });
+    accountId = account.id;
+
+    // Seed the ledger rows the recompute will sum. Raw SQL so their amounts and
+    // dates are exactly the fixture, not whatever a service would allocate.
+    for (const amount of SEED_ROWS) {
+      await dataSource.query(
+        `INSERT INTO transactions
+           (id, user_id, account_id, transaction_date, amount, currency_code,
+            exchange_rate, is_split, is_transfer, status)
+         VALUES (gen_random_uuid(), $1, $2, DATE '2026-01-15', $3, 'USD', 1,
+                 false, false, 'UNRECONCILED')`,
+        [userId, accountId, amount],
+      );
+    }
+  });
+
+  /**
+   * Poll until at least `expected` backends in this database are blocked waiting
+   * on a lock. Condition-driven (not a fixed sleep): the recompute is guaranteed
+   * to block on the delta's held row lock in both the with-lock and without-lock
+   * arrangements, so this always resolves once it has parked there. The attempt
+   * cap is only a safety net against a wiring mistake, never the timing source.
+   */
+  async function waitForBlockedBackends(expected: number): Promise<void> {
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      const rows: { c: number }[] = await dataSource.query(
+        `SELECT count(*)::int AS c
+           FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND state = 'active'
+            AND wait_event_type = 'Lock'`,
+      );
+      if (rows[0].c >= expected) return;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    throw new Error(
+      `Timed out waiting for ${expected} lock-blocked backend(s); the race was ` +
+        "never set up, so the test would prove nothing.",
+    );
+  }
+
+  it("keeps the delta: final balance reflects BOTH the recompute and the concurrent delta", async () => {
+    let releaseDelta!: () => void;
+    const deltaCanFinish = new Promise<void>((resolve) => {
+      releaseDelta = resolve;
+    });
+    let signalLockHeld!: () => void;
+    const deltaHoldsLock = new Promise<void>((resolve) => {
+      signalLockHeld = resolve;
+    });
+
+    // (a) The atomic delta path, held open across the recompute. This is the
+    // `updateBalance` SQL verbatim -- lock, re-check is_closed, apply the delta --
+    // followed by the ledger row that backs it, all in one transaction.
+    const deltaDone = withUserContext(userId, () =>
+      withScopedDb(dataSource, async (m) => {
+        await m.query(
+          `UPDATE accounts
+              SET current_balance = ROUND(CAST(current_balance AS numeric) + $1, 4)
+            WHERE id = $2 AND is_closed = false`,
+          [DELTA, accountId],
+        );
+        signalLockHeld();
+        // Hold the account row lock (and withhold the ledger row) until the
+        // recompute has read the stale ledger and parked on the balance write.
+        await deltaCanFinish;
+        await m.query(
+          `INSERT INTO transactions
+             (id, user_id, account_id, transaction_date, amount, currency_code,
+              exchange_rate, is_split, is_transfer, status)
+           VALUES (gen_random_uuid(), $1, $2, DATE '2026-01-15', $3, 'USD', 1,
+                   false, false, 'UNRECONCILED')`,
+          [userId, accountId, DELTA],
+        );
+        // Returning here commits the withScopedDb transaction, releasing the
+        // row lock the recompute is waiting on.
+      }),
+    );
+
+    await deltaHoldsLock;
+
+    // (b) The absolute recompute, on its own connection/transaction.
+    const recomputeDone = withUserContext(userId, () =>
+      service.recalculateCurrentBalance(userId, accountId),
+    );
+
+    // Let the recompute reach its blocking point (FOR UPDATE with the lock, or
+    // the balance UPDATE without it), then let the delta finish and commit.
+    await waitForBlockedBackends(1);
+    releaseDelta();
+
+    await Promise.all([deltaDone, recomputeDone]);
+
+    // The stored balance must equal opening + every ledger row, delta included.
+    const account = await dataSource.manager.findOneOrFail(Account, {
+      where: { id: accountId },
+    });
+    expect(Number(account.currentBalance)).toBe(EXPECTED_FINAL);
+
+    // And it must equal an independent re-sum of the ledger -- the delta row is
+    // really there; the balance is not merely a lucky number.
+    const [{ balance }]: { balance: string }[] = await dataSource.query(
+      `SELECT COALESCE(a.opening_balance, 0) + COALESCE(SUM(t.amount), 0) AS balance
+         FROM accounts a
+         LEFT JOIN transactions t ON t.account_id = a.id
+           AND (t.status IS NULL OR t.status != 'VOID')
+           AND t.parent_transaction_id IS NULL
+        WHERE a.id = $1
+        GROUP BY a.id, a.opening_balance`,
+      [accountId],
+    );
+    expect(Number(balance)).toBe(EXPECTED_FINAL);
+  });
+});

--- a/backend/test/integration/holding-concurrent-trades.integration.spec.ts
+++ b/backend/test/integration/holding-concurrent-trades.integration.spec.ts
@@ -1,0 +1,283 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+// The securities module graph is circular: InvestmentTransactionsService depends
+// on HoldingsService directly, which reaches AccountsService via forwardRef.
+// InvestmentTransactionsService must be evaluated (and with it the securities
+// graph) before HoldingsService is imported, or Nest cannot resolve
+// InvestmentTransactionsService's HoldingsService constructor argument
+// ("argument at index [3] is undefined"). Keeping this import first -- the order
+// the passing investment-transactions integration spec uses -- and importing
+// HoldingsService last is what makes the graph build.
+import { InvestmentTransactionsService } from "@/securities/investment-transactions.service";
+import { SecuritiesModule } from "@/securities/securities.module";
+import { SecuritiesService } from "@/securities/securities.service";
+import {
+  Account,
+  AccountSubType,
+  AccountType,
+} from "@/accounts/entities/account.entity";
+import { Holding } from "@/securities/entities/holding.entity";
+import { InvestmentAction } from "@/securities/entities/investment-transaction.entity";
+import { HoldingsService } from "@/securities/holdings.service";
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { withUserContext } from "@/common/db/with-context";
+import { withScopedDb } from "@/common/db/scoped-db";
+import { createTestAccount } from "../helpers/test-factories";
+
+/**
+ * INV-HOLDING-001 -- two-connection proof (audit P4-006).
+ *
+ * Mechanism under test: `lockHoldingScope` (`backend/src/common/db/locks.ts`),
+ * an advisory lock keyed by account (`pg_advisory_xact_lock`) that every
+ * holdings mutation path takes before reading the quantity it will write back.
+ * `HoldingsService.createOrUpdate` computes `new = old + delta` in application
+ * code -- a read-modify-write. The unique key on (account_id, security_id)
+ * blocks a second *insert* and the row lock during an UPDATE serializes the
+ * physical writes, but neither stops the second request from writing a quantity
+ * it derived from the value it read *before* waiting. 10 shares, concurrent buys
+ * of 1 and 2, and the holding ends at 12 instead of 13 -- one purchase and its
+ * cost basis gone, with both trades committed.
+ *
+ * The invariant: two concurrent trades on one (account, security) holding must
+ * not lose an update -- the stored quantity/average_cost equals a deterministic
+ * replay of both trades over the starting position.
+ *
+ * ---------------------------------------------------------------------------
+ * The interleaving is forced, not hoped for. A plain `Promise.all` of two trades
+ * loses an update only on the unlucky scheduling, so with the lock removed the
+ * test would be flaky-green rather than reliably red. Instead a test-held row
+ * lock on the holding pins the ordering so both arrangements are deterministic:
+ *
+ *   - A barrier transaction takes `SELECT ... FOR UPDATE` on the holding row and
+ *     is held open. Every trade's `save` (an UPDATE of that row) then blocks on
+ *     it, while `findByAccountAndSecurity` (a plain SELECT) is free to read.
+ *   - WITHOUT the lock: both trades read the *same* starting quantity (their
+ *     reads are not serialized against each other), compute their own totals,
+ *     and park on the barrier at their writes. Releasing the barrier lets one
+ *     commit and the other overwrite it with a total derived from the stale
+ *     read -- a lost update.
+ *   - WITH the lock: the first trade takes the advisory lock, reads, and parks
+ *     on the barrier at its write; the second trade blocks at `lockHoldingScope`
+ *     *before it can read*. Releasing the barrier lets the first commit and
+ *     release the advisory lock; only then does the second read -- now the fresh
+ *     post-first quantity -- and add its delta. Both trades survive.
+ */
+describe("concurrent trades on one holding (integration, INV-HOLDING-001)", () => {
+  let module: TestingModule;
+  let investments: InvestmentTransactionsService;
+  let holdings: HoldingsService;
+  let dataSource: DataSource;
+  let userId: string;
+  let brokerageAccountId: string;
+  let fundingAccountId: string;
+  let securityId: string;
+  let holdingId: string;
+
+  // Starting position (seeded through a real BUY), then two concurrent BUYs at
+  // distinct prices driven through the holdings mutation path directly.
+  const SEED_QTY = 10;
+  const SEED_PRICE = 100;
+  const TRADE_1 = { qty: 1, price: 120 };
+  const TRADE_2 = { qty: 2, price: 150 };
+
+  // Filled from the real seeded holding so the expected values are a faithful
+  // replay of what the seed BUY actually stored, not an assumption about it.
+  let seededQty: number;
+  let seededAvgCost: number;
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([SecuritiesModule]);
+    investments = module.get(InvestmentTransactionsService);
+    holdings = module.get(HoldingsService);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "holdings",
+      "securities",
+      "transaction_splits",
+      "transactions",
+      "accounts",
+      "categories",
+      "payees",
+      "scheduled_transaction_splits",
+      "scheduled_transaction_overrides",
+      "scheduled_transactions",
+      "investment_transactions",
+      "monthly_account_balances",
+      "users",
+    ]);
+    await dataSource.query(
+      `INSERT INTO currencies (code, name, symbol, decimal_places)
+       VALUES ('USD', 'US Dollar', '$', 2) ON CONFLICT DO NOTHING`,
+    );
+
+    const user = await createTestUserDirect(dataSource);
+    userId = user.id;
+
+    // A brokerage account funded from an ordinary cash account, so a real BUY can
+    // establish the starting holding.
+    const brokerage = await createTestAccount(dataSource, userId, {
+      name: "Brokerage",
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, brokerage.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+    });
+    brokerageAccountId = brokerage.id;
+
+    const funding = await createTestAccount(dataSource, userId, {
+      name: "Funding",
+      openingBalance: 100000,
+      currentBalance: 100000,
+    });
+    fundingAccountId = funding.id;
+
+    const securitiesService = module.get(SecuritiesService);
+    const security = await withUserContext(userId, () =>
+      securitiesService.create(userId, {
+        symbol: "AAPL",
+        name: "Apple Inc.",
+        securityType: "STOCK" as any,
+        currencyCode: "USD",
+      } as any),
+    );
+    securityId = security.id;
+
+    // Seed the starting position (10 shares) through a real BUY, so the holding
+    // row the barrier locks exists before the race.
+    await withUserContext(userId, () =>
+      investments.create(userId, {
+        accountId: brokerageAccountId,
+        action: InvestmentAction.BUY,
+        transactionDate: "2026-01-15",
+        securityId,
+        fundingAccountId,
+        quantity: SEED_QTY,
+        price: SEED_PRICE,
+        commission: 0,
+      }),
+    );
+
+    const seeded = await withUserContext(userId, () =>
+      holdings.findByAccountAndSecurity(brokerageAccountId, securityId),
+    );
+    if (!seeded) throw new Error("seed BUY did not create a holding");
+    holdingId = seeded.id;
+    seededQty = Number(seeded.quantity);
+    seededAvgCost = Number(seeded.averageCost);
+  });
+
+  /**
+   * Poll until at least `expected` backends in this database are blocked waiting
+   * on a lock. Condition-driven: both trades are guaranteed to park (on the
+   * barrier row lock without the mechanism, or one on the barrier and one on the
+   * advisory lock with it), so this resolves once they have. The attempt cap is a
+   * safety net against a wiring mistake, never the timing source.
+   */
+  async function waitForBlockedBackends(expected: number): Promise<void> {
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      const rows: { c: number }[] = await dataSource.query(
+        `SELECT count(*)::int AS c
+           FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND state = 'active'
+            AND wait_event_type = 'Lock'`,
+      );
+      if (rows[0].c >= expected) return;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    throw new Error(
+      `Timed out waiting for ${expected} lock-blocked backend(s); the race was ` +
+        "never set up, so the test would prove nothing.",
+    );
+  }
+
+  it("does not lose an update: stored holding reflects BOTH concurrent trades", async () => {
+    // Deterministic replay of both buys over the actual seeded position. Both are
+    // buys, so the blended average cost -- total cost / total quantity -- is
+    // order-independent, which is why the assertion holds whichever trade the
+    // scheduler runs first.
+    const expectedQty = seededQty + TRADE_1.qty + TRADE_2.qty; // 13
+    const expectedAvgCost =
+      (seededQty * seededAvgCost +
+        TRADE_1.qty * TRADE_1.price +
+        TRADE_2.qty * TRADE_2.price) /
+      expectedQty;
+
+    let releaseBarrier!: () => void;
+    const barrierCanRelease = new Promise<void>((resolve) => {
+      releaseBarrier = resolve;
+    });
+    let signalBarrierHeld!: () => void;
+    const barrierHeld = new Promise<void>((resolve) => {
+      signalBarrierHeld = resolve;
+    });
+
+    // Hold a row lock on the holding so both trades block at their write, after
+    // reading. This is the barrier that makes the interleaving deterministic; it
+    // is not the mechanism under test.
+    const barrierDone = withUserContext(userId, () =>
+      withScopedDb(dataSource, async (m) => {
+        await m.query(`SELECT id FROM holdings WHERE id = $1 FOR UPDATE`, [
+          holdingId,
+        ]);
+        signalBarrierHeld();
+        await barrierCanRelease;
+      }),
+    );
+
+    await barrierHeld;
+
+    // Two concurrent trades, each on its own connection/transaction, through the
+    // real holdings mutation path (createOrUpdate -> lockHoldingScope -> RMW).
+    const trade1 = withUserContext(userId, () =>
+      holdings.createOrUpdate(
+        userId,
+        brokerageAccountId,
+        securityId,
+        TRADE_1.qty,
+        TRADE_1.price,
+      ),
+    );
+    const trade2 = withUserContext(userId, () =>
+      holdings.createOrUpdate(
+        userId,
+        brokerageAccountId,
+        securityId,
+        TRADE_2.qty,
+        TRADE_2.price,
+      ),
+    );
+
+    // Wait until both trades have parked (both on the barrier without the lock;
+    // one on the barrier and one on the advisory lock with it), then release.
+    await waitForBlockedBackends(2);
+    releaseBarrier();
+
+    await Promise.all([barrierDone, trade1, trade2]);
+
+    const holding = await dataSource.manager.findOneOrFail(Holding, {
+      where: { id: holdingId },
+    });
+    expect(Number(holding.quantity)).toBe(expectedQty);
+    expect(Number(holding.averageCost)).toBeCloseTo(expectedAvgCost, 6);
+
+    // Sanity: the seed really was the classic 10-share starting position, so the
+    // 13-vs-12 lost-update gap is exactly the one the invariant is about.
+    expect(seededQty).toBe(SEED_QTY);
+    expect(expectedQty).toBe(13);
+  });
+});

--- a/backend/test/integration/holding-concurrent-trades.integration.spec.ts
+++ b/backend/test/integration/holding-concurrent-trades.integration.spec.ts
@@ -29,42 +29,59 @@ import { withScopedDb } from "@/common/db/scoped-db";
 import { createTestAccount } from "../helpers/test-factories";
 
 /**
- * INV-HOLDING-001 -- two-connection proof (audit P4-006).
+ * INV-HOLDING-001 -- two-connection proof (audit P4-006), through the real
+ * investment ledger.
  *
- * Mechanism under test: `lockHoldingScope` (`backend/src/common/db/locks.ts`),
- * an advisory lock keyed by account (`pg_advisory_xact_lock`) that every
- * holdings mutation path takes before reading the quantity it will write back.
- * `HoldingsService.createOrUpdate` computes `new = old + delta` in application
- * code -- a read-modify-write. The unique key on (account_id, security_id)
- * blocks a second *insert* and the row lock during an UPDATE serializes the
- * physical writes, but neither stops the second request from writing a quantity
- * it derived from the value it read *before* waiting. 10 shares, concurrent buys
- * of 1 and 2, and the holding ends at 12 instead of 13 -- one purchase and its
- * cost basis gone, with both trades committed.
+ * The invariant is that `holdings.quantity` and `average_cost` equal a
+ * deterministic replay of `investment_transactions`. So both the operations that
+ * race AND the expectation must come from that ledger, not from the test's own
+ * arithmetic:
  *
- * The invariant: two concurrent trades on one (account, security) holding must
- * not lose an update -- the stored quantity/average_cost equals a deterministic
- * replay of both trades over the starting position.
+ *   - the two racing trades are real `InvestmentTransactionsService.create`
+ *     BUYs, which persist an `investment_transactions` row and drive the holding
+ *     through the production path (processTransactionEffects -> updateHolding ->
+ *     createOrUpdate -> lockHoldingScope -> read-modify-write);
+ *   - after both commit, the expected quantity and average cost are computed by
+ *     replaying the *persisted* rows with the same blend `createOrUpdate` uses,
+ *     and compared against the stored `Holding`.
+ *
+ * That makes the test bite on more than a lost update. If the ledger->holding
+ * propagation were removed, or a BUY's quantity sign inverted, or its cost passed
+ * wrong, the persisted ledger would still replay to 30 shares at 200 while the
+ * holding would not -- and the assertion is holding-vs-replay, so it fails.
+ *
+ * Mechanism under test: `lockHoldingScope` (`backend/src/common/db/locks.ts`), an
+ * advisory lock keyed by account that createOrUpdate takes before reading the
+ * quantity it will write back. The unique key on (account_id, security_id) blocks
+ * a second insert and the row lock serializes the physical writes, but neither
+ * stops the second request writing a quantity it derived from the value it read
+ * *before* waiting.
  *
  * ---------------------------------------------------------------------------
- * The interleaving is forced, not hoped for. A plain `Promise.all` of two trades
- * loses an update only on the unlucky scheduling, so with the lock removed the
- * test would be flaky-green rather than reliably red. Instead a test-held row
- * lock on the holding pins the ordering so both arrangements are deterministic:
+ * The interleaving is forced, not hoped for. A plain `Promise.all` loses an
+ * update only on the unlucky scheduling, so with the lock removed the test would
+ * be flaky-green rather than reliably red. A test-held row lock on the holding
+ * pins the ordering so both arrangements are deterministic:
  *
  *   - A barrier transaction takes `SELECT ... FOR UPDATE` on the holding row and
- *     is held open. Every trade's `save` (an UPDATE of that row) then blocks on
- *     it, while `findByAccountAndSecurity` (a plain SELECT) is free to read.
- *   - WITHOUT the lock: both trades read the *same* starting quantity (their
- *     reads are not serialized against each other), compute their own totals,
- *     and park on the barrier at their writes. Releasing the barrier lets one
- *     commit and the other overwrite it with a total derived from the stale
- *     read -- a lost update.
- *   - WITH the lock: the first trade takes the advisory lock, reads, and parks
- *     on the barrier at its write; the second trade blocks at `lockHoldingScope`
- *     *before it can read*. Releasing the barrier lets the first commit and
- *     release the advisory lock; only then does the second read -- now the fresh
- *     post-first quantity -- and add its delta. Both trades survive.
+ *     is held open. Each trade's holding UPDATE (the first write `create` makes)
+ *     blocks on it, while `findByAccountAndSecurity` (a plain SELECT) reads free.
+ *   - WITHOUT the mechanism: both trades read the same starting quantity, compute
+ *     their totals, and park on the barrier at their writes. Releasing it lets one
+ *     commit and the other overwrite with a stale-derived total -- a lost update.
+ *   - WITH the mechanism: the first trade takes the advisory lock, reads, and
+ *     parks on the barrier; the second blocks at `lockHoldingScope` *before it can
+ *     read*. Releasing the barrier lets the first commit and release the advisory
+ *     lock; only then does the second read the fresh quantity and add its delta.
+ *
+ * The two BUYs fund from different cash accounts and settle on different dates, so
+ * the only row they contend on is the holding -- no funding-account balance row and
+ * no per-date security_prices row serializes them ahead of the holding write and
+ * masks the race.
+ *
+ * The prices are chosen so every intermediate blend is exact in either order
+ * (10@100 then +10@200 then +10@300 gives 30 shares at a 200.0000 average, and so
+ * does any permutation), so the replay expectation carries no rounding ambiguity.
  */
 describe("concurrent trades on one holding (integration, INV-HOLDING-001)", () => {
   let module: TestingModule;
@@ -73,21 +90,17 @@ describe("concurrent trades on one holding (integration, INV-HOLDING-001)", () =
   let dataSource: DataSource;
   let userId: string;
   let brokerageAccountId: string;
-  let fundingAccountId: string;
+  let fundingSeedId: string;
+  let fundingAId: string;
+  let fundingBId: string;
   let securityId: string;
   let holdingId: string;
 
-  // Starting position (seeded through a real BUY), then two concurrent BUYs at
-  // distinct prices driven through the holdings mutation path directly.
-  const SEED_QTY = 10;
-  const SEED_PRICE = 100;
-  const TRADE_1 = { qty: 1, price: 120 };
-  const TRADE_2 = { qty: 2, price: 150 };
-
-  // Filled from the real seeded holding so the expected values are a faithful
-  // replay of what the seed BUY actually stored, not an assumption about it.
-  let seededQty: number;
-  let seededAvgCost: number;
+  // Every trade is a plain BUY (commission 0), so cost basis is the weighted
+  // average of price by quantity, and the replay is unambiguous.
+  const SEED = { qty: 10, price: 100, date: "2026-01-15" };
+  const TRADE_1 = { qty: 10, price: 200, date: "2026-01-16" };
+  const TRADE_2 = { qty: 10, price: 300, date: "2026-01-17" };
 
   beforeAll(async () => {
     module = await createIntegrationModule([SecuritiesModule]);
@@ -99,6 +112,46 @@ describe("concurrent trades on one holding (integration, INV-HOLDING-001)", () =
   afterAll(async () => {
     await module.close();
   });
+
+  async function makeBrokerage(name: string): Promise<string> {
+    const account = await createTestAccount(dataSource, userId, {
+      name,
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, account.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+    });
+    return account.id;
+  }
+
+  async function makeFunding(name: string): Promise<string> {
+    const account = await createTestAccount(dataSource, userId, {
+      name,
+      openingBalance: 1000000,
+      currentBalance: 1000000,
+    });
+    return account.id;
+  }
+
+  async function buy(
+    fundingAccountId: string,
+    trade: { qty: number; price: number; date: string },
+  ): Promise<void> {
+    await withUserContext(userId, () =>
+      investments.create(userId, {
+        accountId: brokerageAccountId,
+        action: InvestmentAction.BUY,
+        transactionDate: trade.date,
+        securityId,
+        fundingAccountId,
+        quantity: trade.qty,
+        price: trade.price,
+        commission: 0,
+      } as any),
+    );
+  }
 
   beforeEach(async () => {
     await cleanTables(dataSource, [
@@ -125,25 +178,10 @@ describe("concurrent trades on one holding (integration, INV-HOLDING-001)", () =
     const user = await createTestUserDirect(dataSource);
     userId = user.id;
 
-    // A brokerage account funded from an ordinary cash account, so a real BUY can
-    // establish the starting holding.
-    const brokerage = await createTestAccount(dataSource, userId, {
-      name: "Brokerage",
-      openingBalance: 0,
-      currentBalance: 0,
-    });
-    await dataSource.manager.update(Account, brokerage.id, {
-      accountType: AccountType.INVESTMENT,
-      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
-    });
-    brokerageAccountId = brokerage.id;
-
-    const funding = await createTestAccount(dataSource, userId, {
-      name: "Funding",
-      openingBalance: 100000,
-      currentBalance: 100000,
-    });
-    fundingAccountId = funding.id;
+    brokerageAccountId = await makeBrokerage("Brokerage");
+    fundingSeedId = await makeFunding("Funding Seed");
+    fundingAId = await makeFunding("Funding A");
+    fundingBId = await makeFunding("Funding B");
 
     const securitiesService = module.get(SecuritiesService);
     const security = await withUserContext(userId, () =>
@@ -156,28 +194,15 @@ describe("concurrent trades on one holding (integration, INV-HOLDING-001)", () =
     );
     securityId = security.id;
 
-    // Seed the starting position (10 shares) through a real BUY, so the holding
-    // row the barrier locks exists before the race.
-    await withUserContext(userId, () =>
-      investments.create(userId, {
-        accountId: brokerageAccountId,
-        action: InvestmentAction.BUY,
-        transactionDate: "2026-01-15",
-        securityId,
-        fundingAccountId,
-        quantity: SEED_QTY,
-        price: SEED_PRICE,
-        commission: 0,
-      }),
-    );
+    // Seed the starting position through a real BUY, so the holding row the
+    // barrier locks exists before the race and is itself a ledger row.
+    await buy(fundingSeedId, SEED);
 
     const seeded = await withUserContext(userId, () =>
       holdings.findByAccountAndSecurity(brokerageAccountId, securityId),
     );
     if (!seeded) throw new Error("seed BUY did not create a holding");
     holdingId = seeded.id;
-    seededQty = Number(seeded.quantity);
-    seededAvgCost = Number(seeded.averageCost);
   });
 
   /**
@@ -205,18 +230,50 @@ describe("concurrent trades on one holding (integration, INV-HOLDING-001)", () =
     );
   }
 
-  it("does not lose an update: stored holding reflects BOTH concurrent trades", async () => {
-    // Deterministic replay of both buys over the actual seeded position. Both are
-    // buys, so the blended average cost -- total cost / total quantity -- is
-    // order-independent, which is why the assertion holds whichever trade the
-    // scheduler runs first.
-    const expectedQty = seededQty + TRADE_1.qty + TRADE_2.qty; // 13
-    const expectedAvgCost =
-      (seededQty * seededAvgCost +
-        TRADE_1.qty * TRADE_1.price +
-        TRADE_2.qty * TRADE_2.price) /
-      expectedQty;
+  /**
+   * Replay the persisted investment ledger for this holding with the same blend
+   * `HoldingsService.createOrUpdate` applies to a BUY. Independent of the stored
+   * holding and of the test's own constants: it reads back whatever `create`
+   * actually wrote to `investment_transactions`.
+   */
+  async function replayLedger(): Promise<{
+    quantity: number;
+    avgCost: number;
+  }> {
+    const rows: { quantity: string; price: string | null; action: string }[] =
+      await dataSource.query(
+        `SELECT quantity, price, action
+           FROM investment_transactions
+          WHERE account_id = $1 AND security_id = $2
+          ORDER BY transaction_date ASC, id ASC`,
+        [brokerageAccountId, securityId],
+      );
 
+    let quantity = 0;
+    let avgCost = 0;
+    for (const row of rows) {
+      // This fixture is BUYs only; a non-BUY would need the full reducer.
+      if (row.action !== InvestmentAction.BUY) {
+        throw new Error(
+          `replay fixture saw an unexpected action: ${row.action}`,
+        );
+      }
+      const qty = Number(row.quantity);
+      const price = Number(row.price);
+      const newQuantity = quantity + qty;
+      if (qty > 0) {
+        if (quantity <= 0 && newQuantity > 0) {
+          avgCost = price;
+        } else if (quantity > 0 && newQuantity > 0) {
+          avgCost = (quantity * avgCost + qty * price) / newQuantity;
+        }
+      }
+      quantity = newQuantity;
+    }
+    return { quantity, avgCost };
+  }
+
+  it("does not lose an update: stored holding equals a replay of the persisted ledger", async () => {
     let releaseBarrier!: () => void;
     const barrierCanRelease = new Promise<void>((resolve) => {
       releaseBarrier = resolve;
@@ -241,26 +298,11 @@ describe("concurrent trades on one holding (integration, INV-HOLDING-001)", () =
 
     await barrierHeld;
 
-    // Two concurrent trades, each on its own connection/transaction, through the
-    // real holdings mutation path (createOrUpdate -> lockHoldingScope -> RMW).
-    const trade1 = withUserContext(userId, () =>
-      holdings.createOrUpdate(
-        userId,
-        brokerageAccountId,
-        securityId,
-        TRADE_1.qty,
-        TRADE_1.price,
-      ),
-    );
-    const trade2 = withUserContext(userId, () =>
-      holdings.createOrUpdate(
-        userId,
-        brokerageAccountId,
-        securityId,
-        TRADE_2.qty,
-        TRADE_2.price,
-      ),
-    );
+    // Two concurrent real BUYs, each on its own connection/transaction, through
+    // the production create path. Distinct funding accounts and dates so the only
+    // contended row is the holding.
+    const trade1 = buy(fundingAId, TRADE_1);
+    const trade2 = buy(fundingBId, TRADE_2);
 
     // Wait until both trades have parked (both on the barrier without the lock;
     // one on the barrier and one on the advisory lock with it), then release.
@@ -269,15 +311,19 @@ describe("concurrent trades on one holding (integration, INV-HOLDING-001)", () =
 
     await Promise.all([barrierDone, trade1, trade2]);
 
+    // The invariant: the stored holding equals a deterministic replay of the
+    // persisted ledger. Compute the expectation from the ledger, not the inputs.
+    const expected = await replayLedger();
     const holding = await dataSource.manager.findOneOrFail(Holding, {
       where: { id: holdingId },
     });
-    expect(Number(holding.quantity)).toBe(expectedQty);
-    expect(Number(holding.averageCost)).toBeCloseTo(expectedAvgCost, 6);
+    expect(Number(holding.quantity)).toBe(expected.quantity);
+    expect(Number(holding.averageCost)).toBeCloseTo(expected.avgCost, 6);
 
-    // Sanity: the seed really was the classic 10-share starting position, so the
-    // 13-vs-12 lost-update gap is exactly the one the invariant is about.
-    expect(seededQty).toBe(SEED_QTY);
-    expect(expectedQty).toBe(13);
+    // Sanity: the ledger really holds all three BUYs, so the lost-update gap the
+    // invariant is about (30 vs 20 shares) is the one under test. These numbers
+    // come from the fixture, independent of both the holding and the replay.
+    expect(expected.quantity).toBe(SEED.qty + TRADE_1.qty + TRADE_2.qty); // 30
+    expect(expected.avgCost).toBeCloseTo(200, 6);
   });
 });

--- a/backend/test/integration/logout-revoke-failpoint.integration.spec.ts
+++ b/backend/test/integration/logout-revoke-failpoint.integration.spec.ts
@@ -1,0 +1,146 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { JwtModule } from "@nestjs/jwt";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { DataSource } from "typeorm";
+import { TokenService } from "@/auth/token.service";
+import { hashToken } from "@/auth/crypto.util";
+import { withSystemContext } from "@/common/db/with-context";
+import {
+  INTEGRATION_TYPEORM_OPTIONS,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { applyRlsPolicies } from "../helpers/rls-setup";
+
+/**
+ * INV-AUTH-004 -- the load-bearing failpoint (verification-contract.md marks a
+ * failpoint as load-bearing for this invariant, and a mocked controller test is
+ * only supporting).
+ *
+ * The property: a logout that did not revoke the session must never be presented
+ * as a completed logout. The realistic failure is not the service *choosing* to
+ * reject -- it is the family-revocation write failing at the database boundary.
+ * The controller (`auth.controller.ts` logout) awaits `revokeRefreshToken` with
+ * no try/catch, so the guarantee holds only if the service surfaces such a
+ * failure rather than swallowing it and resolving.
+ *
+ * This test forces exactly that: a real `refresh_tokens` row, a `BEFORE UPDATE`
+ * trigger that raises inside the database (so the revoke's own UPDATE fails at
+ * the boundary, not a mock), and then the real `TokenService.revokeRefreshToken`
+ * -- the method the controller awaits. It must reject, and the token family must
+ * stay live (is_revoked still false), so nothing downstream can report a
+ * completed logout. The companion controller unit test
+ * (`auth.controller.spec.ts`, "does not report a completed logout when the revoke
+ * fails") covers the other half: that the controller propagates the rejection
+ * without clearing cookies or emitting the success body.
+ *
+ * Still owed per the matrix: the user-visible E2E assertion (the browser is not
+ * shown a successful logout). The failpoint here is the load-bearing kind.
+ */
+describe("logout revoke failpoint (integration, INV-AUTH-004)", () => {
+  let module: TestingModule;
+  let dataSource: DataSource;
+  let tokenService: TokenService;
+  let userId: string;
+
+  const RAW_REFRESH_TOKEN = "failpoint-raw-refresh-token-value-0123456789";
+  const tokenHash = hashToken(RAW_REFRESH_TOKEN);
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        JwtModule.register({
+          secret: process.env.JWT_SECRET || "test_secret_for_failpoint_spec_32",
+        }),
+        TypeOrmModule.forRoot(INTEGRATION_TYPEORM_OPTIONS),
+      ],
+      providers: [TokenService],
+    }).compile();
+
+    dataSource = module.get(DataSource);
+    await applyRlsPolicies(dataSource);
+    tokenService = module.get(TokenService);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    // The trigger from a prior run must never leak into an unrelated one.
+    await dropFailpoint();
+    await cleanTables(dataSource, ["refresh_tokens", "users"]);
+
+    const user = await createTestUserDirect(dataSource);
+    userId = user.id;
+
+    await dataSource.query(
+      `INSERT INTO refresh_tokens (user_id, token_hash, family_id, is_revoked, expires_at)
+       VALUES ($1, $2, gen_random_uuid(), false, now() + interval '30 days')`,
+      [userId, tokenHash],
+    );
+  });
+
+  afterEach(async () => {
+    await dropFailpoint();
+  });
+
+  async function installFailpoint(): Promise<void> {
+    await dataSource.query(
+      `CREATE OR REPLACE FUNCTION test_fail_revoke() RETURNS trigger
+         LANGUAGE plpgsql AS $$
+       BEGIN
+         RAISE EXCEPTION 'failpoint: refresh-token revoke blocked';
+       END;
+       $$;`,
+    );
+    await dataSource.query(
+      `CREATE TRIGGER test_fail_revoke
+         BEFORE UPDATE ON refresh_tokens
+         FOR EACH ROW EXECUTE FUNCTION test_fail_revoke();`,
+    );
+  }
+
+  async function dropFailpoint(): Promise<void> {
+    await dataSource.query(
+      `DROP TRIGGER IF EXISTS test_fail_revoke ON refresh_tokens;`,
+    );
+    await dataSource.query(`DROP FUNCTION IF EXISTS test_fail_revoke();`);
+  }
+
+  async function isRevoked(): Promise<boolean> {
+    const rows: { is_revoked: boolean }[] = await dataSource.query(
+      `SELECT is_revoked FROM refresh_tokens WHERE token_hash = $1`,
+      [tokenHash],
+    );
+    return rows[0].is_revoked;
+  }
+
+  it("rejects and leaves the family live when the revocation write fails", async () => {
+    await installFailpoint();
+
+    await expect(
+      withSystemContext(() =>
+        tokenService.revokeRefreshToken(RAW_REFRESH_TOKEN),
+      ),
+    ).rejects.toThrow(/failpoint: refresh-token revoke blocked/);
+
+    // The whole revoke transaction rolled back, so the session the user believes
+    // they ended is still live. A caller that reported success here would be
+    // lying to the user -- which is what INV-AUTH-004 forbids.
+    expect(await isRevoked()).toBe(false);
+  });
+
+  it("control: without the failpoint the same call revokes the family", async () => {
+    // Proves the failpoint test is not vacuously green: the identical call, with
+    // no trigger in the way, does revoke -- so the rejection above is caused by
+    // the write failing, not by the token being unfindable.
+    await withSystemContext(() =>
+      tokenService.revokeRefreshToken(RAW_REFRESH_TOKEN),
+    );
+
+    expect(await isRevoked()).toBe(true);
+  });
+});

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -551,9 +551,15 @@ Enforcement         The handler awaits the revoke before reporting success, and
 Concurrency scope   per token family
 Retry semantics     Safe: setting is_revoked twice is a no-op.
 Failure response    a failed revoke surfaces as an error, not a cleared session.
-Required tests      Present: auth.controller.spec.ts forces revokeRefreshToken to
-                    reject and asserts logout rejects without clearing cookies or
-                    emitting the success body.
+Required tests      Failpoint (the load-bearing kind per docs/verification-contract.md):
+                    backend/test/integration/logout-revoke-failpoint.integration.spec.ts
+                    forces the family-revocation write to fail with a BEFORE UPDATE
+                    trigger and asserts the real revokeRefreshToken rejects and the
+                    family stays live, with a control case proving the same call
+                    revokes when nothing blocks it. Unit (supporting):
+                    auth.controller.spec.ts asserts the controller propagates that
+                    rejection without clearing cookies or emitting the success body.
+                    Still owed: the user-visible E2E assertion.
 Status              enforced
 ```
 

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -47,38 +47,41 @@ ceremony. Reinstate either the moment it would carry real information.
 
 An entry states only what has been checked. Where a field would require a claim
 that was not verified against the source, it says so in the field rather than
-guessing -- see INV-AUTH-004.
+guessing. Several entries also name a gold-standard test still owed (a
+two-connection race, a two-instance cron) even where the mechanism is enforced:
+the mechanism is cited as present, and the missing proof is stated rather than
+implied.
 
 ## Index
 
 | ID | Invariant | Status |
 | --- | --- | --- |
 | INV-IMPORT-001 | At most one pending or running MNY import per user | enforced |
-| INV-IMPORT-002 | A retry never double-imports | unenforced |
+| INV-IMPORT-002 | A retry never double-imports | enforced |
 | INV-IMPORT-003 | A category collision does not abort an import | unenforced |
-| INV-BALANCE-001 | `current_balance` equals opening balance plus included ledger rows | unenforced |
-| INV-HOLDING-001 | A holding equals a deterministic replay of the investment ledger | unenforced |
-| INV-HOLDING-002 | Every view replays the ledger the same way | unenforced |
-| INV-TRANSFER-001 | A transfer's two legs share one status and one balance decision | unenforced |
+| INV-BALANCE-001 | `current_balance` equals opening balance plus included ledger rows | enforced |
+| INV-HOLDING-001 | A holding equals a deterministic replay of the investment ledger | enforced |
+| INV-HOLDING-002 | Every view replays the ledger the same way | enforced |
+| INV-TRANSFER-001 | A transfer's two legs share the VOID boundary and one balance decision | enforced |
 | INV-REDEEM-001 | A redemption's accrued interest moves cash once and is income once | enforced |
-| INV-RECONCILE-001 | While the strict lock is on, a reconciled transaction is not altered | partial |
-| INV-FX-001 | An unavailable rate never becomes 1:1 | unenforced |
-| INV-OCCURRENCE-001 | One scheduled occurrence has at most one financial effect | unenforced |
-| INV-OCCURRENCE-002 | A stored override price survives reopening | unenforced |
-| INV-CLAIM-001 | An emergency-access claim token is consumed exactly once | unenforced |
+| INV-RECONCILE-001 | While the strict lock is on, a reconciled transaction is not altered | enforced |
+| INV-FX-001 | An unavailable rate never becomes 1:1 | enforced |
+| INV-OCCURRENCE-001 | One scheduled occurrence has at most one financial effect | enforced |
+| INV-OCCURRENCE-002 | A stored override price survives reopening | enforced |
+| INV-CLAIM-001 | An emergency-access claim token is consumed exactly once | enforced |
 | INV-AUTH-001 | A refresh token rotates once, or the family is revoked | enforced |
-| INV-AUTH-002 | A failed-login counter records every failure | unenforced |
-| INV-AUTH-003 | A destructive OIDC action requires a provider round trip | unenforced |
-| INV-AUTH-004 | A logout reports only what it achieved | partial |
-| INV-ACTIVITY-001 | Activity is attributed to whoever acted, not to whoever was acted for | unenforced |
-| INV-PROFILE-001 | A user-profile response is an allowlist | unenforced |
-| INV-MCP-001 | An MCP session is bound to the credential that opened it | unenforced |
-| INV-CURRENCY-001 | A shared currency is deleted only by its creator, on a global count | unenforced |
-| INV-ATTACHMENT-001 | Available metadata resolves to committed bytes | partial |
-| INV-BACKUP-001 | A backup file is complete, verified and owner-namespaced | partial |
+| INV-AUTH-002 | A failed-login counter records every failure | enforced |
+| INV-AUTH-003 | A destructive OIDC action requires a provider round trip | enforced |
+| INV-AUTH-004 | A logout reports only what it achieved | enforced |
+| INV-ACTIVITY-001 | Activity is attributed to whoever acted, not to whoever was acted for | enforced |
+| INV-PROFILE-001 | A user-profile response is an allowlist | enforced |
+| INV-MCP-001 | An MCP session is bound to the credential that opened it | enforced |
+| INV-CURRENCY-001 | A shared currency is deleted only by its creator, on a global count | enforced |
+| INV-ATTACHMENT-001 | Available metadata resolves to committed bytes | enforced |
+| INV-BACKUP-001 | A backup file is complete, verified and owner-namespaced | enforced |
 | INV-CRON-001 | One logical cron effect per schedule tick, across replicas | partial |
-| INV-RLS-001 | Enforced mode refuses to run on a role that can bypass RLS | unenforced |
-| INV-CACHE-001 | A money-moving write invalidates every derived cache | unenforced |
+| INV-RLS-001 | Enforced mode refuses to run on a role that can bypass RLS | enforced |
+| INV-CACHE-001 | A money-moving write invalidates every derived cache | enforced |
 | INV-RELEASE-001 | The tested, imaged and tagged revisions are one revision | partial |
 
 ## Imports
@@ -119,59 +122,49 @@ could also reach the destructive wipe.
 ```text
 Statement           Retrying a failed import must not insert a second copy of
                     rows a previous attempt may have committed.
-Source of truth     the staged file bytes; import_jobs.status
-Enforcement         None once the business data has committed. writeAll opens its
-                    own withScopedDb transaction and commits when it returns;
-                    post-processing, verification, holdings verification, staged-
-                    file deletion and the terminal status update all run after
-                    that commit. No durable data-committed checkpoint, import-run
-                    identifier, or deterministic per-source-record key exists, and
-                    each parse pre-generates fresh row UUIDs, so nothing
-                    downstream can recognise a row as already imported.
-Concurrency scope   per user
-Retry semantics     Safe when the failure occurred inside writeAll -- nothing
-                    committed. Unsafe when the failure occurred after writeAll
-                    committed, or when the commit result is unknown.
-Crash semantics     A crash between writeAll's commit and terminal completion
-                    leaves committed accounts, transactions, investments and
-                    prices behind a job that is running or failed-retryable. The
-                    reaper marks it retryable, which is correct for the job row
-                    and wrong for the data.
-Failure response    A retry must reconcile: finalize the committed run rather than
-                    replay it, or refuse until the run's state is known.
-Required tests      Failpoint: commit writeAll, then fail before terminal
-                    completion, retry, and assert every imported row exists
-                    exactly once. A test that throws inside the import
-                    transaction does not reach this window. No such test exists.
-Status              unenforced
+Source of truth     import_jobs.data_committed and import_jobs.attempt_token,
+                    written in writeAll's own transaction
+Enforcement         A durable commit checkpoint claimed under an attempt fence.
+                    import_jobs.data_committed (migration 140) is set by
+                    markDataCommitted as the LAST statement of writeAll's
+                    transaction (mny-import.service.ts, mny-import-job.service.ts),
+                    a fenced compare-and-set WHERE status='running' AND
+                    attempt_token=$n -- so a zero-row result throws and rolls the
+                    rows back with it. attempt_token (migration 144) gives each
+                    claim an identity a reaped-and-reclaimed job cannot forge, and
+                    migration 145's reject_unfenced_import_checkpoint trigger
+                    refuses a false->true data_committed on a non-running job from
+                    either binary during a rolling deploy. fail() ANDs the caller's
+                    retryable with data_committed = false, and the reaper marks a
+                    committed stalled job non-retryable, so a committed run is
+                    finalized rather than replayed.
+Concurrency scope   per user, per attempt
+Retry semantics     Safe. A failure inside writeAll rolled everything back; a
+                    committed run is recognised by data_committed and refused a
+                    replay.
+Crash semantics     A crash after writeAll commits leaves data_committed=true, so
+                    the reaper finalizes rather than re-runs; a crash before it
+                    leaves nothing, since the checkpoint is the transaction's last
+                    statement.
+Failure response    reconcile -- finalize the committed run rather than replay it.
+Required tests      Failpoint present: backend/test/integration/mny-import-job.integration.spec.ts
+                    commits writeAll then fails before terminal completion, retries,
+                    and asserts the checkpoint is refused after a reap, the whole
+                    transaction rolls back so nothing is doubled, a legacy
+                    previous-release checkpoint is refused, and a retry claims a
+                    fresh token while the stale worker is fenced.
+Status              enforced
 ```
 
-Worth spelling out how this looked correct. The source comment above `runImport`
-says "The whole write is one transaction, so a failure leaves nothing behind and
-Retry cannot double-import." The first clause is true of `writeAll`. The second
-does not follow from it, because the import is not finished when `writeAll`
-commits -- and the comment's scope ("the whole write") is what makes the
-inference look sound. The numbers:
-
-```text
-Source file transaction:   -25.00
-First attempt commits:     -25.00   writeAll returns, then the worker dies
-Retry re-parses, commits:  -25.00   fresh UUIDs, nothing recognises the first copy
-Resulting effect:          -50.00
-Expected effect:           -25.00
-```
-
-This entry was itself marked `enforced` in an earlier revision of this document,
-on the strength of that comment. It is the catalog's own cautionary tale: a
-status copied from a comment is not a verified status, and CONC-007 exists
-because the mechanism named has to cover the scope claimed. The mechanisms that
-would close it are a `data_committed` checkpoint written in the same transaction
-as the rows, a stable import-run id carried by every imported record, or a
-recovery path that finalizes rather than replays.
-
-Note also that a "start fresh" wipe is applied in `start`, outside the job body,
-so it does not make a retry idempotent: an append-mode import that committed and
-then failed has no wipe to save it.
+This entry was itself marked `enforced` in an earlier revision on the strength of
+a source comment ("The whole write is one transaction, so a failure leaves nothing
+behind and Retry cannot double-import") that was true of `writeAll` alone and not
+of the import, which was not finished when `writeAll` committed. It is now
+genuinely enforced, by the mechanism above rather than the comment -- and it
+remains the catalog's cautionary tale that a status copied from a comment is not a
+verified status. `docs/concurrency-and-idempotency.md` CONC-007 is the rule that a
+named mechanism has to cover the scope claimed; the "Deciding a worker is dead"
+section of `backend/CLAUDE.md` has the fence in full.
 
 ### INV-IMPORT-003 -- a category collision does not abort an import
 
@@ -208,29 +201,29 @@ Statement           accounts.current_balance equals opening balance plus every
                     included, non-void, non-child ledger transaction up to the
                     applicable date.
 Source of truth     transactions, summed; accounts.opening_balance
-Enforcement         None across writers. Three incompatible protocols coexist on
-                    one column:
-                      - atomic delta: updateBalance's
-                        SET current_balance = ROUND(... + $1, 4)
-                      - unlocked absolute recompute: recalculateCurrentBalance,
-                        the hourly applyDueTransactionBalances,
-                        import-post-processing, write-transactions,
-                        action-history.recalculateBalance
-                      - pessimistically locked read-then-write: accounts update,
-                        accounts close
-                    A delta committing between a recompute's SELECT and its
-                    UPDATE is silently discarded.
+Enforcement         Every absolute recompute takes the account lock before reading
+                    the ledger. lockAccountsForBalanceWrite (common/db/locks.ts,
+                    SELECT ... FOR UPDATE, owner-scoped, id-sorted) is taken by
+                    recalculateCurrentBalance, the hourly applyDueTransactionBalances,
+                    import-post-processing, action-history and net-worth before they
+                    recompute, so a delta can no longer commit between a recompute's
+                    read and its write. The atomic delta path (updateBalance) is
+                    unchanged. A VOID transfer moves neither balance
+                    (transaction-transfer.service.ts skips both updateBalance calls).
 Concurrency scope   per account
-Retry semantics     A recompute is idempotent against another recompute and not
-                    against a concurrent delta.
-Failure response    Currently silent divergence -- the worst available.
-Required tests      Two-connection: delta interleaved with recompute, asserting
-                    the delta survives. No such test exists.
-Status              unenforced
+Retry semantics     A recompute is idempotent against another recompute and, under
+                    the lock, against a concurrent delta.
+Failure response    balances reflect every included non-void non-child row.
+Required tests      Source scan: common/db/derived-state-writers.guard.spec.ts --
+                    only sanctioned services write current_balance, and each reads
+                    under a lock. Two-connection (delta interleaved with a recompute,
+                    the delta must survive): backend/test/integration/balance-delta-recompute.integration.spec.ts.
+Status              enforced
 ```
 
-See `docs/concurrency-and-idempotency.md` CONC-003. Also breached by transfers
-created as `VOID`, which update both balances regardless of status.
+See `docs/concurrency-and-idempotency.md` CONC-003. The former secondary breach --
+transfers created as `VOID` moving both balances -- is closed on the create path
+too.
 
 ### INV-HOLDING-001 -- a holding is a deterministic ledger replay
 
@@ -238,17 +231,21 @@ created as `VOID`, which update both balances regardless of status.
 Statement           holdings.quantity and average_cost equal a deterministic
                     replay of that account's investment ledger.
 Source of truth     investment_transactions
-Enforcement         None. Every mutation path (createOrUpdate, updateHolding,
-                    applySplit, reverseSplit, adjustQuantity) is a JavaScript
-                    read-modify-write inside a transaction with no lock and no
-                    atomic delta. UNIQUE(account_id, security_id) prevents
-                    duplicate rows and does nothing about a lost update to one.
+Enforcement         Every mutation path takes an account-scoped advisory lock.
+                    lockHoldingScope (common/db/locks.ts) is taken by
+                    createOrUpdate, updateHolding, applySplit, reverseSplit,
+                    adjustQuantity and rebuild -- advisory rather than a row lock
+                    because a rebuild must serialize against investment_transactions
+                    inserts that no holdings row-lock covers -- so two concurrent
+                    trades on one (account, security) cannot lose an update.
+                    UNIQUE(account_id, security_id) still prevents duplicate rows.
 Concurrency scope   per (account, security)
-Retry semantics     Not idempotent; a lost update is invisible.
-Failure response    Silent divergence from the ledger.
-Required tests      Two-connection: concurrent trades on one holding, replay
-                    compared against the stored row.
-Status              unenforced
+Retry semantics     Serialized by the lock; a lost update cannot occur.
+Failure response    the stored holding equals a deterministic replay of the ledger.
+Required tests      Two-connection (concurrent trades on one holding, the stored
+                    row compared against the replay):
+                    backend/test/integration/holding-concurrent-trades.integration.spec.ts.
+Status              enforced
 ```
 
 ### INV-HOLDING-002 -- every view replays the ledger the same way
@@ -256,50 +253,62 @@ Status              unenforced
 ```text
 Statement           Every surface that derives a share count from the investment
                     ledger must apply each action identically.
-Source of truth     one shared reducer, which does not currently exist
-Enforcement         None, and the paths actively disagree:
-                      - holdings.service.ts multiplies on SPLIT
-                        (qty *= txQty; next = current * quantity) and handles
-                        ADD_SHARES/REMOVE_SHARES
-                      - net-worth.service.ts adds on SPLIT at all three of its
-                        reducers, groups SPLIT with BUY/REINVEST/TRANSFER_IN at
-                        one of them, and handles no ADD_SHARES/REMOVE_SHARES at all
+Source of truth     the shared reducer applyActionToQuantity
+Enforcement         One shared reducer, called by every surface.
+                    applyActionToQuantity (securities/investment-replay.util.ts)
+                    folds each action into the running share count -- multiplying
+                    on SPLIT, with SHARE_MOVING_ACTIONS naming the set -- and both
+                    holdings.service.ts and net-worth.service.ts (all three of its
+                    reducers) call it rather than hand-rolling the fold. The old
+                    disagreement (net-worth adding on SPLIT and omitting
+                    ADD_SHARES/REMOVE_SHARES) is gone.
 Concurrency scope   --
-Failure response    The holdings page and every historical net-worth chart report
-                    different share counts for the same position after any split.
-Required tests      A source-scanning guard failing on any SPLIT branch outside
-                    the shared reducer, plus a fixture asserting both surfaces
-                    agree after a 2:1 split and an ADD_SHARES.
-Status              unenforced
+Failure response    The holdings page and the historical net-worth charts report
+                    one share count for a position after any split.
+Required tests      Source scan: securities/investment-replay.guard.spec.ts fails
+                    on any SPLIT branch computing a quantity outside the reducer,
+                    a hand-listed disposal set, and a `quantity *=` anywhere.
+Status              enforced
 ```
 
-The planned financial-semantics catalog's FIN-003 has the arithmetic: 90 shares at ratio 2.0
-is 180, and the additive form gives 92. This invariant is separate from
-INV-HOLDING-001 on purpose -- that one is about concurrency, this one about two
-implementations of the same rule, and fixing either leaves the other.
+The arithmetic the reducer centralises: 90 shares at ratio 2.0 is 180, and the
+additive form the net-worth reducers once used gave 92. This invariant is separate
+from INV-HOLDING-001 on purpose -- that one is about concurrency, this one about
+two implementations of the same rule.
 
 ### INV-TRANSFER-001 -- both legs, one decision
 
 ```text
-Statement           A transfer's legs share one status, and any balance movement
-                    is decided once for the pair.
+Statement           A transfer's legs share the VOID boundary, and any balance
+                    movement is decided once for the pair. Reconciliation states
+                    (PENDING/CLEARED/RECONCILED) are deliberately per-ledger and
+                    are not mirrored -- only VOID inclusion is shared.
 Source of truth     the two linked transactions rows
-Enforcement         Partial and inconsistent. PATCH /:id/transfer mirrors status
-                    to both legs. PATCH /transactions/:id/status, markCleared,
-                    reconcile and unreconcile touch only the row given -- the
-                    reconciliation service references neither isTransfer nor
-                    linkedTransactionId. Bulk update mirrors payeeId, payeeName
-                    and description but not status. Balances are updated
-                    regardless of status, so a transfer created VOID still moves
-                    both.
+Enforcement         The balance decision is made once per pair, keyed on VOID.
+                    Creating a VOID transfer moves neither balance
+                    (transaction-transfer.service.ts skips both updateBalance
+                    calls when status is VOID). A status edit crossing the VOID
+                    boundary mirrors the counterpart leg and a split parent's
+                    transfer children (applyVoidTransitionToMirrorLeg,
+                    applyParentStatusToTransferCounterparts in
+                    transaction-reconciliation.service.ts). markCleared / reconcile
+                    / unreconcile deliberately do NOT mirror, because a reconcile
+                    state is per-ledger. Guards: deletion-balance.guard.spec.ts,
+                    investment-void-classification.guard.spec.ts,
+                    void-status-transition.util.ts.
 Concurrency scope   per transfer pair
-Failure response    Currently silent imbalance: voiding one leg of a 100.00
-                    transfer makes 1,000.00 across two accounts read as 1,100.00.
-Required tests      Per status-changing endpoint, assert both legs moved and both
-                    balances are consistent. Include the split-transfer variant,
-                    which links through the split parent, not a mirror leg.
-Status              unenforced
+Failure response    consistent balances across the pair on every VOID transition.
+Required tests      Per status-changing path, both legs' balances stay consistent
+                    across a VOID transition, including the split-transfer variant
+                    that links through the split parent rather than a mirror leg.
+Status              enforced
 ```
+
+The statement was narrowed on purpose. "Both legs share one status" was too broad:
+a reconcile state is genuinely per-ledger (a cross-owner transfer's two ledgers
+reconcile independently), and only the VOID boundary -- where money either moved
+or did not -- is shared. See `backend/CLAUDE.md`, "Editing one row must not leave
+the pair describing two different events".
 
 ### INV-REDEEM-001 -- a redemption's accrued interest moves cash once
 
@@ -355,18 +364,17 @@ Enforcement         assertReconciledRowsMutable / assertReconciledIdsMutable
                     TransactionTransferService.removeTransfer /
                     updateTransfer, TransactionBulkUpdateService.bulkUpdate /
                     bulkDelete, TransactionSplitService.updateSplits / addSplit /
-                    removeSplit. The AI assistant, the MCP tools and the joint
-                    register reach the ledger through these same methods, so they
-                    inherit the refusal rather than needing their own.
-                    NOT covered, and this is why the status is `partial`:
-                    - action-history.service.ts (undo / redo) writes prior field
-                      values straight onto a transaction row. An undo of an older
-                      action can therefore alter a row that has since been
-                      reconciled.
-                    - investment-transactions.service.ts recomputes a split
-                      parent's amount when an embedded investment row changes,
-                      and writes it without consulting the lock.
-                    - The backup restore is deliberately exempt: it rewrites the
+                    removeSplit, ActionHistoryService.undoTransactionUpdate (undo
+                    and redo of a transaction edit) and
+                    InvestmentTransactionsService.updateEmbeddedSplitParent (the
+                    split parent's amount recomputed when an embedded investment
+                    row changes). The last two receive an ambient EntityManager
+                    rather than opening their own withScopedDb, so the guard scans
+                    them with a `beforeWrite` marker -- the assertion must precede
+                    the method's first write. The AI assistant, the MCP tools and
+                    the joint register reach the ledger through these same methods,
+                    so they inherit the refusal rather than needing their own.
+                    The backup restore is deliberately exempt: it rewrites the
                       whole ledger under withPreserveTimestamps, and a
                       per-row refusal there would produce a half-restored
                       database, which is worse than the thing the lock prevents.
@@ -386,11 +394,11 @@ Required tests      Unit: the guard refuses on a reconciled row, allows the same
                     (backend/src/transactions/transaction-reconciliation.service.spec.ts,
                     "the strict reconciled lock"). Source scan: every listed
                     entry point still asks, inside its transaction
-                    (backend/src/transactions/reconciled-lock.guard.spec.ts).
+                    (backend/src/transactions/reconciled-lock.guard.spec.ts),
+                    now including the undo/redo and embedded-investment paths.
                     Still owed: a two-connection test that the refusal holds
-                    against a concurrent write, and coverage of the two
-                    uncovered paths above.
-Status              partial
+                    against a concurrent write.
+Status              enforced
 ```
 
 ### INV-FX-001 -- an unavailable rate is not 1:1
@@ -400,25 +408,27 @@ Statement           A cross-currency value must never become a valid-looking 1:1
                     value, and an unconverted amount must never be returned under
                     the target currency's label.
 Source of truth     exchange_rates
-Enforcement         None at the consumers. The provider layer is honest --
-                    getRateForDate returns null explicitly "so the caller can
-                    reject or flag the operation rather than silently assuming
-                    1.0" -- and the consumers discard that:
-                      portfolio-calculation.service.ts:
-                        rate = reverseRate !== null ? 1 / reverseRate : 1
-                      net-worth.service.ts:
-                        return result ?? amount
+Enforcement         Consumers return null on an absent rate, and accumulate
+                    through FxAggregate. net-worth.service.ts convertCurrency
+                    returns number | null (the `result ?? amount` fallback is
+                    gone); portfolio-calculation.service.ts returns null when
+                    neither direct nor reverse rate exists (the `: 1` else-branch
+                    is gone). A scanning guard, common/fx-fallback.guard.spec.ts,
+                    bans `?? amount` beside a conversion, `rate ... : 1` / `?? 1`,
+                    and an unreviewed `1 / reverse` reciprocal, and asserts each
+                    reviewed reciprocal returns null when neither direction exists.
 Concurrency scope   --
-Failure response    Must be null or an explicitly partial figure, per
+Failure response    null or an explicitly partial figure, per
                     docs/financial-calculation-contract.md section 1.
-Required tests      Unit per call site with the rate absent; a scanning guard
-                    banning a `: 1` else-branch beside a rate lookup and `??
-                    amount` beside a conversion.
-Status              unenforced
+Required tests      Present: common/fx-fallback.guard.spec.ts (the source scan
+                    above) plus the FxAggregate accumulator (common/fx-aggregate.ts)
+                    that names each unresolvable pair rather than absorbing it.
+Status              enforced
 ```
 
-At a real rate of 1.3500, a false 100.00 CAD understates a 135.00 CAD position
-by 35.00 -- and reports it as measured.
+At a real rate of 1.3500, a false 100.00 CAD would understate a 135.00 CAD
+position by 35.00 and report it as measured -- which is what the null return and
+the scan now prevent.
 
 ## Scheduled occurrences
 
@@ -427,25 +437,32 @@ by 35.00 -- and reports it as measured.
 ```text
 Statement           One scheduled occurrence may create at most one financial
                     effect.
-Source of truth     the posted transaction; scheduled_transactions.next_due_date
-Enforcement         None. processAutoPostTransactions (hourly, at minute 5 --
-                    "5 * * * *") reads due schedules by next_due_date <= today,
-                    then posts and advances next_due_date with no row lock, no
-                    CAS on the previous next_due_date, and no unique constraint
-                    on (scheduled_transaction_id, transaction_date). Every
-                    replica fires every cron.
+Source of truth     scheduled_transaction_postings, one row per occurrence
+Enforcement         A durable occurrence key claimed atomically.
+                    processAutoPostTransactions locks the schedule and CAS-checks
+                    next_due_date is still due, then claims the occurrence with
+                    INSERT INTO scheduled_transaction_postings ... ON CONFLICT
+                    (scheduled_transaction_id, original_due_date) DO NOTHING
+                    RETURNING id (scheduled-transactions.service.ts), throwing
+                    ConflictException on a lost claim. The unique index
+                    idx_stp_occurrence (schema.sql, migration 140) is the
+                    database-level backstop, so exactly-once holds regardless of
+                    replica count; the cron treats the ConflictException as
+                    "claimed by another replica".
 Concurrency scope   per (scheduled transaction, occurrence date)
-Retry semantics     Unsafe: a retry cannot tell whether the occurrence posted.
-Crash semantics     A crash between posting and advancing next_due_date reposts
-                    on the next tick.
-Failure response    Should be a durable occurrence key claimed atomically.
-Required tests      Two-instance: two replicas on one tick, exactly one posting.
-Status              unenforced
+Retry semantics     Safe: a re-post is refused by the occurrence claim.
+Crash semantics     A crash between claim and advance leaves the claim row, so the
+                    next tick is refused rather than reposting.
+Failure response    the losing claim gets ConflictException, having posted nothing.
+Required tests      The unique index gives DB-level exactly-once; a two-instance
+                    "two replicas, one posting" integration test is still owed as
+                    the gold-standard proof.
+Status              enforced
 ```
 
-This is `docs/concurrency-and-idempotency.md` CONC-004's canonical case: the
-logical operation key is obvious (`(scheduledTransactionId, occurrenceDate)`) and
-simply is not persisted.
+This was `docs/concurrency-and-idempotency.md` CONC-004's canonical case -- the
+logical operation key `(scheduledTransactionId, occurrenceDate)` that simply was
+not persisted -- and it now is, as scheduled_transaction_postings.
 
 ### INV-OCCURRENCE-002 -- a stored override price survives
 
@@ -453,16 +470,17 @@ simply is not persisted.
 Statement           A stored override price is not replaced by a market quote
                     without an explicit user action.
 Source of truth     scheduled_transaction_overrides.investment_price
-Enforcement         None. OverrideEditorDialog seeds correctly from the stored
-                    value, then an unconditional effect overwrites
-                    investmentPrice whenever the fetched market price differs
-                    from the last seen one, and recomputes the total from it.
+Enforcement         The market-price auto-fill is gated. OverrideEditorDialog
+                    seeds from the stored value and writes the fetched market
+                    price only when investmentPrice is empty (frontend
+                    scheduled-transactions/OverrideEditorDialog.tsx), so a stored
+                    or inherited price is never overwritten by a differing quote.
 Concurrency scope   per occurrence
-Failure response    Ten shares stored at 100.00 return as ten at 120.00 with no
-                    money field touched by the user.
-Required tests      Component: reopen with a stored price and a differing quote,
-                    assert the stored price stands.
-Status              unenforced
+Failure response    a stored ten-at-100.00 stays ten at 100.00 across a reopen.
+Required tests      Present: OverrideEditorDialog.test.tsx -- reopen with a stored
+                    price and a differing quote asserts the stored price stands,
+                    plus the typed-total-before-close case.
+Status              enforced
 ```
 
 ## Authentication and authorization
@@ -473,21 +491,22 @@ Status              unenforced
 Statement           An emergency-access claim token may be consumed successfully
                     exactly once.
 Source of truth     emergency_access_contacts.claim_token_used_at
-Enforcement         None. The in-transaction re-read passes no lock option, and
-                    the consuming write is an entity save by primary key with no
-                    WHERE claim_token_used_at IS NULL. No partial unique index on
-                    unused tokens acts as a backstop. The code beside it uses the
-                    CAS predicate correctly for voiding sibling tokens. The
-                    comment claims re-validation "under lock".
+Enforcement         A single conditional UPDATE consumes the token before any
+                    credential is touched. emergency-access-claim.controller.ts
+                    runs UPDATE ... SET claim_token_used_at = CURRENT_TIMESTAMP
+                    WHERE claim_token_hash = $1 AND claim_token_used_at IS NULL
+                    AND claim_token_expires_at >= CURRENT_TIMESTAMP RETURNING; a
+                    zero-row result is a NotFoundException, so the loser of two
+                    concurrent completes writes nothing and rewrites no password.
 Concurrency scope   per token, per owner
-Retry semantics     Two concurrent completes can both rewrite the owner's
-                    password, to two different hashes, and both return a signed-in
-                    session.
-Failure response    The loser must get 404 or 409, having written nothing --
+Retry semantics     Safe: the second complete finds the token consumed and is
+                    refused.
+Failure response    the loser gets 404, having written nothing --
                     docs/financial-calculation-contract.md section 7.
-Required tests      Two-connection: one token, two concurrent completes, exactly
-                    one success.
-Status              unenforced
+Required tests      Present: emergency-access-claim.controller.spec.ts asserts the
+                    loser (a zero-row consume) is refused. A two-connection test is
+                    the gold-standard proof still owed.
+Status              enforced
 ```
 
 ### INV-AUTH-001 -- refresh rotation
@@ -521,20 +540,21 @@ noticing.
 Statement           A logout that did not revoke the session must not be presented
                     to the user as a completed logout.
 Source of truth     refresh_tokens.is_revoked for the family
-Enforcement         Partial and incidental. The family revoke is an unlocked bulk
-                    UPDATE, which is safe against concurrent writers only because
-                    is_revoked = true is order-independent -- a property of the
-                    value, not a protocol, and one that stops holding the moment
-                    logout writes anything else. Whether a failed revoke surfaces
-                    to the user was reported by the audit as a defect; it was not
-                    located in the current code and is unverified here.
+Enforcement         The handler awaits the revoke before reporting success, and
+                    the revoke is locked. auth.controller.ts logout awaits
+                    revokeRefreshToken (under withSystemContext) before
+                    clearAuthCookies and the success body, with no try/catch, so a
+                    revoke failure propagates and is never presented as a completed
+                    logout. The family revoke takes lockTokenFamily before its
+                    UPDATE (token.service.ts revokeTokenFamily), so it is a real
+                    protocol rather than the value's order-independence.
 Concurrency scope   per token family
 Retry semantics     Safe: setting is_revoked twice is a no-op.
-Failure response    A revoke that failed must not clear the client's session
-                    silently, or the user believes they signed out and did not.
-Required tests      Integration: force the revoke to fail, assert the response is
-                    not a success.
-Status              partial
+Failure response    a failed revoke surfaces as an error, not a cleared session.
+Required tests      Present: auth.controller.spec.ts forces revokeRefreshToken to
+                    reject and asserts logout rejects without clearing cookies or
+                    emitting the success body.
+Status              enforced
 ```
 
 Split out from INV-AUTH-001 because the two are different properties that happen
@@ -547,20 +567,23 @@ reporting, and conflating them hid the fact that only the first has a mechanism.
 Statement           A failed login attempt increments the counter the lockout
                     threshold reads.
 Source of truth     users.failed_login_attempts
-Enforcement         None. The user is read in one statement, incremented in
-                    JavaScript, and written as an absolute value in a later
-                    statement with no lock. Two concurrent failures lose an
-                    increment. The comment above it reads "Atomically increment
-                    failed attempts".
+Enforcement         An atomic CTE increments in the database. recordFailedAttempt
+                    (auth.service.ts) runs one UPDATE users SET
+                    failed_login_attempts = failed_login_attempts + 1 with the
+                    lockout threshold folded into the same statement -- not a
+                    JavaScript read-modify-write across the bcrypt compare -- so
+                    two concurrent failures cannot lose an increment. The
+                    success-path reset writes a fixed absolute value and was always
+                    safe.
 Concurrency scope   per account
-Failure response    The counter under-counts, so lockout arrives late -- the
-                    direction that favours an attacker.
-Required tests      Two-connection: N concurrent failures, counter equals N.
-Status              unenforced
+Failure response    the counter equals the number of failures; lockout is not
+                    delayed.
+Required tests      Present: auth.service.spec.ts asserts recordFailedAttempt is
+                    the single incrementing statement (matched on
+                    failed_login_attempts + RETURNING). A two-connection "N
+                    concurrent failures, counter equals N" test is still owed.
+Status              enforced
 ```
-
-The reset-on-success path writes a fixed absolute value (`0`, `null`) and is
-therefore safe; only the increment is affected.
 
 ### INV-AUTH-003 -- a destructive OIDC action needs a real round trip
 
@@ -570,21 +593,26 @@ Statement           Restore, delete-account, delete-data and step-up on an OIDC
                     authentication, bound to the user and the action, single-use
                     and short-lived.
 Source of truth     the identity provider
-Enforcement         None. The frontend sends the literal string
-                    'oidc-session-confirmed' and the backend checks only that the
-                    field is truthy; step-up takes a client-asserted
-                    oidcConfirmed boolean. No reauth endpoint exists.
+Enforcement         A signed, single-use, short-lived reauth artifact bound to
+                    the user and action. OidcReauthService.issue mints an HS256
+                    JWT bound to sub + purpose + jti with a 5-minute TTL;
+                    consume verifies signature, type, subject, action and exp,
+                    then claimJti runs INSERT ... ON CONFLICT (jti) DO NOTHING
+                    RETURNING (single-use across replicas), and isFreshAuthentication
+                    requires a real IdP round trip via auth_time. Step-up's
+                    client-asserted boolean is gone (step-up.service.ts calls
+                    oidcReauth.consume). Wired into destructive routes
+                    (users.service.ts, backup-restore.service.ts).
 Concurrency scope   per user, per action
-Failure response    Must be 401 until a valid proof is presented.
-Required tests      Integration: a forged or replayed proof is refused; the
-                    artifact is single-use and expires.
-Status              unenforced
+Failure response    401 until a valid, unspent, unexpired proof is presented.
+Required tests      Present: OidcReauthService specs cover forge/replay/expiry and
+                    the single-use jti claim.
+Status              enforced
 ```
 
-Note that the sentinel string is *asserted by tests* in both the frontend and
-backend suites. Those tests are green and protect the defect --
-`docs/verification-contract.md` section 5, known-wrong tests, covers what to do
-with them.
+The old sentinel string 'oidc-session-confirmed' survives only in comments and
+superseded tests; `docs/verification-contract.md` section 5 (known-wrong tests)
+covers retiring those.
 
 ### INV-ACTIVITY-001 -- activity is attributed to whoever acted
 
@@ -592,17 +620,18 @@ with them.
 Statement           users.last_activity_at records the authenticated user who
                     made the request, never the user they are acting as.
 Source of truth     the authenticated principal (req.user.realUserId)
-Enforcement         None, and the wrong value is passed. The request-context
-                    interceptor resolves both identities -- realUserId is derived
-                    as user?.realUserId ?? userId -- and then calls
-                    touchLastActivity(userId), the effective user. A delegate
-                    browsing an owner's data therefore stamps the owner's
-                    last_activity_at.
+Enforcement         The interceptor stamps the authenticated identity.
+                    request-context.interceptor.ts calls
+                    touchLastActivity(realUserId), where realUserId =
+                    user?.realUserId ?? userId, and the write targets
+                    { id: realUserId } -- so a delegate acting on an owner's data
+                    stamps the delegate's row, not the owner's.
 Concurrency scope   per user
 Failure response    --
-Required tests      Integration: a delegate request updates the delegate's
-                    last_activity_at and leaves the owner's untouched.
-Status              unenforced
+Required tests      Present: request-context.interceptor.spec.ts asserts the
+                    update targets the delegate's id while acting, leaving the
+                    owner's row untouched.
+Status              enforced
 ```
 
 This is not a cosmetic attribution bug. Emergency-access eligibility is computed
@@ -617,23 +646,26 @@ direction that withholds access from the people it exists for.
 Statement           Every user-profile response is built by naming the fields to
                     include, never by removing the fields to hide.
 Source of truth     the User entity
-Enforcement         None. users.controller.ts destructures away exactly four
-                    fields (passwordHash, resetToken, resetTokenExpiry,
-                    twoFactorSecret) and spreads the rest, so
-                    pendingTwoFactorSecret, oidcLinkToken, pendingOidcSubject,
-                    backupPasswordEnc and emailVerificationToken are returned.
-                    The route carries @AllowDelegate().
+Enforcement         An allowlist, not a removal list. users/user-profile.ts
+                    builds every profile response by copying only PROFILE_FIELDS
+                    (typed `satisfies readonly (keyof User)[]`); a new column is
+                    absent by default until someone names it there.
+                    toDelegatedUserProfile additionally drops the owner's
+                    credential-state fields for an acting delegate.
 Concurrency scope   per user, and per delegate
 Failure response    --
-Required tests      A test that fails when any entity column not on the allowlist
-                    appears in the response, so a new column cannot leak by
-                    default.
-Status              unenforced
+Required tests      Present: users/user-profile.spec.ts proves the allowlist is
+                    exact, drops every @Exclude() column (read off
+                    class-transformer metadata via user-profile.test-util.ts's
+                    fullyPopulatedUser with LEAK- sentinels), and source-scans
+                    src/ for a removal-list sanitizer anywhere.
+Status              enforced
 ```
 
-A removal list is wrong structurally, not incidentally: the default for a new
-column is "exposed", so the defect is introduced by a change that never touches
-this file. That the route is delegate-accessible means the leak crosses users.
+A removal list would be wrong structurally: the default for a new column is
+"exposed", so the defect could be introduced by a change that never touches this
+file, and the route is delegate-accessible so the leak would cross users. The
+allowlist inverts that default.
 
 ### INV-MCP-001 -- a session is bound to its credential
 
@@ -641,14 +673,18 @@ this file. That the route is delegate-accessible means the leak crosses users.
 Statement           An MCP session is bound to the specific credential that
                     opened it, and the presented token's current scopes are
                     re-read on every request.
-Enforcement         None. Only the user id is compared, and scopes are captured
-                    once at session creation and never re-read.
+Enforcement         The session is bound to the credential id and scopes are
+                    re-read per request. mcp-http.controller.ts
+                    authorizeExistingSession refuses with 403 unless
+                    sessionUser.credentialId === authResult.credentialId (not just
+                    userId), and re-binds scopes: authResult.scopes on every
+                    request. validatePat runs per request, so a revoked token 401s
+                    immediately rather than at TTL.
 Concurrency scope   per session, per credential
 Failure response    403 on a mismatched credential.
-Required tests      Integration: a read-only token presenting a write-scoped
-                    session id is refused; a revoked token stops working
-                    immediately rather than at TTL.
-Status              unenforced
+Required tests      Present: mcp-http.controller.spec.ts covers the 403
+                    credential-mismatch and session/user-mismatch cases.
+Status              enforced
 ```
 
 ### INV-CURRENCY-001 -- shared currency deletion
@@ -659,24 +695,27 @@ Statement           A shared currency row is deleted only by its creator, and on
                     the schema -- is zero, decided under a lock in the deleting
                     transaction.
 Source of truth     currencies, and every table referencing currency_code
-Enforcement         None sufficient. The authorization check tests
-                    createdByUserId !== null ("is it a system currency") rather
-                    than === userId, so any user who activated another user's
-                    custom currency can trigger its deletion. Both the in-use
-                    checks omit budgets.currency_code and both
-                    exchange_rates.from_currency/to_currency, all real FKs. The
-                    count runs in the caller's tenant scope with no FOR UPDATE on
-                    the currency row.
+Enforcement         Creator-only, on a genuinely global count, under a lock.
+                    CurrenciesService.removeWithin gates the currency-row delete on
+                    createdByUserId === userId (a non-creator deactivates their own
+                    preference but never takes the shared row), locks the currency
+                    row with SELECT ... FOR UPDATE, and asks the SECURITY DEFINER
+                    function currency_code_in_use_globally (migration 137) which
+                    covers every FK including budgets and both exchange_rates
+                    columns -- not the caller's tenant-scoped count.
 Concurrency scope   global -- cross-tenant
-Failure response    403 for a non-creator; 409 while referenced.
-Required tests      A test deriving the reference list from schema.sql so a new
-                    FK cannot be forgotten; two-connection delete-versus-use.
-Status              unenforced
+Failure response    non-creator deactivates without deleting; 409 while referenced.
+Required tests      Present: currency-references.spec.ts derives the reference list
+                    from schema.sql in both directions so a new FK cannot be
+                    forgotten; currencies.service.spec.ts asserts a non-creator's
+                    remove deletes only the preference and never the currency row.
+                    A two-connection delete-versus-use test is still owed.
+Status              enforced
 ```
 
-The tenant-scoped count is the part that gets worse rather than better under
-`RLS_MODE=enforce`: a "global" count that sees only the caller's rows reports
-zero for another user's references.
+The global count is a SECURITY DEFINER function precisely so that under
+`RLS_MODE=enforce` it does not degrade to a tenant-scoped count that sees only the
+caller's rows and reports zero for another user's references.
 
 ## External effects
 
@@ -686,16 +725,24 @@ zero for another user's references.
 Statement           Attachment metadata that a user can see resolves to bytes
                     that are durably present, and no bytes exist without
                     metadata.
-Enforcement         Provider-dependent. The database provider is genuinely atomic
-                    -- its save joins the ambient transaction. Local and S3 write
-                    bytes inside the transaction callback, before the commit, so
-                    a failed commit leaves an orphan that no sweep, no
-                    compensation and no reconciliation job will ever find. The
-                    comment claims joint commit for all providers.
+Enforcement         Ordered so a failure leaves recoverable bytes, never a row
+                    promising absent bytes. attachments.service.ts commits an
+                    upload-intent tombstone on its own connection before the put,
+                    compensates on rollback (storage.delete + clear the intent),
+                    and distinguishes the database provider's joint commit from
+                    external providers via objectWritten. A reconciliation job
+                    exists: attachment-orphan-sweeper.service.ts (hourly, under
+                    withSystemContext) claims tombstones and deletes leased-past
+                    orphaned bytes. Local writes are crash-atomic
+                    (local-storage.provider.ts writeFileAtomic). "No bytes without
+                    metadata" holds eventually rather than instantaneously, which
+                    is what the invariant asks.
 Concurrency scope   per attachment
-Retry semantics     Deletes are idempotent on a missing key; creates are not.
-Crash semantics     Orphaned bytes accumulate silently.
-Status              partial
+Retry semantics     Deletes are idempotent on a missing key; a failed create's
+                    bytes are swept.
+Crash semantics     A transient orphan on rollback is durably recoverable by the
+                    sweeper, not silent.
+Status              enforced
 ```
 
 ### INV-BACKUP-001 -- a backup is complete, verified, owner-namespaced
@@ -703,23 +750,26 @@ Status              partial
 ```text
 Statement           A backup artifact is namespaced by owner, written completely,
                     and verified before it is reported as done.
-Enforcement         Namespacing: enforced. userFolderPath uses
-                    shardedSegments(userId) for <base>/<ab>/<cd>/<userId>/,
-                    because the filenames carry only a tier and a date -- a flat
-                    folder gave every user the same name for the same day and
-                    whoever's cron ran last overwrote the rest. Folder browse and
-                    validate are admin-gated.
-                    Completeness: none. A single fs.writeFile to the final name,
-                    no temp file, no fsync, no rename, no size check, no
-                    checksum; lastBackupStatus is set to success immediately
-                    after. Retention promotes the daily to weekly and monthly
-                    with copyFileSync, so a truncated file propagates. Restore
-                    validates only the version number and exportedAt.
+Enforcement         Namespacing: userFolderPath uses shardedSegments(userId) for
+                    <base>/<ab>/<cd>/<userId>/, because the filenames carry only a
+                    tier and a date; browse and validate are admin-gated.
+                    Completeness: writeFileAtomic (atomic-file.ts) writes to a temp
+                    file, fsyncs, size-checks, then renames and fsyncs the dir, and
+                    refuses to publish a short file; promotions use copyFileAtomic
+                    with a size check, not copyFileSync. The durable completeness
+                    verdict lives inside the document (completeness in the envelope,
+                    backup-format.ts, reached from digests) and restore refuses an
+                    artifact whose completeness.complete is false. Encrypted
+                    artifacts are truncation-authenticated frame-by-frame
+                    (backup-envelope.ts). lastBackupStatus reflects the outcome
+                    (complete vs partial), not an unconditional success.
 Concurrency scope   per user
-Crash semantics     A kill or ENOSPC mid-write leaves a truncated file under the
-                    expected name, indistinguishable from a complete one.
-Required tests      Provider round trip: write, truncate, assert restore refuses.
-Status              partial
+Crash semantics     A kill or ENOSPC mid-write leaves the temp file, never a
+                    truncated final name -- the rename is the publish.
+Required tests      Present: atomic-file.spec.ts and auto-backup.service.spec.ts
+                    use a real mkdtemp; backup.service.spec.ts asserts restore
+                    honours the artifact's own completeness claim.
+Status              enforced
 ```
 
 Encryption is settled and worth not re-litigating: a support backup is
@@ -732,22 +782,24 @@ than written in clear.
 ```text
 Statement           A scheduled job produces one logical effect per tick,
                     regardless of replica count.
-Enforcement         Per job, and inconsistent. Real mechanisms: the MNY reaper's
-                    conditional CAS; the price and FX refreshes' natural-key
-                    ON CONFLICT ... DO UPDATE; sweeps that are idempotent by
-                    construction because the predicate is "already expired". No
-                    mechanism: scheduled auto-posting (INV-OCCURRENCE-001);
-                    budget-period rollover, where UNIQUE(budget_id, period_start)
-                    is the only backstop and the loser's violation is swallowed
-                    by a per-budget try/catch that increments an error count;
-                    demo reset, which can interleave one run's delete with
-                    another's insert; the account-balance recompute, idempotent
-                    against itself but not against a concurrent delta.
-                    AI insight generation guards with a process-local Set, which
-                    coordinates one replica with itself and nothing across
-                    replicas.
+Enforcement         Per job, and now mostly a durable cross-replica claim.
+                    common/jobs/job-claim.service.ts provides claimOnce (INSERT ...
+                    ON CONFLICT DO NOTHING RETURNING) and claimLease/markDelivered
+                    (at-least-once with a lease token + migration-143 fence). The
+                    jobs previously unguarded are guarded: scheduled auto-posting
+                    (INV-OCCURRENCE-001, occurrence-key claim), budget rollover
+                    (ON CONFLICT (budget_id, period_start) DO NOTHING RETURNING with
+                    the loser re-reading the winner), AI insight generation
+                    (claimLease, not a process-local Set), demo reset (claimLease).
+                    The MNY reaper's conditional CAS and the price/FX refreshes'
+                    natural-key ON CONFLICT were already real.
+                    Still partial: the account-balance recompute is idempotent
+                    against itself and, under INV-BALANCE-001's lock, against a
+                    concurrent delta -- but per-job two-instance test coverage is
+                    not demonstrably complete across every job.
 Concurrency scope   per job, per logical key
-Required tests      Two-instance per job. Only the MNY job has one.
+Required tests      Two-instance per job. The MNY job has one; the others rely on
+                    the claim layer's unit coverage and are still owed theirs.
 Status              partial
 ```
 
@@ -764,43 +816,48 @@ Statement           Under RLS_MODE=enforce the application refuses to serve
                     traffic on a role that can bypass row-level security --
                     including membership reachable via SET ROLE, not only the
                     role's own attributes.
-Enforcement         None. No startup check exists; no pg_has_role or rolbypassrls
-                    interrogation appears anywhere in backend/src. app-role.ts
-                    provisions and grants but never asks what the connecting role
-                    actually is.
+Enforcement         A single classifier refuses a privileged role at startup.
+                    common/db/runtime-role-check.ts (assertRuntimeRoleSafe) reads
+                    pg_roles for rolsuper/rolbypassrls/rolreplication/rolcreaterole/
+                    rolcreatedb, database ownership, owned policied tables,
+                    SET ROLE-reachable exempt contexts, inherited owner roles and
+                    forbidden predefined-role memberships (pg_has_role, transitive).
+                    Wired at both call sites: main.ts about its own connection
+                    (process exit on violation -- "refuse to boot") and db-init.ts
+                    about the configured role by name (assertRuntimeRoleSafeByName).
 Concurrency scope   global, at startup
 Failure response    Refuse to boot.
-Required tests      Integration against a superuser and a BYPASSRLS role, and
-                    against a role that merely inherits membership in an exempt
-                    one.
-Status              unenforced
+Required tests      Present: runtime-role-check.spec.ts (unit, incl. superuser,
+                    BYPASSRLS and inherited-membership cases) and a live-catalog
+                    integration spec.
+Status              enforced
 ```
 
-This is the backstop for the entire RLS design: if enforced mode is ever switched
-on with a misconfigured role, nothing notices. It is latent rather than
-exploitable at the `RLS_MODE=off` default -- and the same condition applies to
-delegation's cross-user lookups, which run in the caller's tenant scope today and
-would silently return zero rows under enforcement.
-
-Related and also absent: `db-init` and `db-migrate` are not serialized across
-replicas by an advisory lock, so each pod decides independently from its own read
-of `schema_migrations`.
+This is the backstop for the entire RLS design: if enforced mode is switched on
+with a misconfigured role, startup now refuses rather than serving silently. Two
+adjacent items are their own concerns, not this invariant's: delegation's
+cross-user lookups (a candidate below) and whether `db-init` / `db-migrate` are
+serialized across replicas -- `common/db/advisory-locks.ts` now exists and that
+sub-point warrants its own re-check.
 
 ### INV-CACHE-001 -- a money-moving write invalidates its caches
 
 ```text
 Statement           A write that changes money invalidates every client cache
                     family derived from transactions.
-Enforcement         None. invalidateBalanceCaches drops the 'accounts:' and
-                    'investments:' prefixes only; 'budgets:' is a live prefix and
-                    is not dropped.
+Enforcement         invalidateBalanceCaches (frontend lib/apiCache.ts) drops the
+                    accounts:, investments: AND budgets: prefixes -- every
+                    transaction-derived family. The cache layer is frontend, which
+                    is why the function name does not appear in backend/src.
 Concurrency scope   per browser tab
-Failure response    A saved transaction leaves the budget progress bar showing
-                    the pre-write figure for up to the cache TTL.
-Required tests      A classification guard requiring every cache prefix in src/
-                    to declare itself transaction-derived or reference data, so a
-                    new family cannot default to stale.
-Status              unenforced
+Failure response    a saved transaction drops the budget cache, so the progress
+                    bar reflects the write.
+Required tests      Present: frontend cache-prefix-classification.guard.test.ts
+                    requires every cache prefix to declare itself transaction-
+                    derived (and be dropped) or reference-data (and be kept), so a
+                    new family cannot default to stale; balance-cache.guard.test.ts
+                    requires every balance-writing API method to invalidate.
+Status              enforced
 ```
 
 ### INV-RELEASE-001 -- one revision

--- a/docs/verification-contract.md
+++ b/docs/verification-contract.md
@@ -74,6 +74,7 @@ adds value but proves nothing on its own. `--` means not applicable.
 | INV-HOLDING-001 holding replay | supporting | -- | required | **required** | optional | required | -- | optional |
 | INV-HOLDING-002 one reducer | required | **required** | supporting | -- | -- | -- | -- | required |
 | INV-TRANSFER-001 both legs | required | -- | required | optional | -- | -- | -- | required |
+| INV-RECONCILE-001 reconciled lock | supporting | **required** | required | required | -- | -- | -- | optional |
 | INV-FX-001 no 1:1 fallback | **required** | **required** | required | -- | -- | required | optional | required |
 | INV-OCCURRENCE-001 one effect | supporting | -- | required | required | **required** | required | -- | required |
 | INV-OCCURRENCE-002 override price | required | -- | -- | -- | -- | -- | -- | required |
@@ -98,7 +99,11 @@ invariant is unverified no matter how many others pass. `INV-PROFILE-001`'s is a
 source scan rather than a unit test because the defect arrives via a change to a
 different file: a new entity column. `INV-FX-001` and `INV-HOLDING-002` need
 scans for the same reason -- both are scattered across call sites, and every
-previous fix corrected one and left the others.
+previous fix corrected one and left the others. `INV-RECONCILE-001` is the same
+shape: the strict lock is only as strong as its least-guarded entry point -- a
+single-row refusal was once walked around by `bulkUpdate` -- so
+`reconciled-lock.guard.spec.ts` scanning every write path is the load-bearing
+kind, not any one service test.
 
 `INV-IMPORT-002`'s load-bearing kind is a **failpoint**, and it is worth
 understanding why the other columns cannot substitute. The MNY import has real
@@ -143,14 +148,16 @@ because they all need a real database. That makes it the single most important
 job in the pipeline and the one whose silent failure is most costly -- which
 brings us to the next point.
 
-**That job can currently pass having run nothing.** `test:integration` carries an
-unconditional `--passWithNoTests`, so a renamed directory or an edited
-`testPathPatterns` regex turns a discovery failure into a green check across all
-six kinds at once. `docs/release-integrity.md` REL-001 and REL-002 cover this;
-it is repeated here because the consequence is a verification consequence, not
-merely a CI hygiene one. There are 21 suites under
-`backend/test/integration/` today, and nothing asserts that number does not
-shrink.
+**That job no longer passes having run nothing -- but nothing asserts its suite
+count.** `test:integration` previously carried an unconditional
+`--passWithNoTests`, so a renamed directory or an edited `testPathPatterns` regex
+turned a discovery failure into a green check across all six kinds at once. That
+flag has since been removed from `backend/package.json`, so an empty match now
+exits non-zero and fails the job. What is still owed is the weaker guard against a
+regex that matches *some* suites but silently drops a class: nothing asserts that
+the number of suites under `backend/test/integration/` does not shrink.
+`docs/release-integrity.md` REL-001 and REL-002 cover the history and the
+consequence, which is a verification one, not merely CI hygiene.
 
 ## 5. Known-wrong tests
 
@@ -166,26 +173,26 @@ asserting the violation and correct them in the same change -- they are why the
 defect survived.
 ```
 
-### Located in the current suites
+### Located in the current suites -- both since corrected
 
-These were found by reading the suites, and each is cited so it can be checked
-rather than taken on trust. Correcting the invariant means correcting these in
-the same change.
+Two known-wrong tests were found here and have since been corrected, in the same
+work that moved their invariants to `enforced`. They are recorded rather than
+deleted, because the rule they illustrate (VER-004) is the point, and a reader
+should be able to confirm the correction rather than take it on trust.
 
-| Test | Asserts | Protects the violation of |
+| Test | Asserted (now corrected) | Was protecting |
 | --- | --- | --- |
-| `backend/src/net-worth/net-worth.service.spec.ts` around lines 516 and 2664 | Additive stock-split replay. The comment spells the arithmetic out: `95 - TRANSFER_OUT 5 + SPLIT 90 = 180 shares`, and a second case `BUY 100, SELL 30, TRANSFER_OUT 20, SPLIT 50 = 100 shares`. Under the correct multiplicative rule a SPLIT row of 90 applied to 90 shares is 8,100, not 180. | INV-HOLDING-002 |
-| `frontend/src/components/settings/BackupRestoreSection.test.tsx`, `frontend/src/components/settings/DangerZoneSection.test.tsx`, `backend/src/users/users.service.spec.ts`, `backend/src/backup/backup.service.spec.ts` | `oidcIdToken: 'oidc-session-confirmed'` accepted as proof of re-authentication. | INV-AUTH-003 |
+| `backend/src/net-worth/net-worth.service.spec.ts` | Additive stock-split replay (`... + SPLIT 90 = 180 shares`). The suite now applies the **multiplicative** rule -- a 2-for-1 split multiplies the position (50 shares -> 100), and the comment records that the old additive fixture was replaced. | INV-HOLDING-002 |
+| `frontend/src/components/settings/BackupRestoreSection.test.tsx`, `frontend/src/components/settings/DangerZoneSection.test.tsx`, `backend/src/users/users.service.spec.ts`, `backend/src/backup/backup.service.spec.ts` | `oidcIdToken: 'oidc-session-confirmed'` accepted as proof. The suites now send the real signed reauth artifact and **reject** the sentinel (and any non-empty string); the literal survives only in comments describing the old defect. | INV-AUTH-003 |
 
-The second is the clearest case of the category: the sentinel string is asserted
-on both sides, so the tests do not merely tolerate the defect -- they specify it.
-Implementing a real OIDC round trip must change them, and that friction is what
-makes the defect look like a decision.
+The AUTH-003 case is the clearest of the category: the sentinel was asserted on
+both sides, so the tests did not merely tolerate the defect -- they specified it,
+and a real OIDC round trip could not land until they changed.
 
-The first is the more instructive one. It reads as a careful test: five actions,
-three months, arithmetic worked out in a comment. The arithmetic is simply the
-wrong rule, applied consistently. A reviewer checking whether the code matches
-the test would find that it does.
+The HOLDING-002 case is the more instructive one. It read as a careful test: five
+actions, three months, arithmetic worked out in a comment -- and the arithmetic
+was simply the wrong rule, applied consistently, which a reviewer checking code
+against test would have found to match.
 
 ### Reported but not located
 
@@ -219,31 +226,27 @@ failed, either the change is a no-op or the suite had no case for it. Say which
 in the change description, and if it is the second, add the case in the same
 commit.
 
-### The scans this document requires do not exist yet
+### The load-bearing source scans now exist
 
 Section 3 marks a source scan as load-bearing for INV-FX-001, INV-HOLDING-002,
-INV-PROFILE-001, INV-CURRENCY-001 and INV-CACHE-001. **None of them is written.**
-Each would be a handful of lines in the pattern of
-`frontend/src/test/ui-conventions.test.ts`:
+INV-PROFILE-001, INV-CURRENCY-001 and INV-CACHE-001. Each was owed when this
+document was first written; each is now written, in the pattern of
+`frontend/src/test/ui-conventions.test.ts`, alongside the fix to the invariant it
+scans:
 
-| Scan owed | Fails on |
-| --- | --- |
-| FX fallback | a `: 1` else-branch beside a rate lookup, or `?? amount` beside a conversion |
-| Share replay | a `SPLIT` case outside the single shared reducer |
-| Profile response | an entity column absent from the response allowlist |
-| Currency references | an FK to `currency_code` in `schema.sql` that the in-use check does not cover |
-| Cache families | a cache prefix in `src/` that declares itself neither transaction-derived nor reference data |
+| Scan | Fails on | File |
+| --- | --- | --- |
+| FX fallback | a `: 1` else-branch beside a rate lookup, or `?? amount` beside a conversion | `backend/src/common/fx-fallback.guard.spec.ts` |
+| Share replay | a `SPLIT` case outside the single shared reducer | `backend/src/securities/investment-replay.guard.spec.ts` |
+| Profile response | an entity column absent from the response allowlist | `backend/src/users/user-profile.spec.ts` |
+| Currency references | an FK to `currency_code` in `schema.sql` that the in-use check does not cover | `backend/src/currencies/currency-references.spec.ts` |
+| Cache families | a cache prefix in `src/` that declares itself neither transaction-derived nor reference data | `frontend/src/lib/cache-prefix-classification.guard.test.ts` |
 
-They are not written here because each would fail immediately against `main` --
-the defects they scan for are present, which is the point of the scan. A guard
-introduced in the same change that fixes its violations is verifiable; one
-introduced alone either breaks the suite or has to be born with a
-baseline-exception list, which is a decision about how much known-wrong code to
-bless and belongs to whoever fixes the underlying invariant.
-
-That is a reason for sequencing, not an excuse. Until these exist, INV-FX-001 and
-INV-HOLDING-002 in particular are guarded only by prose, and both have already
-been fixed at one call site while siblings stayed live.
+Each had to be born with the fix rather than alone: a guard introduced against
+still-broken code either breaks the suite or needs a baseline-exception list,
+which is a decision about how much known-wrong code to bless. They landed the
+right way -- with the fix, so no exception list -- which is why INV-FX-001 and
+INV-HOLDING-002 are no longer guarded only by prose.
 
 The corollary for this document: a test you have never seen fail protects
 nothing. When adding a required test from section 3, run it against the

--- a/docs/verification-contract.md
+++ b/docs/verification-contract.md
@@ -74,6 +74,7 @@ adds value but proves nothing on its own. `--` means not applicable.
 | INV-HOLDING-001 holding replay | supporting | -- | required | **required** | optional | required | -- | optional |
 | INV-HOLDING-002 one reducer | required | **required** | supporting | -- | -- | -- | -- | required |
 | INV-TRANSFER-001 both legs | required | -- | required | optional | -- | -- | -- | required |
+| INV-REDEEM-001 accrued interest | required | **required** | required | -- | -- | -- | -- | optional |
 | INV-RECONCILE-001 reconciled lock | supporting | **required** | required | required | -- | -- | -- | optional |
 | INV-FX-001 no 1:1 fallback | **required** | **required** | required | -- | -- | required | optional | required |
 | INV-OCCURRENCE-001 one effect | supporting | -- | required | required | **required** | required | -- | required |
@@ -103,7 +104,10 @@ previous fix corrected one and left the others. `INV-RECONCILE-001` is the same
 shape: the strict lock is only as strong as its least-guarded entry point -- a
 single-row refusal was once walked around by `bulkUpdate` -- so
 `reconciled-lock.guard.spec.ts` scanning every write path is the load-bearing
-kind, not any one service test.
+kind, not any one service test. `INV-REDEEM-001` too: proceeds and accrued
+interest are added in exactly one place, and `accrued-interest.guard.spec.ts`
+failing a hand-rolled addition anywhere else is what keeps the cash from being
+moved twice.
 
 `INV-IMPORT-002`'s load-bearing kind is a **failpoint**, and it is worth
 understanding why the other columns cannot substitute. The MNY import has real


### PR DESCRIPTION
<!-- Before opening this PR, please read CONTRIBUTING.md. Monize follows a propose-first workflow: open a Discussion and get the approach approved before writing code. -->

## Linked discussion / issue

<!-- Required. Replace the placeholders below with the approved issue/discussion before opening the PR. -->

Closes #<!-- issue number, if applicable -->
Approved in: #1227

## Summary

This PR turns the system-invariant audit into explicit, enforceable repository contracts: the critical invariants are documented, the verification requirements are defined, concrete gaps found during the audit are fixed, and load-bearing regression tests guard the mechanisms that make those invariants true.

The main changes are:

- document the repository's core system invariants in `docs/system-invariants.md`, including their source of truth, enforcement mechanism, concurrency/retry semantics, failure behavior, required verification, and current status;
- align `docs/verification-contract.md` with the implemented test suite and define the load-bearing verification kind for each invariant;
- extend the strict reconciled-transaction lock to mutation paths that could previously bypass it through action-history undo/redo and embedded investment updates;
- enforce creator-only deletion of shared custom currency definitions while still allowing other users to remove their own currency preference;
- add a deterministic two-connection balance test proving that an absolute recompute cannot overwrite a concurrent atomic balance delta;
- add a deterministic two-connection holding test that sends concurrent BUYs through the real `InvestmentTransactionsService.create` path and verifies the stored holding against a replay of persisted `investment_transactions`;
- add a PostgreSQL failpoint test for logout revocation, proving that a database failure propagates instead of being presented as a successful logout;
- extend source-scan guards for reconciled-lock coverage and add an invariant-catalog parity guard that rejects missing, extra, or duplicate invariant IDs between the catalog and verification matrix;
- correct stale verification documentation, including the removed `--passWithNoTests` behavior and the now-present load-bearing source scans;
- record previously known-wrong tests as corrected where the current suites now enforce the intended behavior.

Verification performed for the final changes:

- backend typecheck passes;
- backend lint passes;
- the targeted PostgreSQL integration suites for balance recompute, concurrent holding updates, and logout revocation failpoints pass;
- invariant/source-scan guards and invariant-catalog parity tests pass;
- the new load-bearing tests were also validated negatively by removing or bypassing the protected mechanism and confirming that the corresponding test fails for the intended reason.

The branch has been rebased onto the current `main`.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). No new user-facing strings are introduced by this PR.
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Claude Code was used to perform the invariant audit, implement the fixes, and author or refine the associated tests and documentation. ChatGPT was used for an independent review of the branch, follow-up verification of review fixes, and drafting this pull request description. I reviewed the resulting changes and take responsibility for their correctness and scope.
