### PR TITLE
Money import: show correct quantity for cash-like investments on import report (affects report only)

### DIFF
--- a/backend/src/import/mny/map/check-holdings.spec.ts
+++ b/backend/src/import/mny/map/check-holdings.spec.ts
@@ -48,6 +48,19 @@ const securities: MappedSecurities = mapSecurities({
   activeHandles: new Set([1]),
 });
 
+// A file mixing a lot-tracked fund with a lot-less instrument (a CD, savings
+// bond or money-market fund): Money records the CD's trades but keeps no `LOT`
+// row for it.
+const securitiesWithCd: MappedSecurities = mapSecurities({
+  securities: [
+    mnySecurity({ handle: 1, symbol: "VOO", name: "Vanguard" }),
+    mnySecurity({ handle: 2, symbol: "CD-5PCT", name: "5% Certificate" }),
+  ],
+  currencyByHandle: new Map(),
+  baseCurrency: "USD",
+  activeHandles: new Set([1, 2]),
+});
+
 function tx(
   action: InvestmentAction,
   quantity: number | null,
@@ -254,5 +267,60 @@ describe("crossCheckHoldings", () => {
     });
 
     expect(result.checks[0].matches).toBe(true);
+  });
+
+  // Money keeps no `LOT` row for a CD, savings bond or money-market fund, so its
+  // open-lot reading is a spurious zero. The report must reconcile it against
+  // the transaction replay -- Money's own data -- rather than flag a difference
+  // the correct import never introduced.
+  it("reconciles a lot-less security against its replay, not a zero", () => {
+    const result = crossCheckHoldings({
+      accounts: accountsFixture(),
+      securities: securitiesWithCd,
+      transactions: [
+        tx(InvestmentAction.BUY, 10),
+        tx(InvestmentAction.BUY, 5, { securityHandle: 2 }),
+      ],
+      // A LOT row for the fund only; the CD has none.
+      lots: [mnyLot({ account: 10, security: 1, quantity: 10 })],
+    });
+
+    const cd = result.checks.find((check) => check.symbol === "CD-5PCT");
+    expect(cd).toMatchObject({
+      lotQuantity: 5,
+      replayQuantity: 5,
+      delta: 0,
+      matches: true,
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  // A security that genuinely has an open lot but disagrees with the replay is
+  // still a real mismatch: the lot-less fallback must not swallow it.
+  it("still flags a security whose open lot disagrees with the replay", () => {
+    const result = crossCheckHoldings({
+      accounts: accountsFixture(),
+      securities: securitiesWithCd,
+      transactions: [
+        tx(InvestmentAction.BUY, 10),
+        tx(InvestmentAction.BUY, 5, { securityHandle: 2 }),
+      ],
+      lots: [
+        mnyLot({ account: 10, security: 1, quantity: 10 }),
+        mnyLot({ account: 10, security: 2, quantity: 4 }),
+      ],
+    });
+
+    const cd = result.checks.find((check) => check.symbol === "CD-5PCT");
+    expect(cd).toMatchObject({
+      lotQuantity: 4,
+      replayQuantity: 5,
+      matches: false,
+    });
+    expect(result.warnings).toContainEqual({
+      code: "holdingsMismatch",
+      subject: "Brokerage - Investments: CD-5PCT",
+      detail: "replay 5 vs lots 4",
+    });
   });
 });

--- a/backend/src/import/mny/map/check-holdings.ts
+++ b/backend/src/import/mny/map/check-holdings.ts
@@ -140,6 +140,18 @@ export function crossCheckHoldings(
   const lots = openLotPositions(input.lots, input.accounts.keyByHandle);
   const warnings: MnyWarning[] = [];
 
+  // Money keeps no `LOT` rows for CDs, U.S. savings bonds or money-market funds:
+  // it records their trades in `TRN_INV` but tracks no tax lots for them, so
+  // their open-lot reading is a spurious zero that flagged every such position
+  // as a discrepancy even though the import was correct. For a security the file
+  // records no lot for at all, its own transaction replay -- still Money's data,
+  // read from `TRN_INV` instead of `LOT` -- is the authoritative Money reading.
+  const securitiesWithLots = new Set(
+    input.lots
+      .map((lot) => lot.security)
+      .filter((security): security is number => security !== null),
+  );
+
   const nameByKey = new Map(
     input.accounts.accounts.map((account) => [account.key, account.name]),
   );
@@ -152,10 +164,9 @@ export function crossCheckHoldings(
         replay.get(key) ?? 0,
         QUANTITY_DECIMALS,
       );
-      const lotQuantity = roundToDecimals(
-        lots.get(key) ?? 0,
-        QUANTITY_DECIMALS,
-      );
+      const lotQuantity = securitiesWithLots.has(securityHandle)
+        ? roundToDecimals(lots.get(key) ?? 0, QUANTITY_DECIMALS)
+        : replayQuantity;
       const delta = roundToDecimals(
         replayQuantity - lotQuantity,
         QUANTITY_DECIMALS,

--- a/backend/src/import/mny/model/mny-import-model.ts
+++ b/backend/src/import/mny/model/mny-import-model.ts
@@ -518,7 +518,12 @@ export interface MnyHoldingCheck {
   readonly accountKey: string;
   readonly securityHandle: number;
   readonly symbol: string;
-  /** Shares open lots say the account holds (`LOT` rows with no `htrnSell`). */
+  /**
+   * Shares open lots say the account holds (`LOT` rows with no `htrnSell`), or
+   * the replay quantity for a security the file keeps no lot for at all -- CDs,
+   * savings bonds and money-market funds, which Money records in `TRN_INV` but
+   * tracks no tax lots for.
+   */
   readonly lotQuantity: number;
   /** Shares replaying the mapped investment actions produces. */
   readonly replayQuantity: number;

--- a/docs/ms-money-data-model.md
+++ b/docs/ms-money-data-model.md
@@ -532,6 +532,14 @@ Open positions are the sum of `qty` over lots with an empty `htrnSell`. This is
 the most reliable statement of what Money considers held: it sidesteps replaying
 transactions and handles transfers, splits and corporate actions for free.
 
+**Not every held security has a lot.** Money keeps no `LOT` row for a CD, a U.S.
+savings bond or a money-market fund -- it records their trades in `TRN_INV` but
+tracks no tax lots for them. Their open-lot reading is therefore `0` even while
+the position is open, so the verification cross-check falls back to the
+transaction replay (still Money's own data) for any security the file records no
+lot for at all. Treating the absent lot as zero shares flagged every such
+position as a discrepancy the correct import never introduced.
+
 Monize does **not** import holdings from `LOT`. Holdings come only from the
 canonical rebuild over imported transactions -- a second, private fold is what
 left the proof of concept with negative positions. `LOT` is used instead as an


### PR DESCRIPTION
<!-- Before opening this PR, please read CONTRIBUTING.md. Monize follows a propose-first workflow: open a Discussion and get the approach approved before writing code. -->

## Linked discussion / issue

<!-- Required. Paste the link to the approved discussion or issue that agreed on this change's scope and approach. -->

Closes #1216
Approved in: Not approved yet

## Summary

The bug was in the import verification report, not the import itself. For investments Money records as CDs, U.S. savings bonds, or money-market funds, Money keeps trades in TRN_INV but creates no LOT rows for them — it doesn't track tax lots for those instruments. The reconciliation used open LOT rows as the authoritative "Shares in Money" reading, so a lot-less security read as 0, producing a non-zero difference and a "check" flag even though Monize imported the correct quantity.

The fix, in check-holdings.ts:

Build a set of security handles that appear in any LOT row. For a security the file records no lot for at all, fall back to the transaction replay (still Money's own data, read from TRN_INV) as the "Shares in Money" figure instead of a spurious 0. Securities that do have lots are unchanged, so a genuine lot-vs-replay disagreement is still flagged. This is version-independent and reads no sct code for meaning, matching the codebase's activity-based approach. With it, the report shows the correct held quantity under "Shares in Money" and a 0 difference.

Changes:

check-holdings.ts — the lot-less fallback.
check-holdings.spec.ts — two regression tests: a lot-less security reconciles against its replay, and a lotted security that disagrees is still flagged. mny-import-model.ts — updated lotQuantity doc.
ms-money-data-model.md — recorded the "not every held security has a lot" fact. Note: this manifests only in mixed files (some lotted securities plus lot-less ones). A file with only CDs/money-market has no LOT table, so the report already omits the holdings section entirely — no spurious flag there.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [X] This PR addresses a **single concern** (large work is split into a series).
- [X] New behavior has tests, and the existing suite passes.
- [X] All user-facing strings are translated for **every** locale (i18n parity).
- [X] No shared/core areas were refactored without prior agreement.
- [X] The branch is rebased on the latest `main`.
- [X] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Co-authored with AI
