### PR TITLE
Fix the remaining over-cap `limit` call site, and scan for the next one

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -45,6 +45,37 @@ npm run i18n:check         # Verify the pseudo-locale is up to date (CI gate)
 
 Feature API modules (one per feature, typed axios wrappers) live alongside `api.ts`. Use the filesystem to discover them.
 
+### A paged endpoint is never asked for more rows than it accepts
+
+`API_MAX_PAGE_LIMIT` (`lib/api-page-limits.ts`) is the ceiling both paged list
+endpoints enforce, and neither of them clamps: `GET /transactions` (via the
+backend's `PAGINATION_MAX_LIMIT`) and `GET /investment-transactions` (a
+hand-written check in its controller) answer **400** to a larger `limit`. Every
+one of these calls sits behind a `.catch()` that degrades to an empty list, so
+the rejection never reaches the user as an error -- it reaches them as a figure
+that is quietly, permanently zero. `limit: 500` on the recurring-charges panel is
+issue #1229 (no subscriptions ever detected); the same literal on the investment
+detail page reported every year's dividends and interest as $0.00.
+
+Lowering the literal to the cap is **not** the fix. That trades a visible zero
+for a plausible undercount, which is the worse of the two: nothing on screen
+distinguishes a truncated year from a quiet one. Either walk the pages --
+`transactionsApi.getAllPages` and `investmentsApi.getAllTransactionPages`, both
+defaulting their page size to the constant -- or narrow the query server-side
+until one page is genuinely enough. The YTD income figure does the second,
+asking for `DIVIDEND` and `INTEREST` separately because that endpoint matches one
+action per request, and still walks pages within each.
+
+Prefer narrowing to walking. A page walk that pulls a whole year of rows down in
+order to distil a handful of ids is a side panel paying for a report, and the
+request count grows with the user's history.
+
+`src/test/api-page-limits.test.ts` scans the tree for a call site above the cap
+and checks the constant against **both** backend sources, so the layers cannot
+drift apart quietly. Its known-violation register is the honest half: an entry
+there is a defect being tracked with the change that fixes it, and the test fails
+once the violation is gone, so a stale entry cannot outlive its fix.
+
 ### A write that moves money calls `invalidateBalanceCaches()`
 
 `accountsApi.getAll`, `investmentsApi.getPortfolioSummary` and the budget

--- a/frontend/src/components/accounts/investment-detail/InvestmentDetailView.test.tsx
+++ b/frontend/src/components/accounts/investment-detail/InvestmentDetailView.test.tsx
@@ -54,12 +54,12 @@ vi.mock('@/lib/accounts', () => ({
 }));
 
 const mockGetPortfolioSummary = vi.fn();
-const mockGetTransactions = vi.fn();
+const mockGetAllTransactionPages = vi.fn();
 const mockGetRealizedGains = vi.fn();
 vi.mock('@/lib/investments', () => ({
   investmentsApi: {
     getPortfolioSummary: (...a: unknown[]) => mockGetPortfolioSummary(...a),
-    getTransactions: (...a: unknown[]) => mockGetTransactions(...a),
+    getAllTransactionPages: (...a: unknown[]) => mockGetAllTransactionPages(...a),
     getRealizedGains: (...a: unknown[]) => mockGetRealizedGains(...a),
   },
 }));
@@ -99,18 +99,15 @@ beforeEach(() => {
     holdingsByAccount: [],
     allocation: [],
   });
-  mockGetTransactions.mockImplementation((params: { startDate?: string }) =>
+  // Income is fetched one action at a time, server-side, so each call answers
+  // with only the rows for the action it asked for.
+  mockGetAllTransactionPages.mockImplementation((params: { action?: string }) =>
     Promise.resolve(
-      params?.startDate
-        ? {
-            data: [
-              { id: 'd1', action: 'DIVIDEND', totalAmount: 50 },
-              { id: 'i1', action: 'INTEREST', totalAmount: 10 },
-              { id: 'b1', action: 'BUY', totalAmount: 1000 },
-            ],
-            pagination: {},
-          }
-        : { data: [{ id: 't1', action: 'BUY', totalAmount: 1000 }], pagination: {} },
+      params?.action === 'DIVIDEND'
+        ? [{ id: 'd1', action: 'DIVIDEND', totalAmount: 50 }]
+        : params?.action === 'INTEREST'
+          ? [{ id: 'i1', action: 'INTEREST', totalAmount: 10 }]
+          : [],
     ),
   );
   mockGetRealizedGains.mockResolvedValue([{ realizedGain: 120 }, { realizedGain: -20 }]);
@@ -136,6 +133,50 @@ describe('InvestmentDetailView', () => {
     await renderView();
     await waitFor(() => expect(screen.getByText('$60.00')).toBeInTheDocument());
     expect(screen.getByText('$100.00')).toBeInTheDocument();
+  });
+
+  // The YTD income figure asked for 500 rows in one page. The endpoint caps a
+  // page at 200 and answers 400 rather than clamping, the .catch() below turned
+  // that into an empty list, and the figure read $0.00 for every account, every
+  // year -- with nothing on screen to say the request had failed at all.
+  it('asks for income a page at a time, never as one over-cap request', async () => {
+    await renderView();
+    await waitFor(() => expect(mockGetAllTransactionPages).toHaveBeenCalled());
+
+    const params = mockGetAllTransactionPages.mock.calls.map(([p]) => p);
+    expect(params.map((p) => p.action).sort()).toEqual(['DIVIDEND', 'INTEREST']);
+    // No caller-supplied page size: the helper's default is the cap itself.
+    expect(params.every((p) => p.limit === undefined && p.pageSize === undefined)).toBe(true);
+    expect(params.every((p) => p.accountIds === 'br-1,cash-1')).toBe(true);
+  });
+
+  // Lowering the old literal to the cap would have swapped a visible zero for a
+  // silent undercount, which is the worse failure of the two: a year with more
+  // than one page of income has to total all of it.
+  it('counts income past the first page', async () => {
+    mockGetAllTransactionPages.mockImplementation((params: { action?: string }) =>
+      Promise.resolve(
+        params?.action === 'DIVIDEND'
+          ? Array.from({ length: 250 }, (_, i) => ({
+              id: `d${i}`,
+              action: 'DIVIDEND',
+              totalAmount: 2,
+            }))
+          : [],
+      ),
+    );
+
+    await renderView();
+    await waitFor(() => expect(screen.getByText('$500.00')).toBeInTheDocument());
+  });
+
+  // A failed lookup is not a year without income, but it is all the component
+  // can say -- so the rest of the page must still render rather than blanking.
+  it('survives an income lookup that fails', async () => {
+    mockGetAllTransactionPages.mockRejectedValue(new Error('boom'));
+    await renderView();
+    await waitFor(() => expect(mockGetPortfolioSummary).toHaveBeenCalled());
+    expect(screen.getByTestId('portfolio-summary')).toBeInTheDocument();
   });
 
   // The header owns both actions now (InvestmentDetailActions), so the body

--- a/frontend/src/components/accounts/investment-detail/InvestmentDetailView.tsx
+++ b/frontend/src/components/accounts/investment-detail/InvestmentDetailView.tsx
@@ -28,6 +28,14 @@ function round2(value: number): number {
 }
 
 /**
+ * The actions that count towards the YTD income figure. Filtered server-side,
+ * one request each, because `GET /investment-transactions` matches a single
+ * action per call -- the reinvestment actions are deliberately absent, matching
+ * what this figure has always counted.
+ */
+const INCOME_ACTIONS = ['DIVIDEND', 'INTEREST'] as const;
+
+/**
  * The investment detail body for a brokerage/cash pair. Resolves the pair (via
  * investment-pair, falling back to a standalone brokerage), then composes the
  * existing portfolio components scoped to the pair's accounts: summary,
@@ -71,11 +79,24 @@ export function InvestmentDetailView({ account, refreshKey = 0 }: InvestmentDeta
       const today = format(now, 'yyyy-MM-dd');
       const yearStart = `${now.getFullYear()}-01-01`;
 
+      // Income is asked for one action at a time and walked a page at a time.
+      // A single unfiltered request capped the year at one page, and asking for
+      // a bigger page is what the server refuses outright -- the 400 landed in
+      // the catch below and reported the year's dividends as 0.00.
       const [summaryData, incomeTx, realized] = await Promise.all([
         investmentsApi.getPortfolioSummary(ids).catch(() => null),
-        investmentsApi
-          .getTransactions({ accountIds: idsStr, startDate: yearStart, endDate: today, limit: 500 })
-          .catch(() => ({ data: [] as InvestmentTransaction[] })),
+        Promise.all(
+          INCOME_ACTIONS.map((action) =>
+            investmentsApi.getAllTransactionPages({
+              accountIds: idsStr,
+              startDate: yearStart,
+              endDate: today,
+              action,
+            }),
+          ),
+        )
+          .then((perAction) => perAction.flat())
+          .catch(() => [] as InvestmentTransaction[]),
         investmentsApi
           .getRealizedGains({ accountIds: idsStr, startDate: yearStart, endDate: today })
           .catch(() => [] as RealizedGainEntry[]),
@@ -85,9 +106,7 @@ export function InvestmentDetailView({ account, refreshKey = 0 }: InvestmentDeta
       setBrokerage(resolvedBrokerage);
       setCash(resolvedCash);
       setSummary(summaryData);
-      const income = incomeTx.data
-        .filter((tx) => tx.action === 'DIVIDEND' || tx.action === 'INTEREST')
-        .reduce((sum, tx) => sum + (Number(tx.totalAmount) || 0), 0);
+      const income = incomeTx.reduce((sum, tx) => sum + (Number(tx.totalAmount) || 0), 0);
       setDividendInterestYtd(round2(income));
       setRealizedGainsYtd(round2(realized.reduce((sum, r) => sum + (Number(r.realizedGain) || 0), 0)));
       setLoadedForId(account.id);

--- a/frontend/src/lib/api-page-limits.ts
+++ b/frontend/src/lib/api-page-limits.ts
@@ -1,0 +1,24 @@
+/**
+ * The row-per-page ceiling the paged list endpoints enforce, held once on the
+ * client so a call site cannot pick a number the server will refuse.
+ *
+ * The server does not clamp an over-cap `limit` -- it rejects the request. Both
+ * `GET /transactions` (via `PAGINATION_MAX_LIMIT` in
+ * `backend/src/common/dto/pagination-query.dto.ts`) and
+ * `GET /investment-transactions` (a hand-written check in
+ * `backend/src/securities/investment-transactions.controller.ts`) answer 400 to
+ * a larger one. Every such call in this app sits behind a `.catch()` that
+ * degrades to an empty list, so the 400 never reaches the user as an error: it
+ * reaches them as a figure that is silently, permanently zero (issue #1229, and
+ * the YTD income figure on the investment detail page).
+ *
+ * Asking for more rows than this is therefore never the answer. Walk the pages
+ * instead -- `transactionsApi.getAllPages` and
+ * `investmentsApi.getAllTransactionPages` both default their page size to this
+ * constant -- or narrow the query so one page is enough.
+ *
+ * `src/test/api-page-limits.test.ts` scans the tree for a call site that
+ * exceeds it and checks this value against both backend sources, so the two
+ * layers cannot drift apart quietly.
+ */
+export const API_MAX_PAGE_LIMIT = 200;

--- a/frontend/src/lib/investments.test.ts
+++ b/frontend/src/lib/investments.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import apiClient from './api';
 import { investmentsApi } from './investments';
 import { invalidateCache } from './apiCache';
+import { API_MAX_PAGE_LIMIT } from './api-page-limits';
 
 vi.mock('./api', () => ({
   default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -101,6 +102,62 @@ describe('investmentsApi', () => {
     await investmentsApi.getTransactions({ page: 1, limit: 20 });
     expect(apiClient.get).toHaveBeenCalledWith('/investment-transactions', {
       params: { page: 1, limit: 20 },
+    });
+  });
+
+  describe('getAllTransactionPages', () => {
+    /** A page of `count` rows, reporting whether another follows it. */
+    function page(count: number, hasMore: boolean, idPrefix = 'it') {
+      return {
+        data: Array.from({ length: count }, (_, i) => ({ id: `${idPrefix}-${i}` })),
+        pagination: { page: 1, limit: API_MAX_PAGE_LIMIT, total: 0, totalPages: 0, hasMore },
+      };
+    }
+
+    it('never asks for more rows than the endpoint accepts', async () => {
+      // The whole point of the helper. `GET /investment-transactions` answers
+      // 400 above this, and the caller's .catch() turns that into a zero.
+      vi.mocked(apiClient.get).mockResolvedValue({ data: page(1, false) });
+      await investmentsApi.getAllTransactionPages({ accountIds: 'a-1' });
+
+      const limits = vi
+        .mocked(apiClient.get)
+        .mock.calls.map(([, config]) => (config as { params: { limit: number } }).params.limit);
+      expect(limits.every((limit) => limit <= API_MAX_PAGE_LIMIT)).toBe(true);
+    });
+
+    it('walks past the first page and returns every row', async () => {
+      vi.mocked(apiClient.get)
+        .mockResolvedValueOnce({ data: page(2, true, 'p1') })
+        .mockResolvedValueOnce({ data: page(1, false, 'p2') });
+
+      const rows = await investmentsApi.getAllTransactionPages({ action: 'DIVIDEND' });
+
+      expect(rows.map((r) => r.id)).toEqual(['p1-0', 'p1-1', 'p2-0']);
+      expect(apiClient.get).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(apiClient.get).mock.calls[1][1]).toMatchObject({
+        params: { page: 2, action: 'DIVIDEND' },
+      });
+    });
+
+    it('stops on an empty page even when the server still claims more', async () => {
+      // Without this the walk spins to MAX_PAGES against a backend whose
+      // hasMore is wrong, which is a hang rather than a wrong number.
+      vi.mocked(apiClient.get)
+        .mockResolvedValueOnce({ data: page(1, true, 'p1') })
+        .mockResolvedValue({ data: page(0, true) });
+
+      const rows = await investmentsApi.getAllTransactionPages();
+
+      expect(rows.map((r) => r.id)).toEqual(['p1-0']);
+      expect(apiClient.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('passes the filter through and does not swallow a failure', async () => {
+      // A rejection has to reach the caller: a caller that cannot tell a failed
+      // lookup from an empty result reports an outage as a confident zero.
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('boom'));
+      await expect(investmentsApi.getAllTransactionPages()).rejects.toThrow('boom');
     });
   });
 

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -36,6 +36,7 @@ import {
 } from '@/types/investment';
 import { IntradayBreakdown } from '@/types/net-worth';
 import { getCached, setCache, invalidateBalanceCaches, invalidateCache } from './apiCache';
+import { API_MAX_PAGE_LIMIT } from './api-page-limits';
 
 export const investmentsApi = {
   // Get portfolio summary
@@ -252,6 +253,50 @@ export const investmentsApi = {
       { params },
     );
     return response.data;
+  },
+
+  /**
+   * Every investment transaction matching the filter, walked a page at a time.
+   *
+   * The counterpart to `transactionsApi.getAllPages`, and it exists for the
+   * same reason: `GET /investment-transactions` rejects a `limit` above
+   * {@link API_MAX_PAGE_LIMIT} with a 400 rather than clamping it, so a caller
+   * that wants more than one page walks the pages. Reaching for a bigger
+   * `limit` produces a request the server refuses, which every caller here
+   * degrades into an empty list -- a figure that reads as a confident zero.
+   *
+   * Prefer narrowing the query (`action`, `symbol`, a date range) over walking
+   * a whole register client-side; use this when the filtered set can still run
+   * past one page.
+   */
+  getAllTransactionPages: async (
+    params?: {
+      accountIds?: string;
+      startDate?: string;
+      endDate?: string;
+      symbol?: string;
+      action?: string;
+    } & { pageSize?: number },
+  ): Promise<InvestmentTransaction[]> => {
+    const MAX_PAGES = 5000;
+    const { pageSize = API_MAX_PAGE_LIMIT, ...rest } = params ?? {};
+    const all: InvestmentTransaction[] = [];
+    let page = 1;
+    let hasMore = true;
+    while (hasMore && page <= MAX_PAGES) {
+      const result = await investmentsApi.getTransactions({
+        ...rest,
+        page,
+        limit: pageSize,
+      });
+      // Defend against a backend that reports hasMore=true on an empty page;
+      // without new rows there is nothing left to fetch.
+      if (result.data.length === 0) break;
+      all.push(...result.data);
+      hasMore = result.pagination.hasMore;
+      page++;
+    }
+    return all;
   },
 
   /**

--- a/frontend/src/lib/transactions.ts
+++ b/frontend/src/lib/transactions.ts
@@ -24,6 +24,7 @@ import {
   RegisterFilterOptions,
 } from '@/types/transaction';
 import { invalidateBalanceCaches } from './apiCache';
+import { API_MAX_PAGE_LIMIT } from './api-page-limits';
 
 /** Convert array filter params to comma-separated strings for the API. */
 function buildFilterParams(params?: {
@@ -145,7 +146,7 @@ export const transactionsApi = {
     params?: TransactionsGetAllParams & { pageSize?: number },
   ): Promise<Transaction[]> => {
     const MAX_PAGES = 5000;
-    const { pageSize = 200, ...rest } = params ?? {};
+    const { pageSize = API_MAX_PAGE_LIMIT, ...rest } = params ?? {};
     const all: Transaction[] = [];
     let page = 1;
     let hasMore = true;

--- a/frontend/src/test/api-page-limits.test.ts
+++ b/frontend/src/test/api-page-limits.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { API_MAX_PAGE_LIMIT } from '@/lib/api-page-limits';
+
+/**
+ * No call site may ask a paged endpoint for more rows than it accepts.
+ *
+ * The server does not clamp an over-cap `limit`, it rejects the request, and
+ * every one of these calls sits behind a `.catch()` that degrades to an empty
+ * list. So the 400 never surfaces as an error -- it surfaces as a number that
+ * is quietly, permanently zero. That is issue #1229 (the recurring-charges
+ * panel found no subscriptions at all) and it is the same defect that made the
+ * investment detail page report every year's dividends and interest as 0.00.
+ * Both were one literal, in one file, and neither failed a test.
+ *
+ * Lowering the literal to the cap is not the fix either: that turns a visible
+ * zero into a plausible undercount, which is worse. Walk the pages
+ * (`transactionsApi.getAllPages`, `investmentsApi.getAllTransactionPages`) or
+ * narrow the query until one page is enough.
+ *
+ * Modelled on `src/test/ui-conventions.test.ts` -- a scan of the whole tree,
+ * because a test around the one component that was fixed cannot catch the next
+ * instance, and there was always a next instance.
+ */
+const sources = import.meta.glob('/src/**/*.{ts,tsx}', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+
+/**
+ * The client methods that reach a capped endpoint, and the parameter that
+ * becomes the server's `limit`. A page-walk helper is listed too: its
+ * `pageSize` is passed straight through as `limit`, so an over-cap page size
+ * fails on the first request exactly as a raw one does.
+ */
+const CAPPED_CALLS = [
+  { object: 'transactionsApi', method: 'getAll', key: 'limit' },
+  { object: 'transactionsApi', method: 'getAllPages', key: 'pageSize' },
+  { object: 'investmentsApi', method: 'getTransactions', key: 'limit' },
+  { object: 'investmentsApi', method: 'getAllTransactionPages', key: 'pageSize' },
+] as const;
+
+/**
+ * Call sites that are still over the cap, with the change that fixes each one.
+ * An entry here is a live defect, not an exemption -- the test below fails once
+ * the violation is gone, so a stale entry cannot outlive the fix it names.
+ */
+const KNOWN_VIOLATIONS: {
+  path: string;
+  object: string;
+  method: string;
+  key: string;
+  fix: string;
+}[] = [
+  {
+    path: '/src/components/accounts/shared/RecurringChargesPanel.tsx',
+    object: 'transactionsApi',
+    method: 'getAll',
+    key: 'limit',
+    // Issue #1229. The fix -- switching to `getAllPages` -- is in flight in its
+    // own pull request; this entry is deleted when that lands, and the test
+    // below is what says so.
+    fix: 'PR #1230',
+  },
+];
+
+/** Source files only: a test legitimately contains the call it asserts on. */
+function productionSources(): [string, string][] {
+  return Object.entries(sources).filter(([path]) => !/\.test\.tsx?$/.test(path));
+}
+
+/**
+ * The argument text of each `object.method(...)` call in `source`, found by
+ * balancing parentheses from the opening one. Whitespace between the object and
+ * the method is tolerated because that is how the formatter writes these:
+ * `transactionsApi\n  .getAll({ ... })`.
+ */
+function callArguments(source: string, object: string, method: string): string[] {
+  const opener = new RegExp(`\\b${object}\\s*\\.\\s*${method}\\s*\\(`, 'g');
+  const found: string[] = [];
+  let match = opener.exec(source);
+  while (match !== null) {
+    const open = match.index + match[0].length - 1;
+    let depth = 0;
+    let end = open;
+    for (; end < source.length; end++) {
+      if (source[end] === '(') depth++;
+      else if (source[end] === ')' && --depth === 0) break;
+    }
+    found.push(source.slice(open + 1, end));
+    opener.lastIndex = end;
+    match = opener.exec(source);
+  }
+  return found;
+}
+
+/** Numeric literals given to `key` inside one call's arguments. */
+function literalsFor(args: string, key: string): number[] {
+  return [...args.matchAll(new RegExp(`\\b${key}\\s*:\\s*(\\d+)`, 'g'))].map((m) => Number(m[1]));
+}
+
+interface Offence {
+  path: string;
+  object: string;
+  method: string;
+  key: string;
+  value: number;
+}
+
+/** Every over-cap call site in the tree, whether or not it is a known one. */
+function overCapCallSites(): Offence[] {
+  return productionSources().flatMap(([path, content]) =>
+    CAPPED_CALLS.flatMap(({ object, method, key }) =>
+      callArguments(content, object, method)
+        .flatMap((args) => literalsFor(args, key))
+        .filter((value) => value > API_MAX_PAGE_LIMIT)
+        .map((value) => ({ path, object, method, key, value })),
+    ),
+  );
+}
+
+function isKnown(offence: Offence): boolean {
+  return KNOWN_VIOLATIONS.some(
+    (known) =>
+      known.path === offence.path &&
+      known.object === offence.object &&
+      known.method === offence.method &&
+      known.key === offence.key,
+  );
+}
+
+describe('paged endpoints are never asked for more than they accept', () => {
+  it('has no new over-cap call site', () => {
+    const offenders = overCapCallSites()
+      .filter((offence) => !isKnown(offence))
+      .map((o) => `${o.path}: ${o.object}.${o.method}({ ${o.key}: ${o.value} })`);
+
+    // The server answers 400, the call site's .catch() turns that into an empty
+    // list, and the user reads a zero. Walk the pages or narrow the query.
+    expect(offenders).toEqual([]);
+  });
+
+  it('lists no known violation that has already been fixed', () => {
+    const live = overCapCallSites();
+    const stale = KNOWN_VIOLATIONS.filter(
+      (known) =>
+        !live.some(
+          (offence) =>
+            offence.path === known.path &&
+            offence.object === known.object &&
+            offence.method === known.method &&
+            offence.key === known.key,
+        ),
+    ).map((known) => `${known.path}: ${known.object}.${known.method} -- fixed by ${known.fix}`);
+
+    // A known violation is a defect being tracked, not a permitted one. Once
+    // its fix lands the entry is wrong, and leaving it behind would quietly
+    // re-permit the literal it names.
+    expect(stale).toEqual([]);
+  });
+
+  it('still finds the calls it polices, so the scan cannot pass by accident', () => {
+    // Were a client method renamed, both checks above would sweep an empty set
+    // and report success. This fails first and says what to update.
+    const missing = CAPPED_CALLS.filter(
+      ({ object, method }) =>
+        !productionSources().some(([, content]) => callArguments(content, object, method).length),
+    ).map(({ object, method }) => `${object}.${method}`);
+
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('the client cap matches the caps the server enforces', () => {
+  /**
+   * The server states this ceiling twice, in two unrelated shapes, and neither
+   * knows about the other: a shared DTO constant, and a hand-written check in
+   * the investment register's controller whose 400 message spells the number
+   * out in prose. Both are read here so a change to either fails against the
+   * client rather than reaching a user as a swallowed 400.
+   */
+  function backendSource(relativePath: string): string {
+    return readFileSync(join(REPO_ROOT, relativePath), 'utf8');
+  }
+
+  it('matches PAGINATION_MAX_LIMIT on GET /transactions', () => {
+    const dto = backendSource('backend/src/common/dto/pagination-query.dto.ts');
+    const declared = /export const PAGINATION_MAX_LIMIT\s*=\s*(\d+)/.exec(dto);
+
+    expect(declared, 'PAGINATION_MAX_LIMIT not found -- update this test').toBeTruthy();
+    expect(Number(declared![1])).toBe(API_MAX_PAGE_LIMIT);
+  });
+
+  it('matches the hand-written cap on GET /investment-transactions', () => {
+    const controller = backendSource(
+      'backend/src/securities/investment-transactions.controller.ts',
+    );
+    const declared = /limitNum\s*>\s*(\d+)/.exec(controller);
+
+    expect(declared, 'the limit check was rewritten -- update this test').toBeTruthy();
+    expect(Number(declared![1])).toBe(API_MAX_PAGE_LIMIT);
+  });
+});


### PR DESCRIPTION
## Linked discussion / issue

Follow-up to the review of #1230, which fixes one instance of this defect. Same class as #1229.

Closes #
Approved in: not approved yet -- raising it here because the review of #1230 turned up a second live instance and there was no mechanism stopping a third.

## Summary

Reviewing #1230 turned up the same defect one grep away, still live on `main`, plus the fact that nothing would have caught either one.

**The defect.** `GET /transactions` and `GET /investment-transactions` both cap a page at 200 rows, and neither clamps an over-cap `limit` -- they answer **400**. Every call site of this kind sits behind a `.catch()` that degrades to an empty list, so the rejection never surfaces as an error. It surfaces as a figure that is quietly, permanently zero. In #1229 that was "no recurring charges detected, ever". Here it was the investment detail page's YTD income: `investmentsApi.getTransactions({ ..., limit: 500 })` meant every account showed **$0.00 dividends and interest, every year**, with only a console log as evidence.

**Why not just lower the number.** `limit: 200` would have traded a visible zero for a plausible undercount, and nothing on screen distinguishes a truncated year from a quiet one. Instead the figure is asked for the way the endpoint wants to answer it -- filtered server-side to `DIVIDEND` and `INTEREST` (one request each, since it matches a single action per call) and walked a page at a time within each. That moves a handful of rows where the old call pulled a whole year down to filter client-side.

`investmentsApi.getAllTransactionPages` is the counterpart to the existing `transactionsApi.getAllPages` -- same empty-page guard, same page ceiling -- and both now default their page size to one shared `API_MAX_PAGE_LIMIT` instead of a literal.

**The guard.** `frontend/src/test/api-page-limits.test.ts` scans the tree for a `limit` (or page-walk `pageSize`) above the cap, balancing parentheses so a call the formatter split across lines is still seen. Two checks keep it from passing vacuously: it asserts it still finds the methods it polices, so a rename cannot empty the scan, and it reads **both** backend sources of the cap -- the shared `PAGINATION_MAX_LIMIT` and the investment controller's hand-written check, which do not know about each other -- so a change to either fails here rather than reaching a user as a swallowed 400.

**Relationship to #1230.** The recurring-charges panel is the one violation left on `main`, and this PR deliberately does not touch it -- that is #1230's line to fix. It is recorded in a known-violation register naming #1230 as the fix, and a second test fails once the violation is gone, so the entry cannot outlive it. Whichever of the two merges first, the other needs the trivial follow-up: if #1230 lands first, delete the register entry here.

### Verification

- The three new `InvestmentDetailView` tests were run against the previous component and fail there, including the one that totals income past the first page.
- The scan was verified in both directions: injecting `limit: 999` at an unrelated call site fails it with the file and value named, and applying #1230's fix locally fails the register test as designed.
- `npm run type-check`, `npm run lint`, and 918 tests across the 57 affected frontend files pass. Backend `doc-paths` / `source-comment-paths` guards pass against the new files and the `CLAUDE.md` edit.

### Noted, not fixed here

The `.catch()` still renders a failed lookup as a measured `$0.00`, which `frontend/CLAUDE.md` ("an unknown value must not render as a measured zero") says it should not. Fixing it means giving `InvestmentIncomePanel` an unknown state and a translated string, so it is a separate concern from the request-size defect rather than something to smuggle in here.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [X] This PR addresses a **single concern** (large work is split into a series).
- [X] New behavior has tests, and the existing suite passes.
- [X] All user-facing strings are translated for **every** locale (i18n parity). -- no user-facing strings changed.
- [X] No shared/core areas were refactored without prior agreement. -- `transactionsApi.getAllPages` changed only in that its literal page size became the shared constant of the same value.
- [X] The branch is rebased on the latest `main`.
- [X] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written by Claude Code, following its review of #1230. The defect, the choice not to simply lower the literal, and the scope boundary against #1230's own file are called out above so they can be checked rather than taken on trust.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGkrS17rWAkanDHhK4kwfC)_