### PR TITLE
Fix red main: empty the known-violation register now that #1230 has landed

### DIFF
--- a/frontend/src/test/api-page-limits.test.ts
+++ b/frontend/src/test/api-page-limits.test.ts
@@ -48,6 +48,14 @@ const CAPPED_CALLS = [
  * Call sites that are still over the cap, with the change that fixes each one.
  * An entry here is a live defect, not an exemption -- the test below fails once
  * the violation is gone, so a stale entry cannot outlive the fix it names.
+ *
+ * Empty, and worth keeping empty. The register's one entry (the recurring
+ * charges panel, issue #1229) named PR #1230 as its fix, and #1230 landed --
+ * at which point the entry described a violation that no longer existed and
+ * the test below went red. Note where it went red: not on either pull request,
+ * but on `main` after both had merged. The two changed different files, so git
+ * merged them without complaint; only the combination was wrong, and neither
+ * PR's CI ran against it.
  */
 const KNOWN_VIOLATIONS: {
   path: string;
@@ -55,18 +63,7 @@ const KNOWN_VIOLATIONS: {
   method: string;
   key: string;
   fix: string;
-}[] = [
-  {
-    path: '/src/components/accounts/shared/RecurringChargesPanel.tsx',
-    object: 'transactionsApi',
-    method: 'getAll',
-    key: 'limit',
-    // Issue #1229. The fix -- switching to `getAllPages` -- is in flight in its
-    // own pull request; this entry is deleted when that lands, and the test
-    // below is what says so.
-    fix: 'PR #1230',
-  },
-];
+}[] = [];
 
 /** Source files only: a test legitimately contains the call it asserts on. */
 function productionSources(): [string, string][] {


### PR DESCRIPTION
## Linked discussion / issue

Fixes `main`, which is currently red. Follow-up to #1233 and #1230, both merged.

Closes #
Approved in: not applicable -- this repairs a broken `main`.

## Summary

**`main` is red.** `frontend/src/test/api-page-limits.test.ts` still lists the recurring-charges panel as an over-cap call site, naming PR #1230 as the fix in flight. #1230 has merged, so that entry now describes a violation that no longer exists, and the register's second test -- which exists precisely to stop an entry outliving its fix -- correctly fails:

```
× lists no known violation that has already been fixed
+   "/src/components/accounts/shared/RecurringChargesPanel.tsx: transactionsApi.getAll -- fixed by PR #1230"
```

This PR empties the register. It stays in place: there is no violation left, the first test holds that unaided, and the second now has nothing to expire.

### How this reached `main`

Worth recording, because the guard did its job and the process around it did not.

- #1230 removed the violation (`RecurringChargesPanel.tsx`).
- #1233 added the register naming it (`api-page-limits.test.ts`).
- **Different files, so git merged them with no conflict.** The incompatibility was semantic, not textual.
- Each PR's CI was green against its own base, and neither base contained the other's change — so **no CI run ever evaluated the combination that actually landed**. The failure is visible only on `main`, after both merges.

I flagged this interaction on both PRs and said the second to merge would need the entry deleted. That was correct but insufficient: it relied on someone acting between two merges that were five minutes apart. A note in a PR body is not a mechanism.

The durable fix is requiring branches to be up to date with `main` before merging, which would have re-run #1233's CI against post-#1230 `main` and caught this before the merge button. `docs/release-integrity.md` already records that this repository carries no branch-protection policy; this is a concrete instance of what that gap costs. I have not changed any repository settings — that is the maintainer's call.

### Verification

- The guard test fails on `origin/main` as quoted above, and passes on this branch.
- 1,023 tests across the 61 files either PR touched pass on this branch (`src/test/`, `src/components/accounts/`, `src/app/accounts`, the transactions and investments clients).
- No source change: the diff is the register literal and the comment explaining why it is empty.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [X] This PR addresses a **single concern** (large work is split into a series).
- [X] New behavior has tests, and the existing suite passes. -- no new behavior; this restores an existing test to green.
- [X] All user-facing strings are translated for **every** locale (i18n parity). -- no strings changed.
- [X] No shared/core areas were refactored without prior agreement.
- [X] The branch is rebased on the latest `main`.
- [X] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written by Claude Code. The register that broke `main` was mine, on #1233; so is this repair, and the account above of why flagging the interaction in a PR body was not enough to prevent it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGkrS17rWAkanDHhK4kwfC)_