### PR TITLE
Compact all CLAUDE.md files for efficient reading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,70 +30,63 @@ Everything runs in Docker: `docker compose -f docker-compose.dev.yml up`.
 - Always create tests for any new functionality added
 
 ### Shared AI tools (AI Assistant + MCP server)
-- Every AI tool that reads or aggregates data must share its implementation between the AI Assistant (`backend/src/ai/query/tool-executor.service.ts`) and the MCP server (`backend/src/mcp/tools/*.tool.ts`).
-- Put the shared logic on the relevant domain service (e.g., `PortfolioService.getLlmSummary`, `TransactionAnalyticsService.getTransfersByAccount`). The two tool layers become thin adapters that call it.
-- Both surfaces must return the same data shape. The AI tool executor wraps it with `{ summary, sources }`; MCP just `toolResult(data)`s it.
-- Adding a new AI tool means wiring it into both layers in the same PR -- never ship a tool to only one of the two.
+Every AI tool that reads or aggregates data shares one implementation between the AI Assistant (`backend/src/ai/query/tool-executor.service.ts`) and the MCP server (`backend/src/mcp/tools/*.tool.ts`). Put the shared logic on the relevant domain service (e.g. `PortfolioService.getLlmSummary`, `TransactionAnalyticsService.getTransfersByAccount`); the two tool layers are thin adapters returning the same data shape (the AI executor wraps `{ summary, sources }`; MCP just `toolResult(data)`s it). Adding a tool means wiring both layers in the same PR -- never ship to only one.
 
 ### Internationalization (i18n)
-Every user-facing string must be internationalized -- no hardcoded literals in toasts, labels, placeholders, validation messages, or emails. Develop **English-first**: while a change is under development and review, add and edit only the English catalogs and regenerate the pseudo-locale; defer translating the other locales until the code and its copy are functionally accepted. A feature is not *merged* until it is fully internationalized and translated for every supported locale, but that full translation is a single pass done at acceptance as the final commit on the same PR, not continuous work throughout development.
-- **Frontend** (`next-intl`): read strings via `useTranslations('namespace')`; catalogs live in `frontend/src/i18n/messages/{locale}/{namespace}.json` (register new namespaces in `src/i18n/messages.ts`). Use `t.rich` for embedded markup and `t.raw` for template strings.
-- **Backend** (`nestjs-i18n`): wrap exception messages in `tr(key, fallback, args)`; render emails with an `EmailT` translator (`emailTranslator(i18n, recipientLang)`) so copy matches the recipient's stored locale, not the request's. Catalogs live in `backend/src/i18n/locales/{locale}/*.json`.
-- **Supported locales** are defined in `frontend/src/i18n/config.ts` and `backend/src/i18n/config.ts` -- keep the two lists in sync. Currently `de` (German), `en` (English -- Canadian-flavoured base), `en-US` (American English), `en-CA` (Canadian English), `en-GB` (British English), `es` (Spanish), `fr` (French), `hi` (Hindi), `id` (Indonesian), `it` (Italian), `ja` (Japanese), `ko` (Korean), `nl` (Dutch), `pl` (Polish), `pt` (Portuguese), `pt-BR` (Brazilian Portuguese), `ru` (Russian), `tr` (Turkish), `uk` (Ukrainian), `vi` (Vietnamese), `zh-CN` (Simplified Chinese), `zh-TW` (Traditional Chinese), and `xx` (dev-only pseudo-locale for QA). The `en-*` variants are lean regional variants (see their `base` in config): each ships only the strings that differ from `en` and inherits the rest per key -- `en-CA` ships no catalog folder at all, because `en` is already the Canadian-flavoured base, and that absence is intended rather than missing work.
-- **During development, edit only the English catalogs (`en/*`)** -- do not hand-translate the other locales while the copy is still in flux. Once the change is functionally accepted, run one localization pass that fills every locale. Parity tests (`frontend/src/i18n/messages.parity.test.ts`, `backend/src/i18n/locales.parity.spec.ts`) fail when a locale is missing a key or references a placeholder `en` does not supply -- on a work-in-progress branch that failure is expected until the localization pass, and is not a reason to translate early. `main` still requires full parity, so released code is never partially translated.
-- After editing any `en/*.json`, regenerate the pseudo-locale: `npm run i18n:pseudo` (CI enforces freshness via `npm run i18n:check`) -- never hand-edit `xx/*`, which is generated.
-- **A key added to a catalog that already has it is invisible.** `JSON.parse` keeps the *last* duplicate, so the file loads, parity counts one key and passes, `i18n:check` compares parsed objects and passes, and the only effect is that the reviewed copy is not the copy that ships. A merge is where it happens, not an edit: both sides append to the end of the same object and a textual auto-merge keeps both lines -- that is how one branch replaced `mnyJobStalledAfterCommit` in twenty languages at once. Adding a string means grepping for it first. `frontend/src/i18n/messages.duplicate-keys.test.ts` scans the bytes of every catalog, because by the time it is an object the evidence is gone.
-- The user's language lives in `user_preferences.language` and is chosen in Settings -> Preferences (`LanguageSelector`); unauthenticated screens offer `AuthLanguageSwitcher` (cookie-only) on login/register. See `frontend/src/i18n/messages/README.md` and `backend/src/i18n/README.md` for the full contributor flow.
+Every user-facing string must be internationalized -- no hardcoded literals in toasts, labels, placeholders, validation messages, or emails. Develop **English-first**: while a change is under development, edit only the English catalogs and regenerate the pseudo-locale; translate every other locale in a single pass at acceptance, as the final commit on the same PR. `main` requires full parity; a WIP branch failing parity is expected and not a reason to translate early.
+- **Frontend** (`next-intl`): `useTranslations('namespace')`; catalogs in `frontend/src/i18n/messages/{locale}/{namespace}.json` (register new namespaces in `src/i18n/messages.ts`). `t.rich` for embedded markup, `t.raw` for template strings.
+- **Backend** (`nestjs-i18n`): wrap exception messages in `tr(key, fallback, args)`; render emails with an `EmailT` translator (`emailTranslator(i18n, recipientLang)`) so copy matches the recipient's stored locale. Catalogs in `backend/src/i18n/locales/{locale}/*.json`.
+- **Supported locales** are defined in `frontend/src/i18n/config.ts` and `backend/src/i18n/config.ts` -- keep the two lists in sync. The `en-*` variants are lean regional variants (see their `base` in config): each ships only the strings that differ from `en` and inherits the rest per key. `en-CA` ships no catalog folder at all -- `en` is already the Canadian-flavoured base -- and that absence is intended.
+- Parity tests (`frontend/src/i18n/messages.parity.test.ts`, `backend/src/i18n/locales.parity.spec.ts`) fail when a locale is missing a key or references a placeholder `en` does not supply.
+- After editing any `en/*.json`, regenerate the pseudo-locale: `npm run i18n:pseudo` (CI enforces freshness via `npm run i18n:check`) -- never hand-edit `xx/*`.
+- **Grep for a key before adding it.** `JSON.parse` keeps the *last* duplicate, so a key added to a catalog that already has it loads, passes parity and `i18n:check`, and silently ships the wrong copy. Textual auto-merges (both branches appending to the same object) are how it happens. `frontend/src/i18n/messages.duplicate-keys.test.ts` scans the raw bytes of every catalog.
+- The user's language lives in `user_preferences.language` (Settings -> Preferences, `LanguageSelector`); unauthenticated screens offer `AuthLanguageSwitcher` (cookie-only). Full contributor flow: `frontend/src/i18n/messages/README.md` and `backend/src/i18n/README.md`.
 
 ### Code Style
 - No emojis in code, comments, or documentation
 - Immutability always -- never mutate objects or arrays
-- No `console.log` in production code; use NestJS `Logger` class -- including the scripts that run before the app boots and the `docker-entrypoint.sh` steps, so the whole startup log has one shape (backend `no-console` lint rule + `backend/src/startup-logging.spec.ts`)
+- No `console.log` in production code; use NestJS `Logger` class -- including pre-boot scripts and the `docker-entrypoint.sh` steps, so the whole startup log has one shape (backend `no-console` lint rule + `backend/src/startup-logging.spec.ts`)
 - Use proxy, not middleware (middleware is deprecated in this project)
 
 ### Follow the existing pattern, and pin it down when you miss it
 
-Before writing a UI control, a data access path, or anything a user interacts with, find how the codebase already does that thing and do it the same way. This project has one way to make a table row clickable, one date input, one money formatter, one door to the database. Reaching for the generic solution -- a raw `<input type="date">`, a hand-rolled dropdown, a fresh `overflow-y-auto` -- when one already exists produces code that looks fine in isolation and wrong in place.
+Before writing a UI control, a data access path, or anything a user interacts with, find how the codebase already does that thing and do it the same way. This project has one way to make a table row clickable, one date input, one money formatter, one door to the database. The generic solution (a raw `<input type="date">`, a hand-rolled dropdown) looks fine in isolation and wrong in place.
 
 **When a human points out a defect in code an AI wrote, that is a missing rule, not just a bug.** Fixing it is half the work. Also:
 
-1. Find how the codebase already solves that problem, and switch to it -- there is usually an existing helper or hook, and not using it was the actual mistake.
-2. Add a regression test that fails on the original mistake, not merely one that covers the fix. Where the mistake is mechanical (a raw element instead of the shared component), prefer a guard test that scans the source and fails for *any* occurrence, so the next instance is caught wherever it appears -- `frontend/src/test/ui-conventions.test.ts` and `frontend/src/lib/tours/anchors.uniqueness.test.ts` are the pattern.
+1. Find how the codebase already solves that problem and switch to it -- there is usually an existing helper or hook, and not using it was the actual mistake.
+2. Add a regression test that fails on the original mistake, not merely one that covers the fix. Where the mistake is mechanical, prefer a guard test that scans the source and fails for *any* occurrence -- `frontend/src/test/ui-conventions.test.ts` and `frontend/src/lib/tours/anchors.uniqueness.test.ts` are the pattern.
 3. Write the rule down here or in the layer's `CLAUDE.md`, in one or two sentences, naming the thing to use and the thing not to.
 
-The point is that the next agent inherits the correction. A fix that lives only in one file will be re-broken in the next one.
+**Prefer the rule the machine can check.** Ranked by how well they hold: a type the compiler enforces, a lint rule, a test that scans the source, a paragraph in a `CLAUDE.md`. A rule in prose gets read, agreed with, and violated anyway; reach for the highest form the mistake allows.
 
-**Prefer the rule the machine can check.** A rule in prose gets read, agreed with, and violated anyway; the financial contracts in `docs/` have been all three more than once. Ranked by how well they hold: a type the compiler enforces, a lint rule, a test that scans the source, a paragraph in a `CLAUDE.md`. Reach for the highest one the mistake allows, and use prose for the part that genuinely needs judgement rather than as the first resort.
+**A green suite after a behaviour change is a finding.** Either the change is a no-op or the suite had no case for it. Say which in the change description, and if it is the second, add the case in the same commit. `docs/financial-calculation-contract.md` section 8.1 has the long form; it applies everywhere, not only to money.
 
-**A green suite after a behaviour change is a finding.** If you changed what the code produces and nothing failed, either the change is a no-op or the suite had no case for it. Say which, in the change description, and if it is the second, add the case in the same commit. `docs/financial-calculation-contract.md` section 8.1 has the long form; it applies everywhere, not only to money.
+**Asynchronous data belongs to the request that produced it.** Keep the payload and its request key together, adopt a mutation's response only when its captured origin still matches the current selection, and never treat a failed lookup as an empty result. `frontend/CLAUDE.md` has the full rule and the regression matrix.
 
-**Asynchronous data belongs to the request that produced it.** A payload without its request key cannot be told apart from the previous payload, so every action offered beside it may be aimed at the wrong thing. Keep the pair together, adopt a mutation's response only when its captured origin still matches the current selection, and never treat a failed lookup as an empty result. `frontend/CLAUDE.md` has the full rule and the regression matrix.
+**A behavior promised "when a filter is active" keys off the filter itself, carried explicitly on the command -- never off a transport detail that sometimes coincides with it.** Bulk update keyed its split-line restriction off `mode === "filter"`, but hand-picked rows ship as mode `ids`, so the filter silently stopped applying. The client sends the active filter as its own field in both modes (`BulkUpdateDto.categoryFilterIds`) and the server restricts on that; regression tests assert the ids-mode payload carries it and honors it.
 
-**A behavior promised "when a filter is active" keys off the filter itself, carried explicitly on the command — never off a transport detail that sometimes coincides with it.** Bulk update's split-line restriction keyed off `mode === "filter"`, but hand-picked rows ship as mode `ids` with bare ids, so the filter the user was looking through silently stopped applying and every category line changed. The client sends the active filter as its own field in both modes (`BulkUpdateDto.categoryFilterIds`) and the server restricts on that; the regression tests assert the ids-mode payload carries it and the ids-mode update honors it.
+**`.dockerignore` is not `.gitignore`: a filename glob needs an explicit `**/`.** A slashless pattern matches only against the path relative to the build context, so `*.spec.ts` excludes nothing under `src/`. Give every filename glob a leading globstar, including its negation (`!**/.env.example`); `frontend/src/test/dockerignore.test.ts` scans all three files and fails on a bare one.
 
-**`.dockerignore` is not `.gitignore`: a filename glob needs an explicit `**/`.** A pattern with no slash is matched against the path relative to the build context and nothing else, so `*.spec.ts` excludes a spec beside the Dockerfile and none under `src/`. Git would have walked it down the tree; Docker does not, and nothing says so until something reads the files that were supposed to be gone -- `src/test/` (a directory path, so it matched) was excluded while every test importing `@/test/render` was copied in, and `next build` type-checks those as of 16.3. Give every filename glob a leading globstar, including its negation (`!**/.env.example`); `frontend/src/test/dockerignore.test.ts` scans all three files and fails on a bare one.
+**A list of columns that means something is written once, in the place that can check it.** The columns referencing `currencies(code)` were spelled out in four places and wrong in all four. Prefer a SQL function the database evaluates (`currency_code_in_use_globally`, `currency_codes_referenced_by_user_data`, and `currency_codes_referenced_by_user` derived from the last) so the answer cannot be a tenant's view of a global question; when a caller genuinely cannot ask the database, keep one TypeScript constant checked against `database/schema.sql` in both directions. **Two callers wanting slightly different answers is not a licence to write the list twice** -- derive one from the other and let the guard test check the derivation. `backend/src/currencies/currency-references.spec.ts` is the pattern; the same applies to the restore's insertion order and deferred foreign keys (declared as data in `restore-plan.ts`, proven against the schema by `restore-plan.spec.ts`).
 
-**A list of columns that means something is written once, in the place that can check it.** `currencies(code)` is referenced from a dozen columns, and that list was spelled out in **four** places and wrong in all four: a global liveness query missing `budgets` and `exchange_rates`, a restore cleanup that listed every column but ran under the caller's RLS scope where the rows it looked for were invisible, an export that never used the list at all, and a delete gate (`CurrenciesService.isInUse`) missing `budgets` -- so a user with a budget in a custom currency was told the code was not in use, lost their activation row, and kept a budget in a currency their settings no longer showed. Prefer a SQL function the database evaluates (`currency_code_in_use_globally`, `currency_codes_referenced_by_user_data`, and `currency_codes_referenced_by_user` derived from the last) so the answer cannot be a tenant's view of a global question; when a caller genuinely cannot ask the database, keep one TypeScript constant and check it against `database/schema.sql` in both directions. **Two callers wanting slightly different answers is not a licence to write the list twice** -- derive one function from the other, as the composite does from the `_data` variant, and let the guard test check the derivation. `backend/src/currencies/currency-references.spec.ts` is the pattern. The same applies to the restore's insertion order and its deferred foreign keys -- declared as data in `restore-plan.ts`, proven against the schema by `restore-plan.spec.ts`.
+**Where an external side effect sits relative to the commit is a decision, and only one side of it is survivable.** Object stores, filesystems and buckets do not roll back. Order them so a failure leaves *bytes nobody references* (a storage cost), never *a row promising bytes that are gone*: write bytes before the commit and clean up on failure; delete bytes after it. The `database` provider is the exception both ways -- its `save`/`delete` are nested `withScopedDb` calls that genuinely join the transaction -- so the rule is provider-aware, not global.
 
-**Where an external side effect sits relative to the commit is a decision, and only one side of it is survivable.** Object stores, filesystems and buckets do not roll back. So order them such that a failure leaves *bytes nobody references* -- a storage cost -- and never *a row promising bytes that are gone*, which the user cannot tell from a working record. Concretely: write bytes before the commit and clean up on failure; delete bytes after it. `AttachmentsService` had the delete inside the transaction and got this backwards. The `database` provider is the exception both ways, because its `save`/`delete` are nested `withScopedDb` calls that genuinely join the transaction -- so the rule is provider-aware, not global.
+**A lenient decoder is not a validator.** `Buffer.from(value, "base64")` silently discards characters outside the alphabet instead of failing -- on `x-export-password` that encrypts a backup under a password nobody knows and reports success. Anywhere a decode result is used as a credential or a key, assert the round trip.
 
-**A lenient decoder is not a validator.** `Buffer.from(value, "base64")` silently discards characters outside the alphabet instead of failing, so a client that forgot to encode got a *different password* back and no error anywhere. On a login check that is a confusing 401; on `x-export-password` it encrypts the user's backup under a password nobody knows and reports success. Anywhere a decode result is used as a credential or a key, assert the round trip.
+**A driver value is not a JSON value.** `pg` returns `bytea` as a `Buffer` and DATE/TIMESTAMP as `Date`; `JSON.stringify` mangles a Buffer into `{"type":"Buffer","data":[...]}`. The backup export reads every bytea column through `encode(col, 'base64')`, and `backend/src/backup/export-driver-values.spec.ts` fails if a new one is added without it. Same family as the raw-select rule in `backend/CLAUDE.md`.
 
-**A driver value is not a JSON value.** `pg` returns `bytea` as a `Buffer` and DATE/TIMESTAMP as `Date`. `JSON.stringify` turns a Buffer into `{"type":"Buffer","data":[...]}`, and any walker that rebuilds objects with `Object.entries` destructures it into numeric keys. The backup export reads every bytea column through `encode(col, 'base64')` for exactly this reason, and `backend/src/backup/export-driver-values.spec.ts` fails if a new one is added without it. Same family as the raw-select rule in `backend/CLAUDE.md`.
+**A mocked filesystem cannot demonstrate a filesystem property.** `rename` being called is not the claim; what the directory looks like after an unfinished write is. For anything about atomicity, containment, symlinks or ownership, use a real temporary directory (`mkdtemp`) -- `backend/src/backup/atomic-file.spec.ts` and `auto-backup.service.spec.ts` are the pattern. Skip a permission case under uid 0 rather than weakening it into an assertion that passes for the wrong reason.
 
-**A mocked filesystem cannot demonstrate a filesystem property.** `rename` being called is not the claim; what the directory looks like after a write that did not finish is. The auto-backup suite passed throughout the period when the daily write truncated its own final filename and every user shared one namespace, because it asserted the calls rather than the result. For anything about atomicity, containment, symlinks or ownership, use a real temporary directory (`mkdtemp`) -- `backend/src/backup/atomic-file.spec.ts` and `auto-backup.service.spec.ts` are the pattern. Skip a permission case under uid 0 rather than weakening it into an assertion that passes for the wrong reason.
+**A count of things you did not do never goes in the total of things you did.** `restored` is summed by the client, so deliberately skipped attachments are a sibling field (`skippedAttachments`, omitted when zero) -- "a subtotal is not a total", applied to counts. And the user has to be *told*: a success dialogue silent about files that did not come back is worse than the number being in the wrong place.
 
-**A count of things you did not do never goes in the total of things you did.** `restored` is summed by the client into a row total, so the number of attachments deliberately skipped is a sibling field (`skippedAttachments`), omitted when zero. This is the same rule as "a subtotal is not a total", applied to counts rather than money -- and the honest half of it is that the user has to be *told*: a success dialogue silent about the files that did not come back is worse than the number being in the wrong place.
+**Code and schema ship in one image; they do not arrive in one process.** `db-migrate` runs at container start and the server after it, so "this build calls a SQL function" and "this database has it" are separate facts; the gap surfaces as `function ... does not exist` behind a generic 500. Every SQL function `src/` calls is declared once in `backend/src/common/db/required-db-functions.ts` with the migration that creates it, and both `main.ts` and `db-migrate` refuse to serve a database missing one. `required-db-functions.spec.ts` holds the list in both directions -- crucially, a function defined in `schema.sql` and mentioned anywhere in `src/` must be registered.
 
-**Code and schema ship in one image; they do not arrive in one process.** `db-migrate` runs once at container start and the server runs after it, so "this build calls a SQL function" and "this database has it" are separate facts -- a dev watcher that rebuilt the source without restarting the container, a migration step that was skipped or pointed elsewhere, a volume restored under a newer image, all produce a server whose SQL names an object that is not there. It surfaces as `function ... does not exist` behind a generic 500, from whichever request reached the gap first; for a restore that is *after* `deleteAllUserData` has begun. So every SQL function `src/` calls is declared once in `backend/src/common/db/required-db-functions.ts` with the migration that creates it, and both `main.ts` and `db-migrate` refuse rather than serve a database that is missing one. `required-db-functions.spec.ts` holds the list in both directions, and the direction that matters is the second: a function defined in `schema.sql` and mentioned anywhere in `src/` must be registered, so a new one cannot ship uncovered.
-
-**A doc that names an identifier is making a claim about the source.** Renaming or deleting a field, flag or helper means grepping `docs/` and every `CLAUDE.md` in the same commit. A document describing a model that no longer exists is worse than none: it gets read, believed, and built on. The same goes for a comment asserting that *every* call site does something -- that is a scanning test, not a comment.
-
-For the half of this a machine can check -- named *files* -- it now does: `backend/src/common/doc-paths.spec.ts` fails when a path (bare filenames included) in any `CLAUDE.md` or top-level `docs/*.md` does not resolve. This rule in prose was read, agreed with, and violated anyway (a plan doc sent readers to `backend/src/ai/query/` for a service under `backend/src/transactions/`), which is the argument for the test rather than the paragraph. `docs/future-plans/` gets the weaker claim a plan can actually make: naming files that do not exist yet is what a plan is for, but an unresolved path whose basename exists elsewhere in the tree is a moved or renamed file, not a planned one, and fails the suite -- that is exactly the defect that motivated the guard, and the original scope excluded the directory it lived in. `docs/release-notes/` and `docs/audits/` are shipped records that must not be edited to match a later tree, so they are out of scope entirely. A path in another branch or repository is not a claim about this tree, so qualify it (`branch:path/to/file.md`) rather than letting it read as one -- the suite exempts that shape deliberately, with a test. The inverse holds too: a doc arguing that a file is *missing* -- `docs/release-integrity.md`'s gap register, on the branch-protection policy this repository does not carry -- names it in plain prose, because a backticked span is the idiom for "this file is here" and that passage says the opposite.
+**A doc that names an identifier is making a claim about the source.** Renaming or deleting a field, flag or helper means grepping `docs/` and every `CLAUDE.md` in the same commit. A comment asserting that *every* call site does something is a scanning test, not a comment. For named *files* the machine checks: `backend/src/common/doc-paths.spec.ts` fails when a path (bare filenames included) in any `CLAUDE.md` or top-level `docs/*.md` does not resolve. `docs/future-plans/` may name files that do not exist yet, but an unresolved path whose basename exists elsewhere is a moved file and fails. `docs/release-notes/` and `docs/audits/` are shipped records, out of scope. A path in another branch or repository is qualified (`branch:path/to/file.md`); a doc arguing a file is *missing* names it in plain prose, since a backticked span means "this file is here".
 
 ### The contract documents
 
-Cross-layer rules live in `docs/`, not in this file, because they are too long to state twice and too easily violated to state loosely. `docs/system-invariants.md` is the index: it lists every invariant with a stable ID, the mechanism that enforces it, and an honest status of `enforced`, `partial` or `unenforced`. An entry marked `unenforced` describes something the system currently gets wrong, with the violation cited -- that gap is the point, and editing the document does not close it.
+Cross-layer rules live in `docs/`. `docs/system-invariants.md` is the index: every invariant with a stable ID, the mechanism that enforces it, and an honest status of `enforced`, `partial` or `unenforced` (an `unenforced` entry describes something the system currently gets wrong -- editing the document does not close the gap).
 
 | Document | Covers |
 |---|---|
@@ -105,30 +98,17 @@ Cross-layer rules live in `docs/`, not in this file, because they are too long t
 | `docs/release-integrity.md` | Zero-discovered-tests is a failure; the tested, imaged and tagged revisions must be one revision. |
 | `docs/adr/` | Why a decision was made, and what was rejected. Supersede, never rewrite. |
 
-Two of these say something about a guarantee's wording that applies everywhere: any use of "atomic", "single-use", "exactly once", "retryable", "cannot", "always", "complete" or "transactional" must name the mechanism that makes it true -- the transaction, the index, the conditional `UPDATE`, the verified checksum. Three comments in this codebase claimed a lock, an atomic increment and a joint commit that the code beside them did not implement, and each was believed for as long as it existed. If the mechanism cannot be named, the wording is wrong, not merely vague.
+Any use of "atomic", "single-use", "exactly once", "retryable", "cannot", "always", "complete" or "transactional" must name the mechanism that makes it true -- the transaction, the index, the conditional `UPDATE`, the verified checksum. If the mechanism cannot be named, the wording is wrong, not merely vague.
 
-### Running the suites locally -- four ways a green branch reads as red
+### Running the suites locally
 
-CI runs in UTC with one Playwright worker. A local run does neither, and both differences produce failures that look like regressions and are not.
+CI runs in UTC with one Playwright worker; a local run does neither, and both differences produce failures that look like regressions and are not.
 
-- **`TZ=UTC` for the unit suites.** A handful of tests read `new Date()` and count completed periods against fixtures; under any other offset they can land on the wrong side of a boundary. `backend/src/ai/insights/insights-aggregator.service.spec.ts` and `backend/src/net-worth/net-worth.service.spec.ts` are the ones that bite. `TZ=UTC npm run test:unit` matches CI; without it, believing the failures means chasing a bug that does not exist.
-- **`--workers=1` for the whole E2E suite.** `playwright.config.ts` sets one worker only when `CI` is set, so a local `npx playwright test` runs several in parallel -- and `e2e/tests/zz-danger-zone.spec.ts` deletes the shared account. The `zz-` prefix orders it last, which only means anything when the run is serial; in parallel it takes out whatever is still running. A single spec file is safe to run without the flag.
-
-There is a third way, and it is the nastier one because no flag fixes it: **a test that reads the wall clock is a test about today's date.** `TZ=UTC` pins the offset, not the day. `AutoBackupService` promotes a daily artifact to weekly on the 7th, 14th, 21st and 28th and to monthly on the 1st, so on five days a month a single backup leaves two files in the folder and every assertion counting artifacts fails -- ten of them did, on `main`, with nothing having changed. A suite that is green because of the date it ran is not evidence about the code, and the failure it eventually produces points at the module rather than at the calendar.
-
-So pin the clock in the spec rather than waiting the failure out, and derive the pinned value from the constants the behaviour actually branches on (`WEEKLY_DAYS`, `MONTHLY_DAY` are exported for this) so widening one fails a named guard instead of silently re-dating ten assertions. `backend/src/backup/auto-backup.service.spec.ts` is the pattern: fake `Date` only -- faking `nextTick`/`queueMicrotask` under real `fs.promises` deadlocks rather than fails -- install the fake timers once, move the date through a single `withClockAt` helper, and let a source scan fail a second installation.
-
-The fourth is the one that hides a failure in the file you are writing rather than
-in one you did not touch: **a guard that walks the tree with `gitListFiles` cannot
-see an untracked file.** `doc-paths.spec.ts` and `source-comment-paths.spec.ts` list
-their subjects with `git ls-files` (`backend/src/common/repo-tree.util.ts`), which
-is right -- a scan must not read build output or somebody's scratch file -- and it
-means a brand-new spec or util is invisible to them until it is staged. So a run
-that is green before `git add` and red in CI on the same content is not a flake:
-the new file was simply not among the files scanned. Run those guards after staging
-(`git add -N` is enough), not before.
-
-Also: `scripts/verify-schema.sh` reproduces the "Schema vs Migrations Drift" job locally and needs nothing but Docker. Every migration has to be a no-op replayed on top of `schema.sql` (`CREATE ... IF NOT EXISTS`, `DROP ... IF EXISTS` before `CREATE POLICY`/`TRIGGER`), because that is also how the app boots: `db-init` applies `schema.sql` and `db-migrate` then replays the whole directory. A migration missing its guard does not just fail the drift check -- it aborts container start-up, and the E2E and Lighthouse jobs then report only "backend exited (1)".
+- **`TZ=UTC npm run test:unit`** matches CI. A few tests count periods against `new Date()` and land on the wrong side of a boundary under other offsets (`backend/src/ai/insights/insights-aggregator.service.spec.ts`, `backend/src/net-worth/net-worth.service.spec.ts`).
+- **`--workers=1` for the whole E2E suite.** `playwright.config.ts` sets one worker only when `CI` is set, and `e2e/tests/zz-danger-zone.spec.ts` deletes the shared account -- its `zz-` ordering only means anything serially. A single spec file is safe without the flag.
+- **A test that reads the wall clock is a test about today's date** -- `TZ=UTC` pins the offset, not the day (auto-backup promotes artifacts on specific days of the month, so ten assertions failed on `main` with nothing changed). Pin the clock in the spec and derive the pinned value from the constants the behaviour branches on (`WEEKLY_DAYS`, `MONTHLY_DAY` are exported for this). `backend/src/backup/auto-backup.service.spec.ts` is the pattern: fake `Date` only (faking `nextTick`/`queueMicrotask` under real `fs.promises` deadlocks), install fake timers once, move the date through a single `withClockAt` helper, and let a source scan fail a second installation.
+- **A guard that walks the tree with `gitListFiles` cannot see an untracked file.** `doc-paths.spec.ts` and `source-comment-paths.spec.ts` list their subjects with `git ls-files` (`backend/src/common/repo-tree.util.ts`), so a brand-new file is invisible to them until staged. Green before `git add` and red in CI on the same content is not a flake -- run those guards after staging (`git add -N` is enough).
+- `scripts/verify-schema.sh` reproduces the "Schema vs Migrations Drift" job locally (needs only Docker). Every migration must replay as a no-op on top of `schema.sql` (`CREATE ... IF NOT EXISTS`, `DROP ... IF EXISTS` before `CREATE POLICY`/`TRIGGER`) because that is how the app boots; a migration missing its guard also aborts container start-up, and the E2E and Lighthouse jobs then report only "backend exited (1)".
 
 ### Code Intelligence
 Prefer LSP over Grep/Read for code navigation — it's faster, precise, and avoids reading entire files:
@@ -143,31 +123,13 @@ After writing or editing code, check LSP diagnostics and fix errors before proce
 
 ### Files on disk are sharded by an id, and which id differs
 
-Anything the server writes to disk goes through `shardedSegments` in
-`backend/src/common/shard-path.util.ts`, which returns `[ab, cd, id]` -- two
-levels of two hex characters, then the id. That keeps any one directory small
-enough for filesystems that scan linearly or over a network. Do not hand-roll a
-second sharding scheme.
+Anything the server writes to disk goes through `shardedSegments` in `backend/src/common/shard-path.util.ts`: `[ab, cd, id]` -- two levels of two hex characters, then the id. Do not hand-roll a second sharding scheme.
 
-**The scheme is shared; the shard key and the shape are not.** Automatic backups
-shard by *user* id and the last segment is a directory
-(`<base>/<ab>/<cd>/<userId>/monize-backup-daily-2026-08-03.json.gz`), because the
-filename carries only a tier and a date -- a flat folder gave every user the same
-name for the same day, whoever's cron ran last overwrote the rest, and one user's
-retention pass deleted another's files. Local attachments shard by *attachment*
-id and the last segment is the file itself (`<base>/<ab>/<cd>/<attachmentId>`),
-because that id is already globally unique.
+**The scheme is shared; the shard key and the shape are not.** Automatic backups shard by *user* id with the id as a directory (`<base>/<ab>/<cd>/<userId>/monize-backup-daily-2026-08-03.json.gz`), because the filename carries only tier and date and a flat folder let one user's retention pass delete another's files. Local attachments shard by *attachment* id with the id as the file itself, because that id is already globally unique.
 
-So a backup's owner is recoverable from its path and **an attachment's owner is
-not** -- no user id appears in an attachment path. Attachment ownership is
-database-authoritative via its metadata row, and no cleanup, retention or
-migration tool may infer it from the filesystem. Sharding is storage
-distribution, never tenant isolation or authorization. `docs/adr/0003` has the
-reasoning and the rejected alternatives.
+So a backup's owner is recoverable from its path and **an attachment's owner is not**. Attachment ownership is database-authoritative via its metadata row; no cleanup, retention or migration tool may infer it from the filesystem. Sharding is storage distribution, never tenant isolation or authorization. `docs/adr/0003` has the reasoning.
 
-A path built from an id must still be validated (`isShardableId`) and asserted
-to resolve inside its base before it reaches the filesystem, even when the id is
-server-generated (CWE-22).
+A path built from an id must still be validated (`isShardableId`) and asserted to resolve inside its base before it reaches the filesystem, even when the id is server-generated (CWE-22).
 
 ### Security (Do Not Regress)
 - Parameterized queries only (TypeORM QueryBuilder or parameterized raw SQL). Never interpolate user input into SQL strings
@@ -183,7 +145,7 @@ server-generated (CWE-22).
 
 Any operation that touches multiple tables or does read-modify-write MUST run in a single transaction. This is the most common source of bugs in this codebase.
 
-**A rejected command must not already have written.** Every check that can refuse a request -- ownership, tenant or scenario identity, revision, precondition -- runs inside the same transaction as the mutation, and under the same lock where concurrency matters. A `403`, `404`, `409` or validation failure claims the change did not happen, and an HTTP status cannot undo a committed row: validating after a service has saved and committed leaves the client with an error on screen and the write in the database. Pass the caller's expectation down into the operation so it can refuse, rather than letting a higher layer reject something already done. `docs/financial-calculation-contract.md` section 7 has the rule, the forbidden sequence and the test obligation.
+**A rejected command must not already have written.** Every check that can refuse a request -- ownership, tenant or scenario identity, revision, precondition -- runs inside the same transaction as the mutation, and under the same lock where concurrency matters. A `403`, `404`, `409` or validation failure claims the change did not happen, and an HTTP status cannot undo a committed row. Pass the caller's expectation down into the operation so it can refuse, rather than letting a higher layer reject something already done. `docs/financial-calculation-contract.md` section 7 has the rule, the forbidden sequence and the test obligation.
 
 ```typescript
 async createSomething(userId: string, dto: CreateDto) {
@@ -197,19 +159,13 @@ async createSomething(userId: string, dto: CreateDto) {
 }
 ```
 
-`withScopedDb` commits when the callback returns and rolls back when it throws, so there is no
-commit/rollback/release bookkeeping to get wrong. **There are no `QueryRunner`s left in `src/`** —
-RLS tasks R1–R7 converted every one, and lint now bans the pattern outright (L1). Helpers take an `EntityManager`,
-never a `QueryRunner`. If you find a `createQueryRunner()` in a diff, it is new and wrong.
+`withScopedDb` commits when the callback returns and rolls back when it throws -- no commit/rollback/release bookkeeping. **There are no `QueryRunner`s left in `src/`** -- RLS tasks R1-R7 converted every one, and lint bans the pattern outright (L1). Helpers take an `EntityManager`, never a `QueryRunner`. If you find a `createQueryRunner()` in a diff, it is new and wrong.
 
-An operation that uses `INSERT ... ON CONFLICT DO NOTHING` and then returns a read model must follow a conflict
-with a fresh read of the authoritative state, inside the same transaction. Never build the response from a snapshot
-loaded before the insert attempt -- the request that lost the race would return data missing the rows the winner
-just inserted.
+An operation that uses `INSERT ... ON CONFLICT DO NOTHING` and then returns a read model must follow a conflict with a fresh read of the authoritative state, inside the same transaction -- never build the response from a snapshot loaded before the insert attempt.
 
 ## Database Access & Row-Level Security (RLS lint bans — CRITICAL)
 
-**All** database access goes through `withScopedDb` (`backend/src/common/db/scoped-db.ts`) — the single RLS-compliant door to the DB. **Never add an `@InjectRepository(...)` field, a `this.dataSource.createQueryRunner()` call, a `this.dataSource.transaction(...)` call, or a bare `this.dataSource.query(...)`.** ESLint bans the first three outright (RLS task L1, `backend/eslint.config.mjs`): importing `InjectRepository`, or calling `.createQueryRunner()` or `.transaction()`, anywhere in `src/` (outside `scoped-db.ts`, specs and test helpers) fails "Backend Lint & Type Check". `DataSource.transaction()` is banned for a reason the `createQueryRunner` ban did not cover: it opens a transaction that does not know about the ambient scoped manager, so it carries no identity GUCs under enforcement and, nested inside a caller's `withScopedDb`, commits independently of that caller's rollback. The same config restricts importing `common/db/with-context` to an explicit `WITH_CONTEXT_ALLOWLIST` — a new `withSystemContext`/`withUserContext` call site means adding the file to that allowlist in the same PR, as a reviewed decision. (R1–R7 converted the ~91 original sites; the old counting ratchet is gone.)
+**All** database access goes through `withScopedDb` (`backend/src/common/db/scoped-db.ts`) -- the single RLS-compliant door to the DB. **Never add an `@InjectRepository(...)` field, a `this.dataSource.createQueryRunner()` call, a `this.dataSource.transaction(...)` call, or a bare `this.dataSource.query(...)`.** ESLint bans the first three outright (RLS task L1, `backend/eslint.config.mjs`) anywhere in `src/` outside `scoped-db.ts`, specs and test helpers. `DataSource.transaction()` is banned for a reason the `createQueryRunner` ban did not cover: it opens a transaction that does not know about the ambient scoped manager, so it carries no identity GUCs under enforcement and, nested inside a caller's `withScopedDb`, commits independently of that caller's rollback. Importing `common/db/with-context` is restricted to an explicit `WITH_CONTEXT_ALLOWLIST` -- a new `withSystemContext`/`withUserContext` call site means adding the file to that allowlist in the same PR, as a reviewed decision.
 
 ```typescript
 // Read: one short tenant transaction, identical to today's autocommit read.
@@ -226,16 +182,16 @@ await withScopedDb(this.dataSource, async (m) => {
 ```
 
 - Inject `DataSource`, not a repository. Get repositories from the transaction's `EntityManager` (`m.getRepository(X)`); helpers take the `EntityManager`, never a `QueryRunner`.
-- `withScopedDb` **throws** without an ambient identity context. Authenticated cookie/JWT routes already have it (the `RequestContextInterceptor` seeds `{ userId }` around the handler). **Everything else must seed its own** (`backend/src/common/db/with-context.ts`):
-  - `withUserContext(userId, fn)` — cron per-user bodies, background writes, and any surface the interceptor cannot see. **Bearer-only routes count**: `/mcp` has no `AuthGuard('jwt')`, so `req.user` is unset and the interceptor's scope carries an undefined userId — the MCP transport seeds the session's user itself.
-  - `withSystemContext(fn)` — genuinely cross-user work: cron fan-outs, seeders, bootstrap hooks (`onModuleInit` / `onApplicationBootstrap` have no request), admin, and anything that sweeps every user.
-  - `withDelegateContext(ownerUserId, delegateUserId, fn)` — a delegate acting on an owner's data, where the two GUCs must **differ**. `withUserContext` collapses them onto one id, which silently returns zero rows for whichever half it is not. Used by `jwt.strategy`'s acting-context re-validation and `AccountDelegateGuard`.
-  - `withPreserveTimestamps(fn)` — extends the ambient context (identity inherited, never granted) so every transaction inside emits `app.preserve_timestamps` and the GUC-aware `updated_at` trigger keeps supplied values instead of stamping. Backup restore is the only caller; it replaced the restore's old `DISABLE TRIGGER` DDL, and trigger DDL must never come back (a source-scan guard in `backup.service.spec.ts` enforces this).
-- Nested `withScopedDb` calls join the ambient transaction (same connection/atomicity), so a service method calling another is safe — no pool-exhaustion deadlock. The exceptions are deliberate: `runOutsideActiveScopedManager` for a background timer or a progress write a concurrent reader must see.
-- A callback that returns early (before writing) commits an empty transaction — that is the correct replacement for an explicit rollback, not a bug.
+- `withScopedDb` **throws** without an ambient identity context. Authenticated cookie/JWT routes have it (`RequestContextInterceptor` seeds `{ userId }`). **Everything else must seed its own** (`backend/src/common/db/with-context.ts`):
+  - `withUserContext(userId, fn)` -- cron per-user bodies, background writes, and any surface the interceptor cannot see. **Bearer-only routes count**: `/mcp` has no `AuthGuard('jwt')`, so the MCP transport seeds the session's user itself.
+  - `withSystemContext(fn)` -- genuinely cross-user work: cron fan-outs, seeders, bootstrap hooks (`onModuleInit` / `onApplicationBootstrap` have no request), admin, and anything that sweeps every user.
+  - `withDelegateContext(ownerUserId, delegateUserId, fn)` -- a delegate acting on an owner's data, where the two GUCs must **differ**. `withUserContext` collapses them onto one id, which silently returns zero rows for whichever half it is not. Used by `jwt.strategy`'s acting-context re-validation and `AccountDelegateGuard`.
+  - `withPreserveTimestamps(fn)` -- extends the ambient context (identity inherited, never granted) so the GUC-aware `updated_at` trigger keeps supplied values. Backup restore is the only caller; it replaced the restore's old `DISABLE TRIGGER` DDL, and trigger DDL must never come back (a source-scan guard in `backup.service.spec.ts` enforces this).
+- Nested `withScopedDb` calls join the ambient transaction (same connection/atomicity), so a service method calling another is safe. The exceptions are deliberate: `runOutsideActiveScopedManager` for a background timer or a progress write a concurrent reader must see.
+- A callback that returns early (before writing) commits an empty transaction -- the correct replacement for an explicit rollback, not a bug.
 - Pass an isolation level as the optional third argument only when the logic depends on it (registration uses `"SERIALIZABLE"` for the first-user-admin race). Requesting one while joining an ambient transaction throws rather than silently downgrading.
-- At `RLS_MODE=off` (the default) `withScopedDb` still wraps the transaction but skips the identity GUCs, so behavior is identical to pre-RLS. See `docs/future-plans/row-level-security.md`.
-- **`docs/row-level-security-contract.md` is canonical** for which tables are exempt from RLS, why, and which direct-`DataSource` access paths are sanctioned. There is exactly one such exception -- `oauth_payloads`, reached by the `oidc-provider` adapter with **no ambient context at all**, because the provider is mounted as raw Express middleware outside Nest's pipeline. It is not precedent for a user-owned table, and `eslint.config.mjs`'s `OAUTH_PAYLOAD_ALLOWLIST` plus `backend/src/oauth/oauth-payload-access.spec.ts` fail when a second production reader appears. The exempt-table list itself lives once, as `RLS_EXEMPT_TABLES` -- it was previously kept in five places, four of which disagreed, and the rationale written beside it in four of them was factually wrong about the code for over a year.
+- At `RLS_MODE=off` (the default) `withScopedDb` still wraps the transaction but skips the identity GUCs. See `docs/future-plans/row-level-security.md`.
+- **`docs/row-level-security-contract.md` is canonical** for which tables are exempt from RLS and why. There is exactly one sanctioned direct-`DataSource` exception -- `oauth_payloads`, reached by the `oidc-provider` adapter with no ambient context because the provider is mounted as raw Express middleware outside Nest's pipeline. It is not precedent for a user-owned table; `eslint.config.mjs`'s `OAUTH_PAYLOAD_ALLOWLIST` plus `backend/src/oauth/oauth-payload-access.spec.ts` fail when a second production reader appears. The exempt-table list lives once, as `RLS_EXEMPT_TABLES`.
 
 ## Financial Math
 
@@ -259,306 +215,107 @@ Balance updates use atomic SQL: `UPDATE accounts SET current_balance = current_b
 
 ### An exchange rate is not money -- never round one to 4dp
 
-Money is `decimal(20,4)`; an exchange rate is `NUMERIC(20,10)` (`exchange_rates.rate` and every `exchange_rate` column that mirrors it). Reaching for `roundMoney` on a rate looks harmless and is not: `roundMoney(1 / 1.3652)` stored `0.7325`, which inverts back to `1.3661` -- and a bank quoting USD/CAD to six decimals reconciles cents off on a four-figure amount. Round rates with `roundFxRate` (`backend/src/common/fx-entry.util.ts`, 10dp) and display them at `FX_RATE_DISPLAY_DECIMALS` (`frontend/src/lib/format.ts`, 6dp) -- never `toFixed(4)`.
-
-Convert with `applyFxConversion` (backend) so the account's `fxFeePercent` is folded in the same way the transaction form does; validate a foreign-currency payload with `normalizeFxEntry`, which transactions and scheduled transactions share so both accept and reject exactly the same shapes.
+Money is `decimal(20,4)`; an exchange rate is `NUMERIC(20,10)`. `roundMoney(1 / 1.3652)` stored `0.7325`, which inverts back to `1.3661` -- cents off on a four-figure amount. Round rates with `roundFxRate` (`backend/src/common/fx-entry.util.ts`, 10dp) and display them at `FX_RATE_DISPLAY_DECIMALS` (`frontend/src/lib/format.ts`, 6dp) -- never `toFixed(4)`. Convert with `applyFxConversion` (backend) so the account's `fxFeePercent` is folded in the same way the transaction form does; validate a foreign-currency payload with `normalizeFxEntry`, shared by transactions and scheduled transactions so both accept and reject exactly the same shapes.
 
 ### Rate 1 means "same currency", never "no rate found"
 
-A failed rate lookup is unknown. It is not `1`, and it is not the amount passed
-through unchanged -- four conversion paths ended in one of those two, and 1,000
-USD came out of a EUR total as 1,000 EUR: an 11% error that is numerically
-plausible, which is exactly what makes it survive review. Nothing in the response
-let a consumer tell a real 1:1 pair from an absent one.
-
-Aggregate through `FxAggregate` (`backend/src/common/fx-aggregate.ts`) rather than
-`total += convert(...)`. The accumulator cannot silently absorb a missing
-component: it names each unresolvable pair, and its `total` is `null` while
-`knownSubtotal` carries what did convert. Zero and negative rates are absent, not
-applicable. `backend/src/common/fx-fallback.guard.spec.ts` scans for a new silent
-fallback; `docs/specs/fx-conversion-completeness.md` has the invariants and the
-staged rollout of nullable response totals.
+A failed rate lookup is unknown -- not `1`, and not the amount passed through unchanged (four conversion paths did one of those two, producing plausible-looking 11% errors). Aggregate through `FxAggregate` (`backend/src/common/fx-aggregate.ts`) rather than `total += convert(...)`: it names each unresolvable pair, and its `total` is `null` while `knownSubtotal` carries what did convert. Zero and negative rates are absent, not applicable. `backend/src/common/fx-fallback.guard.spec.ts` scans for a new silent fallback; `docs/specs/fx-conversion-completeness.md` has the invariants.
 
 ### A currency code is derived from the account, not accepted from the request
 
-`amount` and `currencyCode` on a transaction are the account-currency pair --
-foreign entry belongs in `originalAmount`/`originalCurrencyCode`/`exchangeRate`.
-Nothing checked it, so `amount=100, currencyCode=USD` against a EUR account moved
-the balance 100 EUR and stored a row reporting 100 USD; both fields persist, so it
-survived into every report and every backup. Derive with
-`assertTransactionCurrencyMatchesAccount` (`backend/src/common/fx-entry.util.ts`),
-which rejects a mismatch.
+`amount`/`currencyCode` on a transaction are the account-currency pair; foreign entry belongs in `originalAmount`/`originalCurrencyCode`/`exchangeRate`. Derive with `assertTransactionCurrencyMatchesAccount` (`backend/src/common/fx-entry.util.ts`), which rejects a mismatch -- an unchecked `currencyCode` moved 100 EUR while recording 100 USD, and both fields persist into every report and backup.
 
-A transfer is the same rule twice, plus conservation: two same-currency accounts
-must move the same amount (no rate or fee can make that unequal, so an explicit
-destination amount that disagrees is a rejection, not an override), and a
-cross-currency pair resolves its rate server-side or refuses. A caller holding
-only one side's currency -- a scheduled transaction -- sends neither code.
+A transfer is the same rule twice, plus conservation: two same-currency accounts must move the same amount (an explicit destination amount that disagrees is a rejection, not an override), and a cross-currency pair resolves its rate server-side or refuses. A caller holding only one side's currency -- a scheduled transaction -- sends neither code.
 
 ### A preview computes what the commit will do, through the same code
 
-A preview that resolves a rate as `?? 1` while the commit resolves a real one has
-the user approve one figure and receive another. This has happened twice: an
-investment preview multiplied cash impact by a zero rate the commit then treated
-as 1, and a transfer preview passed the source amount through for a
-cross-currency pair. Call the same resolver from both.
+A preview that resolves a rate as `?? 1` while the commit resolves a real one has the user approve one figure and receive another (this has happened twice). Call the same resolver from both.
 
 ### Missing data: a subtotal is not a total (CRITICAL)
 
-A field named `total*`, `portfolioValue`, `transferValue`, `gain`, `tax`, or `estimated*` may only carry a value when **every** component of the calculation is known. Filtering out `null` components and summing the rest produces a subtotal, not a total -- if any component is unknown, the total is `null`, and the partial sum, if returned at all, goes in a separate explicitly named field (`knownMarketValueSubtotal`), never in the total's field. Never default an unknown price, cost basis, or rate to `0` (or an exchange rate to `1`) to keep a formula running, and never treat a missing period price as a 0% return.
+A field named `total*`, `portfolioValue`, `transferValue`, `gain`, `tax`, or `estimated*` may only carry a value when **every** component is known. If any component is unknown, the total is `null`, and the partial sum, if returned at all, goes in a separate explicitly named field (`knownMarketValueSubtotal`), never in the total's field. Never default an unknown price, cost basis, or rate to `0` (or an exchange rate to `1`), and never treat a missing period price as a 0% return.
 
-**`null` is not the safe answer either.** It means "not known", so a state that *is* known must not use it: empty accounts hold zero, move zero, realize zero and owe zero, and reporting those as unknown tells the user a settled question could not be worked out -- while making "nothing to do" indistinguishable from "cannot compute". Decide which of the two each branch is in before writing it.
+**`null` is not the safe answer either.** It means "not known", so a state that *is* known must not use it: empty accounts hold zero, move zero, realize zero and owe zero. Decide which of the two each branch is in before writing it.
 
 ### An investment action is folded into a share count in exactly one place
 
-`applyActionToQuantity` (`backend/src/securities/investment-replay.util.ts`), with
-`SHARE_MOVING_ACTIONS` naming the set. `quantity` means shares for most actions
-and a **ratio** for `SPLIT`, which is the distinction duplication kept losing:
-seven replays existed, three added the ratio instead of multiplying by it and the
-same three omitted `ADD_SHARES`/`REMOVE_SHARES`, so a post-split position read 40%
-light on every history chart while the holdings page was right. Each copy was
-internally consistent, which is why nothing failed. Cost goes through
-`acquisitionCost` in the same file -- commission included, `null` for an unpriced
-row. `investment-replay.guard.spec.ts` scans for a new hand-rolled fold in either
-the `case` or the `if` form.
+`applyActionToQuantity` (`backend/src/securities/investment-replay.util.ts`), with `SHARE_MOVING_ACTIONS` naming the set. `quantity` means shares for most actions and a **ratio** for `SPLIT` -- the distinction duplicated replays kept losing (seven replays existed; three added the ratio instead of multiplying, and omitted `ADD_SHARES`/`REMOVE_SHARES`). Cost goes through `acquisitionCost` in the same file -- commission included, `null` for an unpriced row. `investment-replay.guard.spec.ts` scans for a new hand-rolled fold in either the `case` or the `if` form.
 
-**A Money activity label is not always its raw `TRN.act` code.** Money Plus has
-stored a register activity displayed as "Redeem CD/Bond" as `act = 2` (SELL)
-with positive `TRN_INV.amtInt`, while older redemptions use `act = 30`. The
-importer normalizes SELL plus accrued interest to REDEEM, keeps that SELL row's
-`TRN.amt` as proceeds, and takes the gross payout from the principal-plus-interest
-split; do not gate accrued-interest import on raw `act = 30` alone.
+**A Money activity label is not always its raw `TRN.act` code.** Money Plus stores some "Redeem CD/Bond" rows as `act = 2` (SELL) with positive `TRN_INV.amtInt`, while older redemptions use `act = 30`. The importer normalizes SELL plus accrued interest to REDEEM, keeps the SELL row's `TRN.amt` as proceeds, and takes the gross payout from the principal-plus-interest split; do not gate accrued-interest import on raw `act = 30` alone.
 
 ### VOID means no balance moved -- on every path that writes one
 
-A `VOID` row records something that did not happen, and
-`recalculateCurrentBalance` excludes it. So an incremental balance update must
-agree: creating a VOID transfer moved money the next recompute silently took back;
-a status-only edit wrote VOID on both legs and left both balances carrying the
-amount; a bulk void of one leg restored the source and left the destination
-holding it; and a VOID split parent credited its transfer target while leaving an
-**active** counterpart leg. Two rows describing one movement of money share a
-status, and a reversal only reverses what was actually included.
+A `VOID` row records something that did not happen, and `recalculateCurrentBalance` excludes it -- so every incremental balance update must agree, on every path (create, status-only edit, bulk void, split parent). Two rows describing one movement of money share a status, and a reversal only reverses what was actually included.
 
-The status is part of what a row is created *with*, not something applied after.
-Three separate paths recreated a voided parent's transfer legs as ACTIVE because
-they rebuilt the rows and forgot the one argument that carries the parent's status;
-each was individually tested, for what it created rather than the state it created
-it in. When a create helper takes the parent's status, every caller passes it.
+The status is part of what a row is created *with*, not something applied after: when a create helper takes the parent's status, every caller passes it (three separate paths recreated a voided parent's transfer legs as ACTIVE by forgetting that argument).
 
-And where two rows can hold *different* statuses -- a cross-owner transfer, whose
-status is deliberately per-ledger -- inclusion is decided per row. Using one leg's
-`wasVoid`/`isVoid` to gate both ledgers is right in two of the four combinations
-and silently wrong in the other two: a VOID own leg beside an active foreign one
-left the foreign balance behind its own row by the whole edit delta. Four states
-means a four-case test matrix, not a representative one.
+Where two rows can hold *different* statuses -- a cross-owner transfer, whose status is deliberately per-ledger -- inclusion is decided per row. Using one leg's `wasVoid`/`isVoid` to gate both ledgers is wrong in two of the four combinations. Four states means a four-case test matrix, not a representative one.
 
 ### Editing one row must not leave the pair describing two different events
 
-A split parent and the transfer legs its children created are one movement of
-money, so voiding *one* leg from the target side is refused rather than applied:
-the parent's split row and total would still record money that left the source and
-never arrived. Refuse and point at the parent -- there is already a propagation
-path from there. Only the VOID boundary is shared; reconciliation states
-(`PENDING`/`CLEARED`/`RECONCILED`) are genuinely per-ledger.
+A split parent and the transfer legs its children created are one movement of money, so voiding *one* leg from the target side is refused rather than applied -- refuse and point at the parent, which already has a propagation path. Only the VOID boundary is shared; reconciliation states (`PENDING`/`CLEARED`/`RECONCILED`) are genuinely per-ledger.
 
-A refusal like that is only worth as much as its least-guarded entry point. The
-same state was reachable through `bulkUpdate`, which expands a transfer leg to its
-counterpart but rightly declines to pull in a split *parent* -- so a bulk void hit
-the leg alone. When you refuse something on one path, grep for the bulk, AI-action
-and MCP routes to the same write in the same commit.
+A refusal is only worth as much as its least-guarded entry point: the same state was reachable through `bulkUpdate`. When you refuse something on one path, grep for the bulk, AI-action and MCP routes to the same write in the same commit.
 
 ### A deletion reverses only what the row actually contributed
 
-A `VOID` row moved no balance, and neither did a future-dated one, so deleting
-either must move none. Nine reversal sites across five services each wrote the rule
-out and four got it wrong -- two of them in the *same function* as a correct one, so
-`removeParentTransaction` guarded the deleted row and the split parent and debited
-every sibling target account. Call `deletionBalanceEffect`
-(`backend/src/common/deletion-balance.util.ts`); `deletion-balance.guard.spec.ts`
-fails on a new hand-rolled `-Number(row.amount)` reaching a balance update.
-
-That guard found two the reviews had not: one site checked VOID and forgot the date,
-which is the same bug facing the other way. Prose had already failed to hold this
-rule three times before it became a scan.
+A `VOID` row moved no balance, and neither did a future-dated one, so deleting either must move none. Nine hand-written reversal sites got this wrong four times (including checking VOID but forgetting the date). Call `deletionBalanceEffect` (`backend/src/common/deletion-balance.util.ts`); `deletion-balance.guard.spec.ts` fails on a new hand-rolled `-Number(row.amount)` reaching a balance update.
 
 ### A balance change is not finished until its derived state is invalidated
 
-Writing the live balance and stopping leaves the user looking at a corrected account
-beside a stale net-worth snapshot, and it stays stale until something unrelated
-touches that account. A helper that moves an account nobody upstream knows about must
-**return** the accounts it moved -- `applyParentStatusToTransferCounterparts` returned
-`void`, so both its callers invalidated only the accounts already in their own list.
-Dispatch the recalculation after the commit, never from inside the transaction: a
-rollback must not leave a recompute queued for state that was never written.
+Writing the live balance and stopping leaves a stale net-worth snapshot until something unrelated touches the account. A helper that moves an account nobody upstream knows about must **return** the accounts it moved (`applyParentStatusToTransferCounterparts` returned `void`, so its callers invalidated only their own lists). Dispatch the recalculation after the commit, never from inside the transaction: a rollback must not leave a recompute queued for state that was never written.
 
 ### A completeness flag nobody displays is not a completeness signal
 
-The backend, the AI adapter and the MCP schema all carried `valuationComplete`
-faithfully while `frontend/src/types/investment.ts` omitted the field entirely, so
-the Investments page rendered the subtotal under "Total Portfolio Value" -- the one
-surface a household user actually reads. Adding metadata to a response is half the
-change; the other half is the consumer that has to branch on it. When you add a
-completeness field, grep the frontend types for the interface it belongs to in the
-same commit, and relabel the figure rather than leaving a total's caption over a
-partial number.
+Backend, AI adapter and MCP all carried `valuationComplete` while `frontend/src/types/investment.ts` omitted it, so the one surface users read rendered a subtotal under "Total Portfolio Value". Adding metadata to a response is half the change; the consumer that branches on it is the other half -- grep the frontend types for the interface in the same commit, and relabel a partial figure rather than leaving a total's caption over it.
 
-Read such a field defensively at the consumer (`=== false`, not `!`): during a
-rolling deploy a page can receive a response from a backend that predates the field,
-and absent means "no information" -- not "incomplete", and certainly not a crash.
-
-And read the flag from the *same aggregate that produced the numbers on screen*. The
-single foreign-account summary card showed account-currency subtotals while checking
-the top-level default-currency flag -- two different conversion graphs -- so an account
-that could not be valued in its own currency rendered zero under a complete-looking
-total. When a view switches which aggregate it displays, it switches which completeness
-it trusts.
+Read the field defensively at the consumer (`=== false`, not `!`): during a rolling deploy, absent means "no information". And read the flag from the *same aggregate that produced the numbers on screen* -- a view that switches which aggregate it displays switches which completeness it trusts.
 
 ### A weighting is in one currency or it is meaningless
 
-Summing `quantity * nativePrice` across USD, JPY and EUR holdings weights them by
-exchange rate as much as by size, so a balanced mix came out of the Monte Carlo
-historical-return calc near -20% instead of 0%. Convert every value into one common
-currency before weighting (the choice of currency does not matter -- normalized weights
-are invariant to it -- only that they share one), through the same resolver everything
-else uses. And an unpriced holding dropped from the weights makes the priced subset
-stand in for the portfolio: refuse the whole statistic (`null`) rather than report a
-subset's.
+Summing `quantity * nativePrice` across currencies weights holdings by exchange rate as much as by size. Convert every value into one common currency before weighting (which currency does not matter; that they share one does), through the same resolver everything else uses. An unpriced holding dropped from the weights makes the priced subset stand in for the portfolio: refuse the whole statistic (`null`) rather than report a subset's.
 
 ### An account, its currency, its rate and its amount are one tuple
 
-Persist all of it or none of it. Moving a transfer's destination leg to an account
-in another currency wrote the account, the currency and the newly resolved rate,
-and left the old destination *number* behind -- 90 GBP at 0.80 against a 100 USD
-source, with the balance already moved by 80, so the next recompute changed the
-account by the difference with no user action behind it. Key the write on "did this
-edit re-price the transfer", never on which request fields happened to be present.
+Persist all of it or none of it. Moving a transfer's destination leg to an account in another currency wrote the account, currency and new rate but left the old destination *number*, so the next recompute moved the balance with no user action behind it. Key the write on "did this edit re-price the transfer", never on which request fields happened to be present.
 
 ### A change is a value difference, not a field being present
 
-The transfer form resends the current accounts, amount and rate on every save, so
-`updateDto.amount !== undefined` does not mean the amount changed. Keying repricing
-off presence made an idempotent full-form payload restate a settled 90 EUR
-destination as 80 and move the balance with it -- from a request whose only real edit
-was a description. Compare against what the row holds. This is the same mistake as
-using one leg's state for both ledgers: asking a question the data can answer instead
-of the one that matters.
+The transfer form resends the current accounts, amount and rate on every save, so `updateDto.amount !== undefined` does not mean the amount changed. Compare against what the row holds -- keying repricing off presence made an idempotent full-form payload move a balance from a description-only edit.
 
 ### A presentation-only edit does not re-resolve a rate
 
-Renaming a transfer's description re-resolved FX and stored today's rate beside an
-unchanged destination amount, making the row internally inconsistent -- and refused
-the rename outright when the pair had no current rate, though the transfer already
-held a valid settlement. Resolve only when the financial structure changes: either
-account, the source amount, an explicit destination amount, an explicit rate. A
-date correction is not a re-pricing; the rate a transfer settled at is a fact about
-the transfer.
+Resolve FX only when the financial structure changes: either account, the source amount, an explicit destination amount, an explicit rate. A rename or date correction is not a re-pricing; the rate a transfer settled at is a fact about the transfer (renames used to store today's rate beside an unchanged destination amount, and refused outright when the pair had no current rate).
 
 ### A clamp bounds the total, not one of its parts
 
-Two children retiring one debt are clamped together. The loan final-payment fix
-capped the amortized principal at the outstanding balance and left the extra
-principal transfer beside it uncapped, so 400 + 300 went into a 500 balance, the
-account crossed zero into a credit, and the payoff check waiting for `<= 0.01`
-never fired. Decide which part yields -- the amortized figure is owed, the
-discretionary extra absorbs the shortfall -- and write the yielding part back:
-shrinking the parent while a child still carries the unclamped number fails the
-split validator's exact-4dp equality at the moment the user expected the loan to
-close. The same rule caught two more instances in `LoanPaymentSetupService`, which
-wrote the first installment and clamped nothing at all.
+Two children retiring one debt are clamped together. The loan final-payment fix capped the amortized principal but not the extra-principal transfer beside it, so the account crossed zero into credit and the payoff check never fired. Decide which part yields (the amortized figure is owed; the discretionary extra absorbs the shortfall) and write the yielding part back -- shrinking the parent while a child carries the unclamped number fails the split validator's exact-4dp equality.
 
 ### A completeness flag covers every total it is documented to cover, on every surface
 
-`fxComplete` claimed to describe all of `PortfolioSummary`'s `total*` fields while
-one aggregate's missing pairs were only written to the log, so an incomplete
-`totalNetInvested` shipped under `fxComplete: true` and fed CAGR as a complete
-denominator. Union every aggregate's gaps, and derive anything downstream (a rate,
-a ratio) only when its own inputs are complete. The flag must also survive the trip
-to each consumer: the compact LLM shape dropped both fields, so the AI Assistant and
-MCP quoted the same subtotal as a settled balance the UI knew was partial -- and for
-a model, the human-readable summary line has to say so too, not just the payload.
+`fxComplete` claimed to describe all of `PortfolioSummary`'s `total*` fields while one aggregate's gaps went only to the log. Union every aggregate's gaps, and derive anything downstream (a rate, a ratio) only when its own inputs are complete. The flag must survive the trip to each consumer -- the compact LLM shape dropped it, so AI/MCP quoted a subtotal as settled; for a model, the human-readable summary line has to say so too.
 
-The converse is equally wrong, and appeared in the same fix: **zero needs no rate.**
-Asking for one made an empty foreign account report its currency as unresolvable and
-took the whole portfolio's totals down to "unknown".
+The converse is equally wrong: **zero needs no rate.** Asking for one made an empty foreign account take the whole portfolio's totals down to "unknown".
 
-And completeness has more than one cause. `fxComplete` covered missing exchange rates
-and nothing else, so a held position with no current **price** was skipped out of the
-total with no gap recorded: a confident `totalPortfolioValue` built from the priced
-half, `fxComplete: true`, and Monte Carlo projecting from it. Track each cause
-separately (`fxComplete`, `pricesComplete`) and give consumers one flag that means
-"every component of every total is known" (`valuationComplete`), so nobody has to
-remember to check both.
-
-Nested totals need their own answer, too. A per-account total is converted into the
-*account's* currency while the top-level total is converted into the *user's* -- two
-different conversion graphs, so a portfolio can be complete at the top and
-unconvertible underneath. A global flag cannot speak for a total it did not compute.
+Completeness has more than one cause: track each separately (`fxComplete`, `pricesComplete`) and give consumers one flag meaning "every component of every total is known" (`valuationComplete`). Nested totals need their own answer -- a per-account total converts into the *account's* currency, the top-level into the *user's*, two different conversion graphs, so a global flag cannot speak for a total it did not compute.
 
 ### `created_at` cannot order rows written in one transaction
 
-`CURRENT_TIMESTAMP` is **transaction start time** in PostgreSQL, and TypeORM
-leans on that column default rather than sending a per-row value. So every row a
-single transaction writes -- a whole `.mny` import, a whole restore -- carries
-the *same* `created_at`, and any ordering that tiebreaks on it falls through to
-whatever comes next. In the register that was `id`, a random UUID: same-day
-imported rows were listed in an arbitrary order.
+`CURRENT_TIMESTAMP` is **transaction start time** in PostgreSQL and TypeORM leans on the column default, so every row a single transaction writes (a whole `.mny` import, a whole restore) carries the same `created_at`, and any tiebreak on it falls through to the next key -- in the register, a random UUID. The stored balance survives that; the running balance beside it does not (a same-day debit ordered before the credit that funded it shows the account overdrawn).
 
-Nothing about a stored balance depends on that, which is why it survived; the
-running balance beside it does. A purchase and the transfer that funded it on
-the same day are two rows, and with the debit ordered first the register shows
-the account overdrawn on a day it was never short -- recovering one row later,
-so it reads as a broken balance rather than a broken sort.
-
-When the clock cannot separate two rows, their signs do: **credits are ordered
-before debits, chronologically**, which for a newest-first list means the
-tiebreak runs *opposite* to the list direction. `applyRegisterOrder`
-(`backend/src/transactions/register-order.ts`) is the only place that order is
-written -- and the reason it has to be one place is that three of its four call
-sites are not the register at all, but the queries that sum the rows on previous
-pages to find where page N's running balance starts. A tiebreak added to the
-register alone re-splits the pages under those sums.
+When the clock cannot separate two rows, their signs do: **credits before debits, chronologically** -- for a newest-first list the tiebreak runs *opposite* to the list direction. `applyRegisterOrder` (`backend/src/transactions/register-order.ts`) is the only place that order is written, because three of its four call sites are the queries that sum previous pages to find a page's starting running balance -- a tiebreak added to the register alone re-splits the pages under those sums.
 
 ### The difference of two 4dp decimals is not a 4dp decimal
 
-`roundMoney` the delta, not just its operands. `newAmount - oldAmount` on two
-values that are each exactly representable to 4dp is not, and that value is what a
-balance moves by.
+`roundMoney` the delta, not just its operands -- `newAmount - oldAmount` is what a balance moves by.
 
-The full rules -- cost basis and tax truth table, cash, valuation, materialized-result versioning, stale quotes, backtests over incomplete history, and the required adversarial test matrix -- live in `docs/financial-calculation-contract.md` and `docs/time-series-contract.md`. Read both **before** writing or changing any financial calculation, not when a review asks about them: every rule those documents contain has been read, agreed with and broken anyway by someone who reached them afterwards. `docs/testing-contract.md` lists the adversarial inputs that have broken this codebase before -- dates, money precision, aggregation, currency conversion, ownership, concurrency -- so a test author picks from a list rather than recalling edge cases; it is explicitly not a requirement that every test use every value. A financial feature of any substance -- it computes money, materializes a derived result, or reads a time series -- starts from a short approved spec (invariants, truth tables, numerical examples, missing-data policy, test matrix), committed *before* the implementation it guides.
+The full rules -- cost basis and tax truth table, cash, valuation, materialized-result versioning, stale quotes, backtests over incomplete history, and the required adversarial test matrix -- live in `docs/financial-calculation-contract.md` and `docs/time-series-contract.md`. Read both **before** writing or changing any financial calculation. `docs/testing-contract.md` lists the adversarial inputs that have broken this codebase before (dates, money precision, aggregation, currency conversion, ownership, concurrency) so a test author picks from a list rather than recalling edge cases. A financial feature of any substance starts from a short approved spec (invariants, truth tables, numerical examples, missing-data policy, test matrix), committed *before* the implementation it guides.
 
 ### What a category cost is its debits NET OF its credits
 
-A refund, a return, a chargeback or a cashback filed against an expense
-category is a debit that came back, so it belongs in that category's total.
-Every surface that reached for the gross instead -- `WHERE amount < 0` plus
-`SUM(ABS(...))` in SQL, `if (amount >= 0) return` in a client-side reduce,
-`summary.totalExpenses` on its own -- put a figure on screen that disagreed
-with the register's own balance for the same filter, which is issue #1125:
-$23,212.25 reported against a $23,206.07 balance, the difference being one
-$6.18 credit.
+A refund, return, chargeback or cashback filed against an expense category is a debit that came back, so it belongs in that category's total. Every surface that reached for the gross (`WHERE amount < 0` + `SUM(ABS(...))`, `if (amount >= 0) return`, `summary.totalExpenses` alone) disagreed with the register's own balance for the same filter (issue #1125). Sum the signed amount over rows of **both** signs, per category, and decide what the row *is* from the net: `isNetSpending` and `NET_SPEND_AMOUNT` (`backend/src/built-in-reports/spending-reports.service.ts`) on the server; `netEntityTotal` (`frontend/src/components/transactions/widget-shared.ts`) for a summary scoped to one category. Never take `totalIncome` or `totalExpenses` alone as a category's headline -- those are a register's in/out split.
 
-Sum the signed amount over rows of **both** signs, per category, and decide
-what the row *is* from the net. `isNetSpending` and `NET_SPEND_AMOUNT`
-(`backend/src/built-in-reports/spending-reports.service.ts`) are that decision
-on the server; `netEntityTotal`
-(`frontend/src/components/transactions/widget-shared.ts`) is the single
-headline figure for a summary scoped to one category. Never take `totalIncome`
-or `totalExpenses` alone as a category's headline -- those two are a register's
-in/out split, and one of them is half the answer. (The payee surfaces are a
-separate decision and deliberately unchanged: `PayeeInfoWidget` prints the
-credits it received as their own line beside the spend, so netting them into
-the headline as well would count them twice.)
-
-Dropping the sign filter means credits are read at all, so income now reaches
-the aggregate and has to leave by a different door: a bucket whose net is not
-spending is not a row in a spending report. That is one predicate, not a
-per-call-site `> 0`, and it is what keeps an income category (and uncategorized
-income, which the row-level filter used to exclude) out of the breakdown.
-
-Netting is **within** one category, never across two. Both halves come from the
-same filtered aggregate, so a refund can only ever reduce the category it was
-filed under.
+Dropping the sign filter means income now reaches the aggregate and has to leave by a different door: a bucket whose net is not spending is not a row in a spending report -- one predicate, not a per-call-site `> 0`. Netting is **within** one category, never across two; both halves come from the same filtered aggregate. (The payee surfaces are deliberately unchanged: `PayeeInfoWidget` prints received credits as their own line beside the spend, so netting them into the headline would count them twice.)
 
 ## Environment
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -29,27 +29,16 @@ npm run migration:lint:test # Self-test for the migration lint
 
 ### `test/*.e2e-spec.ts` is not a gate, and three of the four suites are broken
 
-CI runs `test:unit` and `test:integration` (the latter filtered to
-`test/integration/*.spec.ts`). Nothing runs `test:e2e`, and `tsconfig.json`
-excludes `test/`, so for over a week four suites did not even compile -- a
-namespace `import * as cookieParser` left behind when `main.ts` moved to a
-default import. ESLint's glob covers the directory, but that is a type error, not
-a lint error. `npm run typecheck` now closes the compile half in CI.
-
-What the compile error was hiding, once removed:
+CI runs `test:unit` and `test:integration` (filtered to `test/integration/*.spec.ts`). Nothing runs `test:e2e`, and separate rot accumulated behind a since-fixed compile error (`npm run typecheck` now closes the compile half in CI):
 
 | Suite | State | Why |
 |---|---|---|
-| `test/payee-detail.e2e-spec.ts` | passes (9 tests) | nothing wrong with it; its coverage was simply absent. This is the spec cited below as what caught the raw-select transformer class of bug |
-| `test/payees.e2e-spec.ts` | fails | calls services directly, so there is no request scope; never converted for RLS (`withScopedDb` throws without ambient context) |
+| `test/payee-detail.e2e-spec.ts` | passes (9 tests) | fine; this is the spec that caught the raw-select transformer class of bug |
+| `test/payees.e2e-spec.ts` | fails | calls services directly, so no request scope; never converted for RLS (`withScopedDb` throws without ambient context) |
 | `test/auth.e2e-spec.ts` | fails | `AuthController` gained a `TokenService` dependency its test module does not provide |
 | `test/transactions.e2e-spec.ts` | fails | `DelegateTransferMaskInterceptor` gained a `CrossOwnerAccessService` dependency its test module does not provide |
 
-Each is separate rot that accumulated *behind* the compile error: the RLS
-conversion, the token-service split and the cross-owner-transfers work each moved
-on without these files and nothing complained. Repair them or delete them --
-what they must not stay is present, cited, and dead. Do not add `test:e2e` to CI
-until the three are fixed; it will be red.
+Repair them or delete them -- what they must not stay is present, cited, and dead. Do not add `test:e2e` to CI until the three are fixed; it will be red.
 
 ## Module Structure
 
@@ -125,671 +114,171 @@ transactionDate: string;
 
 **Decimal columns** use a `numericTransformer` to convert PostgreSQL's string representation to `number`. **Timestamps** are `@CreateDateColumn({ name: 'created_at' })` and `@UpdateDateColumn({ name: 'updated_at' })`.
 
-**Raw selects bypass both transformers.** `getRawOne`/`getRawMany` return driver values, not entity-hydrated ones, so a DATE column comes back as a JS `Date` and a numeric as a string -- regardless of the transformer on the entity. Select a DATE as text in SQL (`TO_CHAR(col, 'YYYY-MM-DD')`) and pass a numeric through `Number()` before it reaches a DTO that declares `string`/`number`. `main.ts` installs a global DATE string parser, which hides the DATE half of this in the running server but not in tests, jobs, or any other process -- so do not rely on it. `payee-detail.service.ts` is the worked example; its `test/payee-detail.e2e-spec.ts` is what caught it, because a unit spec with mocked query builders cannot.
+**Raw selects bypass both transformers.** `getRawOne`/`getRawMany` return driver values: a DATE comes back as a JS `Date` and a numeric as a string, regardless of the entity transformer. Select a DATE as text in SQL (`TO_CHAR(col, 'YYYY-MM-DD')`) and pass a numeric through `Number()` before it reaches a DTO that declares `string`/`number`. `main.ts` installs a global DATE string parser, which hides the DATE half in the running server but not in tests, jobs, or any other process -- so do not rely on it. `payee-detail.service.ts` is the worked example; `test/payee-detail.e2e-spec.ts` caught it, because a unit spec with mocked query builders cannot.
 
-**A hand-written column name is checked by nobody -- so a scan checks it.** A
-mocked `manager.query` records the string and resolves, which makes every raw
-statement's column names untested by construction. `AutoBackupService`'s claim
-ended `RETURNING id`, `auto_backup_settings` has no `id` (its primary key is
-`user_id`), and the spec beside it asserted
-`expect(sql).toContain("RETURNING id")` -- so the mistake was not merely
-uncaught, it was pinned. In production every hourly sweep raised
-`column "id" does not exist` (42703) and no user's automatic backup ran.
-`src/common/db/raw-sql-columns.spec.ts` now checks every `RETURNING` list,
-`INSERT` column list and `UPDATE ... SET` target in `src/` against
-`database/schema.sql`, with the grammar in `raw-sql-columns.ts` unit-tested
-separately. Assert the *column*, not the substring: a mock cannot tell a real
-column from a plausible one.
+**A hand-written column name is checked by nobody -- so a scan checks it.** A mocked `manager.query` records the string and resolves, making every raw statement's column names untested by construction (`AutoBackupService` wrote `RETURNING id` against a table whose primary key is `user_id`, the spec pinned the wrong string with `toContain`, and no user's automatic backup ran). `src/common/db/raw-sql-columns.spec.ts` checks every `RETURNING` list, `INSERT` column list and `UPDATE ... SET` target in `src/` against `database/schema.sql`. Assert the *column*, not the substring.
 
-**A per-user loop in a cron isolates each user, including the steps before the
-work starts.** The auto-backup sweep's `try` began *below* the claim, so an
-error while deciding whether to run -- the maintenance pre-check, the claim's
-own `UPDATE` -- left the whole handler and every remaining user was skipped,
-with nothing recorded as failed. Wrap the entire per-user body, record the
-failure on the row so the surface that shows a last-run status tells the truth,
-and record it through a path that cannot itself throw (the outcome write is a
-database call, and whatever broke the work can break the recording of it).
-`enrollManagedUsers` in the same file already had the rule; the loop below it
-did not.
+**A per-user loop in a cron isolates each user, including the steps before the work starts.** Wrap the entire per-user body in the `try` -- an error while deciding whether to run (a pre-check, the claim's own `UPDATE`) must not leave the handler and skip every remaining user. Record the failure on the row so the last-run status tells the truth, and record it through a path that cannot itself throw.
 
 ## DTO Conventions
 
 ### An optional field with a format validator needs `@ValidateIf`, not just `@IsOptional`
 
-`@IsOptional()` waives validation for `undefined` and `null` only. A text input the user left alone arrives as `""` -- react-hook-form gives the empty string and the form sends it -- so an `@IsUrl` / `@IsEmail` sitting beside `@IsOptional()` still runs on it and rejects it. Because validation fails per *request*, one blank optional field breaks every save from that form, not just the field. Add `@ValidateIf((_o, value) => value !== null && value !== "")` for a column that is nullable, so a blank clears it. `src/common/optional-url-dto.spec.ts` sweeps every URL-validated DTO property and fails on a new one; a field whose column is NOT NULL belongs on that file's exemption list with the reason, not silently rejecting a blank.
-
-This class of bug is invisible to unit tests, which construct payloads by hand and never send what the form sends. It surfaces in E2E or in production.
+`@IsOptional()` waives validation for `undefined` and `null` only. A text input the user left alone arrives as `""` (react-hook-form sends it), so an `@IsUrl` / `@IsEmail` beside `@IsOptional()` still rejects it -- and because validation fails per *request*, one blank optional field breaks every save from that form. Add `@ValidateIf((_o, value) => value !== null && value !== "")` for a nullable column so a blank clears it. `src/common/optional-url-dto.spec.ts` sweeps every URL-validated DTO property; a NOT NULL field belongs on its exemption list with a reason. This class of bug is invisible to unit tests (hand-built payloads); it surfaces in E2E or production.
 
 ### A request-supplied array declares an upper bound
 
-Every `@IsArray()` DTO property carries `@ArrayMaxSize(n)` beside it -- an unbounded array turns any per-element work downstream (one UPDATE per id inside a transaction) into a denial-of-service lever, and CodeQL flags the loop as `js/loop-bound-injection` (CWE-834). `src/common/array-bound-dto.spec.ts` sweeps validator metadata and fails on a new unbounded property; properties older than the guard are grandfathered there, and that list may only shrink. Relatedly, never use a request value's `.length` as a loop bound inside a `withScopedDb` callback: CodeQL cannot track an outer `Array.isArray` guard through the closure, so iterate `for (const [i, v] of xs.entries())` instead of `for (let i = 0; i < xs.length; i++)`.
+Every `@IsArray()` DTO property carries `@ArrayMaxSize(n)` -- an unbounded array turns per-element work downstream into a denial-of-service lever (CodeQL `js/loop-bound-injection`, CWE-834). `src/common/array-bound-dto.spec.ts` sweeps validator metadata; its grandfather list may only shrink. Relatedly, never use a request value's `.length` as a loop bound inside a `withScopedDb` callback (CodeQL cannot track the outer guard through the closure): iterate `for (const [i, v] of xs.entries())`.
 
 ## `complete()` is not `completeWithTools()` with the tools left off
 
-The two take the same `AiCompletionRequest`, which makes them look
-interchangeable, and they are not: `complete()` maps messages through
-`toSimpleMessages`, which **filters `role: "tool"` out entirely**. Reach for it
-to summarise a tool-use conversation and you send a transcript stripped of
-every tool result and get back a confident summary of nothing -- no error, no
-empty response, just an answer about no data.
+Both take `AiCompletionRequest`, but `complete()` maps messages through `toSimpleMessages`, which **filters `role: "tool"` out entirely** -- summarising a tool-use conversation through it sends a transcript stripped of every tool result and returns a confident summary of nothing.
 
-A tool-free turn over a tool-use transcript therefore goes through
-`completeWithTools`/`streamWithTools` with an empty tool list, and every
-provider builds the field with `toolsField` (`src/ai/providers/tools-field.util.ts`)
-so it is **omitted** rather than sent as `[]` -- OpenAI rejects `tools: []`
-outright. `tools-field.util.spec.ts` scans every `*.provider.ts` and fails on a
-bare `tools:` key, so a sixth provider cannot reintroduce it; the per-provider
-specs assert the request body in both directions.
-
-The one caller is `AiQueryService.streamFinalSynthesis`, the pass that turns an
-unfinished investigation -- budget-truncated, or stalled per the rule below --
-into an answer instead of an apology.
+A tool-free turn over a tool-use transcript goes through `completeWithTools`/`streamWithTools` with an empty tool list, and every provider builds the field with `toolsField` (`src/ai/providers/tools-field.util.ts`) so it is **omitted** rather than sent as `[]` (OpenAI rejects `tools: []`). `tools-field.util.spec.ts` scans every `*.provider.ts` for a bare `tools:` key; per-provider specs assert the request body both ways. The one caller is `AiQueryService.streamFinalSynthesis`, the pass that turns an unfinished investigation into an answer.
 
 ## A turn that ends on a promise is not an answer
 
-Nothing runs between turns. So a tool-free turn saying "I am gathering the split
-details for those 17 transactions. One moment." ends the query: the loop's exit
-condition is `stopReason !== "tool_use"`, control goes back to the user, and the
-second message they are now waiting for cannot ever arrive. It reads as a hang,
-and the smaller the model the more often it happens -- assistant training data is
-full of transcripts where a human speaks next.
+Nothing runs between turns, so a tool-free turn saying "One moment, I'm gathering..." ends the query (the loop exits on `stopReason !== "tool_use"`) and reads as a hang. The loop therefore does not treat every tool-free turn as an answer: `isDeferredContinuation` (`src/ai/query/continuation.ts`) recognises the promise, and the loop replies with `CONTINUATION_NUDGE` in the user's place for at most `MAX_CONTINUATION_NUDGES` passes, then breaks to the tool-free synthesis pass with `cutoff = "stalled"`. The stalled text stays in the thinking buffer and never becomes the answer bubble.
 
-The loop therefore does not treat every tool-free turn as an answer.
-`isDeferredContinuation` (`src/ai/query/continuation.ts`) recognises the promise,
-and the loop replies with `CONTINUATION_NUDGE` in the user's place -- "your turn
-does not resume; call the tool now or answer now" -- for at most
-`MAX_CONTINUATION_NUDGES` passes, after which it breaks to the tool-free
-synthesis pass with `cutoff = "stalled"`, because a model with no tools left
-cannot answer with another promise. The stalled text stays in the thinking
-buffer and never becomes the answer bubble.
+Detector shape (both asymmetries are in its spec): a wait request ("one moment") is decisive; a bare work announcement is not, and an offer ("let me know", a trailing `?`) wins over it; only the tail of the message is examined. A false positive costs one extra pass; a false negative is the hang. The strongest signal needs no prose judgement: `promisesPendingAction` pairs a promise of confirmation cards against `proposingToolResults === 0` -- prefer pairing a text claim against state the loop already tracks over adding another regex phrase. `QUERY_SYSTEM_PROMPT` asks for the same thing, but a prompt rule is not a guarantee.
 
-Two asymmetries decide the detector's shape, and both are in its spec. A wait
-request ("one moment", "hold on") is decisive; a bare work announcement ("I'll
-pull the rest") is not, because the same words end a finished answer that offers
-more -- so an offer (`let me know`, `if you want`, a trailing `?`) wins over it.
-And only the tail of the message is examined: mid-answer narration is followed
-by the answer itself. A false positive costs one extra pass; a false negative is
-the hang this exists to stop.
+**A stall is often a dead end the model found and could not name.** Both reported stalls were a request the tools could not express (recategorizing one line in 17 split transactions, with one proposing call allowed per query). Batch rows now carry `splits` (`BatchUpdateTransactionRow.splits`, applied in `executeBatchRow` inside the same `UpdateTransactionDto` as the scalar fields, per invariant I1); the individual-card path passes `result.splits` through. Two rules the tests hold: a row that resends no splits must carry none (an empty set would rewrite the lines it was asked to leave), and a row's preview shows its lines instead of a category name. The general point: when you add a limit, put it in the tool description in the same commit.
 
-One of these signals needs no judgement about prose, and it is the strongest:
-`promisesPendingAction` recognises a promise of confirmation cards, and a card
-exists **only** if a write tool call in that same turn produced a pending
-action. Promised cards plus `proposingToolResults === 0` is a broken promise the
-loop can prove. Prefer that shape -- pair a claim in the text against state the
-loop already tracks -- over adding another phrase to a regex list.
+**A filtered read is not a complete read, and only one of its two readers can tell.** `applyCategoryFilters` hydrates only the split lines matching the filter -- right for the register, wrong for anything that sends the lines back, because `manage_transactions` replaces a split set with exactly what it is given. The LLM path reloads the full set per split parent (`loadCompleteSplits`). Before reusing a list query in a tool, ask what its `where` does to the collections it hydrates: a filter on a joined child table silently truncates the parent's children.
 
-The prompt asks for the same thing in `QUERY_SYSTEM_PROMPT` ("FINISH THE TURN YOU
-ARE IN") and the safety reminder, since the cheapest stall is the one that never
-happens -- but a prompt rule is not a guarantee, which is why the loop enforces
-it too.
-
-**A stall is often a dead end the model found and could not name.** Both reported
-stalls were the same request: recategorize one line inside 17 split
-transactions. It could not be done. A split update had to be a single-item call
-(batch rows dropped the splits), and `AiQueryService` allows one proposing tool
-call per *query* -- so one split transaction per user request, seventeen
-requests, and nothing said so. The model narrated progress towards something
-unreachable instead.
-
-Batch rows now carry `splits` (`BatchUpdateTransactionRow.splits`, applied in
-`executeBatchRow` inside the same `UpdateTransactionDto` as the scalar fields,
-per invariant I1), so one call recategorizes up to 25 split transactions and the
-individual-card path passes `result.splits` through rather than silently
-dropping them. Two rules the tests hold: a row that resends no splits must carry
-none (an empty set would rewrite the lines it was asked to leave), and a row's
-preview shows its lines instead of a category name, because a card reading
-"Groceries" while writing three other lines is a card approved for something
-else.
-
-The general point outlives this feature: when you add a limit, put it in the
-tool description in the same commit. An assistant that says "I can do six of
-these at a time" is working; one that discovers the wall mid-answer stalls.
-
-**A filtered read is not a complete read, and only one of its two readers can
-tell.** `applyCategoryFilters` hydrates *only* the split lines matching the
-filter, which is right for the register (it wants a partial total and refetches
-the whole transaction to edit it) and wrong for anything that will send the
-lines back. `getLlmTransactionRows` reuses that query, so a model asking for
-"transactions in Business: Cell Phone" received one line of a three-line split
--- and `manage_transactions` replaces a split set with exactly what it is given.
-The observed outcome was a one-line replacement set, refused only by the
-unrelated "a split needs at least 2 lines" rule, with the model then offering to
-convert the transactions to non-split ones. Two lines matching out of three
-would have passed that rule and silently destroyed the third.
-
-So the LLM path reloads the full set per split parent (`loadCompleteSplits`) and
-its rows are always complete. Before reusing a list query in a tool, ask what
-its `where` does to the collections it hydrates: a filter on a joined child
-table silently truncates the parent's children, and the caller cannot tell a
-truncated set from a short one.
-
-**A refusal the caller cannot act on is a refusal that ends the task.** Every
-bulk tool path computes a per-row reason and then used to throw it away,
-answering "None of the transaction edits could be prepared. Check each
-transactionId and the fields to change." The next attempt at the 17 splits
-failed exactly there: all 17 rows were refused because a split's categories
-live on its lines and the edit resent none -- the reason said so, in words the
-model could have acted on -- and it was told to check the ids, which were
-correct. It concluded the task was impossible and stopped.
-
-`describeSkippedRows` (`common/bulk-create.types.ts`) is now the only way those
-messages are built: identical reasons collapse to one line with a count,
-distinct ones are listed up to three with a tail count. `bulk-skip-reporting.spec.ts`
-scans all four tool sources and fails on a "None of ... could be prepared"
-message that does not carry its reasons -- and a generic message is worse than
-none when it *guesses*, because a confident wrong diagnosis sends the reader
-away from the fix. Individual-card paths that counted skips (`skipped++`) now
-collect reasons too, for the same reason.
+**A refusal the caller cannot act on is a refusal that ends the task.** Every bulk tool path computes a per-row reason; `describeSkippedRows` (`common/bulk-create.types.ts`) is the only way those messages are built (identical reasons collapse with a count; distinct ones list up to three). `bulk-skip-reporting.spec.ts` scans all four tool sources and fails on a "None of ... could be prepared" message that does not carry its reasons -- a generic message that *guesses* sends the reader away from the fix. Individual-card paths that count skips collect reasons too.
 
 ## A numeric env knob is declared as data, next to its documentation
 
-Coerce every numeric environment variable through `resolvePositiveInt`
-(`src/common/env-number.util.ts`) rather than a bare `Number(...)`: env values
-arrive as strings, and `Number` is willing enough to turn `true` into 1 and
-`[5]` into 5. It separates *absent* from *invalid* so the caller can log the
-second -- a typo that silently runs on the default is an afternoon lost to
-wondering why the setting did nothing.
-
-Where a feature has more than one knob, declare the set as one table of
-`{ envVar, default, description }` and resolve from it in a loop --
-`src/ai/query/query-budgets.ts` is the pattern -- so a new knob cannot be added
-without a name, and a copied spec object that reads a neighbour's variable
-fails a test rather than moving two budgets together. A knob nobody can find is
-not configurable, so `query-budgets.spec.ts` checks `.env.example` in both
-directions: every declared budget is documented with its current default, and
-no `AI_QUERY_*` line documents a variable the code does not read.
+Coerce every numeric environment variable through `resolvePositiveInt` (`src/common/env-number.util.ts`), never a bare `Number(...)` -- it separates *absent* from *invalid* so a typo is logged rather than silently running on the default. Where a feature has more than one knob, declare the set as one table of `{ envVar, default, description }` and resolve in a loop (`src/ai/query/query-budgets.ts` is the pattern). `query-budgets.spec.ts` checks `.env.example` in both directions: every declared budget documented with its current default, and no `AI_QUERY_*` line documenting a variable the code does not read.
 
 ## An environment variable configures the deployment's own resource, not somebody else's
 
-The AI provider is the worked example, and it has two owners. `AI_DEFAULT_*`
-builds the **centrally managed** provider -- the operator's, used for anyone who
-has configured none of their own, editable nowhere in the UI. Everything else in
-`ai_provider_configs` is a row a *user* created, pointed at their own key or
-their own Ollama box, and can see and edit.
+The AI provider has two owners. `AI_DEFAULT_*` builds the **centrally managed** provider (the operator's, used when a user has configured none, editable nowhere in the UI); everything else in `ai_provider_configs` is a row a *user* created and can edit. So `AI_QUERY_*` sizes the central provider only; a user's provider carries the same five budgets as nullable columns, set in Settings -> AI, defaulting to the built-in numbers -- never to the environment. `resolveQueryBudgetsForConfig` is the single place that decision is made; `AiService.resolveToolUseProvider` hands the caller the configuration alongside the provider, and the transient system-default config is marked `isSystemDefault`.
 
-A setting about how hard the assistant may work belongs to whichever of those
-two owns the provider. So `AI_QUERY_*` sizes the central provider only, and a
-user's provider carries the same five budgets as nullable columns on its row,
-set per provider in Settings -> AI and defaulting to the built-in numbers --
-never to the environment. `resolveQueryBudgetsForConfig` is the single place
-that decision is made; `AiService.resolveToolUseProvider` hands the caller the
-configuration alongside the provider so it can be made at all, and the transient
-system-default config is marked `isSystemDefault` because that is the only thing
-distinguishing it from a row.
-
-Before adding an env var for anything a user can also configure, ask which
-resource it describes. An operator's ceiling for the model they host says
-nothing about the model somebody else is paying for, and a global limit quietly
-reshaping a configuration the user is looking at reads as a broken form rather
-than as a policy. The reverse mistake is worse: a per-user knob for something
-the operator is paying for hands out their budget.
-
-`query-budgets.spec.ts` holds the split from both sides -- the environment must
-not reach a user's provider, and a stored value outside the declared range falls
-back to the documented default rather than being clamped to a number nobody
-chose. The bounds live in the same spec table as the defaults, so the DTO
-(`QueryBudgetFieldsDto`), the migration and the frontend form all derive from
-one place; the form's copy of the numbers is checked against it by
-`frontend/src/lib/ai-query-budgets.contract.test.ts`.
+Before adding an env var for anything a user can also configure, ask which resource it describes -- an operator's ceiling says nothing about a model somebody else is paying for, and the reverse mistake (a per-user knob for the operator's resource) hands out their budget. `query-budgets.spec.ts` holds the split from both sides; a stored value outside the declared range falls back to the documented default rather than being clamped. The bounds live in the same spec table as the defaults, so the DTO (`QueryBudgetFieldsDto`), the migration and the frontend form derive from one place; the form's copy is checked by `frontend/src/lib/ai-query-budgets.contract.test.ts`.
 
 ## A label the exporter writes itself must need no escaping
 
-The CSV formula-injection guard in `account-export.service.ts` exists for
-user-controlled text -- a payee named `=cmd|...`, a description opening with
-`+`. When one of the *exporter's own* strings trips it, the guard is neutralizing
-a threat the exporter invented: `-- Split --` was prefixed with an apostrophe on
-the parent row of every split in every account export, and no test saw it,
-because `toContain("-- Split --")` is satisfied by `'-- Split --`.
+The CSV formula-injection guard in `account-export.service.ts` exists for user-controlled text; when one of the exporter's *own* strings trips it (`-- Split --` got an apostrophe prefix on every split parent row), rename the label so it opens with a character no spreadsheet evaluates (`CSV_SPLIT_CATEGORY_LABEL` is `(Split)`) -- do not exempt the literal. Assert the *field*, not the line (`toContain` is satisfied by the neutralized cell), and keep the document-level check: export an all-ordinary-text fixture and assert no cell carries the guard's prefix.
 
-Do not fix that by exempting the literal -- Excel evaluates a leading dash, so an
-unguarded `-- Split --` reads as `#NAME?`, which is worse. Rename the label so it
-opens with a character no spreadsheet evaluates (`CSV_SPLIT_CATEGORY_LABEL` is
-now `(Split)`), and assert the *field* rather than the line, so a neutralized
-cell cannot satisfy the assertion again. The document-level check is the durable
-half: export a fixture whose every user-supplied field is ordinary text, and
-assert no cell carries the guard's prefix. Any future literal that needs
-escaping fails it, wherever it is added.
-
-A transfer's label is `csvTransferLabel` in the same file, and it names the
-direction as well as the counterpart (`Transfer To Savings`): money leaving this
-account went *to* the other one, money arriving came *from* it, and a split line
-is asked with its own amount rather than the parent's. `Transfer: Savings` named
-the counterpart without saying which way the money moved -- the half a reader
-cannot recover from the sign of a column they are looking at in a spreadsheet.
-Its twin is `transferCsvLabel` in `frontend/src/lib/transfer-label.ts`; the QIF
-export keeps Quicken's `L[Account]` form and is deliberately untouched.
+A transfer's label is `csvTransferLabel` in the same file, and it names the direction as well as the counterpart (`Transfer To Savings`); a split line is asked with its own amount, not the parent's. Its twin is `transferCsvLabel` in `frontend/src/lib/transfer-label.ts`; the QIF export keeps Quicken's `L[Account]` form deliberately.
 
 ## A blank transfer payee is stored blank and resolved at read time
 
-A transfer created without a payee persists `payee_name` as NULL (issue #1214);
-the display label ("Transfer to Savings") is resolved per read from the linked
-leg's account -- its CURRENT name, in the reader's language -- so renames and
-language switches reach every historical row. The English form for
-machine-facing surfaces (CSV/QIF export, AI/MCP rows, custom reports) lives
-only in `src/transactions/transfer-payee-label.util.ts`, and
-`transfer-payee-stamp.guard.spec.ts` fails on a `Transfer to/from ${...}`
-template anywhere else in `src/`. Migration 161 blanked the rows the old
-writers stamped (exact match against the counterpart's current name only);
-`updateTransfer` heals a surviving legacy stamp to NULL when it recognises
-one, and never regenerates it. A read surface that joins
-`linkedTransaction.account` for this must mask or restrict cross-owner
-counterparts the reader cannot read -- the account export masks, the custom
-report query restricts the join to same-owner legs.
+A transfer created without a payee persists `payee_name` as NULL (issue #1214); the display label is resolved per read from the linked leg's account -- its CURRENT name, in the reader's language. The English form for machine-facing surfaces (CSV/QIF export, AI/MCP rows, custom reports) lives only in `src/transactions/transfer-payee-label.util.ts`, and `transfer-payee-stamp.guard.spec.ts` fails on a `Transfer to/from ${...}` template anywhere else in `src/`. Migration 161 blanked the legacy-stamped rows; `updateTransfer` heals a surviving stamp to NULL and never regenerates it. A read surface joining `linkedTransaction.account` for this must mask or restrict cross-owner counterparts the reader cannot read (the account export masks; the custom report query restricts the join to same-owner legs).
 
-The guard also asks what a value *is* rather than what it starts with, matching
-its twin in `frontend/src/lib/csv-export.ts`: a value a spreadsheet reads as a
-number is data, and prefixing one stops the column adding up (issue #1134).
-Amounts here bypass `escapeCsv`, so the rule covers the text columns that can
-still hold a number, such as a cheque number written `-123`.
+The guard also asks what a value *is* rather than what it starts with, matching its twin in `frontend/src/lib/csv-export.ts`: a value a spreadsheet reads as a number is data, and prefixing one stops the column adding up (issue #1134) -- amounts bypass `escapeCsv`, so the rule covers text columns that can still hold a number (a cheque number written `-123`).
 
 ## A partial escape is indistinguishable from a correct one
 
-Interpolating a literal into a pattern goes through `escapeRegExp`
-(`src/common/escape-regexp.util.ts`) -- never a hand-written
-`replace(/[.*+?^${}()|[\]\\]/g, "\\$&")`, and never a subset of that class.
-`repo-paths.util.ts` escaped only dots, which reads as complete because a
-repository path contains dots and nothing else interesting; it left `\` alone,
-so a prefix carrying `\d` would have interpolated as the digit class and matched
-input nobody wrote (CodeQL `js/incomplete-sanitization`, CWE-020). The class was
-already spelled out in four other files, and the fifth copy was the wrong one --
-which is the argument for one function rather than a remembered character class.
-`escape-regexp.guard.spec.ts` scans `src/` and fails on either shape.
-
-Where the pattern is built from a list, export the builder and test it against a
-prefix carrying a metacharacter. `ROOTED`'s entries contain at most a dot, so
-over its real inputs the broken escape and the correct one agree exactly; only a
-synthetic prefix can tell them apart (`buildPlainRootedPathPattern`). Do not
-escape `-`: outside a character class it is literal, and `\-` is a SyntaxError
-under the `u` flag -- so never interpolate the result *inside* a class.
+Interpolating a literal into a pattern goes through `escapeRegExp` (`src/common/escape-regexp.util.ts`) -- never a hand-written character class, and never a subset of one (`repo-paths.util.ts` escaped only dots and left `\` alone; CodeQL `js/incomplete-sanitization`, CWE-020). `escape-regexp.guard.spec.ts` scans `src/` for either shape. Where the pattern is built from a list, export the builder and test it against a prefix carrying a metacharacter (`buildPlainRootedPathPattern`) -- over real inputs the broken and correct escapes can agree exactly. Do not escape `-`: outside a class it is literal, and `\-` is a SyntaxError under the `u` flag -- so never interpolate the result *inside* a class.
 
 ## A cached brand favicon is four columns, one fetcher, and one export rule
 
-Institutions and payees both resolve a website's favicon server-side and cache
-the bytes so the browser never contacts a third party. Everything shared lives
-in `src/common/favicon/`: `FaviconService` (the gstatic fetch, with its
-timeout, size cap and image-only content-type check) and `brandLogoColumns`,
-which turns a fetch result into the four columns
-(`logo_data`, `logo_content_type`, `has_logo`, `logo_fetched_at`). A third
-entity imports `FaviconModule`; it does not copy the fetcher.
+Institutions and payees resolve a website's favicon server-side and cache the bytes so the browser never contacts a third party. Shared code lives in `src/common/favicon/`: `FaviconService` (the gstatic fetch, with timeout, size cap and image-only content-type check) and `brandLogoColumns` (the four columns `logo_data`, `logo_content_type`, `has_logo`, `logo_fetched_at`). A third entity imports `FaviconModule`, not a copy. Four shared rules, each with a test:
 
-Four rules the two implementations share, each of which has a test:
-
-- **The fetch stays outside the transaction.** It is best-effort -- a favicon
-  that could not be resolved never fails the create or update around it -- and
-  a slow remote host must not hold a database connection open.
-- **Re-resolve only when the address actually changed.** The form resends the
-  current website on every save, and a re-fetch that failed would clear a
-  perfectly good icon. Clearing the address clears the icon with it.
-- **The flag and the bytes move together.** `has_logo` is what every list read
-  answers "is there an icon?" with, because the bytes are `select: false` and
-  never serialized; they leave only through that entity's `GET /:id/logo`,
-  which 404s so the client can draw its own badge. `logo_fetched_at` stamps the
-  *attempt*, so null means never looked for.
-- **A bytea column breaks `SELECT *`.** The driver returns a Buffer, which JSON
-  cannot carry and the restore's `decode(..., 'base64')` cannot read, so the
-  table's export query must list its columns and wrap the bytes in
-  `encode(logo_data, 'base64')` -- `export-driver-values.spec.ts` is what
-  catches the omission. The support backup drops the bytes and forces
-  `has_logo` to false, because a brand icon re-identifies a payee whose name
-  was masked.
+- **The fetch stays outside the transaction** -- best-effort, never fails the create/update, never holds a connection on a slow host.
+- **Re-resolve only when the address actually changed.** The form resends the current website on every save, and a failed re-fetch would clear a good icon. Clearing the address clears the icon.
+- **The flag and the bytes move together.** `has_logo` answers every list read (the bytes are `select: false`, leaving only through `GET /:id/logo`, which 404s so the client draws its own badge); `logo_fetched_at` stamps the *attempt*.
+- **A bytea column breaks `SELECT *`.** The export query must list columns and wrap the bytes in `encode(logo_data, 'base64')` (`export-driver-values.spec.ts` catches the omission). The support backup drops the bytes and forces `has_logo` false, because a brand icon re-identifies a masked payee.
 
 ## Rejection happens before the write
 
-A check capable of refusing a command belongs inside the transaction that performs it, and under the same lock when concurrency is in play. A service that mutates, commits, and returns a success-shaped value for a caller to reject afterwards has already done the thing the `409` says it did not do.
+A check capable of refusing a command belongs inside the transaction that performs it, and under the same lock where concurrency is in play. A service that mutates, commits, and returns a success-shaped value for a caller to reject afterwards has already done the thing the `409` says it did not do.
 
 Give the operation the caller's precondition as a parameter -- the expected owner, scenario or revision -- and let it refuse before writing. Return the refusal distinguishably: "no such row", "not yours" and "done" are three answers, and folding two into `null` makes the caller guess. Tests assert the rejected response **and** the stored state; see `docs/financial-calculation-contract.md` section 7.
 
 ## A category's leaf name is not its identity
 
-"Cell Phone" under **Bills** and "Cell Phone" under **Business** is an ordinary
-chart of accounts, not an edge case -- so a bare leaf name identifies nothing,
-and every surface that emitted one was guessing on the reader's behalf. The
-analytics breakdown grouped on `splitCat.name`, which merged the two categories
-into a single row carrying `MIN(id)`; the LLM transaction rows sent the model
-`s.category.name`, so a split filed under Business came back as "Cell Phone" and
-was reported under whichever parent the model had seen elsewhere.
+"Cell Phone" under **Bills** and under **Business** is an ordinary chart of accounts, so a bare leaf name identifies nothing. Both halves go through `categories/category-name.util.ts`:
 
-Both halves now go through `categories/category-name.util.ts`:
+- **Emitting**: `qualifiedCategoryName` / `loadQualifiedCategoryNames` produce `"Business: Cell Phone"`. Analytics groups on `SPLIT_CATEGORY_ID` and resolves the label from the map -- there is deliberately no category-*name* SQL fragment left, and `transaction-split-query.util.spec.ts` fails if one reappears.
+- **Accepting**: `resolveCategoryNamePaths` matches a name the model sends back, separator- and spacing-insensitive, and **refuses an ambiguous one** with the qualified candidates rather than picking a winner.
 
-- **Emitting**: `qualifiedCategoryName` / `loadQualifiedCategoryNames` produce
-  `"Business: Cell Phone"`. Analytics groups on `SPLIT_CATEGORY_ID` and resolves
-  the label from the map -- there is deliberately no category-*name* SQL
-  fragment left to reach for, and `transaction-split-query.util.spec.ts` fails if
-  one reappears.
-- **Accepting**: `resolveCategoryNamePaths` matches a name the model sends back,
-  separator- and spacing-insensitive, and **refuses an ambiguous one** with the
-  qualified candidates rather than picking a winner.
+The test that matters is the round trip: every name we emit must resolve back to the category we emitted it for (`category-name.util.spec.ts`) -- four hand-rolled resolvers had drifted apart, and one rejected the exact spelling every tool description tells the model to type, falling through to a last-segment fallback that silently read the *other* "Cell Phone".
 
-The two are one contract, and the test that matters is the round trip: every
-name we emit must resolve back to the category we emitted it for
-(`category-name.util.spec.ts`). Four hand-rolled resolvers had drifted apart
-before this, and the one the tools used accepted `"Business:Cell Phone"` and
-`"Business : Cell Phone"` but **not** `"Business: Cell Phone"` -- the single
-spelling every tool description and error message tells the model to type. That
-miss fell through to a last-segment fallback that returned the *other* "Cell
-Phone", and because results were labelled with the leaf name, nothing in the
-answer could reveal that the wrong category had been read.
-
-Also: `Uncategorized` (the user filed it nowhere) and `Unknown category` (we
-could not resolve the name of the category they did file it under) are different
-facts and have different constants. Do not fold the second into the first.
+Also: `Uncategorized` (the user filed it nowhere) and `Unknown category` (we could not resolve the name of the category they did file it under) are different facts with different constants. Do not fold the second into the first.
 
 ## A predicate that decides which row counts is written once
 
-When "is this row the one we mean" takes more than one clause -- current
-algorithm version *and* matching configuration fingerprint, say -- name it and
-call it. Written out at each site it drifts, and the drift is invisible: the
-GEM signal service spelled the condition out four times, and the fourth asked
-only whether the *date* had an answer. A date can hold two rows once a unique
-key carries a version, so a superseded row could win the lookup and be stored
-as the next period's predecessor -- a wrong decision, persisted, from rules no
-longer in force.
-
-The same goes for the `where` clause that reads such a row back. A key that
-grew a column selects more than one row now; a query still written against the
-old key returns whichever the database offers first. Grep for reads of a
-unique key in the migration that widens it.
+When "is this row the one we mean" takes more than one clause (current algorithm version *and* matching configuration fingerprint), name it and call it. Spelled out per site it drifts invisibly: the GEM signal service wrote it four times and the fourth checked only the date, so a superseded row could be stored as the next period's predecessor. Same for the `where` that reads such a row back: a unique key that grew a column selects more than one row under the old `where` -- grep for reads of a unique key in the migration that widens it.
 
 ## One classifier decides whether a database role is safe
 
-`common/db/runtime-role-check.ts` owns the question "may this role serve
-enforced traffic": one facts query template, one violation list, one verdict.
-Every surface that asks goes through its exports -- `main.ts` about its own
-connection (`assertRuntimeRoleSafe`), `db-init` about the configured role by
-name (`assertRuntimeRoleSafeByName`). Do not write a second role-safety query:
-a hand-written copy in `app-role.ts` once warned on CREATEDB/CREATEROLE/
-REPLICATION where the original refuses them, so the pre-flight blessed a role
-the runtime check then rejected (PR #1076). `runtime-role-check.spec.ts` pins
-the two exported queries to one template ("only the subject swapped") and the
-two asserts to one verdict per input.
+`common/db/runtime-role-check.ts` owns "may this role serve enforced traffic": one facts query template, one violation list, one verdict. Every surface asks through its exports -- `main.ts` about its own connection (`assertRuntimeRoleSafe`), `db-init` about the configured role by name (`assertRuntimeRoleSafeByName`). Do not write a second role-safety query (a hand-written copy in `app-role.ts` once blessed a role the runtime check then rejected, PR #1076). `runtime-role-check.spec.ts` pins the two exported queries to one template and the two asserts to one verdict per input.
 
 ## A read about somebody else needs somebody else's identity
 
-`users_self` exposes exactly two rows to a session: `app_current_user_id()` and
-`app_real_user_id()`. So **any query keyed on another person -- by their id, or
-worse, by their email -- returns zero rows from the caller's own scope**, and
-under `RLS_MODE=enforce` that empty result is what the caller gets back. It does
-not raise, it does not log, and "no rows" is the same shape as "no such user".
-`AuthService` finds a login by email only because it runs pre-identity, under a
-bypass; `DelegationService.delegateEmailExists` ran the identical `where` under
-`scoped()` and told owners that an account which demonstrably logs in did not
-exist. `listDelegates` had the same defect as a `relations: ["delegate"]` join,
-`revokeDelegate` decided whether to delete a login from three counts the
-database had refused to answer, and the delegate 2FA gate concluded that no
-owner requires 2FA.
+`users_self` exposes exactly two rows to a session: `app_current_user_id()` and `app_real_user_id()`. **Any query keyed on another person -- by id, or worse, by email -- returns zero rows from the caller's own scope** under `RLS_MODE=enforce`, without raising or logging, and "no rows" looks like "no such user". (`AuthService` finds a login by email only because it runs pre-identity, under a bypass; `DelegationService.delegateEmailExists` ran the identical `where` under `scoped()` and told owners an account that demonstrably logs in did not exist.)
 
 Before writing a query, ask whose row it is. There are three answers, not two:
 
 | Whose row | Use | Why |
 |---|---|---|
 | The caller's | `scoped()` / `withScopedDb` | The policy is the point. |
-| An owner's, read by their delegate | `withDelegateContext(owner, delegate)` | `current = owner, real = delegate` is the identity `users_self` and `user_preferences_isolation` were written for. **No bypass** -- the delegation is an identity the policies already understand, and `app.real_user_id` stays true about who is authenticated. |
+| An owner's, read by their delegate | `withDelegateContext(owner, delegate)` | `current = owner, real = delegate` is the identity the policies were written for. **No bypass** -- `app.real_user_id` stays true about who is authenticated. |
 | A delegate's, read by their owner (or any genuine cross-user sweep) | `withSystemContext` | There is no policy arm for it. Decide authorization *first*, under `scoped()`, and let only the minimum out. |
 
-Reaching for `withSystemContext` when the middle row applies is the easy wrong
-answer: it works, so nothing complains, and the bypass fence widens by one.
+Reaching for `withSystemContext` when the middle row applies is the easy wrong answer: it works, so nothing complains, and the bypass fence widens by one.
 
-`src/delegation/rls-context-smoke.spec.ts` is the guard, and the shape is worth
-copying. Per-service specs mock `withScopedDb` away, which makes them
-structurally incapable of seeing this class of bug -- so that suite runs the
-**real** `withScopedDb` at `RLS_MODE=enforce`, records the ambient context at
-each repository call, and asserts the ordered sequence of identities plus the
-`set_config` statements actually emitted. Asserting the order is what proves the
-fence: the authorization read must appear under the caller's own identity
-*before* any bypass opens.
+`src/delegation/rls-context-smoke.spec.ts` is the guard, and its shape is worth copying: per-service specs mock `withScopedDb` away and are structurally incapable of seeing this class of bug, so that suite runs the **real** `withScopedDb` at `RLS_MODE=enforce`, records the ambient context at each repository call, and asserts the ordered sequence of identities plus the emitted `set_config` statements. Asserting the order is what proves the fence: the authorization read must appear under the caller's own identity *before* any bypass opens.
 
 ## A joint account is only shared where somebody remembered to share it
 
-`transaction.userId = :userId` is the wrong ownership predicate for any
-own-context read a delegate can reach: a jointly shared account's rows belong
-to the **owner**, so the grantee matches none of them and the endpoint returns
-a confident empty answer rather than an error. That is how the register got the
-joint scope on day one while the summary, grouped totals and monthly totals
-beside it did not -- a joint account's detail page drew a full balance chart
-with an empty cash flow, no top categories and no top payees under it.
+`transaction.userId = :userId` is the wrong ownership predicate for any own-context read a delegate can reach: a jointly shared account's rows belong to the **owner**, so the grantee matches none of them and the endpoint returns a confident empty answer (the register had joint scope on day one; the summary, grouped totals and monthly totals beside it did not).
 
-Own-context reads resolve their scope through
-`TransactionsController.resolveOwnContextJointScope` (the accounts controller's
-equivalents are `jointAccountIdSetFor` for list reads and a `NotFoundException`
-fallback through `jointAccessFor` for `:id` reads, as on `getBalance` and
-`getBalanceForecast`). Filtered to exactly one joint account, the query runs as
-the owner so every derived value -- category descendant expansion, the search
-term parsed in the user's number/date format, the money math -- is byte-identical
-to the owner's own view; anything else keeps the caller's scope and widens it by
-the already-authorized joint ids, never by raw request input. The widened
-predicate itself is written once per service (`registerScope`,
-`analyticsScope`).
-
-An endpoint that deliberately stays owner-only says so where it is skipped:
-`tag-key-breakdown` does, because tags are personal and a joint row never
-carries the grantee's.
+Own-context reads resolve their scope through `TransactionsController.resolveOwnContextJointScope` (the accounts controller's equivalents are `jointAccountIdSetFor` for list reads and a `NotFoundException` fallback through `jointAccessFor` for `:id` reads, as on `getBalance` and `getBalanceForecast`). Filtered to exactly one joint account, the query runs as the owner so every derived value is byte-identical to the owner's own view; anything else keeps the caller's scope and widens it by the already-authorized joint ids, never by raw request input. The widened predicate is written once per service (`registerScope`, `analyticsScope`). An endpoint that deliberately stays owner-only says so where it is skipped (`tag-key-breakdown` does: tags are personal).
 
 ## A stored price says which session it belongs to, not which minute it was fetched
 
-`security_prices` holds one row per trading day, and the thing that row is
-supposed to hold is the **session**: the official close, the full-day volume,
-the high and low over the whole day, and the adjusted close. A live quote is
-none of those. `regularMarketPrice` is the last print at the moment it was
-asked for, which is a true statement about 14:42 and a false one about the day.
+`security_prices` holds one row per trading day, and that row is the **session**: official close, full-day volume, high/low, adjusted close. A live quote (`regularMarketPrice`) is a true statement about 14:42 and a false one about the day -- and the frontend auto-refreshes quotes through the session (`usePriceRefresh`), so a row for today exists long before the day is over. Three rules, each with a test:
 
-The frontend auto-refreshes quotes through the trading session
-(`usePriceRefresh`), so a row for today exists long before the day is over --
-and the closing job used to treat that as "already done" and skip the security,
-leaving whichever mid-session quote arrived last stored as the close. On real
-data that was sixteen of seventeen consecutive rows disagreeing with the
-provider, by a cent or two, with volumes at a third of the real figure. The two
-correct ones were the days nobody opened the app.
+- **"Has a price for today" is not "the day is settled".** Ask whether the *session* has ended -- `isSessionSettled` (`providers/settled-bar.util.ts`), on the market's own clock in the market's own zone, from the stored `market_timezone` / `market_close_time`. Never from the presence of a row or the server's clock.
+- **The closing job settles the day from the daily bar, after the quote refresh.** `settleDailyBars` re-reads a bounded recent window and upserts the bars whose sessions have ended, so a missed run or provider outage repairs itself. The quote is what a still-open market can offer; the bar is what the finished session did, and the bar wins.
+- **A calculated column needs a writer on the recurring path.** `adjusted_close` was populated only by the on-demand backfill, and because `loadPriceSeries` picks one basis per series and keeps only adjusted rows, that silently truncated every return series at the last backfill date. The quote path fills `adjusted_close` with the close it is writing -- definitional for the newest session (adjustment factor 1), but only where the series already carries an adjusted close; both conditions live in the `CASE ... EXISTS` inside the statement (an MSN-priced series given exactly one adjusted close flips `bool_or(...)` and collapses to that row).
 
-Three rules, each with a test rather than a paragraph:
+A daily bar is not a quote, so settling clears `quoted_at`; and a `source = 'manual'` row is a user correction no provider write may overwrite -- the quote path and `bulkUpsertPrices` both carry `WHERE security_prices.source IS DISTINCT FROM 'manual'`, and the quote path treats the refusal as a successful no-op that reads back the winning row. The honest cost: a manual row on a provider-priced security has no adjusted close, so that day stays out of the adjusted series.
 
-- **"Has a price for today" is not "the day is settled".** Ask whether the
-  *session* has ended -- `isSessionSettled` (`providers/settled-bar.util.ts`),
-  on the market's own clock in the market's own zone, from the
-  `market_timezone` / `market_close_time` the quote refresh stores. Never from
-  the presence of a row, and never from the server's clock.
-- **The closing job settles the day from the daily bar, after the quote
-  refresh.** `settleDailyBars` re-reads a bounded recent window and upserts the
-  bars whose sessions have ended, so a missed run, a provider outage or a week
-  of intraday-only rows repairs itself. Order matters: the quote is what a
-  still-open market can offer, the bar is what the finished session did, and
-  the bar has to win.
-- **A calculated column needs a writer on the recurring path.**
-  `adjusted_close` was populated by the on-demand backfill and by nothing else,
-  so it was null on every row the daily job wrote. Because `loadPriceSeries`
-  picks one basis per series and then keeps only the adjusted rows, that did
-  not degrade to raw prices -- it silently truncated every return series at the
-  last backfill date.
-
-The quote path fills `adjusted_close` with the close it is writing, so today is
-in the series from the first intraday refresh rather than only after
-settlement. That is definitional, not a guess -- the newest session's
-adjustment factor is 1 -- but it holds *only* for the newest session, and only
-where the series already carries an adjusted close. Both conditions live in the
-`CASE ... EXISTS` inside the statement, because the second one is not obvious:
-an MSN-priced series has no adjusted closes anywhere, and giving it exactly one
-flips `bool_or(...)` and collapses the series to that single row.
-
-A daily bar is also not a quote, so settling clears `quoted_at`; and a
-`source = 'manual'` row is a correction the user typed, which no provider write
-may overwrite -- the quote path and `bulkUpsertPrices` both carry
-`WHERE security_prices.source IS DISTINCT FROM 'manual'`, and the quote path
-treats the refusal as a successful no-op that reads back the row that won,
-not as a failure. The guard is what makes a nightly settlement pass safe to
-add at all; without it every manual correction would be destroyed each night.
-Its cost, which is the honest half: a manual row on a provider-priced security
-has no adjusted close and no way to derive one, so that day stays out of the
-adjusted series rather than being overwritten into it.
-
-A related one, in the same family as the DATE-transformer rule above: **a bar's
-timestamp is the instant its session opened, so the day it belongs to is the
-exchange's calendar day.** `barDate` reads it in `meta.exchangeTimezoneName`,
-falling back to UTC. Reading it with `setHours(0,0,0,0)` made `price_date` a
-function of the container's timezone and put an ASX bar on the wrong day.
+Related: **a bar's timestamp is the instant its session opened, so the day it belongs to is the exchange's calendar day.** `barDate` reads it in `meta.exchangeTimezoneName`, falling back to UTC; `setHours(0,0,0,0)` made `price_date` a function of the container's timezone.
 
 ## A payload coarser than daily is a different series, not a sparse one
 
-Ask a provider for a long range and it may answer with weekly or monthly bars.
-Written into a daily table those rows are indistinguishable from daily ones --
-and they overwrite the real daily rows that sat on those dates, so the damage
-is not limited to what was added. `market_index_prices` refused this from the
-day it was written; `security_prices` did not, and one production catalogue
-carried **six years of a single adjusted row per month** spliced through a daily
-history. Under the one-basis-per-series rule that did not merely add noise: the
-monthly rows carried adjusted closes and the daily ones did not, so
-`loadPriceSeries` kept the monthly rows and *dropped every daily row around
-them*, reducing six years of return series to twelve points a year.
-
-`assertDailySeries` (`providers/daily-spacing.util.ts`) is the one test, and it
-runs inside `bulkUpsertPrices` -- not in its callers, of which there are four,
-because a guard one caller forgets is not a guard. Every caller already wraps
-that write in a try/catch that reports a failed security, so the throw surfaces
-as "this one did not update" rather than as a crash. The threshold, the median
-(never the mean -- one long exchange closure must not make a daily series look
-weekly) and the minimum sample size live there too, and
-`daily-spacing.util.spec.ts` fails if a second copy of any of them appears
-anywhere under `securities/`.
+A provider asked for a long range may answer weekly or monthly bars; written into a daily table they overwrite the real daily rows on those dates, and under the one-basis-per-series rule monthly rows carrying adjusted closes made `loadPriceSeries` *drop every daily row around them*. `assertDailySeries` (`providers/daily-spacing.util.ts`) is the one test, and it runs inside `bulkUpsertPrices` -- not in its four callers, because a guard one caller forgets is not a guard (each caller already reports a failed security, so the throw surfaces as "this one did not update"). The threshold, the median (never the mean -- one long exchange closure must not make a daily series look weekly) and the minimum sample size live there too; `daily-spacing.util.spec.ts` fails on a second copy of any of them under `securities/`.
 
 ## History depth is a request, not a property of the holding
 
-`backfillSecurityHoldingPeriod` clips its write to the first transaction date,
-which is right for a position valuation and wrong for everything else: a
-backtest, the GEM report and the performance comparison all need prices from
-before the user bought. A security first transacted in May 2025 therefore held
-fifteen months of history out of ten available, with no way to ask for more --
-`backfillSecurityRange` can fetch any range but has no HTTP route of its own,
-reachable only as a side effect of running one of those reports.
-
-Both backfill endpoints now take `range` (`BackfillPricesQueryDto`), and
-supplying it means two things at once, deliberately: fetch that range, **and**
-store all of it. Omitting it keeps the clipped default. When you add a caller,
-decide which of the two questions it is asking -- "what is this position worth
-over the time I held it" or "what did this instrument do" -- rather than
-reaching for `max` because more data seems safer; the clip exists so an
-untouched catalogue does not accumulate decades of prices nobody reads.
+`backfillSecurityHoldingPeriod` clips its write to the first transaction date -- right for position valuation, wrong for backtests, the GEM report and performance comparison, which need prices from before the user bought. Both backfill endpoints take `range` (`BackfillPricesQueryDto`); supplying it means fetch that range **and** store all of it, omitting it keeps the clipped default. When adding a caller, decide which question it asks -- "what is this position worth over the time I held it" or "what did this instrument do" -- rather than reaching for `max`; the clip exists so an untouched catalogue does not accumulate decades of prices nobody reads.
 
 ## A money value carries the currency it was calculated into
 
-Not the currency of the account it is filed under. `InvestmentTransaction.exchangeRate`
-converts a trade out of the security's currency and into the *settlement*
-account's -- the funding account when the row names one, otherwise the
-brokerage's linked cash account -- so a replayed cost basis is denominated
-there, and a PLN brokerage funded from EUR holds a EUR basis. A consumer that
-assumed the holding account's currency set that against a PLN market value and
-reported the exchange rate as profit, then taxed it.
-
-So the amount and its currency travel together (`ReplayedLot.currencyCode`),
-and a consumer compares that field against what it is reporting in. A mismatch
-is **unknown**, not a conversion: today's rate answers today's question, and
-the acquisition happened at its own. Two acquisitions that settled in
-different currencies cannot be summed at all.
+Not the currency of the account it is filed under. `InvestmentTransaction.exchangeRate` converts a trade into the *settlement* account's currency (the funding account when named, else the brokerage's linked cash account), so a PLN brokerage funded from EUR holds a EUR cost basis. The amount and its currency travel together (`ReplayedLot.currencyCode`), and a consumer compares that field against what it is reporting in. A mismatch is **unknown**, not a conversion -- today's rate answers today's question, not the acquisition's -- and two acquisitions settled in different currencies cannot be summed at all.
 
 ## A fallback answers only the question it was asked
 
-A lookup that fails is a fact about *that* lookup. A stale scenario id that no
-longer resolves says nothing about the user's other scenarios, so an empty
-report hardcoding `strategies: []` made a second claim -- that there are none
--- without looking, and took away the switcher that was the only route back.
-Fall back to the default rather than to nothing, and fill the surrounding
-fields from a real read.
-
-And a retry has to change something. `getReport` recursed with the same
-strategy id after establishing that the id was gone, so every attempt took the
-identical path: a retry whose inputs are unchanged is a comment claiming a
-recovery that cannot happen.
+A lookup that fails is a fact about *that* lookup. A stale scenario id says nothing about the user's other scenarios, so an empty report hardcoding `strategies: []` made a second claim without looking -- and took away the switcher that was the only route back. Fall back to the default rather than to nothing, and fill the surrounding fields from a real read. And a retry has to change something: recursing with the same id after establishing the id is gone is a comment claiming a recovery that cannot happen.
 
 ## Backup and restore
 
-`docs/backup-restore-contract.md` is the contract: what a backup promises, what
-it deliberately does not, and the known gaps. Read it before changing anything
-under `src/backup/`.
+`docs/backup-restore-contract.md` is the contract: what a backup promises, what it deliberately does not, and the known gaps. Read it before changing anything under `src/backup/`. Three things a test enforces:
 
-Three things it will not let you get wrong by accident, because a test enforces
-them:
+- **A new foreign key between two backed-up tables** must keep `src/backup/restore-plan.spec.ts` green (it parses every FK out of `database/schema.sql` and fails on ordering/self-reference problems).
+- **A new column referencing `currencies(code)`** must keep `src/currencies/currency-references.spec.ts` green -- both SQL functions and the TypeScript constant.
+- **A new table** must be exported or listed in `INTENTIONALLY_EXCLUDED_TABLES` with a reason, and classified in the support backup rules.
 
-- **A new foreign key between two backed-up tables** has to keep
-  `src/backup/restore-plan.spec.ts` green. It parses every FK out of
-  `database/schema.sql` and fails when a restored table references a table
-  inserted later, or itself, without being stripped on insert and repaired
-  afterwards.
-- **A new column referencing `currencies(code)`** has to keep
-  `src/currencies/currency-references.spec.ts` green -- both SQL functions and
-  the TypeScript constant the support backup uses.
-- **A new table** has to be exported or listed in
-  `INTENTIONALLY_EXCLUDED_TABLES` with a reason, and classified in the support
-  backup rules.
+**A file's name is its identity, so anything that decides whether it may be deleted has to be in the name.** An automatic backup that could not include every attachment is published as `monize-backup-partial-<date>` in its own retention tier, and the name is chosen *after* the export from what the export found -- `writeFileAtomic` replaces a final name by design, so a partial artifact written under the `daily-` name had already destroyed that day's complete copy before any status column could say so. State beside the file cannot govern a decision the write has already made; the durable copy of the fact goes *inside* the document (`completeness` in the envelope).
 
-**A file's name is its identity, so anything that decides whether it may be
-deleted has to be in the name.** An automatic backup that could not include every
-attachment is published as `monize-backup-partial-<date>` in its own retention
-tier, and the name is chosen *after* the export from what the export found --
-`writeFileAtomic` replaces a final name by design, so a partial artifact written
-under the ordinary `daily-` name had already destroyed that day's complete copy
-by the time `applyBackupOutcome` recorded `partial` in the settings row, and
-every later retention pass then counted it as a complete daily. State beside the
-file (a status column, a variable, a later check) cannot govern a decision the
-write has already made. The durable copy of the same fact goes *inside* the
-document (`completeness` in the envelope), because a filename does not survive a
-rename and a settings row does not survive the machine.
+**Nothing in the export path may hold a whole table, a whole artifact, or a whole attachment set.** Rows come through the cursor in `src/backup/export-cursor.ts`, the document is serialised a row at a time under the chunk budget in `export-json-stream.ts`, and an object store is opened one object at a time. A `manager.query` for an export table, a `JSON.stringify` over an array of rows, or an array of base64 built before serialising are each the same defect (issue #1070). The guards in `src/backup/export-streaming.spec.ts` assert the ordering (batched fetches, loads interleaved with writes, reads that stop when the client does) rather than the memory.
 
-**Nothing in the export path may hold a whole table, a whole artifact, or a whole
-attachment set.** Rows come through the cursor in `src/backup/export-cursor.ts`,
-the document is serialised a row at a time under the chunk budget in
-`export-json-stream.ts`, and an object store is opened one object at a time and
-the bytes dropped once written. A `manager.query` for an export table, a
-`JSON.stringify` over an array of rows, or an array of base64 built before
-serialising are each the same defect (issue #1070), and each looks reasonable in
-isolation -- which is how it survived five audits. The guards are in
-`src/backup/export-streaming.spec.ts`: they assert the ordering (batched fetches,
-loads interleaved with writes, reads that stop when the client does) rather than
-the memory, because peak RSS needs a cgroup harness this repository does not have.
+**`verifyAuthentication` is the one refusal deliberately not first.** An OIDC restore is authorized by a single-use `OidcReauthService` artifact, and the round trip that mints one loses the user's file selection -- so the restore validates everything free (decrypt, decompress, envelope) *before* spending it. It still precedes every write. Do not reorder it forward, and do not reorder it backward past a `DELETE FROM`; section 5 of the contract has the reasoning, and `backup.service.spec.ts` pins both edges.
 
-And one thing about `verifyAuthentication` that is easy to undo by accident. An
-OIDC restore is authorized by a single-use `OidcReauthService` artifact, and the
-round trip that mints one loses the user's file selection -- so the restore
-validates everything free (decrypt, decompress, envelope) *before* spending it,
-and a wrong backup password costs no identity-provider round trip. That makes it
-the one refusal in the path that is deliberately not first; it still precedes
-every write. Do not reorder it forward to match section 3's list, and do not
-reorder it backward past a `DELETE FROM`. Section 5 of the contract has the
-reasoning, and `backup.service.spec.ts` pins both edges.
-
-**A value encrypted with server configuration cannot travel in a document.**
-`ai_provider_configs.api_key_enc` is ciphertext under `AI_ENCRYPTION_KEY`, and
-that variable is not in the backup and must not be -- shipping the master key
-beside the ciphertext would make encrypting the column pointless. Exported
-verbatim it restored onto any other instance *populated and unreadable*, which is
-the worst shape a failure can have: the column is non-null, so every "is a key
-configured?" check said yes, the row drew a masked key, and the only symptom was
-that AI calls failed. So the key is decrypted on the way out and re-encrypted on
-the way in (`ai-provider-key-transport.ts`), and both directions live in one file
-because the field name and the fallbacks are one contract -- an export writing a
-field the restore does not read loses the secret silently. The cost is that the
-artifact holds the credential in plaintext, which is stated in
-`docs/backup-restore-contract.md` §1, logged by the export, and the reason the
-support backup drops the table outright. Anything else stored under server-side
-configuration and put in a user-facing document has the same problem; solve it
-the same way, or exclude it.
+**A value encrypted with server configuration cannot travel in a document.** `ai_provider_configs.api_key_enc` is ciphertext under `AI_ENCRYPTION_KEY`, which is not in the backup and must not be. Exported verbatim it restored onto any other instance *populated and unreadable* -- every "is a key configured?" check said yes and only the AI calls failed. The key is decrypted on the way out and re-encrypted on the way in (`ai-provider-key-transport.ts`), both directions in one file because the field name and fallbacks are one contract. The cost -- the artifact holds the credential in plaintext -- is stated in `docs/backup-restore-contract.md` §1, logged by the export, and why the support backup drops the table. Anything else stored under server-side configuration gets the same treatment, or is excluded.
 
 ### `BackupService` is a facade; put new code in the component that owns it
 
-Issue #1092 split the 2,600-line original into `BackupExportService`,
-`BackupRestoreService`, `BackupAttachmentTransferService` and
-`BackupRestoreDatabaseService`, with the file format in `backup-format.ts` and
-the table list in `export-table-queries.ts`. Section 0 of the contract says which
-owns what. `BackupService` itself is one delegation per method and holds no
-`DataSource` and no storage provider -- a query there is how the original grew,
-and `src/backup/module-shape.spec.ts` fails on the dependency as well as on the
-line count. That spec's grandfather list may only shrink.
+Issue #1092 split the 2,600-line original into `BackupExportService`, `BackupRestoreService`, `BackupAttachmentTransferService` and `BackupRestoreDatabaseService`, with the file format in `backup-format.ts` and the table list in `export-table-queries.ts`. Section 0 of the contract says which owns what. `BackupService` is one delegation per method and holds no `DataSource` and no storage provider; `src/backup/module-shape.spec.ts` fails on the dependency as well as the line count, and its grandfather list may only shrink.
 
-**A source-scanning guard names a file, so a split disarms it silently.** Four of
-them pointed at `backup.service.ts` -- the two attachment readers, the trigger-DDL
-ban, the export's bytea encoding and `currency-references.spec.ts`'s "one
-predicate" check -- and every one would have gone on passing while scanning code
-that had moved out from under it. A scan whose subject is "wherever this appears"
-walks the directory (`backupModuleSources()` in `backup.service.spec.ts` is the
-pattern); one that must name a file throws when its marker is missing rather than
-returning an empty match set. Grep `readFileSync(` under the module you are
-splitting before you split it.
+**A source-scanning guard names a file, so a split disarms it silently.** Four guards pointed at `backup.service.ts` and would have gone on passing while scanning code that had moved out from under them. A scan whose subject is "wherever this appears" walks the directory (`backupModuleSources()` in `backup.service.spec.ts` is the pattern); one that must name a file throws when its marker is missing rather than returning an empty match set. Grep `readFileSync(` under the module you are splitting before you split it.
 
 ## Testing Conventions
 
@@ -797,162 +286,65 @@ Mock repositories use `Record<string, jest.Mock>`; tests use `Test.createTesting
 
 ### A mock must return what the real collaborator returns
 
-`Record<string, jest.Mock>` is fine for a repository, whose surface the driver defines. For **one of our own services**, type the double -- `jest.Mocked<TheService>`, or a `Partial<jest.Mocked<T>>` cast once -- so `tsc` rejects a return shape the real method cannot produce.
+`Record<string, jest.Mock>` is fine for a repository, whose surface the driver defines. For **one of our own services**, type the double -- `jest.Mocked<TheService>`, or a `Partial<jest.Mocked<T>>` cast once -- so `tsc` rejects a return shape the real method cannot produce. Untyped, a mock quietly becomes fiction, and the branch that reads that fiction is green and unreachable:
 
-Untyped, a mock quietly becomes fiction, and the branch that reads that fiction is green and unreachable. Two ways it happens:
-
-- **A shape the driver never returns.** A TypeORM insert result mocked as `{ generatedMaps: [] }` made an entire lost-the-race path testable, tested and dead: the real driver signals a conflict elsewhere, so the branch never ran in production and its tests never ran anything else.
-- **A signature that moved.** A service method growing from `Promise<boolean>` to `Promise<string | null>` leaves `mockResolvedValue(true)` behind it -- still truthy, still passing, still describing a contract nothing has any more. When you change a method's return type, grep its mocks in the same commit.
+- **A shape the driver never returns.** A TypeORM insert result mocked as `{ generatedMaps: [] }` made an entire lost-the-race path testable, tested and dead.
+- **A signature that moved.** A method growing from `Promise<boolean>` to `Promise<string | null>` leaves `mockResolvedValue(true)` behind it -- still truthy, still passing. When you change a return type, grep its mocks in the same commit.
 
 ### Fixtures are claims about production data
 
-`docs/testing-contract.md` is the shared list of adversarial inputs to choose from. A fixture is evidence only if the code that writes the real data could have written it. Before adding one, look at the producer: the query's sampling, whether the column is nullable, whether the format guarantees what the fixture assumes. A price series three points a quarter apart proves nothing about code reading daily closes, and weightings that always sum to 1 never exercise the remainder the storage format allows. `docs/financial-calculation-contract.md` section 8.3 has the full rule.
+`docs/testing-contract.md` is the shared list of adversarial inputs to choose from. A fixture is evidence only if the code that writes the real data could have written it -- check the producer's sampling, nullability, and format guarantees before adding one. `docs/financial-calculation-contract.md` section 8.3 has the full rule.
 
 ### Do not trust a suite that stayed green
 
-Changing what a service computes and seeing every test pass means the change is a no-op or the suite has a hole -- see `docs/financial-calculation-contract.md` sections 8.1 and 8.2. Establish which before moving on, and break each new invariant on purpose once to confirm its test actually fails.
+Changing what a service computes and seeing every test pass means the change is a no-op or the suite has a hole -- `docs/financial-calculation-contract.md` sections 8.1 and 8.2. Establish which before moving on, and break each new invariant on purpose once to confirm its test actually fails.
 
 ## Internationalization (i18n)
 
-Server-rendered strings (exception messages, email copy) are localized via `nestjs-i18n`. Wrap exception messages in `tr(key, fallback, args)` (`src/i18n/translate.ts`), which resolves against the request locale and returns the English `fallback` outside an HTTP context (jobs, schedulers, tests). Render emails with an `EmailT` translator (`emailTranslator(i18n, recipientLang)` from `src/i18n/email-translator.ts`) so copy matches the recipient's stored locale rather than the request's. Catalogs live in `src/i18n/locales/{locale}/*.json`, one folder per supported locale; the authoritative locale list is `SUPPORTED_LOCALE_CODES` in `src/i18n/config.ts` (root `CLAUDE.md` enumerates them) -- keep it in sync with the frontend's. The `en-*` entries are lean regional variants (declared in `LOCALE_BASES`): they hold only the keys that differ from `en` and fall back to it per key. Adding or changing a string means updating every locale -- the parity test `src/i18n/locales.parity.spec.ts` fails otherwise -- then regenerating the pseudo-locale with `npm run i18n:pseudo`. Full contributor flow: `src/i18n/README.md`.
+Server-rendered strings (exception messages, email copy) are localized via `nestjs-i18n`. Wrap exception messages in `tr(key, fallback, args)` (`src/i18n/translate.ts`), which resolves against the request locale and returns the English `fallback` outside an HTTP context. Render emails with `emailTranslator(i18n, recipientLang)` (`src/i18n/email-translator.ts`) so copy matches the recipient's stored locale. Catalogs live in `src/i18n/locales/{locale}/*.json`; the authoritative locale list is `SUPPORTED_LOCALE_CODES` in `src/i18n/config.ts` (root `CLAUDE.md` enumerates them) -- keep in sync with the frontend's. The `en-*` entries are lean regional variants (`LOCALE_BASES`), falling back to `en` per key. Adding or changing a string means updating every locale (`src/i18n/locales.parity.spec.ts` fails otherwise), then `npm run i18n:pseudo`. Full flow: `src/i18n/README.md`.
 
 ## Every line in the log has the same shape
 
-`[Nest] pid - date LEVEL [Context] message`, produced by the NestJS `Logger`.
-That includes the lines written before the app exists: `Logger` works outside an
-application context, so `db-init`, `db-migrate`, `db-demo-check` and the seeders
-each construct `new Logger("<Context>")` rather than calling `console`. Backend
-`src/` bans `console` outright (`no-console`, `eslint.config.mjs`); the only
-exception is `oauth/oidc-provider-log-bridge.ts`, which has to hold the real
-console methods in order to forward everything that is not a provider notice.
-
-`docker-entrypoint.sh` prints nothing itself. A shell `echo` is the one line in
-the container log with no timestamp, level or context, and an inline `node -e`
-blob cannot reach the `Logger` without restating its format -- so each step logs
-for itself and the entrypoint just runs the steps.
-`src/startup-logging.spec.ts` scans for both mistakes and for a `console` call in
-any pre-boot script.
+`[Nest] pid - date LEVEL [Context] message`, produced by the NestJS `Logger` -- including the lines written before the app exists: `db-init`, `db-migrate`, `db-demo-check` and the seeders each construct `new Logger("<Context>")`. Backend `src/` bans `console` outright (`no-console` in `eslint.config.mjs`); the only exception is `oauth/oidc-provider-log-bridge.ts`, which must hold the real console methods to forward non-provider output. `docker-entrypoint.sh` prints nothing itself -- each step logs for itself. `src/startup-logging.spec.ts` scans for both mistakes and for `console` in any pre-boot script.
 
 ## OAuth / OIDC provider
 
-**A page whose form submission must redirect off-origin needs its own CSP.**
-Helmet's app-wide policy merges in the default `form-action 'self'`, and Chrome
-enforces `form-action` against every redirect hop that follows a form submit --
-so the OAuth consent page's Allow/Deny POST (303 to `/oauth/auth` resume, 303 to
-the client's `redirect_uri` with the code) is silently cancelled on the final,
-cross-origin hop. The server logs `authorization.success`, the browser stays
-parked on the consent form, and the MCP client never receives its code. The
-interaction controller therefore sets a per-page policy with
-`form-action 'self' https:` (`setInteractionPageHeaders`); the redirect_uri is
-per-client and dynamic, so it cannot be enumerated. Do not "fix" this by
-loosening the global Helmet `form-action` -- only this page needs it.
+**A page whose form submission must redirect off-origin needs its own CSP.** Helmet's app-wide `form-action 'self'` is enforced by Chrome against every redirect hop after a form submit, so the OAuth consent POST's final cross-origin hop to the client's `redirect_uri` was silently cancelled -- server logs `authorization.success`, browser parked on the consent form. The interaction controller sets a per-page `form-action 'self' https:` (`setInteractionPageHeaders`); the redirect_uri is per-client and dynamic, so it cannot be enumerated. Do not loosen the global Helmet `form-action` -- only this page needs it.
 
-`node-oidc-provider` prints its own `oidc-provider NOTICE:`/`WARNING:` lines with bare `console.info`/`console.warn`, outside the Nest `Logger`. The library exposes no logger hook, so `oauth/oidc-provider-log-bridge.ts` -- installed at the top of `main.ts`, before anything can instantiate the provider -- re-routes exactly those lines to a `[OidcProvider]` logger and passes any other console output through untouched. That fixes the formatting only: every such notice still means a config option was left at its default, so fix the config rather than treating the bridge as the answer. In particular, `ttl` needs an explicit number for every artifact the provider can issue (`AccessToken`, `AuthorizationCode`, `IdToken`, `RefreshToken`, `Grant`, `Interaction`, `Session`); the guard test in `src/oauth/oauth-provider.service.spec.ts` fails when one is missing.
+`node-oidc-provider` prints `oidc-provider NOTICE:`/`WARNING:` lines with bare `console.info`/`console.warn` and exposes no logger hook, so `oauth/oidc-provider-log-bridge.ts` -- installed at the top of `main.ts` -- re-routes exactly those lines to a `[OidcProvider]` logger. That fixes only the formatting: every such notice means a config option was left at its default, so fix the config. In particular, `ttl` needs an explicit number for every artifact the provider can issue (`AccessToken`, `AuthorizationCode`, `IdToken`, `RefreshToken`, `Grant`, `Interaction`, `Session`); the guard in `src/oauth/oauth-provider.service.spec.ts` fails when one is missing.
 
 ## Money investment mapping is finalized after both mappers run
 
-`mapInvestments` cannot know whether `mapTransactions` will preserve or
-collapse a cash split. Reconcile generated investment companions only after
-cash-source mapping: when a redemption remains embedded, its preserved sibling
-is the interest record, so the generated companion and mutual link must not be
-written as a second representation of that income.
+`mapInvestments` cannot know whether `mapTransactions` will preserve or collapse a cash split. Reconcile generated investment companions only after cash-source mapping: when a redemption remains embedded, its preserved sibling is the interest record, so the generated companion and mutual link must not be written as a second representation of that income.
 
 ## Automatic backups are an operator setting, not a user preference
 
-The auto-backup endpoints live on `AutoBackupController`, whose class-level
-`@Roles("admin")` is the whole access rule -- put a new endpoint there and it is
-admin-only without anyone remembering to say so. Manual export/restore, which
-touches only the caller's own data, stays on `BackupController` for everyone.
+Auto-backup endpoints live on `AutoBackupController`, whose class-level `@Roles("admin")` is the whole access rule -- a new endpoint there is admin-only automatically. Manual export/restore (caller's own data) stays on `BackupController` for everyone.
 
-Every other user is enrolled on the deployment defaults by
-`AutoBackupService.enrollManagedUsers`, which runs at the top of the hourly
-cron: nobody but an admin can switch the feature on, so without it a non-admin
-would silently have no backups. It reconciles rather than seeds -- a row that
-has drifted is written back to the defaults, an unchanged one is not written at
-all, and `lastBackup*`/`nextBackupAt` are left alone so enrollment never
-re-triggers a backup.
+`AutoBackupService.enrollManagedUsers` runs at the top of the hourly cron and enrolls every other user on the deployment defaults -- without it a non-admin would silently have no backups. It reconciles rather than seeds: drifted rows are written back to the defaults, unchanged ones are not written, and `lastBackup*`/`nextBackupAt` are left alone so enrollment never re-triggers a backup.
 
-Backups are encrypted with the user's own password. For a local-auth account
-the server only ever holds that in plaintext at the moment they type it, so
-`rememberLoginPassword` captures it from registration, login and
-change-password and nothing asks them to configure anything. An OIDC account
-has no password of ours, so those users set a dedicated one in Settings
-(`setBackupPasswordForOidcUser`) or go unencrypted; `getStatus().manageable` is
-what the UI gates that section on, and both management methods refuse a
-local-auth caller rather than accepting a change the next login would undo.
-
-A stored copy is checked against the account's current password hash before it
-is used (`resolveBackupPassword`) -- encrypting with a password the user has
-since changed produces a file that looks like a backup and cannot be opened.
-That resolution has three outcomes, not two: nothing stored (write plaintext), a
-usable password (encrypt), and stored-but-undecryptable (refuse, because the
-previous backups are encrypted and silently downgrading is worse than failing).
+Backups are encrypted with the user's own password. Local-auth accounts have it captured at the moment they type it (`rememberLoginPassword` from registration, login and change-password). OIDC accounts set a dedicated one in Settings (`setBackupPasswordForOidcUser`) or go unencrypted; `getStatus().manageable` gates that UI section, and both management methods refuse a local-auth caller. A stored copy is checked against the account's current password hash before use (`resolveBackupPassword`) -- three outcomes, not two: nothing stored (write plaintext), usable password (encrypt), stored-but-undecryptable (refuse -- silently downgrading previous encrypted backups is worse than failing).
 
 ## Cron Jobs
 
-Cron jobs use `@Cron()` from `@nestjs/schedule` and run **in the API process** -- `ScheduleModule.forRoot()` is registered in `app.module.ts`; there is no separate scheduler process (on k8s with more than one backend replica, every replica fires every cron). For the full schedule, see `docs/cron-jobs.md` or grep `@Cron(`.
+Cron jobs use `@Cron()` from `@nestjs/schedule` and run **in the API process** (`ScheduleModule.forRoot()` in `app.module.ts`; on k8s with multiple replicas, every replica fires every cron). Full schedule: `docs/cron-jobs.md`, or grep `@Cron(`.
 
-Every `@Cron` handler is an out-of-request entry point, so its body must seed its own RLS context (tasks C2-C4): the cross-user fan-out under `withSystemContext`, each per-user body under `withUserContext(userId)`. A handler that reaches the DB with no ambient context throws `DB access outside request/user/system context` in every `RLS_MODE`, including `off` -- the per-module `rls-context-smoke.spec.ts` specs are the pattern for proving a cron runs clean.
+Every `@Cron` handler is an out-of-request entry point, so its body must seed its own RLS context (tasks C2-C4): the cross-user fan-out under `withSystemContext`, each per-user body under `withUserContext(userId)`. A handler that reaches the DB with no ambient context throws in every `RLS_MODE`, including `off` -- the per-module `rls-context-smoke.spec.ts` specs are the pattern for proving a cron runs clean.
 
 ### Cleanup somebody is blocked on belongs on the request path
 
-Before choosing an interval, ask what the stale row *does* while it sits there.
-If it is only untidy, a schedule is the whole answer. If it **refuses the user's
-next request** -- a slot, a lock, a uniqueness guard -- then the interval is a
-lockout the user cannot end, and picking a smaller number only makes the outage
-shorter. Run the cleanup inside the transaction of the request that is about to
-be refused by it, scoped to that caller, and leave the cron as a cross-user
-backstop for whoever never comes back. `MnyImportJobService` is the worked
-example: `reapStaleJobsForUser` runs in `create` and in the poll's `findOne`, so
-a dead import clears itself within one 1.5s poll instead of within ten minutes,
-and `reapStaleJobs` dropped from every five minutes to hourly.
+Before choosing an interval, ask what the stale row *does* while it sits there. Only untidy: a schedule is the whole answer. But if it **refuses the user's next request** (a slot, a lock, a uniqueness guard), the interval is a lockout the user cannot end. Run the cleanup inside the transaction of the request about to be refused, scoped to that caller, and leave the cron as a cross-user backstop. `MnyImportJobService` is the worked example: `reapStaleJobsForUser` runs in `create` and the poll's `findOne`, so a dead import clears within one 1.5s poll, and `reapStaleJobs` dropped to hourly.
 
-Two things that path has to get right, both of which have a test rather than a
-paragraph. The staleness predicate is **one exported constant** used by the reap
-and negated by the advisory pre-check -- an advisory check that still counts what
-the reap would clear throws the refusal before the request ever reaches the
-transaction that would have cleared it, which reinstates the lockout through the
-back door and looks correct at every individual site. And a per-user cleanup
-whose predicate is a disjunction needs its own parentheses inside the
-`user_id = $n AND (...)`, or the trailing arm escapes the tenant restriction
-entirely; assert the composed clause, not an `"AND ("` prefix, since a condition
-that opens with its own paren satisfies that prefix while ungrouped.
+Two things that path must get right, both tested: the staleness predicate is **one exported constant** used by the reap and negated by the advisory pre-check (an advisory check that still counts what the reap would clear reinstates the lockout through the back door); and a per-user cleanup whose predicate is a disjunction needs its own parentheses inside `user_id = $n AND (...)` -- assert the composed clause, not an `"AND ("` prefix.
 
 ### Deciding a worker is dead does not stop it -- revoke, do not merely record
 
-A reaper reads a heartbeat and concludes a worker is gone. That conclusion can be
-wrong in the one direction that costs money: the heartbeat runs on its own
-connection while the work runs on another, so a worker that is merely *blocked*
-gets written off, wakes up, and finishes. Marking its row `failed` changed
-nothing about what it was about to write -- and because the reap also advertised
-a retry, the file lands twice.
+A reaper's conclusion can be wrong in the direction that costs money: a merely *blocked* worker gets written off, wakes up, and finishes -- and if the reap also advertised a retry, the file lands twice. So an attempt gets an identity, not just a status: `import_jobs.attempt_token` is minted by `claim()`, required by every write that worker makes, and set to NULL by both reaps. The worker's commit checkpoint (`markDataCommitted`) is a fenced compare-and-set on that token and the **last statement of the transaction that wrote the rows**, so a zero-row result throws and rolls all of them back -- one statement later would be a check after the commit (see "Rejection happens before the write").
 
-So an attempt gets an identity, not just a status. `import_jobs.attempt_token` is
-minted by `claim()`, required by every write that worker makes, and set to NULL by
-both reaps. The worker's own commit checkpoint (`markDataCommitted`) is a fenced
-compare-and-set on that token and is the **last statement of the transaction that
-wrote the rows**, so a zero-row result throws and rolls all of them back. Position
-is load-bearing: the same check one statement later is a check after the commit,
-which is the rule in "Rejection happens before the write".
+Three parts, each a separate way to get it wrong:
 
-Three parts, and each is a separate way to get it wrong:
+- **A status check is not a fence.** `WHERE status = 'running'` passes for a job reaped and re-claimed by a different attempt. Compare the token.
+- **A fence the other binary does not know about is not a fence.** During a rolling deployment the previous release's checkpoint names no token, so the rule lives in the database: migration 145's `BEFORE UPDATE` trigger refuses a false -> true `data_committed` on a non-`running` job, from either binary. Deliberately not "and has a token": an old worker's normal state is `running` with a NULL token.
+- **Terminal states are monotonic.** `complete()` and `fail()` are compare-and-set on `(status, attempt_token)` and return whether they took; the caller must read that boolean (logging "completed" after a refusal contradicts the reaper's line, with the false one more visible).
 
-- **A status check is not a fence.** `WHERE status = 'running'` still passes for a
-  job that was reaped and re-claimed by a *different* attempt. Compare the token.
-- **A fence the other binary does not know about is not a fence.** During a
-  rolling deployment the previous release is still running, and its checkpoint
-  names no token because its code predates the column. That rule has to live in
-  the database -- migration 145's `BEFORE UPDATE` trigger refuses a false -> true
-  `data_committed` on a non-`running` job, which is exactly the reaped case, from
-  either binary. Deliberately not "and has a token": an old worker's normal state
-  is `running` with a NULL token, and refusing that would break every import in
-  flight during the rollout.
-- **Terminal states are monotonic.** `complete()` and `fail()` are compare-and-set
-  on `(status, attempt_token)` and return whether they took, so a woken worker
-  cannot overwrite the terminal state the reaper already wrote. The caller must
-  read that boolean: logging "completed" after a refusal puts the operator's only
-  two lines about the job in contradiction, with the false one the more visible.
-
-The integration suite installs the trigger via `findTriggerMigrations()` in
-`test/helpers/rls-setup.ts` -- `synchronize` creates no triggers, so without that
-step a mixed-version test reports the fence as working while nothing enforces it.
+The integration suite installs the trigger via `findTriggerMigrations()` in `test/helpers/rls-setup.ts` -- `synchronize` creates no triggers, so without that step a mixed-version test reports the fence as working while nothing enforces it.

--- a/backend/src/mcp/CLAUDE.md
+++ b/backend/src/mcp/CLAUDE.md
@@ -1,31 +1,13 @@
 # MCP Server
 
-Monize exposes its financial data over the **Model Context Protocol** so MCP
-clients (Claude Desktop's "Add Connector", IDE agents, etc.) can query and act
-on a user's finances. This directory is the whole server: transport, the
-per-session `McpServer` factory, and the tool/resource/prompt definitions.
-
-Built on `@modelcontextprotocol/sdk` (`McpServer` + `StreamableHTTPServerTransport`).
+Monize exposes its financial data over the **Model Context Protocol** so MCP clients (Claude Desktop's "Add Connector", IDE agents, etc.) can query and act on a user's finances. This directory is the whole server: transport, the per-session `McpServer` factory, and the tool/resource/prompt definitions. Built on `@modelcontextprotocol/sdk` (`McpServer` + `StreamableHTTPServerTransport`).
 
 ## Architecture
 
-- **Transport** (`mcp-http.controller.ts`): Streamable HTTP at `POST/GET/DELETE /mcp`.
-  Manages one transport + one `McpServer` per session, keyed by the
-  `Mcp-Session-Id` header. Sessions have a 1h TTL, a per-user cap, and periodic
-  cleanup. `@SkipCsrf()` + bearer auth only (no cookies).
-- **Auth** (`validatePat`): `Authorization: Bearer <token>`. `pat_*` tokens go
-  through `PatService`; everything else is treated as an OAuth 2.1 access token
-  (`OAuthProviderService`). A 401 returns `WWW-Authenticate` with
-  `resource_metadata` (RFC 9728) pointing at `/.well-known/oauth-protected-resource`.
-- **Server factory** (`mcp-server.service.ts`): `createServer(resolve)` builds a
-  fresh `McpServer`, sets `instructions` + capabilities (logging, tools,
-  resources, prompts), and registers every tool/resource/prompt. The server
-  `version` is read from `backend/package.json` so it tracks the released image
-  automatically -- never hardcode it.
-- **Per-request user context** (`mcp-context.ts`): the controller passes a
-  `resolve(sessionId)` that returns `{ userId, scopes }`. Handlers call
-  `resolve(extra.sessionId)` to get the caller; `userId` always comes from the
-  session, never from tool arguments.
+- **Transport** (`mcp-http.controller.ts`): Streamable HTTP at `POST/GET/DELETE /mcp`. One transport + one `McpServer` per session, keyed by the `Mcp-Session-Id` header; 1h TTL, per-user cap, periodic cleanup. `@SkipCsrf()` + bearer auth only (no cookies).
+- **Auth** (`validatePat`): `Authorization: Bearer <token>`. `pat_*` tokens go through `PatService`; everything else is treated as an OAuth 2.1 access token (`OAuthProviderService`). A 401 returns `WWW-Authenticate` with `resource_metadata` (RFC 9728) pointing at `/.well-known/oauth-protected-resource`.
+- **Server factory** (`mcp-server.service.ts`): `createServer(resolve)` builds a fresh `McpServer`, sets `instructions` + capabilities, and registers every tool/resource/prompt. The server `version` is read from `backend/package.json` -- never hardcode it.
+- **Per-request user context** (`mcp-context.ts`): handlers call `resolve(extra.sessionId)` to get `{ userId, scopes }`; `userId` always comes from the session, never from tool arguments.
 
 ## Directory layout
 
@@ -43,15 +25,11 @@ mcp/
   mcp.module.ts              # NestJS providers/imports
 ```
 
-Each tool/resource/prompt is an `@Injectable()` class with a `register(server, resolve)`
-method, listed in both `mcp.module.ts` (providers) and `mcp-server.service.ts`
-(wired into `createServer`).
+Each tool/resource/prompt is an `@Injectable()` class with a `register(server, resolve)` method, listed in both `mcp.module.ts` (providers) and `mcp-server.service.ts` (wired into `createServer`).
 
 ## Adding a tool (required format)
 
-Every tool MUST declare **`title`**, **`description`**, **`inputSchema`**,
-**`outputSchema`**, and **`annotations`**. The handler MUST resolve context,
-check scope, run inside try/catch, and return via `toolResult` / `safeToolError`.
+Every tool MUST declare **`title`**, **`description`**, **`inputSchema`**, **`outputSchema`**, and **`annotations`**. The handler MUST resolve context, check scope, run inside try/catch, and return via `toolResult` / `safeToolError`.
 
 ```typescript
 server.registerTool(
@@ -82,108 +60,41 @@ server.registerTool(
 
 Checklist for a new tool:
 
-1. Put the data logic on the **domain service** (e.g. `getLlm*`), not in the
-   tool. The tool is a thin adapter. Per the repo rule, the same logic is shared
-   with the AI Assistant tool executor and both must return the same shape -- wire
-   both surfaces in the same PR.
+1. Put the data logic on the **domain service** (e.g. `getLlm*`), not in the tool. Per the repo rule, the same logic is shared with the AI Assistant tool executor and both must return the same shape -- wire both surfaces in the same PR.
 2. Add the tool to its domain `tools/*.tool.ts` with the five config fields above.
-3. Add its output schema to `tool-output-schemas.ts` (see conventions below) and
-   import it.
-4. Pick the right annotation preset (below) and import it.
-5. If it mutates data, derive scope `"write"` and enforce the daily write limit
-   via `McpWriteLimiter` (see `transactions.tool.ts`). `whitelist`-style
-   sanitize user strings with `stripHtml(...)` before persisting. Gate the write
-   behind a user confirmation with `confirmWrite(server, message, extra.requestId)`
-   (the MCP-elicitation equivalent of the AI Assistant's approve/reject card --
-   pass `extra.requestId` so the elicitation is delivered on the tool call's own
-   Streamable HTTP SSE stream rather than the standalone GET stream) and
-   only persist on `"accepted"`/`"unsupported"`; on `"declined"` return a
-   `toolError` without writing. `"unsupported"` means the client can't show a
-   dialog -- it still gates every tool call with its own approval prompt, so
-   proceeding is not a consent bypass.
-   - **Relay first.** When the call is serving a prompt the user typed in the
-     Monize web chat (reverse relay), confirm there instead of in the agent's
-     MCP client: build the signed `PendingAiAction` with `AiActionBuilderService`
-     (shared with the AI Assistant tool executor) and call
-     `AiRelayService.emitPendingAction(userId, action)`. If it returns `true`,
-     the approve/reject card is shown in the browser and committed via
-     `/ai/actions/confirm` on approval -- return `RELAY_PREVIEW_SHOWN` and do
-     NOT write or `confirmWrite`. If it returns `false` (no relay turn for this
-     session), fall through to `confirmWrite` as above.
+3. Add its output schema to `tool-output-schemas.ts` (conventions below) and import it.
+4. Pick the right annotation preset (below).
+5. If it mutates data, derive scope `"write"`, enforce the daily write limit via `McpWriteLimiter` (see `transactions.tool.ts`), and sanitize user strings with `stripHtml(...)` before persisting. Gate the write behind a user confirmation with `confirmWrite(server, message, extra.requestId)` (pass `extra.requestId` so the elicitation is delivered on the tool call's own SSE stream, not the standalone GET stream); persist only on `"accepted"`/`"unsupported"`, return a `toolError` without writing on `"declined"`. `"unsupported"` means the client can't show a dialog -- it still gates every tool call with its own approval prompt, so proceeding is not a consent bypass.
+   - **Relay first.** When the call is serving a prompt the user typed in the Monize web chat (reverse relay), confirm there instead: build the signed `PendingAiAction` with `AiActionBuilderService` (shared with the AI Assistant tool executor) and emit it. If the card is shown in the browser (committed via `/ai/actions/confirm` on approval), return `RELAY_PREVIEW_SHOWN` and do NOT write or `confirmWrite`; otherwise fall through to `confirmWrite`.
+6. Update `mcp-server.service.ts` count and `mcp.module.ts` if it's a new provider class.
+7. Add/extend tests (below). `mcp-annotations.spec.ts` enforces that every tool has title + input/output schema + annotations with the right read/write hints -- bump `EXPECTED_TOOL_COUNT` and `WRITE_TOOLS`/`IDEMPOTENT_WRITES`.
 
 ## A relay turn belongs to one MCP session, for a bounded time
 
-The same user can have two MCP sessions at once -- the agent running the
-web-chat relay loop, and a direct client (Claude Desktop) they are typing at.
-Only one of them is serving a browser prompt, so **"does this write belong to
-the web chat" is a question about the calling session, not about the user**.
+The same user can have two MCP sessions at once -- the agent running the web-chat relay loop, and a direct client (Claude Desktop) they are typing at. Only one is serving a browser prompt, so **"does this write belong to the web chat" is a question about the calling session, not about the user**.
 
-- Emit a card with `emitRelayCard(this.relayService, userId, action)`
-  (`mcp-relay-confirm.ts`), never `relayService.emitPendingAction` directly:
-  the helper supplies the ambient MCP session id that the decision depends on.
-  `mcp-relay-confirm.spec.ts` scans the tool sources and fails on a direct call.
-- A relay turn is a prompt **claimed by this session** (`waitForPrompt` records
-  `claimedBy`), or one of its claims that timed out within the late-answer
-  retention window. It is not connection liveness, not user-wide, and not
-  unbounded in time. Each of those three was tried and each routed a direct
-  client's confirmation into a web chat nobody was watching -- the worst
-  version being user-wide + unbounded, where a single abandoned web-chat turn
-  captured every direct write the user made afterwards, permanently.
-- Liveness is session-scoped for the same reason: a direct client's tool calls
-  are not evidence that some other session's agent is still working, and
-  treating them as such kept dead relay prompts alive indefinitely.
-6. Update `mcp-server.service.ts` count and `mcp.module.ts` if it's a new
-   provider class.
-7. Add/extend tests (below). `mcp-annotations.spec.ts` enforces that every tool
-   has title + input/output schema + annotations and the right read/write hints,
-   so bump `EXPECTED_TOOL_COUNT` and `WRITE_TOOLS`/`IDEMPOTENT_WRITES` there.
+- Emit a card with `emitRelayCard(this.relayService, userId, action)` (`mcp-relay-confirm.ts`), never `relayService.emitPendingAction` directly: the helper supplies the ambient MCP session id the decision depends on. `mcp-relay-confirm.spec.ts` scans the tool sources and fails on a direct call.
+- A relay turn is a prompt **claimed by this session** (`waitForPrompt` records `claimedBy`), or one of its claims that timed out within the late-answer retention window. It is not connection liveness, not user-wide, and not unbounded in time -- each of those was tried, and each routed a direct client's confirmation into a web chat nobody was watching (the worst version captured every direct write the user made afterwards, permanently).
+- Liveness is session-scoped for the same reason: a direct client's tool calls are not evidence that another session's agent is still working.
 
 ## `toolResult` and structured content
 
-`toolResult(data)` (in `mcp-context.ts`) is the only success path. It:
+`toolResult(data)` (in `mcp-context.ts`) is the only success path. It sanitizes every string in the payload (`sanitizeToolResultStrings`), emits a text `content` block with the pretty-printed JSON (the raw data shape, which the AI Assistant relies on -- do not change it), and emits `structuredContent`: objects pass through; **bare arrays are wrapped under `items`**; primitives under `value`.
 
-- sanitizes every string in the payload (`sanitizeToolResultStrings`),
-- emits a text `content` block with the pretty-printed JSON (the raw data shape,
-  which the AI Assistant relies on -- do not change it), and
-- emits `structuredContent`: objects pass through; **bare arrays are wrapped
-  under `items`**; primitives under `value`.
-
-Because every tool declares `outputSchema`, the SDK **requires** `structuredContent`
-and validates it against the schema on each call (errors via `toolError`/`safeToolError`
-set `isError` and bypass validation). So a tool's output schema must accept what
-`toolResult` produces for that tool.
+Because every tool declares `outputSchema`, the SDK **requires** `structuredContent` and validates it on each call (errors via `toolError`/`safeToolError` set `isError` and bypass validation). So a tool's output schema must accept what `toolResult` produces for that tool.
 
 ## Output schema conventions (`tool-output-schemas.ts`)
 
-Each export is a **Zod raw shape** (same form as `inputSchema`), not a `z.object`.
-Schemas are deliberately **tolerant** so they document shape without rejecting
-real runtime data:
+Each export is a **Zod raw shape** (same form as `inputSchema`), not a `z.object`. Schemas are deliberately **tolerant** -- they document shape without rejecting real runtime data:
 
-- Build every object with the shared `looseObject(...)` helper, never bare
-  `z.object(...)`. Tools return entity payloads carrying fields beyond the
-  modeled subset (timestamps, foreign keys, relations). The SDK serializes each
-  schema to JSON Schema in **output mode** for `tools/list`, where a default
-  (strip) object becomes `additionalProperties: false` and the client rejects
-  the extra fields with an output-validation error. `looseObject` emits
-  `additionalProperties: {}`. (The server validates with Zod, which strips
-  unknown keys, so the strictness only bites on the client -- which is why it is
-  easy to miss.) Only model the fields you actually expose.
-- Money/decimals are numbers at runtime (entity `numericTransformer`). Use the
-  shared `num` (`z.number().nullable()`). A divide-by-zero percentage is `NaN`
-  at runtime, which `toolResult` normalizes to `null` (NaN's JSON form). Do
-  **not** use `z.nan()` in a schema: the SDK's JSON Schema serialization throws
-  "NaN cannot be represented in JSON Schema", which fails the entire
-  `tools/list` response and leaves every client showing zero tools.
-- Use `.nullable()` for documented-null fields and `.optional()` for fields that
-  may be absent (including alternate result branches, e.g. dry-run vs created,
-  or success vs not-found error payloads -- make all branch fields optional).
-- Array-returning tools must wrap under `items`: `{ items: z.array(itemSchema) }`,
-  matching `toolResult`'s array wrapping.
+- Build every object with the shared `looseObject(...)` helper, never bare `z.object(...)`. Tools return entity payloads carrying fields beyond the modeled subset, and the SDK serializes each schema to JSON Schema in output mode for `tools/list`, where a default (strip) object becomes `additionalProperties: false` and the *client* rejects the extra fields. `looseObject` emits `additionalProperties: {}`. Only model the fields you actually expose.
+- Money/decimals are numbers at runtime (entity `numericTransformer`). Use the shared `num` (`z.number().nullable()`). A divide-by-zero percentage is `NaN`, which `toolResult` normalizes to `null`. Do **not** use `z.nan()`: the SDK's JSON Schema serialization throws, failing the entire `tools/list` response and leaving every client showing zero tools.
+- Use `.nullable()` for documented-null fields and `.optional()` for fields that may be absent -- including alternate result branches (dry-run vs created, success vs not-found): make all branch fields optional.
+- Array-returning tools wrap under `items`: `{ items: z.array(itemSchema) }`, matching `toolResult`'s array wrapping.
 
 ## Annotation presets (`mcp-annotations.ts`)
 
-All tools operate on the user's own closed dataset, so `openWorldHint` is always
-`false`. Pick by effect:
+All tools operate on the user's own closed dataset, so `openWorldHint` is always `false`. Pick by effect:
 
 | Preset | Use for | Hints |
 |--------|---------|-------|
@@ -191,58 +102,34 @@ All tools operate on the user's own closed dataset, so `openWorldHint` is always
 | `CREATE` | adds a new record | `readOnlyHint:false, destructiveHint:false, idempotentHint:false` |
 | `UPDATE` | sets fields to given values | `readOnlyHint:false, destructiveHint:false, idempotentHint:true` |
 
-There is no destructive preset -- no tool deletes data. Add one only if a
-delete/overwrite tool is introduced.
+There is no destructive preset -- no tool deletes data. Add one only if a delete/overwrite tool is introduced.
 
 ## Scopes
 
-`requireScope(ctx.scopes, ...)` gates each handler. Scopes in use: `read`
-(queries, including report/anomaly tools) and `write` (mutations). Resources
-gate with `hasScope(ctx.scopes, "read")`. There is no separate `reports` scope:
-the OAuth layer only issues `monize:read`/`monize:write`, so reports are folded
-into `read` and OAuth clients (e.g. Claude Desktop) can run them.
+`requireScope(ctx.scopes, ...)` gates each handler. Scopes in use: `read` (queries, including report/anomaly tools) and `write` (mutations). Resources gate with `hasScope(ctx.scopes, "read")`. There is no separate `reports` scope: the OAuth layer only issues `monize:read`/`monize:write`, so reports are folded into `read`.
 
 ## Resources & prompts
 
-- **Resources** (`registerResource`): give a `title` + `description`, return
-  `contents[]` with `mimeType: "application/json"` and the JSON `text`. Same
-  context-resolve + `hasScope` check; on error return a `contents` entry with an
-  `Error: ...` text rather than throwing.
-- **Prompts** (`registerPrompt`): give a `title` + `description` + `argsSchema`
-  (Zod raw shape of optional args), and return `messages[]`. Prompts are
-  templates only -- no data access, no scope check.
+- **Resources** (`registerResource`): `title` + `description`, return `contents[]` with `mimeType: "application/json"` and the JSON `text`. Same context-resolve + `hasScope` check; on error return a `contents` entry with an `Error: ...` text rather than throwing.
+- **Prompts** (`registerPrompt`): `title` + `description` + `argsSchema` (Zod raw shape of optional args), return `messages[]`. Prompts are templates only -- no data access, no scope check.
 
 ## Security (do not regress)
 
 - `userId` is always from the session context, never from tool args.
-- Sanitize user-controlled strings written back: `stripHtml()` before persist,
-  and `toolResult` runs `sanitizeToolResultStrings` on all outgoing strings.
-- `safeToolError` passes through 4xx messages but returns a generic message for
-  5xx/unknown errors -- never leak internals.
+- Sanitize user-controlled strings written back: `stripHtml()` before persist; `toolResult` runs `sanitizeToolResultStrings` on all outgoing strings.
+- `safeToolError` passes through 4xx messages but returns a generic message for 5xx/unknown errors -- never leak internals.
 - Transport is bearer-only and `@SkipCsrf()`; do not add cookie auth here.
 
 ## Testing
 
-Tools/resources/prompts unit tests mock `registerTool`/`registerResource`/
-`registerPrompt` to capture the handler, then drive it with a mocked service and
-assert on `result.content[0].text` (parsed JSON) and `result.isError`. Plus:
+Tools/resources/prompts unit tests mock `registerTool`/`registerResource`/`registerPrompt` to capture the handler, then drive it with a mocked service and assert on `result.content[0].text` (parsed JSON) and `result.isError`. Plus:
 
-- `mcp-annotations.spec.ts` -- every tool has title + input/output schema +
-  annotations with correct read/write hints (update its constants when adding a tool).
-- `tool-output-schemas.spec.ts` -- each output schema accepts a representative
-  `toolResult` payload (incl. NaN, null, and alternate branches), and an
-  end-to-end round-trip through the real SDK via `InMemoryTransport`.
-- `mcp-server.service.spec.ts` -- registration counts and that the advertised
-  version tracks `package.json`.
+- `mcp-annotations.spec.ts` -- every tool has title + input/output schema + annotations with correct read/write hints (update its constants when adding a tool).
+- `tool-output-schemas.spec.ts` -- each output schema accepts a representative `toolResult` payload (incl. NaN, null, and alternate branches), and an end-to-end round-trip through the real SDK via `InMemoryTransport`.
+- `mcp-server.service.spec.ts` -- registration counts and that the advertised version tracks `package.json`.
 
 ## Spec compliance notes
 
-Implemented: Streamable HTTP transport, session management, OAuth 2.1 + RFC 9728
-protected-resource metadata, tools (title/description/input+output schema/
-annotations), resources (title/description/mimeType), prompts
-(title/description/arguments), logging/tools/resources/prompts capabilities.
+Implemented: Streamable HTTP transport, session management, OAuth 2.1 + RFC 9728 protected-resource metadata, tools (title/description/input+output schema/annotations), resources (title/description/mimeType), prompts (title/description/arguments), logging/tools/resources/prompts capabilities.
 
-Intentionally not implemented: `completions` (argument autocompletion) and
-resource `subscribe`/`listChanged`. DNS-rebinding protection on the transport is
-omitted because auth is bearer-only (no ambient browser credentials to steal).
-Add these if a client need arises.
+Intentionally not implemented: `completions` (argument autocompletion) and resource `subscribe`/`listChanged`. DNS-rebinding protection on the transport is omitted because auth is bearer-only (no ambient browser credentials to steal). Add these if a client need arises.

--- a/database/CLAUDE.md
+++ b/database/CLAUDE.md
@@ -1,9 +1,9 @@
 # Database Directory
 
 ## Overview
-Contains the PostgreSQL schema definition and incremental migration scripts for the monize database.
+PostgreSQL schema definition and incremental migration scripts for the monize database.
 
-A constraint here is usually the strongest available form of a system rule, so several entries in [`docs/system-invariants.md`](../docs/system-invariants.md) are enforced -- or unenforced -- by what is in `schema.sql`. `database/migrations/135_import_jobs_single_active.sql` is the model: a partial unique index doing what a read-then-insert in the service could not, with the reasoning in the migration's own header. See [`docs/concurrency-and-idempotency.md`](../docs/concurrency-and-idempotency.md) for when a constraint is the right mechanism, and note that a uniqueness constraint prevents duplicate *rows* and does nothing about a lost update to one.
+A constraint here is usually the strongest available form of a system rule, so several entries in [`docs/system-invariants.md`](../docs/system-invariants.md) are enforced -- or unenforced -- by what is in `schema.sql`. `database/migrations/135_import_jobs_single_active.sql` is the model: a partial unique index doing what a read-then-insert in the service could not, with the reasoning in the migration's own header. See [`docs/concurrency-and-idempotency.md`](../docs/concurrency-and-idempotency.md) for when a constraint is the right mechanism -- and note that a uniqueness constraint prevents duplicate *rows* and does nothing about a lost update to one.
 
 ## Files
 - `schema.sql` - Full database schema (used for fresh installs). Must be kept in sync with all migrations.
@@ -11,17 +11,9 @@ A constraint here is usually the strongest available form of a system rule, so s
 
 ## Automatic Migrations
 
-Migrations run automatically when the backend starts (both dev and production). The `db-migrate` script:
+Migrations run automatically when the backend starts (dev and production). `db-migrate`: creates a `schema_migrations` tracking table if absent, reads all `.sql` files from `migrations/`, compares against applied migrations, runs pending ones in filename order (each in a transaction), and records each success.
 
-1. Creates a `schema_migrations` tracking table if it doesn't exist
-2. Reads all `.sql` files from the `migrations/` directory
-3. Compares against already-applied migrations in `schema_migrations`
-4. Runs pending migrations in filename order, each wrapped in a transaction
-5. Records each successful migration in `schema_migrations`
-
-**Fresh installs:** `db-init` runs `schema.sql` first (which includes `schema_migrations`), then `db-migrate` runs all migrations. Since migrations use `IF NOT EXISTS`, they're no-ops on a fresh schema.
-
-**Existing installs:** `db-init` skips (tables exist), then `db-migrate` applies only new migrations.
+**Fresh installs:** `db-init` runs `schema.sql` first (which includes `schema_migrations`), then `db-migrate` runs all migrations -- no-ops on a fresh schema because they use `IF NOT EXISTS`. **Existing installs:** `db-init` skips, `db-migrate` applies only new migrations.
 
 ## Development Database Connection
 Credentials are in the root `.env` file (`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`).
@@ -29,116 +21,48 @@ Credentials are in the root `.env` file (`POSTGRES_DB`, `POSTGRES_USER`, `POSTGR
 ## Creating a New Migration
 
 1. **Create the migration file** in `database/migrations/` with the next sequential number prefix:
-   - **Read the current max from the directory** (`ls database/migrations | tail`) — do not trust a
-     number written in any document, including this one; they go stale (the RLS task list learned
-     this three times).
-   - **The numeric prefix must be unique** — `ls database/migrations | awk -F_ '{print $1}' | sort | uniq -d` should print nothing.
-     Migrations are applied in filename order; duplicate prefixes (we have a few historical pairs at `022`, `068`, `075`, `116`, `117`) leave the apply order ambiguous and rely on alphabetical tie-breaking, which is brittle.
+   - **Read the current max from the directory** (`ls database/migrations | tail`) -- do not trust a number written in any document, including this one; they go stale.
+   - **The numeric prefix must be unique** -- `ls database/migrations | awk -F_ '{print $1}' | sort | uniq -d` should print nothing. Duplicate prefixes (historical pairs exist at `022`, `068`, `075`, `116`, `117`) leave the apply order to alphabetical tie-breaking, which is brittle.
    - Use `IF NOT EXISTS` / `IF EXISTS` to make migrations idempotent
-
 2. **Update `schema.sql`** to reflect the same change (so fresh installs match migrated databases)
-
-3. **Update the backend TypeORM entity** if the migration modifies a table mapped to an entity. Column names in the database use `snake_case`, entity properties use `camelCase`, with the mapping specified via `@Column({ name: 'snake_case_name' })`.
-
-4. **Update the backend DTO** if the field should be user-editable (add validation decorators from `class-validator`)
-
+3. **Update the backend TypeORM entity** if the migration modifies a mapped table. DB columns are `snake_case`, entity properties `camelCase`, mapped via `@Column({ name: 'snake_case_name' })`.
+4. **Update the backend DTO** if the field should be user-editable (class-validator decorators)
 5. **Update frontend types** in `frontend/src/types/` to match
-
-6. **Classify any new column in the support backup** if its table is exported —
-   `backend/src/backup/support-backup/support-backup-rules.ts`. `RULES` is an
-   allowlist, so an unclassified column is dropped from the output rather than
-   leaked, but the golden test in
-   `backend/test/integration/support-backup.integration.spec.ts` still fails
-   until you classify it deliberately. That failure is the point: it forces a
-   decision about a new field instead of letting a migration quietly change what
-   a de-identified backup contains. Pick `keep` for structure, dates, enums,
-   flags and FKs; `mask` for names; `drop` for free text, secrets, and anything
-   that re-identifies a value masked elsewhere — a URL beside a masked name
-   names the thing the mask hides, which is why `payees.website`,
-   `securities.website` and `securities.msn_instrument_id` are all dropped. Use
-   `const` instead of `drop` when the column is NOT NULL.
-
-7. **Ship the table's RLS policy in the same migration** if the table is user-owned — see
-   "Row-Level Security conventions" below. This is a hard convention, not a suggestion.
-
-8. **Restart the backend** — migrations will be applied automatically on startup
+6. **Classify any new column in the support backup** if its table is exported -- `backend/src/backup/support-backup/support-backup-rules.ts`. `RULES` is an allowlist (an unclassified column is dropped, not leaked), but the golden test in `backend/test/integration/support-backup.integration.spec.ts` fails until you classify it deliberately -- forcing a decision instead of letting a migration quietly change what a de-identified backup contains. Pick `keep` for structure, dates, enums, flags and FKs; `mask` for names; `drop` for free text, secrets, and anything that re-identifies a value masked elsewhere (a URL beside a masked name names the thing the mask hides -- why `payees.website`, `securities.website` and `securities.msn_instrument_id` are all dropped). Use `const` instead of `drop` when the column is NOT NULL.
+7. **Ship the table's RLS policy in the same migration** if the table is user-owned -- see below. This is a hard convention.
+8. **Restart the backend** -- migrations apply automatically on startup
 
 ## Row-Level Security conventions (hard rules)
 
-Every user-owned table carries a row-level-security policy; the app emits per-transaction identity
-GUCs through `withScopedDb` and the policies compare each row's owner against them (see
-`docs/future-plans/row-level-security.md` and the runbook). Two rules bind every migration:
+Every user-owned table carries a row-level-security policy; the app emits per-transaction identity GUCs through `withScopedDb` and the policies compare each row's owner against them (see `docs/future-plans/row-level-security.md` and the runbook). Two rules bind every migration:
 
-1. **A migration that creates a user-owned table ships its `CREATE POLICY` in the same file** —
-   `117_mny_import_staging_and_jobs.sql` and `118_security_documents_rls.sql` are the worked
-   examples. And because `123_rls_enable.sql` derives its `ENABLE ROW LEVEL SECURITY` targets from
-   `pg_policies` *at the moment it runs*, any migration numbered **after** `123` must also ship its
-   own `ALTER TABLE <t> ENABLE ROW LEVEL SECURITY;` — on a deployed database `123` has already been
-   recorded in `schema_migrations` and will never run again, so a later policy without its own
-   enable leaves that table as the single unprotected one under enforcement. (Enabling is inert
-   while the app connects as the table owner, i.e. at `RLS_MODE=off`/`shadow`, so shipping it does
-   not change behavior before the operator flips modes.)
+1. **A migration that creates a user-owned table ships its `CREATE POLICY` in the same file** -- `117_mny_import_staging_and_jobs.sql` and `118_security_documents_rls.sql` are the worked examples. Because `123_rls_enable.sql` derives its `ENABLE ROW LEVEL SECURITY` targets from `pg_policies` *at the moment it runs* and never runs again on a deployed database, any migration numbered after `123` must also ship its own `ALTER TABLE <t> ENABLE ROW LEVEL SECURITY;` -- a later policy without it leaves that table as the single unprotected one under enforcement. (Enabling is inert at `RLS_MODE=off`/`shadow`, so shipping it does not change behavior before the operator flips modes.)
 
-   Every table must land in exactly one of **four buckets**, and the catalog-driven
-   `backend/test/integration/rls-enforcement.integration.spec.ts` fails the moment a table is in
-   none (or several):
-   - **Direct**: the table has a `user_id` column → the uniform policy
-     (`user_id = (SELECT app_current_user_id()) OR (SELECT app_bypass_rls())`), picked up with no
-     spec change. Tables keyed by the *authenticated* user additionally OR in
-     `user_id = (SELECT app_real_user_id())` — see `112_rls_policies_direct.sql` Group B.
-   - **Owner-column**: a bespoke owner column (`owner_user_id`, `delegate_user_id`, `users.id`) →
-     bespoke policy (`114_rls_policies_special.sql`), plus an entry in the spec's owner-column map.
-   - **Indirect**: no owner column → an `EXISTS` back to the owning parent
-     (`113_rls_policies_indirect.sql`), plus an entry in the spec's indirect map.
-   - **Exempt**: no owner column to policy on. The set is `RLS_EXEMPT_TABLES` in
-     `backend/src/common/db/rls-exempt-tables.ts`, mirrored as `rls-exempt:` marker lines in
-     `database/schema.sql` and checked against it in both directions (with no database) by
-     `backend/src/common/db/rls-exempt-tables.spec.ts`. Do not write the list out anywhere else --
-     it was previously kept in five places and had already drifted. Exempting a table takes a
-     rationale in `docs/row-level-security-contract.md`, which is canonical.
+   Every table lands in exactly one of **four buckets**, and the catalog-driven `backend/test/integration/rls-enforcement.integration.spec.ts` fails the moment a table is in none (or several):
+   - **Direct**: has a `user_id` column -> the uniform policy (`user_id = (SELECT app_current_user_id()) OR (SELECT app_bypass_rls())`), picked up with no spec change. Tables keyed by the *authenticated* user additionally OR in `user_id = (SELECT app_real_user_id())` -- see `112_rls_policies_direct.sql` Group B.
+   - **Owner-column**: a bespoke owner column (`owner_user_id`, `delegate_user_id`, `users.id`) -> bespoke policy (`114_rls_policies_special.sql`), plus an entry in the spec's owner-column map.
+   - **Indirect**: no owner column -> an `EXISTS` back to the owning parent (`113_rls_policies_indirect.sql`), plus an entry in the spec's indirect map.
+   - **Exempt**: no owner column to policy on. The set is `RLS_EXEMPT_TABLES` in `backend/src/common/db/rls-exempt-tables.ts`, mirrored as `rls-exempt:` marker lines in `database/schema.sql` and checked in both directions (with no database) by `backend/src/common/db/rls-exempt-tables.spec.ts`. Do not write the list out anywhere else -- it was previously kept in five places and had drifted. Exempting a table takes a rationale in `docs/row-level-security-contract.md`, which is canonical.
 
-   Keep the `(SELECT app_current_user_id())` initplan form — a bare function call relies on
-   SQL-function inlining and evaluates per row on sequential scans.
+   Keep the `(SELECT app_current_user_id())` initplan form -- a bare function call relies on SQL-function inlining and evaluates per row on sequential scans.
 
-2. **No migration may name a role.** `GRANT ... TO monize_app` (or any `CREATE/ALTER/DROP ROLE`)
-   in a migration crash-loops every deployment where the role does not exist. The role and its
-   grants are provisioned idempotently by db-init on every startup
-   (`backend/src/common/db/app-role.ts`); on CNPG the role comes from the `Cluster` manifest
-   (`managed.roles`) instead. New tables created by the owner get their grants automatically via
-   `ALTER DEFAULT PRIVILEGES`. The `role-or-grant-statement` rule in
-   `backend/scripts/migration-lint.mjs` enforces this over every migration, so it is a CI failure
-   rather than a convention.
+2. **No migration may name a role.** `GRANT ... TO monize_app` (or any `CREATE/ALTER/DROP ROLE`) in a migration crash-loops every deployment where the role does not exist. The role and its grants are provisioned idempotently by db-init on every startup (`backend/src/common/db/app-role.ts`); on CNPG the role comes from the `Cluster` manifest (`managed.roles`). New tables created by the owner get grants automatically via `ALTER DEFAULT PRIVILEGES`. The `role-or-grant-statement` rule in `backend/scripts/migration-lint.mjs` enforces this in CI.
 
-   **`PUBLIC` is the exception, for the same reason and not in spite of it:** it is a keyword that
-   always resolves, so it cannot fail for a missing role. It has to be permitted, because
-   `CREATE FUNCTION` grants `EXECUTE` to `PUBLIC` implicitly -- revoking that anywhere but the
-   transaction that created the function leaves a window in which any role can execute a fresh
-   `SECURITY DEFINER` function. `136_currency_global_liveness.sql` is the case. This paragraph used
-   to read as an absolute ban while that `REVOKE` was already in the tree, which is a rule nothing
-   checked disagreeing with the code it governs.
+   **`PUBLIC` is the exception, for the same reason and not in spite of it:** it is a keyword that always resolves, so it cannot fail for a missing role. It has to be permitted, because `CREATE FUNCTION` grants `EXECUTE` to `PUBLIC` implicitly -- revoking that anywhere but the transaction that created the function leaves a window in which any role can execute a fresh `SECURITY DEFINER` function. `136_currency_global_liveness.sql` is the case.
 
 ## Migration File Conventions
 - Numbered prefix for ordering: `NNN_description.sql` (e.g., `079_securities_is_favourite.sql`)
-- Use `ADD COLUMN IF NOT EXISTS` for column additions
-- Use `CREATE TABLE IF NOT EXISTS` for new tables
-- Use `CREATE INDEX IF NOT EXISTS` for new indexes
+- Use `ADD COLUMN IF NOT EXISTS`, `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`
 - Include a comment at the top describing the change
 - Keep migrations small and focused on a single change
 - Migrations must be idempotent (safe to run multiple times)
 
 ## Idempotency is a CI gate
 
-Every statement must be a no-op when re-applied to an up-to-date database --
-a half-applied migration otherwise crash-loops the backend at startup. Two
-checks enforce it, and `docs/database-migrations.md` holds the guard recipes
-(`ADD CONSTRAINT` needs a preceding `DROP CONSTRAINT IF EXISTS`, `CREATE
-TRIGGER` a `DROP TRIGGER IF EXISTS` or a `pg_trigger` `DO` block, `INSERT` an
-`ON CONFLICT`, ...) plus the recovery runbook for a failed migration:
+Every statement must be a no-op when re-applied to an up-to-date database -- a half-applied migration otherwise crash-loops the backend at startup. Two checks enforce it, and `docs/database-migrations.md` holds the guard recipes (`ADD CONSTRAINT` needs a preceding `DROP CONSTRAINT IF EXISTS`, `CREATE TRIGGER` a `DROP TRIGGER IF EXISTS` or a `pg_trigger` `DO` block, `INSERT` an `ON CONFLICT`, ...) plus the recovery runbook for a failed migration:
 
-- `cd backend && npm run migration:lint` -- static guard check, run in the
-  "Backend Lint & Type Check" job (`backend/scripts/migration-lint.mjs`).
-- `scripts/verify-schema.sh` -- applies every migration on top of `schema.sql`
-  **twice** and diffs the result, run in the "Schema vs Migrations Drift" job.
+- `cd backend && npm run migration:lint` -- static guard check, run in the "Backend Lint & Type Check" job (`backend/scripts/migration-lint.mjs`).
+- `scripts/verify-schema.sh` -- applies every migration on top of `schema.sql` **twice** and diffs the result, run in the "Schema vs Migrations Drift" job.
 
 ## Tables
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -23,7 +23,7 @@ npm run i18n:check         # Verify the pseudo-locale is up to date (CI gate)
 
 ## Layout
 
-`src/` contains `app/` (App Router routes), `components/` (feature-organized React components plus shared `ui/`), `contexts/`, `hooks/`, `lib/` (axios API clients and utilities), `store/` (Zustand: `authStore`, `preferencesStore`, `demoStore`), `types/`, `test/`, and `proxy.ts`. Use the filesystem or LSP `workspaceSymbol` to discover specific files -- they're self-describing.
+`src/` contains `app/` (App Router routes), `components/` (feature-organized React components plus shared `ui/`), `contexts/`, `hooks/`, `lib/` (axios API clients and utilities), `store/` (Zustand: `authStore`, `preferencesStore`, `demoStore`), `types/`, `test/`, and `proxy.ts`. Use the filesystem or LSP `workspaceSymbol` to discover specific files.
 
 ## Configuration
 
@@ -43,108 +43,29 @@ npm run i18n:check         # Verify the pseudo-locale is up to date (CI gate)
 - **Response (401):** Token refresh via `/auth/refresh`, queues concurrent requests during refresh
 - **Fallback:** On refresh failure, logs out and redirects to `/login`
 
-Feature API modules (one per feature, typed axios wrappers) live alongside `api.ts`. Use the filesystem to discover them.
+Feature API modules (one per feature, typed axios wrappers) live alongside `api.ts`.
 
 ### A paged endpoint is never asked for more rows than it accepts
 
-`API_MAX_PAGE_LIMIT` (`lib/api-page-limits.ts`) is the ceiling both paged list
-endpoints enforce, and neither of them clamps: `GET /transactions` (via the
-backend's `PAGINATION_MAX_LIMIT`) and `GET /investment-transactions` (a
-hand-written check in its controller) answer **400** to a larger `limit`. Every
-one of these calls sits behind a `.catch()` that degrades to an empty list, so
-the rejection never reaches the user as an error -- it reaches them as a figure
-that is quietly, permanently zero. `limit: 500` on the recurring-charges panel is
-issue #1229 (no subscriptions ever detected); the same literal on the investment
-detail page reported every year's dividends and interest as $0.00.
+`API_MAX_PAGE_LIMIT` (`lib/api-page-limits.ts`) is the ceiling both paged list endpoints enforce, and neither clamps: `GET /transactions` and `GET /investment-transactions` answer **400** to a larger `limit`. These calls sit behind `.catch()`es that degrade to an empty list, so the rejection reaches the user as a figure that is quietly zero (`limit: 500` on the recurring-charges panel is issue #1229; the same literal reported every year's dividends as $0.00).
 
-Lowering the literal to the cap is **not** the fix. That trades a visible zero
-for a plausible undercount, which is the worse of the two: nothing on screen
-distinguishes a truncated year from a quiet one. Either walk the pages --
-`transactionsApi.getAllPages` and `investmentsApi.getAllTransactionPages`, both
-defaulting their page size to the constant -- or narrow the query server-side
-until one page is genuinely enough. The YTD income figure does the second,
-asking for `DIVIDEND` and `INTEREST` separately because that endpoint matches one
-action per request, and still walks pages within each.
+Lowering the literal to the cap is **not** the fix -- that trades a visible zero for a plausible undercount. Either walk the pages (`transactionsApi.getAllPages`, `investmentsApi.getAllTransactionPages`, both defaulting their page size to the constant) or narrow the query server-side until one page is genuinely enough. Prefer narrowing to walking: a page walk that pulls a year of rows to distil a handful of ids is a side panel paying for a report.
 
-Prefer narrowing to walking. A page walk that pulls a whole year of rows down in
-order to distil a handful of ids is a side panel paying for a report, and the
-request count grows with the user's history.
-
-`src/test/api-page-limits.test.ts` scans the tree for a call site above the cap
-and checks the constant against **both** backend sources, so the layers cannot
-drift apart quietly. Its known-violation register is the honest half: an entry
-there is a defect being tracked with the change that fixes it, and the test fails
-once the violation is gone, so a stale entry cannot outlive its fix.
+`src/test/api-page-limits.test.ts` scans for call sites above the cap and checks the constant against **both** backend sources. Its known-violation register tracks defects with the change that fixes them, and fails once a violation is gone, so a stale entry cannot outlive its fix.
 
 ### A filter the server can apply is not a list the client enumerates
 
-`transactionsApi.getRecurringCharges` takes an `accountId`. It used to take only
-`payeeIds`, so the recurring-charges panel read a year of the account's
-transactions, distilled the distinct payee ids and sent those back -- a request
-whose size grew with the account's payee cardinality. Around 250 payees is ~9 KB
-of UUIDs in the query string, past the request-line limit of a typical proxy;
-past ~430 it exceeds Node's header budget, which the JWT cookie also draws on.
-Every one of these calls sits behind a `.catch()` that degrades to an empty
-list, so the failure arrives as "no recurring charges" rather than as an error
--- the same user-visible failure as issue #1229, at the next size threshold.
+`transactionsApi.getRecurringCharges` takes an `accountId`; it used to take only `payeeIds`, so the panel sent back a payee-id list whose size grew with the account (~250 payees exceeded proxy request-line limits; ~430 exceeded Node's header budget) and the failure arrived as "no recurring charges". The tell is a client that fetches rows **only to extract ids from them** -- that is an account-shaped question asked in the shape of an id list. Send the narrow thing the server can filter on; an array parameter is for a bounded set the caller genuinely holds.
 
-The tell is a client that fetches rows **only to extract ids from them**. That
-is an account-shaped (or category-shaped, or date-shaped) question being asked
-in the shape of an id list, and the id list is the part that does not scale.
-Send the narrow thing the server can filter on and let it apply the predicate;
-an array parameter is for a bounded set the caller genuinely holds, like the
-payee surfaces that pass exactly one id.
-
-Two obligations come with moving a filter server-side. The endpoint must
-**authorize** whatever it now accepts -- an `accountId` is a new door into
-another user's rows, so it goes through the same own/joint resolution the
-register uses (`resolveOwnContextJointScope`), and a joint account's detection
-runs as its owner. And the *meaning* usually sharpens rather than staying
-identical: detection scoped to an account measures cadence from that account's
-own rows, so a charge recurring on another card stops being reported on this
-one. Say which of the two you intended, and test it.
-
+Two obligations come with moving a filter server-side: the endpoint must **authorize** what it now accepts (an `accountId` is a new door, so it goes through the same own/joint resolution the register uses, `resolveOwnContextJointScope`, and a joint account's detection runs as its owner), and the *meaning* usually sharpens (detection scoped to an account measures cadence from that account's own rows). Say which you intended, and test it.
 
 ### A write that moves money calls `invalidateBalanceCaches()`
 
-`accountsApi.getAll`, `investmentsApi.getPortfolioSummary` and the budget
-progress views are cached in `apiCache.ts`, and the backend computes all three
-live from transaction rows -- so a write that does not drop those entries leaves
-the Accounts page showing the pre-write number. Navigating away and back does not fix it:
-the page refetches on mount and the refetch is served from the same cache, so
-only a browser reload clears it. Call `invalidateBalanceCaches()` (both
-prefixes at once) after any write that adds, removes, re-dates, re-prices or
-voids a transaction -- and note that "goes through `transactionsApi`" is not the
-test. Posting a scheduled transaction, editing splits (a split can carry a
-`transferAccountId`, so the counterpart lands in an account the parent never
-named), an investment trade hitting its INVESTMENT_CASH account, and a QIF/OFX/
-CSV/MNY import all write transaction rows from their own modules. That omission
-on `scheduledTransactionsApi.post` is the bug this rule came from;
-`src/lib/balance-cache.guard.test.ts` now scans for it.
+`accountsApi.getAll`, `investmentsApi.getPortfolioSummary` and the budget progress views are cached in `apiCache.ts`, and the backend computes all three live from transaction rows -- a write that does not drop those entries leaves stale figures that even navigation cannot fix (the refetch on mount is served from the same cache). Call `invalidateBalanceCaches()` after any write that adds, removes, re-dates, re-prices or voids a transaction. "Goes through `transactionsApi`" is not the test: posting a scheduled transaction, editing splits (a split can carry a `transferAccountId`), an investment trade hitting its INVESTMENT_CASH account, and QIF/OFX/CSV/MNY imports all write transaction rows from their own modules. `src/lib/balance-cache.guard.test.ts` scans for the omission.
 
-**The prefix list inside the helper is the other half of the rule.** It covers
-`accounts:`, `investments:` and `budgets:` -- three views of the same rows. A
-categorised expense moves a budget's progress exactly as it moves the account's
-balance, and `budgets:dashboard` (30s) and `budgets:cat-status:*` (60s) used to
-survive the write, so the toast said saved while the remaining-funds figure
-beside it was pre-write. Adding a cached family that reads transaction rows means
-adding its prefix in `invalidateBalanceCaches` in the same change;
-`apiCache.test.ts` pins the set, both what it drops and what it leaves alone.
+**The prefix list inside the helper is the other half of the rule.** It covers `accounts:`, `investments:` and `budgets:` -- three views of the same rows. Adding a cached family that reads transaction rows means adding its prefix in `invalidateBalanceCaches` in the same change; `apiCache.test.ts` pins the set. Pinning alone is not enough (that is what was green while `budgets:` was missing), so `cache-prefix-classification.guard.test.ts` scans `src/` for every prefix any cache call uses and requires each to be classified as transaction-derived (dropped) or reference data (kept); a prefix in neither list fails, and so does a listed prefix nothing uses.
 
-Pinning the set is not enough on its own, because that is what was green while
-`budgets:` was missing from it: the pinned set matched the helper, and neither
-knew about the new family. So `cache-prefix-classification.guard.test.ts` scans
-`src/` for every prefix any cache call uses and requires each one to be listed as
-transaction-derived (and therefore dropped) or as reference data (and therefore
-kept). A prefix in neither list fails, which forces the decision at the moment it
-is cheap to make. The list also fails when it names a prefix nothing uses any
-more, so it cannot drift into fiction.
-
-Where the write can touch anything -- undo/redo, an AI assistant action, a
-backup restore -- use `clearAllCache()` instead; no prefix is narrow enough to
-be correct. This matters most for `notifyUndoRedo`/`notifyAiAction`: they exist
-to make mounted pages refetch, and a refetch served from a stale cache makes
-the whole signal a no-op.
+Where the write can touch anything -- undo/redo, an AI assistant action, a backup restore -- use `clearAllCache()`; no prefix is narrow enough. This matters most for `notifyUndoRedo`/`notifyAiAction`: a refetch served from a stale cache makes the whole signal a no-op.
 
 ## Proxy (`src/proxy.ts`)
 
@@ -161,7 +82,7 @@ This is Next.js middleware (NOT the deprecated middleware pattern from this proj
 - All interactive components use `'use client'`. Server components are the default for pages/layouts.
 - Use dynamic imports for heavy components: `dynamic(() => import('./Chart'), { ssr: false })`.
 - `ProtectedRoute` (`components/auth/ProtectedRoute.tsx`) wraps authenticated pages.
-- **No `setState` in `useEffect`** — ESLint rule `react-hooks/set-state-in-effect` is enforced. To reset child state when a prop changes (e.g. on a dialog open transition), use the "info from previous render" pattern (track the prop in `useState` and update during render).
+- **No `setState` in `useEffect`** — ESLint rule `react-hooks/set-state-in-effect` is enforced. To reset child state when a prop changes, use the "info from previous render" pattern (track the prop in `useState` and update during render).
 - **Dialogs use `Modal`** (`components/ui/Modal.tsx`) — handles Escape, focus trap, body scroll lock, focus restore, and stacked-modal popstate. Opt into `pushHistory` so the browser back button also closes. `ConfirmDialog` forwards `pushHistory` for stacked confirm flows.
 
 ## Reusing existing UI patterns
@@ -170,949 +91,247 @@ Each of these exists once. Use it; do not hand-roll a second one. Every rule her
 
 ### A panel card is `Card` / `CARD_CLASS`, never an inline class trio
 
-`components/ui/Card.tsx` is the one card surface -- background, radius,
-shadow, and the border that keeps a card legible on themes where the weakest
-shadow disappears. Use the `Card` component where a plain wrapper works
-(`padding="md"` matches the widget shell) and `CARD_CLASS` where the element
-already exists (a table shell with `overflow-hidden`). The old inline
-`bg-white dark:bg-gray-800 rounded-lg shadow` trio survives in a recorded,
-shrink-only baseline in `ui-conventions.test.ts`; converting a file means
-deleting its baseline line, and new code takes the primitive from the start.
-Everything in it stays on the gray ramp so the colour themes re-skin it --
-never add a literal hex or an off-ramp hue to a card.
+`components/ui/Card.tsx` is the one card surface -- background, radius, shadow, and the border that keeps a card legible on themes where the weakest shadow disappears. Use the `Card` component where a plain wrapper works (`padding="md"` matches the widget shell) and `CARD_CLASS` where the element already exists. The old inline `bg-white dark:bg-gray-800 rounded-lg shadow` trio survives in a recorded, shrink-only baseline in `ui-conventions.test.ts`; converting a file means deleting its baseline line. Everything stays on the gray ramp so the colour themes re-skin it -- never add a literal hex or an off-ramp hue to a card.
 
-**A theme with a strong border is a test the rest of the app has to pass.**
-Ten dashboard widgets drew the borderless trio by hand while thirteen went
-through `WidgetCard` -> `Card`, so half the dashboard had an edge and half did
-not. Nobody could see it while the border was `gray-200`; raising
-`highcontrast`'s to `#b0b0b0` turned it into alternating outlined and
-un-outlined panels. All twenty-three now resolve to `CARD_CLASS`.
-
-The tempting fix is the other one -- drop the border so everything matches the
-widgets that had none -- and the numbers say no. Card-versus-page luminance is
-1.045 in `default` light, 1.044 in `midnight` and exactly **1.000** in
-`highcontrast`, whose page and card are both pure white. In those three the
-border is the only thing that defines a card at all, so removing it does not
-make the dashboard consistent, it makes the panels disappear. Every other
-theme clears the guard's 1.15 separation floor and would have survived it,
-which is exactly why this is worth writing down: the change looks safe from
-any theme except the three it breaks.
+**Do not drop the border to make surfaces match.** Card-versus-page luminance is ~1.0 in `default` light, `midnight` and `highcontrast` (page and card both pure white there), so the border is the only thing that defines a card at all in those themes -- removing it makes panels disappear, and the change looks safe from every theme except the three it breaks.
 
 ### A category's colour and icon are inherited, and drawn by `CategoryGlyph`
 
-A category shows its own colour and icon, or the nearest ancestor's when it
-sets none. Both are resolved server-side in one walk up the ancestry
-(`effectiveColor` / `effectiveIcon`), so read `category.effectiveIcon ??
-category.icon` rather than `category.icon` -- the raw column is only what this
-row set, which is null for most leaves.
-
-`components/categories/CategoryGlyph.tsx` draws the result: the icon when
-there is one, the colour dot otherwise, dimmed when the value came from an
-ancestor. Never interpolate `category.icon` into text -- it is a name like
-`shopping-cart`, so `{category.icon} {name}` renders the name of the icon
-instead of the icon, which reads as a typo rather than a missing feature. That
-is what the detail header and the subcategory table both did.
-
-A surface holding a *joined* category row (a transaction, a payee's default
-category) has no inherited value at all, so it reads
-`buildCategoryIconMap` / `buildCategoryColorMap` (`lib/categoryUtils.ts`) built
-from the full category list, exactly as the register does.
+Both are resolved server-side in one walk up the ancestry: read `category.effectiveIcon ?? category.icon`, never the raw column (null for most leaves). `components/categories/CategoryGlyph.tsx` draws the result: icon when there is one, colour dot otherwise, dimmed when inherited. Never interpolate `category.icon` into text -- it is a name like `shopping-cart`, so `{category.icon} {name}` renders the icon's *name*. A surface holding a *joined* category row (a transaction, a payee's default category) has no inherited value, so it reads `buildCategoryIconMap` / `buildCategoryColorMap` (`lib/categoryUtils.ts`) built from the full category list, as the register does.
 
 ### A brand favicon is `BrandLogo`, addressed by its entity's wrapper
 
-`components/ui/BrandLogo.tsx` renders a cached favicon with the neutral badge
-fallback, and owns the one rule that matters: the bytes always come from our
-own backend, never a third party, so drawing a logo cannot leak which
-institutions or payees a user has. `InstitutionLogo` and `PayeeLogo` are thin
-wrappers that only say which `/:id/logo` route to read, gated on the entity's
-`hasLogo` so a list of icon-less rows issues no requests at all. A 404 (no icon
-cached, or the fetch failed) lands on `onError` and shows the same badge, so the
-two "no image" states look identical to the reader. Adding the treatment to a
-third entity means a wrapper, not a second component.
+`components/ui/BrandLogo.tsx` renders a cached favicon with the neutral badge fallback, and owns the one rule that matters: the bytes always come from our own backend, never a third party, so drawing a logo cannot leak which institutions or payees a user has. `InstitutionLogo` and `PayeeLogo` are thin wrappers naming the `/:id/logo` route, gated on `hasLogo` so icon-less rows issue no requests. A 404 lands on `onError` and shows the same badge. A third entity gets a wrapper, not a second component.
 
 ### A status pill is `Badge`; table chrome is `Table.tsx`
 
-`components/ui/Badge.tsx` is the small status pill -- a count, a state, a
-label beside a name. The shape was hand-rolled about fifty times in six
-padding combinations with every colour pair spelled out at the call site.
-Pass `variant` and `size`; pass `as="button"` where the pill is also a
-control, rather than nesting a button inside a span. It deliberately does not
-absorb the pills whose colour *means* something -- `CategoryPill`,
-`AccountTypePill` and `SCHEDULED_KIND_CHIP_CLASSES` are each already one
-source of truth for their mapping, and the guard exempts them by name rather
-than baselining them.
+`components/ui/Badge.tsx` is the small status pill (previously hand-rolled ~50 times). Pass `variant` and `size`; pass `as="button"` where the pill is also a control, rather than nesting a button in a span. It deliberately does not absorb pills whose colour *means* something -- `CategoryPill`, `AccountTypePill` and `SCHEDULED_KIND_CHIP_CLASSES` are each already one source of truth, exempted by name.
 
-`components/ui/Table.tsx` is constants (`TABLE_CLASS`, `TH_CLASS`, `TD_CLASS`)
-plus thin `Th`/`Td` cells, not a `<Table>` wrapper: these tables are hand-laid
-with colspans, sticky cells and per-density padding, so a component owning the
-markup would be fought everywhere. `SortableHeader` deliberately stays off
-`TH_CLASS` -- about twenty-five report tables draw a lighter, non-upper-case
-header inside a `text-sm` table, and folding it in would restyle every report
-under cover of a refactor.
+`components/ui/Table.tsx` is constants (`TABLE_CLASS`, `TH_CLASS`, `TD_CLASS`) plus thin `Th`/`Td` cells, not a `<Table>` wrapper -- these tables are hand-laid with colspans and sticky cells. `SortableHeader` deliberately stays off `TH_CLASS` (about twenty-five report tables draw a lighter header, and folding it in would restyle every report).
 
 ### The card shadow is `--shadow-card`; the bare `shadow` reads no token
 
-A Tailwind v4 trap worth knowing before you try to restyle elevation: the
-bare `shadow` utility is a legacy alias with the stock value compiled into
-it, so redefining `--shadow-sm` in `@theme` does not touch it. It changes
-`shadow-sm`, which in this codebase is worn almost entirely by form fields --
-so that override puffs up every input and leaves every card exactly as flat.
-The mistake is invisible in the source and only shows in the built
-stylesheet, which is why `ui-conventions.test.ts` fails on a `--shadow-sm`
-redefinition. Card elevation goes through `--shadow-card`, worn by
-`CARD_CLASS`.
+Tailwind v4 trap: the bare `shadow` utility is a legacy alias with the stock value compiled in, so redefining `--shadow-sm` in `@theme` touches `shadow-sm` (worn by form fields) and leaves cards flat. `ui-conventions.test.ts` fails on a `--shadow-sm` redefinition. Card elevation goes through `--shadow-card`, worn by `CARD_CLASS`.
 
 ### A focus ring is `focus-visible:`, and a hover animates
 
-`focus:ring-*` paints on a mouse click as well as a Tab, which is the most
-visible unfinished-looking detail a UI can have. Use `focus-visible:` on
-anything clickable. Text inputs are the one exception, in `inputBaseClasses`
-and the element selectors in `globals.css`: a field showing its focused border
-after a click is telling the user where their typing will go.
-
-Row hover comes from `HOVER_ROW_ON_CARD` / `HOVER_ROW_ON_PAGE` in `Card.tsx`,
-not a hand-picked grey -- there were twelve variants of one decision, and the
-half most call sites forgot was the transition. A hover that snaps reads as a
-redraw. Pair any new transition with `motion-reduce:transition-none`.
-
-Both rules carry shrink-only baselines in `ui-conventions.test.ts`; converting
-a file means deleting its line there in the same commit.
+`focus:ring-*` paints on a mouse click as well as a Tab; use `focus-visible:` on anything clickable. Text inputs are the one exception (`inputBaseClasses` and the element selectors in `globals.css`). Row hover comes from `HOVER_ROW_ON_CARD` / `HOVER_ROW_ON_PAGE` in `Card.tsx`, not a hand-picked grey, and includes the transition (a hover that snaps reads as a redraw). Pair any new transition with `motion-reduce:transition-none`. Both rules carry shrink-only baselines in `ui-conventions.test.ts`.
 
 ### A dialog is titled through `Modal`, never by a hand-rolled heading
 
-`Modal` takes `title` (and optional `description`, `footer`, `padding`), draws
-the standard header and wires `aria-labelledby`. Before it existed all 74 call
-sites drew their own heading in eight different treatments, and -- the part
-that mattered -- none of them reached the dialog, so every dialog announced
-itself as an unnamed region. `padding` defaults to `none` and leaves children
-unwrapped, because several call sites make the panel their own scroll or flex
-parent. A header that is genuinely bespoke (ConfirmDialog puts an icon beside
-its heading) stays on the baseline deliberately rather than being flattened.
+`Modal` takes `title` (and optional `description`, `footer`, `padding`), draws the standard header and wires `aria-labelledby` -- before it, none of the 74 hand-rolled headings reached the dialog, so every dialog announced itself as an unnamed region. `padding` defaults to `none` and leaves children unwrapped, because several call sites make the panel their own scroll or flex parent. A genuinely bespoke header (ConfirmDialog's icon) stays on the baseline deliberately.
 
 ### An empty list renders `EmptyState`
 
-`components/ui/EmptyState.tsx` (glyph, title, optional description and
-action) replaced fourteen hand-rolled `text-center py-12` blocks in three
-drifting variants. `ui-conventions.test.ts` bans the container fingerprint
-outside the component, with no grandfathered baseline.
+`components/ui/EmptyState.tsx` (glyph, title, optional description and action). `ui-conventions.test.ts` bans the `text-center py-12` container fingerprint outside the component, with no grandfathered baseline.
 
 ### An auth screen renders inside `AuthShell`
 
-`components/auth/AuthShell.tsx` is the single shell for login, register,
-forgot/reset/change-password, verify-email and setup-2fa: transparent brand
-mark, title/subtitle, a notices slot, and the shared `Card` around the body
-(`plain` for a bare status line). The language picker and version line are
-opt-in props. Use `/icons/monize-logo-transparent.svg` everywhere in the UI
--- the boxed `monize-logo.svg` bakes in a white background rect and renders
-as a white square in dark mode. Guarded in `ui-conventions.test.ts`.
+`components/auth/AuthShell.tsx` is the single shell for login, register, forgot/reset/change-password, verify-email and setup-2fa: transparent brand mark, title/subtitle, notices slot, shared `Card` around the body (`plain` for a bare status line). Language picker and version line are opt-in props. Use `/icons/monize-logo-transparent.svg` everywhere in the UI -- the boxed `monize-logo.svg` bakes in a white background and renders as a white square in dark mode. Guarded in `ui-conventions.test.ts`.
 
 ### Navigation links and their icons live in `lib/nav-links.ts`
 
-The header's link arrays and the per-route Heroicon map are declared side by
-side so `nav-links.test.ts` can hold "every nav route has an icon". The
-mobile drawer and the header dropdowns render `NAV_ICONS[href]`; the desktop
-top-bar pills stay text-only on purpose (the bar collapses at `xl`, and six
-leading icons overflow 1280-1440px laptops). A new route means one entry in
-the array and one in the map, in the same file.
+The header's link arrays and the per-route Heroicon map are declared side by side so `nav-links.test.ts` can hold "every nav route has an icon". The mobile drawer and header dropdowns render `NAV_ICONS[href]`; the desktop top-bar pills stay text-only on purpose (six leading icons overflow 1280-1440px laptops). A new route means one entry in the array and one in the map, in the same file.
 
 ### Account-type colour and icon come from `lib/account-type-meta.tsx`
 
-`ACCOUNT_TYPE_META` maps each account type to its pill classes and Heroicon;
-render `AccountTypePill` / `AccountTypeIcon` rather than re-deriving either.
-`ui-conventions.test.ts` fails on a second type-to-pill-class mapping. An
-account with no institution shows its type icon in the brand-badge slot
-(`InstitutionLogo`'s `fallbackIcon`), not a generic glyph.
+`ACCOUNT_TYPE_META` maps each account type to its pill classes and Heroicon; render `AccountTypePill` / `AccountTypeIcon` rather than re-deriving either. `ui-conventions.test.ts` fails on a second type-to-pill-class mapping. An account with no institution shows its type icon in the brand-badge slot (`InstitutionLogo`'s `fallbackIcon`), not a generic glyph.
 
 ### A register's category chip is `CategoryPill`
 
-`components/transactions/CategoryPill.tsx` owns the colour-mix pill and the
-category's optional icon (drawn via `getIconComponent`, the same way tag
-chips do). Categories carry `icon` end-to-end -- `CategoryForm` collects it
-through the shared `IconPicker` (whose `onClear`/`clearLabel` props make "no
-icon" a real state) -- so a surface that shows a category name with its
-colour should show its icon too, and an unset icon renders nothing, never a
-default glyph.
+`components/transactions/CategoryPill.tsx` owns the colour-mix pill and the category's optional icon (via `getIconComponent`, as tag chips do). Categories carry `icon` end-to-end -- `CategoryForm` collects it through the shared `IconPicker` (whose `onClear`/`clearLabel` props make "no icon" a real state) -- so a surface showing a category name with its colour shows its icon too, and an unset icon renders nothing, never a default glyph.
 
 ### A dashboard widget header carries its icon from `widget-meta.tsx`
 
-`WIDGET_ICONS` gives every registered widget a distinct Heroicon
-(`widget-meta.test.tsx` enforces coverage), rendered as the tinted
-`WidgetIconPuck` -- blue ramp only, so the themes re-tint it. Widgets on
-`WidgetCard` get it from their `widgetId`; a widget that draws its own
-header uses `WidgetHeading`, which also owns the title-button markup the
-core widgets used to duplicate per loading/empty/loaded branch.
+`WIDGET_ICONS` gives every registered widget a distinct Heroicon (`widget-meta.test.tsx` enforces coverage), rendered as the tinted `WidgetIconPuck` -- blue ramp only, so themes re-tint it. Widgets on `WidgetCard` get it from their `widgetId`; a widget drawing its own header uses `WidgetHeading`, which also owns the title-button markup.
 
 ### Date entry -- `DateInput`, never a raw `<input type="date">`
 
-`components/ui/DateInput.tsx` is the only place a raw date input is allowed, and `ui-conventions.test.ts` fails the build if another appears. It carries the lenient parsing of what someone typed, the keyboard shortcuts, and `CalendarPopover` -- the custom picker whose icon is the only one on screen, because the desktop field is no longer a native date input at all. A bare `<input type="date">` gets none of that, and hands the user the browser's segment-jumping entry instead. 32 components use `DateInput`; yours should too.
+`components/ui/DateInput.tsx` is the only place a raw date input is allowed; `ui-conventions.test.ts` fails the build if another appears. It carries lenient parsing of typed text, keyboard shortcuts, and `CalendarPopover`. Key behaviors:
 
-**On a desktop it is a text box, whatever the user's format preference is.** It
-used to render a native `<input type="date">` for the `browser` preference --
-which is the default, so most users got it -- and the shared text input for
-everybody else. That is one component behaving as two: the native control jumps
-to its own next segment after two keystrokes, takes only the first two digits of
-a year typed into a partly-filled field, and cannot be handed `9-14` at all
-(issue #1201). The pointer decides the mode now, not the format: touch keeps the
-native picker, because a phone's date wheel is the better control there and
-nobody types a date on one by choice.
-
-**`browser` is not a pattern, and nothing below `useDateFormat` should see it.**
-`datePattern` off that hook is the concrete arrangement (`MM/DD/YYYY`,
-`DD.MM.YYYY`, ...), resolved from the locale by `resolveDateFormatPattern`
-(`lib/date-parse.ts`). Parsing what someone typed is impossible without it: `7/8`
-is 8 July in one arrangement and 7 August in another, and a sentinel cannot
-answer that question. `parseFlexibleDate` takes the pattern for exactly this
-reason; `parseDateFromFormat` stays strict, for a value that should already be
-canonical.
-
-**A partial entry is completed, and an unreadable one changes nothing.** A day
-and month take the year from the date the field already holds (today when it is
-empty), and a lone number is a day in the month on screen. Text that names no
-real date restores what was there -- clearing the box is the only way to mean
-"no date". None of that happens on the keystroke: the lenient reading waits for
-blur or Enter, because `9` is a valid day on its own and announcing it mid-word
-sends a report off fetching a date nobody asked for.
-
-**A screen that hosts a date field does not answer a load with a second tree.**
-`if (isLoading) return <Skeleton/>` returns a different tree, and React unmounts
-whatever the previous one held at that position -- including the field being
-typed into. Render the load and error states *inside* the one tree the component
-always returns. Duplicating the controls block into the second `return` is not a
-fix and looked like one: `CashFlowReport` did that, and its two trees put the
-block at different child indexes, so React reconciled it against the summary
-cards and unmounted it anyway. `ui-conventions.test.ts` fails both shapes for any
-component that pairs a date control with a `useReportData` loading flag -- the
-flag the date change itself re-triggers. A one-shot prerequisite load (the report
-*forms*' `isLoadingData`) is a different thing and is deliberately not policed:
-it resolves before the date field exists and never fires again.
+- **On desktop it is a text box regardless of format preference** -- the pointer decides the mode, not the format (touch keeps the native picker). The native control's segment-jumping entry is issue #1201.
+- **`browser` is not a pattern, and nothing below `useDateFormat` should see it.** `datePattern` off that hook is the concrete arrangement, resolved by `resolveDateFormatPattern` (`lib/date-parse.ts`). `parseFlexibleDate` takes the pattern (7/8 is ambiguous without it); `parseDateFromFormat` stays strict for canonical values.
+- **A partial entry is completed, and an unreadable one changes nothing.** Day+month take the year from the field's current date (today when empty); a lone number is a day in the month on screen; unparseable text restores what was there -- clearing the box is the only way to mean "no date". None of this happens on the keystroke: the lenient reading waits for blur or Enter.
+- **A screen hosting a date field does not answer a load with a second tree.** `if (isLoading) return <Skeleton/>` unmounts the field being typed into; render load/error states *inside* the one tree. Duplicating the controls block into the second `return` is not a fix (different child indexes still reconcile wrong -- `CashFlowReport` did this). `ui-conventions.test.ts` fails both shapes for any component pairing a date control with a `useReportData` loading flag; a one-shot prerequisite load (the report *forms*' `isLoadingData`) is deliberately not policed.
 
 ### Currency entry -- `CurrencyInput`, never a raw number input
 
-`components/ui/CurrencyInput.tsx` is the only way to take a money amount. It is a `type="text"` field with `inputMode="decimal"`, not `<input type="number">`: it filters non-numeric characters as you type, formats with thousands separators and two decimals on blur, strips the commas and clears a `0.00` on focus so the field is immediately typable, parses back through `parseAmount` so the value reaching the form is rounded to cents, and re-syncs when the parent changes the value externally (a form reset, or a category auto-signing the amount negative). It also accepts inline calculator expressions -- typing `100*1.13` and blurring or pressing Enter evaluates it in place instead of submitting the form -- and offers a calculator modal via the in-field icon. Props worth knowing: `prefix` for the currency symbol, `allowNegative` (default true), `allowCalculator` (default true), `allowSignToggle` for the in-field `±` button. 22 components use it; yours should too.
+`components/ui/CurrencyInput.tsx` is the only way to take a money amount: a `type="text"` field with `inputMode="decimal"` that filters as you type, formats with separators on blur, clears a `0.00` on focus, parses through `parseAmount` (rounded to cents), re-syncs on external value changes, and accepts inline calculator expressions (`100*1.13` + Enter/blur) plus a calculator modal. Props: `prefix`, `allowNegative` (default true), `allowCalculator` (default true), `allowSignToggle`. For non-money numbers (share counts, rates, percentages, day-of-month) use `NumericInput`: same filtering, with `decimalPlaces`, `suffix`, `min`/`max`, `allowNegative` defaulting false, no calculator.
 
-A raw `<input type="number">` gets none of this and adds spinner arrows, scroll-wheel value changes, and locale-dependent decimal handling. For non-money numbers -- share counts, rates, percentages, day-of-month, retention counts -- use `NumericInput` instead: same filtering and blur formatting, but with `decimalPlaces`, a `suffix`, `min`/`max`, `allowNegative` defaulting to false, and no calculator.
+`ui-conventions.test.ts` fails the build on any `<input type="number">` or `<Input type="number">` -- resolving the tag each `type="number"` belongs to, because recharts' `<XAxis type="number">` is not an input and is left alone.
 
-`ui-conventions.test.ts` now fails the build on any `<input type="number">` or `<Input type="number">`. It resolves the tag each `type="number"` belongs to rather than grepping the file, because recharts' `<XAxis type="number">` declares a continuous scale and appears in about twenty chart components -- those are not inputs and are deliberately left alone.
+Both components take a *number* (`value: number | undefined`, `onChange: (value: number | undefined) => void`):
 
-Both components take a *number*, not the field's text: `value: number | undefined` and `onChange: (value: number | undefined) => void`. Two consequences worth knowing before converting a form:
+- **`register()` does not fit.** Wrap in react-hook-form's `Controller` and pass `value`/`onChange`/`onBlur`/`ref` (plus `name={field.name}`, or `name`-based test selectors stop matching). Where the schema stores a string, bridge inside the render callback.
+- **`min` clamps while typing; `max` only on blur.** Every prefix of a number is smaller than the number, so a ceiling must not fire mid-word -- and `min` is wrong for a multi-digit floor (`min={2}` eats the `1` of `14`): leave it off and let Zod report. Where an out-of-range value must be *discarded* rather than trimmed, keep the explicit range check in the component's `onChange` (`MortgageFields`, `BudgetWizardStrategy`).
+- Give each field an explicit `id` when two on one screen share a label -- both components derive `id` from the label text, so a repeated "Years"/"Months" pair collides.
 
-- **`register()` does not fit.** Wrap the field in react-hook-form's `Controller` and pass `value`/`onChange`/`onBlur`/`ref` (plus `name={field.name}`, or a `name`-based test selector stops matching). Where the form's schema stores the field as a string, bridge inside the render callback rather than restructuring the schema.
-- **`min` clamps while typing; `max` only on blur.** Every prefix of a number is smaller than the number, so a ceiling must not fire mid-word -- `max={31}` would otherwise hand the parent 31 while the user is still typing `50`. That also means `min` is wrong for a multi-digit floor (`min={2}` eats the `1` of `14`): leave it off and let Zod report. Where a value outside the range must be *discarded* rather than trimmed -- a budget alert threshold, a months remainder that cannot roll into years -- keep the explicit range check in the component's `onChange`; `MortgageFields` and `BudgetWizardStrategy` are the worked examples.
-
-Give each field an explicit `id` when two on the same screen share a label. Both components derive `id` from the label text, so a "Years"/"Months" pair rendered twice (term and amortization) collides and every label points at the first input.
-
-**A field that hands back its own value has not been edited.** Both components re-parse whatever text is on screen on blur (and `CurrencyInput` on every keystroke and on Enter), and for a field nobody touched that text *is* the parent's value formatted to two decimals. Reporting it is invisible to a parent that only stores the number and destructive to one that does more: the FX panels derive an exchange rate from the converted total and mark it user-overridden, so tabbing through the field replaced the fetched 10dp rate with one reverse-engineered from the cents-rounded total (`1.365234` became `54.61 / 40 = 1.365250`) and stopped the date effect re-fetching -- a rate the user never chose, posted against a date it was never quoted for. Both components now notify only when the value actually moved (`notifyIfChanged`), and both carry a blurred-untouched regression test.
-
-The general rule that follows: **an `onChange` that does more than store the number must also be idempotent**, because a controlled field can legitimately re-report the same value. Guard the side effect on the value having changed at the handler too -- `handleConvertedTotalChange` and `handleConvertedTotalOverride` both return early when the incoming total already equals the derived one -- rather than trusting the field to be the only caller.
+**A field that hands back its own value has not been edited.** Both components re-parse the on-screen text on blur, and for an untouched field that text *is* the parent's value formatted -- reporting it is destructive to parents that do more than store it (the FX panels derived a rate from the cents-rounded total and marked it user-overridden). Both notify only when the value actually moved (`notifyIfChanged`), and both carry a blurred-untouched regression test. The general rule: **an `onChange` that does more than store the number must also be idempotent** -- guard the side effect on the value having changed at the handler too (`handleConvertedTotalChange` returns early when the incoming total equals the derived one).
 
 ### A clickable table row -- `useLongPress({ onClick })`
 
-`useLongPress` takes an `onClick` alongside `onLongPress` for exactly this: a plain click runs the row's primary action, a 750ms press (or right-click) opens the mobile action sheet, and a click that followed a long-press is suppressed. Spread `getRowHandlers(item)` on the `<tr>` and add `cursor-pointer`. The accounts, payees, tags, categories and securities lists all do this.
-
-Do not put the click on a button around the symbol or the name instead. It looks identical and is not: the rest of the row -- all the cell padding, every other column -- becomes dead, and clicking a row "does nothing" for the majority of its area. Controls *inside* the row (a favourite star, `RowActions`) must `stopPropagation` so they act on themselves; both already do.
+`useLongPress` takes `onClick` alongside `onLongPress`: a plain click runs the row's primary action, a 750ms press (or right-click) opens the mobile action sheet, and a click following a long-press is suppressed. Spread `getRowHandlers(item)` on the `<tr>` and add `cursor-pointer` (accounts, payees, tags, categories, securities lists all do). Do not put the click on a button around the name instead -- the rest of the row becomes dead area. Controls *inside* the row (a favourite star, `RowActions`) must `stopPropagation`.
 
 ### A detail page returns to its list above the title, and switches with the caret beside it
 
-Every detail page in the app -- an account, a payee, a category, a security, a
-report -- carries the same two controls: a chevron and "Back to <List>" on the
-line *above* the title, and `EntitySwitcher`'s caret immediately after the
-title, which jumps straight to another entity of the same kind. The way back is
-not an action on the thing being viewed, so it does not belong among the
-buttons on the right; that is where it drifted to on the report pages, and one
-of them grew a breadcrumb instead, so the section read as three pages that
-happened to share a URL prefix.
+Every detail page carries the same two controls: a chevron and "Back to <List>" on the line *above* the title, and `EntitySwitcher`'s caret immediately after the title. The way back is not an action on the thing being viewed, so it does not belong among the buttons on the right. For reports the pair is `BackToReportsLink` and `ReportDetailHeader` (`components/reports/`); `ReportSwitcher` builds the route itself so no call site spells it out. `ui-conventions.test.ts` scans for a hand-rolled back-chevron-to-`/reports`.
 
-For reports the pair is `BackToReportsLink` and `ReportDetailHeader`
-(`components/reports/`), used by the generic `[reportId]` renderer and the
-custom and investment viewers; the GEM report has its own header and mounts the
-two directly. `ReportSwitcher` builds the route itself -- an id in that menu
-*is* a path under `/reports/` -- so no call site spells it out.
-`ui-conventions.test.ts` scans for a hand-rolled back-chevron-to-`/reports`.
+**Two switchers on one line means at least one says its name.** `EntitySwitcher` takes `triggerText` (the GEM report's scenario picker reads "Scenario ⌄"); the bare caret stays the default when it is the only one.
 
-**Two switchers on one line means at least one of them says its name.** The GEM
-report carries both: the report caret beside the title, and a scenario picker
-one level in. Two bare chevrons a few pixels apart are indistinguishable, so
-`EntitySwitcher` takes `triggerText` and the scenario one reads "Scenario ⌄".
-The bare caret stays the default -- it is unambiguous when it is the only one.
+**A detail page's actions sit on the title row, not in a row above the body.** `AccountDetailShell` takes `headerActions` for type-specific actions beside the standard set; a signal they need to send the body travels down as a prop (`refreshKey`) rather than keeping the button in the body. A `size="sm"` button in a report toolbar takes `size="md"` in that header.
 
-**A detail page's actions sit on the title row, not in a row above the body.**
-`AccountDetailShell` takes `headerActions` for the type-specific ones, beside
-the standard Export/View Transactions/Reconcile/Edit set; the investment view
-had grown its own `flex justify-end` row instead, so that page had two action
-rows and neither was where every other detail page puts one. Type-specific
-actions therefore live in a small component the page passes as `headerActions`
-(`InvestmentDetailActions`), and any signal they need to send the body -- a
-price refresh that the body must re-fetch after -- travels down as a prop
-(`refreshKey`) rather than keeping the button in the body to stay near its own
-state. A button that is `size="sm"` in a report toolbar takes `size="md"` in
-that header, or it stands a few pixels short of everything beside it.
-
-A switcher list too long to scan takes `group` on its items
-(`ReportSwitcher` groups by the section the Reports page files each report
-under, in `REPORT_CATEGORIES` order). Sections follow the order their first
-item appears in, so ordering happens in the caller, and a section whose rows
-are all filtered out takes its heading with it.
+A switcher list too long to scan takes `group` on its items (`ReportSwitcher` groups in `REPORT_CATEGORIES` order); sections follow the order their first item appears in, so ordering happens in the caller.
 
 ### A category picker lists every category in tree order as "Parent: Child"
 
-However a surface selects a category -- the transaction form's Combobox, a
-switcher, a reassign target -- the option list is the one shape: built from
-`buildCategoryTree` (each parent followed by its children), a child labelled
-`Parent: Child`, a top-level category by its bare name, and **every row
-selectable, parents included**. A bare leaf name is ambiguous once two parents
-own the same leaf, and a picker shaped differently from the transaction form's
-reads as a second component. `CategorySwitcher` carries the regression tests.
+However a surface selects a category, the option list is one shape: built from `buildCategoryTree` (each parent followed by its children), a child labelled `Parent: Child`, a top-level category by its bare name, and **every row selectable, parents included**. `CategorySwitcher` carries the regression tests.
 
-**A picker the user types into creates through `createCategoryFromInput`
-(`lib/category-create.ts`), and never inline.** It owns title casing and the
-`Parent: Child` shorthand -- create or reuse the parent, then the child under
-it -- and returns every row it created so the caller can append all of them to
-its own list, not only the leaf. Three inline copies of that parsing existed
-and the scheduled transaction form's had none of it, so `travel: hotels` became
-a child of Travel in two fields and one flat category named "Travel: Hotels" in
-the third. The guard in `src/test/ui-conventions.test.ts` fails on a second
-`categoriesApi.create` call site outside the helper and the Categories page's
-own full create form.
+**A picker the user types into creates through `createCategoryFromInput` (`lib/category-create.ts`), never inline.** It owns title casing and the `Parent: Child` shorthand (create or reuse the parent, then the child), and returns every row it created so the caller can append all of them. The guard in `src/test/ui-conventions.test.ts` fails on a second `categoriesApi.create` call site outside the helper and the Categories page's own full create form.
 
-Whether a picker *offers* to create is a property of the surface, not of the
-field: a form that can create passes the creator to **every** category picker it
-renders, its split lines included. `SplitEditor`'s lines silently discarded text
-matching no category while the Category field beside them offered "+ Create"
-(issue #1187) -- the split copy was the same `Combobox` missing
-`allowCustomValue` and `onCreateNew`. An asynchronous create addresses the row
-it came from **by id**: rows can be added, removed or reordered while the
-request is in flight, and the new category's `isIncome` comes from what the
-creator returned, since the parent's appended list has not re-rendered the
-editor yet.
+Whether a picker *offers* to create is a property of the surface, not the field: a form that can create passes the creator to **every** category picker it renders, split lines included (`SplitEditor`'s lines silently discarded unmatched text while the Category field offered "+ Create" -- issue #1187). An asynchronous create addresses the row it came from **by id** (rows can move while the request is in flight), and the new category's `isIncome` comes from what the creator returned.
 
 ### An account balance is coloured by its sign -- `balanceColor`, never by account type
 
-`balanceColor` (`lib/format.ts`) is the one rule: negative is red, everything
-else is the neutral body colour. Do not add `|| isLiability` (or any
-`accountType` test) to that condition. A credit card sitting at a credit balance
-is not in the red, and the transactions sidebar painted every liability red
-regardless of what it held; the same branch also left an overdrawn chequing
-account looking fine on the days its sign was the only thing that had changed.
-The sign already carries the meaning -- the account type adds nothing the number
-does not say.
-
-`gainLossColor` is the sibling for a *change* in value (green when up), not for
-a balance: most accounts are in credit most of the time, and green there spends
-the emphasis on the ordinary case.
+`balanceColor` (`lib/format.ts`) is the one rule: negative is red, everything else neutral. Do not add `|| isLiability` (or any `accountType` test) -- a credit card at a credit balance is not in the red, and the sign already carries the meaning. `gainLossColor` is the sibling for a *change* in value (green when up), not for a balance.
 
 ### A scheduled transaction has four kinds, not two -- `scheduledKind`
 
-`amount < 0` / `amount > 0` answers only half the question, and the half it
-leaves out is invisible: a **transfer** between the user's own accounts is
-neither a bill nor a deposit, and an amount of exactly **zero** is a deliberate
-placeholder for something whose amount is not known until it arrives (a credit
-card bill, a variable utility). A ternary on the sign paints the zero green as a
-deposit, and a `!st.isTransfer` filter deletes the transfer from the screen
-entirely -- which is how a scheduled transfer the Bills list showed was missing
-from both calendars (issue #1124).
+`amount < 0` / `> 0` answers half the question: a **transfer** between own accounts is neither bill nor deposit, and exactly **zero** is a deliberate placeholder for an amount unknown until it arrives. A sign ternary paints the zero green, and a `!st.isTransfer` filter deleted a scheduled transfer from both calendars (issue #1124).
 
-Classify with `scheduledKind` (`lib/scheduled-kind.ts`), which returns
-`bill | deposit | transfer | reminder`, and colour from
-`SCHEDULED_KIND_CHIP_CLASSES` / `SCHEDULED_KIND_AMOUNT_CLASSES` so every surface
-reads the same way -- the two calendars, the dashboard widget's type badge, and
-the budget panel all go through it. Pass the *effective* amount
-(`nextOverride?.amount ?? amount`) where the surface is about one occurrence.
+Classify with `scheduledKind` (`lib/scheduled-kind.ts`) -- `bill | deposit | transfer | reminder` -- and colour from `SCHEDULED_KIND_CHIP_CLASSES` / `SCHEDULED_KIND_AMOUNT_CLASSES`. Pass the *effective* amount (`nextOverride?.amount ?? amount`) where the surface is about one occurrence.
 
-A surface listing *occurrences* -- a calendar, an upcoming list -- includes every
-active schedule whatever its kind. Filtering by kind is for a surface genuinely
-about bills or about deposits (the Bills/Deposits tabs, the budget's committed
-spending), and there a `reminder` belongs in neither bucket rather than silently
-in the positive one -- except where the surface is about *what the user still has
-to pay*, where a zero-amount reminder counts as an upcoming bill contributing
-nothing to the total (`BudgetUpcomingBills`).
-
-A **money total** is the separate decision, and it is not the same list as the
-count: a transfer is counted as something coming up but its amount never joins a
-bills-and-deposits sum, or the same money is reported twice
-(`UpcomingBillsReport`'s `summary.totalOf`). A reminder's zero is a placeholder,
-not a measurement, so it is never given a `+`/`-` sign or a red/green treatment
-that would read as a real amount.
+A surface listing *occurrences* includes every active schedule whatever its kind. Filtering by kind is for a surface genuinely about bills or deposits, and there a `reminder` belongs in neither bucket -- except where the surface is about *what the user still has to pay*, where a zero-amount reminder counts as an upcoming bill contributing nothing (`BudgetUpcomingBills`). A **money total** is a separate decision from the count: a transfer is counted as upcoming but its amount never joins a bills-and-deposits sum (`UpcomingBillsReport`'s `summary.totalOf`), and a reminder's zero is never given a sign or a red/green treatment.
 
 ### A stored occurrence price is an instruction; the market close is a suggestion
 
-An investment price *or quantity* the user saved -- on a scheduled occurrence's
-override, or carried from the schedule -- is a decision, not a stale default, so
-live market data may be *offered* beside it but never *written over* it. Both
-dialogs that fill a price obey this. `OverrideEditorDialog` fills the field from
-the latest close only when the occurrence has no price of its own and the user
-has not typed a total (`hasStoredPrice` false, `userEditedTotal` false, field
-empty), otherwise exposing an explicit "use latest close" action;
-`PostTransactionDialog` skips its market-price refresh when the prefill came from
-a per-occurrence override (`investmentFromStoredOverride`, keyed off a stored
-price *or quantity* -- an override that set only the shares must not have them
-rescaled) or when the user has edited any field, keeping the base-schedule DCA
-refresh only for a price that is a creation-time snapshot.
+An investment price *or quantity* the user saved is a decision, not a stale default: live market data may be *offered* beside it but never *written over* it. `OverrideEditorDialog` auto-fills from the latest close only when the occurrence has no price of its own and the user has not typed a total (`hasStoredPrice` false, `userEditedTotal` false, field empty), otherwise exposing an explicit "use latest close" action. `PostTransactionDialog` skips its market-price refresh when the prefill came from a per-occurrence override (`investmentFromStoredOverride`, keyed off a stored price *or* quantity) or when the user has edited any field (`userEditedInvestment`).
 
-Both fills are **total-first** (issue #1148): they preserve the amount invested
-and re-derive the share count, so the override editor's "use latest close" button,
-its keystroke path (`handleInvestmentPriceChange`), and the post dialog's refresh
-all book the same quantity and total for the same price -- the button used to be
-quantity-first and was the odd one out. The two guards **still differ**, not
-because the precedence differs but because the state each fill runs against does,
-and the guard protects the field the fill would clobber in that state. The
-override editor auto-fills only on an occurrence with no stored price, where the
-price field is empty and no total has been computed yet: with no total present the
-total-first fill degrades to deriving the total from the shares, which preserves a
-quantity-only edit -- so it blocks only once the user has typed a **total**
-(`userEditedTotal`), the one state where a total is present and the fill would
-rescale the quantity beside it. The post dialog's refresh carries the scheduled
-total, so a total is always present and the fill always rescales the shares --
-which is why it must block once the user has typed **anything**
-(`userEditedInvestment`), a typed quantity included. The fetch being asynchronous
-is what makes this matter: it can resolve
-*after* the dialog opens, and a value typed in the meantime (price still blank,
-so an "is the field empty" check alone lets the fill through) is the user's own
-instruction. The defect all of this prevents is a silent re-price: reopening an
-override to change only its date, posting an occurrence whose price the user set,
-or having a value you just typed re-derived under you, must not move money to
-today's close. A NaN or zero close is not a usable price -- normalize it to null
-where `marketPrice` is set (through `usableClose`), so the fill, the placeholder
-and the latch all treat it as "no price" rather than a value.
+Both fills are **total-first** (issue #1148): they preserve the amount invested and re-derive the share count. The two guards differ because the state each fill runs against differs: the override editor blocks only on a typed **total** (the one state where the fill would rescale the quantity), while the post dialog always carries a total and so blocks on **anything** typed. The fetch is asynchronous -- it can resolve after the dialog opens, and a value typed in the meantime is the user's instruction. A NaN or zero close is not a usable price -- normalize to null where `marketPrice` is set (`usableClose`).
 
-`marketPrice == null` is three states at once -- loading, a failed lookup, and a
-genuinely empty history -- so it must not gate the "no price history, enter
-manually" hint: a failed lookup is not an empty dataset, and flashing the hint
-mid-fetch is a lie the resolve then retracts. Each surface carries a
-`priceHistoryEmpty` flag set true *only* when a request completes with no usable
-close, reset false while in flight and left false on rejection; the hint reads
-that flag, never the bare null.
+`marketPrice == null` is three states at once (loading, failed lookup, genuinely empty history), so it must not gate the "no price history, enter manually" hint. Each surface carries a `priceHistoryEmpty` flag set true *only* when a request completes with no usable close, reset while in flight, left false on rejection.
 
-There are three surfaces that fill these fields -- the two dialogs and
-`ScheduledTransactionForm` -- and all three do the price/quantity/total
-arithmetic through `lib/investmentFold.ts` (`totalFromQuantity` /
-`quantityFromTotal` -- one rounding scale and one signed commission fold, so the
-surfaces cannot drift on the math, only on which conversion they run). Never
-hand-roll the fold inline; `lib/investmentFold.guard.test.ts` scans for the 8dp
-share-precision rounding that fingerprints a hand-rolled `quantityFromTotal` and
-fails for any occurrence outside the helper. State a stored price's provenance
-truthfully (a price on this override reads "saved on this occurrence", one
-inherited from the schedule reads "from the schedule" -- the two are different
-keys, not one); and format the "latest close" copy through
-`useNumberFormat().formatPrice` (a price is not money: up to six decimals,
-trailing zeros trimmed by Intl), never a hand-rolled `toFixed`/trailing-zero
-regex, which leaves a dangling separator in comma-decimal locales. Compose any
-"Label: value" line (the transfer and category banners) in the catalog as one
-string a translator can reorder, never as `{t('label')}: {value}` fragments in
-JSX.
+Three surfaces fill these fields -- the two dialogs and `ScheduledTransactionForm` -- and all three do the price/quantity/total arithmetic through `lib/investmentFold.ts` (`totalFromQuantity` / `quantityFromTotal`: one rounding scale, one signed commission fold). Never hand-roll the fold; `lib/investmentFold.guard.test.ts` scans for the 8dp share-precision rounding that fingerprints a hand-rolled copy. State a stored price's provenance truthfully ("saved on this occurrence" vs "from the schedule" are different keys); format "latest close" copy through `useNumberFormat().formatPrice` (a price is not money: up to six decimals, Intl-trimmed), never a hand-rolled `toFixed`. Compose any "Label: value" line in the catalog as one string a translator can reorder, never `{t('label')}: {value}` fragments.
 
-`ScheduledTransactionForm` reconciles the same way the dialogs do, and two more
-invariants live here because its `Total Value` is a shown figure that submit
-recomputes from `quantity * price (+/-) commission`: **the displayed total and
-the persisted amount must never disagree.** So every field that moves the
-economic total -- price, quantity, **commission, and the BUY/SELL action whose
-sign flips the fee** -- recomputes the shown total through the same fold, and the
-async close arriving mid-entry preserves an already-typed total and re-derives
-the quantity from it (total-first) rather than only writing the price. And **a
-market price belongs to one security**: changing the selected security clears the
-auto-filled price (and the seen-market-price latch) so the new security's own
-close fills the field, instead of the previous security's quote lingering because
-the field is non-empty. A NaN or zero close is not a usable price -- gate the
-"Latest:" placeholder on a positive `roundedMarketPrice`, never a bare
-`marketPrice != null`, so it never renders as "Latest: NaN".
+`ScheduledTransactionForm` adds two invariants because its `Total Value` is a shown figure that submit recomputes: **the displayed total and the persisted amount must never disagree** -- every field that moves the economic total (price, quantity, **commission, and the BUY/SELL action whose sign flips the fee**) recomputes the shown total through the same fold, and an async close arriving mid-entry preserves a typed total and re-derives the quantity. And **a market price belongs to one security**: changing the selected security clears the auto-filled price and the seen-market-price latch. Gate the "Latest:" placeholder on a positive `roundedMarketPrice`, never a bare `marketPrice != null`, so it never renders "Latest: NaN".
 
 ### Two transaction lists, two opposite delete contracts -- read the tense
 
-`InvestmentTransactionList`'s `onDelete` **asks the parent to delete**: the list
-raises a confirmation and hands back an id. `TransactionList`'s `onDeleted`
-**reports a delete it already performed** -- it owns the confirmation, the
-`transactionsApi.delete`/`deleteTransfer` call and the toast. The two are a few
-lines apart in `InvestmentRegisterPanel`, and a handler written for the first
-shape and wired to the second deleted every cash row twice: the second request
-404'd on the row the first had removed, so the user got "Transaction deleted"
-and "not found" side by side (issue #1192). Worse for a transfer, where the list
-correctly calls `deleteTransfer` and the parent then calls the plain `delete`.
+`InvestmentTransactionList`'s `onDelete` **asks the parent to delete** (the list confirms and hands back an id). `TransactionList`'s `onDeleted` **reports a delete it already performed** (it owns the confirmation, the API call and the toast). A handler written for the first shape and wired to the second deleted every cash row twice (issue #1192) -- worse for a transfer, where the list correctly calls `deleteTransfer` and the parent then calls plain `delete`. Reach for `onRefresh` to reload after a delete, and for `onDeleted` only when you need the id itself -- never to perform the delete. `ui-conventions.test.ts` scans every `<TransactionList` for an `onDeleted` handler that deletes.
 
-Reach for `onRefresh` to reload after a delete, and for `onDeleted` only when
-you need the id itself (an optimistic removal, a counterpart to drop) -- never to
-perform the delete. `ui-conventions.test.ts` scans every `<TransactionList` for
-an `onDeleted` handler that deletes, in both the named and inline forms.
+**The signal has to reach whatever else is derived from those rows.** The panel's own reload is not the page: the account detail view draws the portfolio summary, allocation and Holdings by Account above the register, and a write that only reloaded the register left all three stale (issue #1190). Dropping caches is half of it -- nothing mounted refetches on its own. `InvestmentRegisterPanel` raises `onDataChanged` after every write, and `InvestmentDetailView` re-runs its load from it.
 
-**The signal has to reach whatever else is derived from those rows.** The panel's
-own reload is not the page: the account detail view draws the portfolio summary,
-the allocation and the Holdings by Account list -- cash row included -- above it,
-and a cash deposit that only reloaded the register left all three at their
-pre-write figures until the page was reloaded by hand (issue #1190). Dropping the
-caches is half of it; `invalidateBalanceCaches` only makes the *next* fetch
-honest, and nothing mounted refetches on its own. `InvestmentRegisterPanel` raises
-`onDataChanged` after every write for exactly this, and `InvestmentDetailView`
-re-runs its load from it.
+**Every write path on a page shares one refresh, including the ones nobody reported.** A delete is a write, and so is an undo, a redo, an AI action and a status change; a reported create symptom says nothing about which paths are broken. `useInvestmentData.refreshAfterWrite` is that one function for the Investments page (`InvestmentRegisterPanel.afterWrite` is the detail page's). When you fix a stale-figure defect, grep the surface for its other write paths and route them through the same function in the same commit.
 
-**Every write path on a page shares one refresh, including the ones nobody
-reported.** The #1190 fix wired the account detail page's writes together and
-left the Investments page's own paths as they were, so adding a cash row there
-refreshed the summary, the allocation, Holdings by Account and the brokerage
-register, while deleting one reloaded the cash rows alone -- the row vanished
-and every figure above it kept its pre-delete value until the user pressed
-Refresh. A delete is a write, and so is an undo, a redo, an AI action and a
-status change; the fact that the reported symptom was a create says nothing
-about which paths are broken. `useInvestmentData.refreshAfterWrite` is that one
-function for the Investments page (`InvestmentRegisterPanel.afterWrite` is the
-detail page's), and each write path calls it rather than reloading the list the
-write happened on. When you fix a stale-figure defect, grep the surface for its
-other write paths and route them through the same function in the same commit.
+**A sibling that fetches for itself needs the signal as a prop, not as a re-render.** `InvestmentValueChart` fetches its own series, so the write reaches it as `refreshKey`. Two details: the intraday series is served from `sessionStorage`, so drop it (`clearAllIntradayCache`) and pass `skipCache`; and the effect must gate on the key it has already **acted on**, not on running -- `loadData` changes identity on every range/account/currency change, and an ungated second effect double-fetches on each.
 
-**A sibling that fetches for itself needs the signal as a prop, not as a
-re-render.** Re-running the parent's load refreshes what the parent fetched, and
-`InvestmentValueChart` fetches its own series -- so the write reaches it as
-`refreshKey`, the same convention the header's price refresh uses. Two details it
-cannot skip: the intraday series is served from `sessionStorage`, so a re-fetch
-that trusted the cache hands back the pre-write points (drop it with
-`clearAllIntradayCache` and pass `skipCache`), and the effect must gate on the
-key it has already **acted on** rather than on running -- `loadData` changes
-identity on every range, account and currency change, and the load effect already
-covers those, so an ungated second effect fetches twice for each of them and
-again on any mount under a non-zero key.
+**Both registers of one account are paged, filtered and drawn the same way.** The bar above the rows is `ListTopToolbar` (`components/ui/ListTopToolbar.tsx`) -- position info left, density toggle and list buttons right -- and both `TransactionList` and `InvestmentTransactionList` compose it; `ui-conventions.test.ts` fails on a second call site handing `Pagination` an `infoRight`.
 
-**Both registers of one account are paged, filtered and drawn the same way.**
-They are one account's two ledgers a toggle apart, so a difference between them
-reads as a bug even when each half is defensible on its own. The bar above the
-rows is `ListTopToolbar` (`components/ui/ListTopToolbar.tsx`) -- where you are in
-the list on the left, the density toggle and the list's own buttons on the right
--- and both `TransactionList` and `InvestmentTransactionList` compose it rather
-than rebuilding the markup; `ui-conventions.test.ts` fails on a second call site
-handing `Pagination` an `infoRight`. A pager *only* below the table is one the
-reader meets after scrolling past everything it could have helped them skip,
-which is what the brokerage register had while the cash register beside it paged
-from above.
+**A register pages from both ends, and the second one is `ListBottomPager`** (`components/ui/ListBottomPager.tsx`). On a single page it draws the count instead of an inert pager -- the opposite of the top strip, which keeps its pager because "Showing 1-7 of 7" answers "did that filter work?". The top strip is the card's own header row and belongs inside the list component; `Pagination` carries its own background and shadow and must sit *outside* the card. `ui-conventions.test.ts` fails on a raw `<Pagination>` anywhere but the two wrappers and the four standalone list pages, and separately requires each register surface to reference `ListBottomPager`. Nothing repeats the density toggle down there: repeating a position is the point, repeating a control is not.
 
-**A register pages from both ends, and the second one is `ListBottomPager`**
-(`components/ui/ListBottomPager.tsx`). The top strip is met before the rows; the
-bottom pager is where a reader who scrolled the whole page actually finishes, and
-the Transactions page has ended that way for as long as it has had a pager. On a
-single page it draws the count instead of an inert pager -- the opposite of the
-top strip, which keeps its pager because "Showing 1-7 of 7" is the answer to "did
-that filter work?", asked once, up where the filter controls are.
+Filtering follows the same rule: a trade is narrowed by symbol and action (the brokerage list's own filter row), a cash row by payee and category (`CashFilterBar`, shared by the Investments page and the account detail page). Each register's page returns to 1 when its filter changes, and the filters belong in the register's request key. The chrome is part of "the same way": one heading (*Recent Transactions* on both -- the toggle already says which ledger), a new-row button marked the same on both, the same gaps.
 
-Which end lives where is a layout fact, not a preference: the top strip is the
-card's own header row, so it belongs inside the list component, while
-`Pagination` carries its own background and shadow and so must sit *outside* the
-card -- inside it, it reads as a white box on a white panel. That is why the
-surface draws the bottom one and passes it the same paging state it gave the
-list. `ui-conventions.test.ts` fails on a raw `<Pagination>` anywhere but the two
-wrappers and the four standalone list pages, and separately requires each
-register surface to reference `ListBottomPager`. Nothing repeats the density
-toggle down there: repeating a position is the point, repeating a control is
-not.
+**A filter picker offers what the rows use, and it loads because the register is on screen.** `useCashFilterOptions` asks `transactionsApi.getRegisterFilterOptions` for the payees and categories the selected accounts' rows actually reference. The endpoint reads split lines as well as parents (a split parent's own `categoryId` is NULL), and returns the **ancestors** of every used category, because `MultiSelect` builds its top level from `parentId == null` and drops a child whose parent is absent. Trigger the load from the view being displayed, never from the click that reaches it (the view is remembered, so the register is reachable without the click).
 
-Filtering follows the same rule with different questions: a trade is narrowed by
-symbol and action (the brokerage list's own filter row), a cash row by payee and
-category (`CashFilterBar`, shared by the Investments page and the account detail
-page). Each register's page returns to 1 when its filter changes, and the filters
-belong in the register's request key -- otherwise the rows keep answering the
-previous question until something else triggers a fetch.
+`useBrokerageFilterOptions` (`hooks/useBrokerageFilterOptions.ts`) fetches the actions and symbols those accounts have actually used. Absent or empty is "no information", so the action list keeps offering everything; whatever is selected stays in the control even when the rows no longer use it. **Symbols come from the rows, never from current holdings** -- a position sold in full is exactly what somebody filtering by symbol is looking for.
 
-The chrome around them is part of "the same way": one heading (*Recent
-Transactions* on both -- the toggle beside it already says which ledger), a
-new-row button marked the same way on both, and the same gap between the header
-and the strip. A heading that renames itself and a spacer present on one side
-only made the toggle read as a navigation rather than a change of ledger. The
-Investments page and the account detail page draw the same two registers, so
-they take the same treatment: both page from the strip and from a
-`ListBottomPager` below the rows, and neither page puts a density toggle in its
-own heading beside the register's.
+**A one-shot fetch guarded by a ref cannot also be cancelled in its cleanup.** Under StrictMode (on in Next.js) an effect runs, cleans up, and runs again: the first pass claims the `loadedKeyRef`, the cleanup marks the only request cancelled, and the second pass starts nothing -- pickers sit empty all session. Let the ref decide instead: adopt the response while `loadedKeyRef.current === key` (which also drops an answer a newer selection overtook). Testing Library does not double-invoke effects, so only a test rendering the hook inside `<StrictMode>` catches this; both hooks carry one.
 
-**A filter picker offers what the rows use, and it loads because the register is
-on screen.** `useCashFilterOptions` asks
-`transactionsApi.getRegisterFilterOptions` for the payees and categories the
-selected accounts' rows actually reference -- a brokerage cash ledger has a dozen
-payees, and offering the household's whole address book to narrow it buries them.
-The endpoint reads split lines as well as parent rows (a split parent's own
-`categoryId` is NULL, and the register's category filter matches split lines), and
-returns the **ancestors** of every used category, because `MultiSelect` builds its
-top level from `parentId == null` and drops a child whose parent is absent.
-Trigger the load from the view being displayed, never from the click that reaches
-it: the Investments page remembers its view, so the cash register is reachable
-without that click, and gating on it left both pickers reading "No options found"
-for the users who live there.
+**A register that has rows keeps them while the next page loads.** Gate the skeleton on there being nothing to show yet (`loadedKey === null`), not on a request being in flight (the Investments page's `hasLoadedRef` is the same decision) -- swapping a table for a skeleton scrolls the reader to the top.
 
-The brokerage side asks the same question of its own vocabulary:
-`useBrokerageFilterOptions` (`hooks/useBrokerageFilterOptions.ts`) fetches the
-actions and symbols those accounts have actually used, and the pickers offer
-those rather than all twenty-odd actions. Absent or empty is "no information" --
-still loading, or the lookup failed -- so the action list keeps offering
-everything; and whatever is currently selected stays in the control even when the
-rows no longer use it, or the list is narrowed by something the user can neither
-see nor undo. **Symbols come from the rows, never from current holdings**: the
-picker was built from `portfolioSummary.holdings`, so a position sold in full was
-not offered, and its trades are exactly the rows somebody filtering by symbol is
-looking for.
+**A pager stays drawn when a filter narrows the list to one page.** The buttons are inert, but "Showing 1-7 of 7" is the answer to "did that filter work?", read at exactly the moment hiding it would remove it.
 
-**A one-shot fetch guarded by a ref cannot also be cancelled in its cleanup.**
-Both option hooks latch a `loadedKeyRef` so a re-render does not re-ask, and both
-originally set a `cancelled` flag in the effect's cleanup. Under React's
-development StrictMode -- which Next.js has on -- an effect runs, is cleaned up,
-and runs again: the first pass claims the key and starts the only request, the
-cleanup marks it cancelled, and the second pass finds the key already claimed and
-starts nothing. The response is then discarded and the pickers sit empty for the
-whole session, which is what "No options found" and an Action picker still
-offering all twenty were. Let the ref decide instead -- adopt the response while
-`loadedKeyRef.current === key` -- which also drops an answer a newer selection has
-overtaken. Testing Library does not double-invoke effects, so this class of defect
-is only caught by a test that renders the hook inside `<StrictMode>`; both hooks
-carry one.
+**A nav tab is lit by the section a page belongs to, not by an exact path.** `isNavSectionActive` (`lib/nav-section.ts`) is the one predicate, used by the header and the mobile drawer: `/accounts/<id>` is Accounts, `/securities/<id>` is Tools. The boundary is a slash, so `/accounts` never claims `/accounts-archive`.
 
-**A register that has rows keeps them while the next page loads.** Answering a
-filter or page change with a skeleton swaps a table for three lines, the page
-shortens under the reader, and the browser scrolls to the top -- which is what
-applying a filter on the account detail page used to do. Gate the skeleton on
-there being nothing to show yet (`loadedKey === null`), not on a request being in
-flight; the Investments page's `hasLoadedRef` is the same decision.
+**A cash register holds rows that are not cash transactions, and one function decides which editor each gets** -- `editCashRow` (`lib/cash-row-edit.ts`). A trade's cash leg (`linkedInvestmentTransactionId`) is edited as the *trade*; a transfer is fetched in full first (the list payload lacks its counterpart); everything else opens on the row as listed. A failed lookup for a trade opens nothing rather than falling back to the cash form -- the fallback is the same defect by another door.
 
-**A pager stays drawn when a filter narrows the list to one page.** The buttons
-are inert there, but the line beside them -- "Showing 1-7 of 7 transactions" --
-is the answer to "did that filter work?", and hiding it exactly when a filter has
-just been applied takes the count away at the moment it is being read.
+**A modal this page already mounts is opened, not navigated to.** Clicking an investment-linked row pushed `/investments?edit=<id>`, remounting and refetching everything to reach a form that was mounted the whole time. Fetch the row and call the modal's own `openEdit`; keep the URL parameter for arrivals from another page.
 
-**A nav tab is lit by the section a page belongs to, not by an exact path.**
-`isNavSectionActive` (`lib/nav-section.ts`) is that one predicate, used by the
-header and the mobile drawer: `/accounts/<id>` is Accounts, `/securities/<id>` is
-Tools. Comparing the pathname to the href unlit the tab the user had just come
-through, so the bar said nothing about where they were. The boundary is a slash,
-so `/accounts` never claims `/accounts-archive`.
+**A form's account list is a property of the form, not of the page that opened it.** `InvestmentTransactionForm` is mounted from two surfaces, and only one passed `allAccounts` -- so "Funds From (optional)" offered only the one option the field exists to replace (issue #1191). When a surface mounts a shared form against a narrower scope, narrow the *scope* props (`accounts`, `defaultAccountId`) and keep supplying the wide ones. A failed lookup stays `undefined`, never `[]`: undefined is "not supplied", an empty array claims the user has no other accounts.
 
-**A cash register holds rows that are not cash transactions, and one function
-decides which editor each gets** -- `editCashRow` (`lib/cash-row-edit.ts`). A
-trade's cash leg (`linkedInvestmentTransactionId`) is edited as the *trade*: its
-amount, date and payee are consequences of the trade, so a cash form over it
-offers to change figures it does not own. A transfer is fetched in full first,
-because the list payload does not carry its counterpart. Everything else opens
-on the row as listed. The account detail page's register had only the third
-case, which is how clicking a trade there opened a cash form -- and a failed
-lookup for a trade opens nothing rather than falling back to the cash form,
-since that fallback is the same defect arriving by another door.
-
-**A modal this page already mounts is opened, not navigated to.** Clicking an
-investment-linked row in the cash register pushed `/investments?edit=<id>`, which
-remounted the page, scrolled it to the top and refetched every section before the
-dialogue appeared -- to reach a form that was mounted the whole time. Fetch the
-row and call the modal's own `openEdit`; keep the URL parameter for arrivals from
-another page.
-
-**A form's account list is a property of the form, not of the page that opened
-it.** The same `InvestmentTransactionForm` is mounted from the Investments page
-and from an account's detail page, and only the first passed `allAccounts` -- so
-"Funds From (optional)" on the detail page offered nothing but the account's own
-linked cash, which is the one option the field exists to replace (issue #1191).
-When a surface mounts a shared form against a narrower scope, narrow the *scope*
-props (`accounts`, `defaultAccountId`) and keep supplying the wide ones. A failed
-lookup there stays `undefined`, never `[]`: the form reads undefined as "not
-supplied" and falls back, while an empty array is a claim that the user has no
-other accounts.
 ### Row density is remembered per view, by one store -- `useDensityPreference(view)`
 
-Each surface keeps its own level -- Accounts at normal while the transactions
-register is dense -- but exactly one store holds them all, under one key. Read
-it with `useDensityPreference(view)` (`@/store/densityStore`), which returns
-`density`, `setDensity` and `cycleDensity` already bound to that view; pass the
-level *down* to rows and `RowActions` as a prop, but never accept a change
-callback back up. `DensityView` is a union, so a mistyped view is a compile
-error rather than a bucket nothing ever writes to.
+Each surface keeps its own level, but exactly one store holds them all. Read it with `useDensityPreference(view)` (`@/store/densityStore`), which returns `density`, `setDensity` and `cycleDensity` bound to that view; pass the level *down* to rows and `RowActions` as a prop, never accept a change callback back up. `DensityView` is a union, so a mistyped view is a compile error. (It was thirteen drifting stores before issue #1193; `densityStore.ts` migrates all twelve legacy keys.)
 
-It was thirteen stores before issue #1193: eleven pages each owning a
-`useLocalStorage('monize-<view>-density')`, `AccountList` hand-rolling a
-twelfth under `accounts.filter.density`, and three surfaces -- the investment
-account detail register among them -- persisting nothing at all, so they fell
-through to a `useState('normal')` that reset on every remount. The defect was
-never that the levels differed per view; it was that each surface reimplemented
-storing them and some forgot. `densityStore.ts` migrates all twelve legacy keys
-into their own views and deletes them, so nobody loses a setting on the release
-that fixes losing settings.
+**A component rendered from more than one surface takes a `densityView` prop.** `TransactionList` is mounted from six places; the prop defaults to the owning page's view, so a caller that forgets it silently shares the register's bucket. The guard fails on a call site outside the owning page that does not pass one.
 
-**A component rendered from more than one surface takes a `densityView` prop.**
-`TransactionList` is mounted from six places and `InvestmentTransactionList`
-from two; the prop defaults to the owning page's view, so a caller that is not
-that page and forgets it silently shares the register's bucket -- two unrelated
-screens moving together, with nothing on screen to explain why. The guard fails
-on a call site outside the owning page that does not pass one.
+The preference is browser-local rather than a `user_preferences` column on purpose -- a laptop and a desktop on the same account should not have to agree -- and is classified in `persisted-storage.guard.test.ts`.
 
-The preference is browser-local rather than a `user_preferences` column on
-purpose -- a 13" laptop and a desktop monitor signed into the same account
-should not have to agree -- and it is classified in
-`persisted-storage.guard.test.ts` like every other localStorage-backed store.
+**The button is `DensityToggle`, and the strip above a table is `DensityToggleBar`** (`components/ui/DensityToggle.tsx`). The copy lives once, at `common.density.*` (per-surface namespaces let fourteen locales drift, with Korean holding six words for "Dense"). Pass `size` (`sm` above a table, `md` beside `text-sm` toolbar controls, `chip` in a filter-chip row) and `className`; never colour or padding.
 
-**The button is `DensityToggle`, and the strip above a table is
-`DensityToggleBar`** (`components/ui/DensityToggle.tsx`). Eleven surfaces drew
-it by hand: seven byte-identical, the rest differing only in size and placement,
-but each reading its label from its own namespace under one of five key shapes.
-That is how the *translations* drifted without anyone noticing -- fourteen of
-nineteen locales had at least one density string that disagreed with itself
-across surfaces, and Korean had six different words for "Dense". The copy now
-lives once, at `common.density.*`. Pass `size` (`sm` above a table, `md` beside
-`text-sm` toolbar controls, `chip` in a row of filter chips) and `className` for
-positioning; never colour or padding.
+**Cell padding is `useTableDensity(density, scale)`**, whose table is data in one file. Two scales are deliberate: `default`, and `wide` for a register with enough columns that the phone inset yields first (the investment register). A third variant means a named entry there, not a `switch` in a component.
 
-**Cell padding is `useTableDensity(density, scale)`**, whose table is data in
-one file. There were five copies of it, agreeing at some levels and silently
-disagreeing at others, so a deliberate difference was indistinguishable from a
-drifted one. Two scales are deliberate: `default`, and `wide` for a register
-with enough columns that the phone inset has to give way before the data does
-(the investment register). A third variant means a named entry there, not a
-`switch` in a component.
-
-None of those files was wrong on its own, which is why the rule is a scan:
-`density-preference.guard.test.ts` fails on a local density `useState` (typed or
-bare), a density key at any storage call site, an `onDensityChange` prop, a
-`cycleDensity` that does not come from the store, a shared list rendered without
-a `densityView`, a second copy of the toggle markup, a density string in any
-catalog but `common`, and a hand-rolled padding `switch`.
+`density-preference.guard.test.ts` holds all of it as a scan: a local density `useState`, a density key at any storage call site, an `onDensityChange` prop, a `cycleDensity` not from the store, a shared list rendered without a `densityView`, a second copy of the toggle markup, a density string in any catalog but `common`, and a hand-rolled padding `switch` all fail.
 
 ### Asking for the Balance column and supplying the balance are one decision
 
-`<TransactionList isSingleAccountView>` draws the Balance column, and the number
-in it is the backend's `startingBalance` run down the page -- the list derives
-nothing on its own, so the column arrives empty without it. `InvestmentRegisterPanel`
-read the rows off `transactionsApi.getAll` and dropped the `startingBalance` that
-came with them, so the account detail page's cash register showed "-" on every row
-while the Investments page's copy of the same register was right (issue #1188).
-
-Take both from the same response and adopt them in the same block: a starting
-balance is computed for one page of one account and means nothing beside another
-page's rows, and a failed reload that keeps the rows has to keep the balance too.
-`ui-conventions.test.ts` fails any `<TransactionList>` that sets
-`isSingleAccountView` without passing `startingBalance`.
+`<TransactionList isSingleAccountView>` draws the Balance column, and the number in it is the backend's `startingBalance` run down the page -- the list derives nothing, so the column arrives empty without it (issue #1188). Take both from the same response and adopt them in the same block: a starting balance is computed for one page of one account, and a failed reload that keeps the rows has to keep the balance too. `ui-conventions.test.ts` fails any `<TransactionList>` setting `isSingleAccountView` without `startingBalance`.
 
 ### An overdue-reconciliation window is the server's number, never the client's
 
-Whether an unreconciled row is *overdue* is decided by `classifyStaleRow`
-(`lib/stale-reconciliation.ts`), and it takes the boundary date as an argument
-because the server owns it: every response that asks for a classification
-carries `overdueBefore` (and `staleAfterDays` for the copy that names it), from
-`STALE_UNRECONCILED_DAYS` in `backend/src/transactions/stale-reconciliation.ts`.
-A component that hardcodes the number goes on saying 45 after the constant
-moves, and the row highlight then disagrees with the count in the header badge
-about which rows it is counting -- two surfaces describing the same ledger,
-neither obviously wrong.
+Whether an unreconciled row is *overdue* is decided by `classifyStaleRow` (`lib/stale-reconciliation.ts`), and it takes the boundary date as an argument because the server owns it: every response that asks for a classification carries `overdueBefore` (and `staleAfterDays` for the copy that names it), from `STALE_UNRECONCILED_DAYS` in `backend/src/transactions/stale-reconciliation.ts`. A hardcoded number goes on saying 45 after the constant moves, and the row highlight then disagrees with the header badge.
 
-**Which of its two answers a surface *draws* is the surface's decision.** The
-register draws `missed` only (`registerStaleReason` in `TransactionList.tsx`):
-"overdue" says nobody has reconciled the account recently, which is true of
-every row in it at once, so on a page of history it marked transaction after
-transaction for a condition about none of them. `ReconcileTable` still draws
-both -- there it is about the statement being worked on -- and the header badge
-still counts both. That is a presentation choice about where the mark helps, and
-it is the *only* thing a call site may vary; everything below is the helper's.
+**Which of its two answers a surface *draws* is the surface's decision** -- the register draws `missed` only (`registerStaleReason` in `TransactionList.tsx`; "overdue" is true of every row at once on a page of history), `ReconcileTable` draws both, the header badge counts both. That presentation choice is the *only* thing a call site may vary. Three things the helper decides that a call site must not re-decide:
 
-Three things the helper decides that a call site must not re-decide:
+- **An account nobody reconciles has no overdue rows** (`lastReconciledDate` null is the whole test) -- reconciliation is opt-in.
+- **`missed` wins over `overdue`** -- a row counted under both makes the reminder's lines add up to more than the badge.
+- **A RECONCILED or VOID row is never outstanding** -- the status test lives inside the helper.
 
-- **An account nobody reconciles has no overdue rows**, whatever their age.
-  `lastReconciledDate` null is the whole of that test. Reconciliation is opt-in,
-  and a badge telling a user who has never reconciled that their entire history
-  is outstanding is one they will turn off and never look at again.
-- **`missed` wins over `overdue`.** A row can satisfy both comparisons; counted
-  under both, the two lines in the reminder add up to more than the badge.
-- **A RECONCILED or VOID row is never outstanding.** The status test lives
-  inside the helper rather than beside each caller, because both callers had
-  their own reason to believe they would never be handed one.
-
-**A failed lookup is not a clean ledger.** `useStaleReconciliation` returns
-`undefined` when the request fails, and every consumer reads undefined as "no
-information" and marks nothing -- the register keeps rendering, the badge does
-not appear. Returning an empty context instead would make an outage
-indistinguishable from a ledger that is up to date, which is the same class of
-mistake as `accounts = []` on a failed accounts request.
+**A failed lookup is not a clean ledger.** `useStaleReconciliation` returns `undefined` on failure, and every consumer reads undefined as "no information" and marks nothing. An empty context instead would make an outage indistinguishable from an up-to-date ledger -- the same class of mistake as `accounts = []` on a failed request.
 
 ### A long list -- page it, or bound it and scroll with `scrollbar-slim`
 
-Two patterns, depending on where it lives:
+A full-page list uses `components/ui/Pagination.tsx`. A list inside a card caps its height and scrolls: `scrollbar-slim max-h-* overflow-y-auto pr-1`. The thing to avoid is the *default* scrollbar, not scrolling -- on Linux/Windows the native bar inside a small card reads as a rendering fault. `scrollbar-slim` (defined in `globals.css` alongside `scrollbar-hide`) keeps a thin themed thumb.
 
-- A full-page list uses `components/ui/Pagination.tsx`.
-- A list inside a card caps its height and scrolls: `scrollbar-slim max-h-* overflow-y-auto pr-1`.
-
-The thing to avoid is the *default* scrollbar, not scrolling. On Linux and Windows
-the native bar is a wide arrowed control drawn hard against the content, and inside
-a small card it reads as a rendering fault rather than as an affordance. That is
-what gets complained about. `scrollbar-slim` keeps the bar -- a bounded list needs
-one, or the rest of it is invisible -- as a thin rounded thumb on an empty track,
-in the theme's greys, light and dark. The utility is defined in `globals.css`
-alongside `scrollbar-hide`; it arrives with the security-detail branch, so on a
-branch that predates it, add it there rather than styling a bar inline.
-
-Bound the height rather than letting the card grow, and rather than hiding rows
-behind a "Show N more" expander. A card in a grid or beside a chart has to be the
-same height whatever its contents, or it drags the layout around: a breakdown card
-next to the price chart left a gap under the chart when it collapsed, and an
-expander also puts a click in front of information the card exists to show at a
-glance. `SecurityWeightingBars` and the detail page's "Held in accounts" are the
-worked examples.
-
-`scrollbar-hide` is for a horizontal strip of chips, where the overflow is obvious
-from the content being cut. Never use it on a vertical list: hiding a bar you need
-is worse than a plain one.
+Bound the height rather than letting the card grow or hiding rows behind a "Show N more" expander -- a card in a grid must be the same height whatever its contents (`SecurityWeightingBars` and the detail page's "Held in accounts" are the worked examples). `scrollbar-hide` is for a horizontal chip strip where overflow is obvious; never use it on a vertical list.
 
 ### A password field declares what may be autofilled into it
 
-Every `<Input type="password">` carries an `autoComplete`, and which value is a
-judgement about the field: `current-password` when it really is this account's
-password (a re-auth prompt, a confirm-before-delete box), `new-password` when one
-is being set here, `off` when it is not a credential of this site at all.
-
-Omitting it is not neutral. A browser or password manager fills a bare password
-box with the saved credential for the origin, and the form then submits it as
-though the user typed it -- so the AI provider's API key field, whose edit form
-sends `apiKey` whenever the box is non-empty, silently replaced the stored
-provider key on the next save: "Saved" on screen, provider dead, and no way to
-tell from the UI because the row shows `****` either way. The backup export
-password is the same shape and worse, since the artifact is then encrypted under
-a password nobody knows. `ui-conventions.test.ts` fails the build on a password
-input with no `autoComplete`, and on a value outside those three.
+Every `<Input type="password">` carries an `autoComplete`: `current-password` when it really is this account's password, `new-password` when one is being set here, `off` when it is not a credential of this site at all. Omitting it is not neutral -- a password manager fills a bare box with the saved credential, and the form submits it as typed: the AI provider's API key field silently replaced the stored key ("Saved" on screen, provider dead, row shows `****` either way), and the backup export password is the same shape and worse. `ui-conventions.test.ts` fails on a password input with no `autoComplete`, and on a value outside those three.
 
 ### A view that graduates to its own page -- delete the modal, do not flag it
 
-Remove the modal mode instead of keeping it behind a prop: an `onClose?` nobody
-passes and an `embedded` flag whose only caller always sets it leave every
-`!embedded` branch compiling, tested and unreachable, still fetching the data
-they no longer show. Delete the props, those branches, the orphaned catalog
-strings in every locale, and whatever in a shared component only that modal used
-(a `Modal` prop, a row-action icon).
+Remove the modal mode instead of keeping it behind a prop: an `onClose?` nobody passes and an `embedded` flag whose only caller always sets it leave every `!embedded` branch compiling, tested and unreachable, still fetching data they no longer show. Delete the props, those branches, the orphaned catalog strings in every locale, and whatever in a shared component only that modal used.
 
 ### Copy -- `--` is comment style, never UI text
 
-This repo writes `--` in code comments, and the habit is strong enough that it
-leaks into catalog strings, where it renders literally on screen and reads as a
-typo. In copy use an em dash, or recast the sentence and drop the aside.
-`messages.punctuation.test.ts` fails the build on a new one; it carries a
-shrink-only baseline of the strings that already had them.
-
-The same applies to anything else that is punctuation rather than words: compose
-it in the catalog, not in JSX. `"{units} ({share})"` is one string a translator
-can reorder; `{value}{' ('}{share}{')'}` in a component is three fragments they
-cannot reach.
+The repo writes `--` in code comments, and the habit leaks into catalog strings, where it renders literally. In copy use an em dash, or recast the sentence. `messages.punctuation.test.ts` fails the build on a new one (shrink-only baseline for existing). The same applies to anything else that is punctuation rather than words: compose it in the catalog, not in JSX -- `"{units} ({share})"` is one string a translator can reorder; `{value}{' ('}{share}{')'}` is three fragments they cannot reach.
 
 ### A transfer's direction comes from the row's own amount -- `transferDirection`
 
-Money leaving an account went **to** the counterpart; money arriving came
-**from** it. So the two legs of one transfer are labelled differently and both
-are right, and a split line pointing at another account is asked with *its* own
-amount rather than the parent's. `transferDirection` (`lib/transfer-label.ts`)
-is the only place that decision is made, and `transferCsvLabel` is the export's
-rendering of it (`Transfer To Savings`); the register renders the same decision
-as its arrow chip.
+Money leaving an account went **to** the counterpart; money arriving came **from** it. The two legs of one transfer are labelled differently and both are right, and a split line pointing at another account is asked with *its* own amount, not the parent's. `transferDirection` (`lib/transfer-label.ts`) is the only place that decision is made; `transferCsvLabel` is the export's rendering, and the register renders the same decision as its arrow chip. A `ui-conventions.test.ts` guard fails on a new `? 'to' : 'from'` outside the helper.
 
-The rule had been written out four times inside `TransactionRow` and was missing
-from both CSV exports entirely -- the Transactions export left the Category cell
-empty for a transfer, and a transfer split line was exported as `Uncategorized`,
-which is not merely blank but wrong. A `ui-conventions.test.ts` guard fails on a
-new `? 'to' : 'from'` outside the helper.
-
-Coerce before comparing: `'-67.9900' < 0` is false, and a decimal string is what
-the API sends, so a hand-rolled comparison labels every debit backwards.
+Coerce before comparing: `'-67.9900' < 0` is false, and a decimal string is what the API sends.
 
 ### A transaction's payee display is `usePayeeDisplay`, never a bare `payeeName` read
 
-A transfer created with a blank payee is PERSISTED blank (issue #1214) --
-nothing stamps "Transfer to Savings" into the row any more, and migration 161
-blanked the rows the old writers stamped. The label is resolved at render
-time: `usePayeeDisplay()` (`hooks/usePayeeDisplay.ts`) returns the stored
-payee when there is one and otherwise, for a transfer leg, the localized
-`common.transferPayee` string built from `linkedTransaction.account.name` --
-the counterpart's CURRENT name, so an account rename or a language switch
-updates every historical row at once. A surface that reads
-`tx.payeeName || tx.payee?.name` directly shows those transfers as unnamed.
-English CSV exports use `transferPayeeCsvLabel` (`lib/transfer-label.ts`), the
-byte-identical twin of the backend's `transferPayeeLabel`.
+A transfer created with a blank payee is PERSISTED blank (issue #1214); migration 161 blanked the legacy-stamped rows. The label is resolved at render time: `usePayeeDisplay()` (`hooks/usePayeeDisplay.ts`) returns the stored payee when there is one, otherwise for a transfer leg the localized `common.transferPayee` string built from `linkedTransaction.account.name` -- the counterpart's CURRENT name, so renames and language switches reach every historical row. A surface reading `tx.payeeName || tx.payee?.name` directly shows those transfers as unnamed. English CSV exports use `transferPayeeCsvLabel` (`lib/transfer-label.ts`), byte-identical twin of the backend's `transferPayeeLabel`.
 
 ### A CSV file is written by `exportToCsv`, and a number in it is a number
 
-`lib/csv-export.ts` is the only CSV writer: it owns the BOM, the CRLF line
-endings, the RFC 4180 quoting, the formula-injection guard and the download.
-Multi-table exports take `exportCsvSections` rather than assembling their own
-lines -- `MonteCarloReport` had a hand-rolled copy that quoted every field and
-guarded none of them, so the report with the *most* user-supplied text in it was
-the one export a formula could ride out of. `ui-conventions.test.ts` fails the
-build on a second `text/csv` Blob or a second `replace(/"/g, '""')`.
+`lib/csv-export.ts` is the only CSV writer: BOM, CRLF, RFC 4180 quoting, formula-injection guard, download. Multi-table exports take `exportCsvSections` (`MonteCarloReport` had a hand-rolled copy that quoted every field and guarded none). `ui-conventions.test.ts` fails on a second `text/csv` Blob or a second `replace(/"/g, '""')`.
 
-The guard cannot key off the first character, because `-` opens both
-`-1+cmd|'/c calc'!A0` and every debit in the ledger. Deciding from that
-character alone is issue #1134: Excel showed `-67.99` as the text ` -67.99` and
-refused to total the column, on 59 of 64 rows. So it asks whether the value *is*
-a number -- an optional sign then only digits, separators, whitespace and
-currency symbols, with an optional `%` -- which is provably inert as a formula
-and covers a formatted `-$1,652.73` as well as a bare `-67.99`.
+The guard cannot key off the first character (`-` opens both a formula and every debit -- issue #1134: Excel refused to total 59 of 64 rows). It asks whether the value *is* a number (optional sign, digits, separators, whitespace, currency symbols, optional `%`), which is provably inert as a formula.
 
-**The reason it reached the user is worth more than the fix.** A prior pass had
-already exempted negative numbers, with a passing test to prove it -- but it
-tested `-100`, the JS number, and the value the API actually sends is the
-*string* `"-67.9900"`. `decimal(20,4)` columns cross the wire as strings while
-`types/transaction.ts` declares `amount: number`, so the fix and its test agreed
-with each other and neither described the running app. Two consequences:
+**The reason it reached the user is worth more than the fix.** A prior pass had exempted negative numbers, with a passing test -- but it tested `-100` the JS number, while the API sends the *string* `"-67.9900"` (`decimal(20,4)` crosses the wire as a string while `types/transaction.ts` declares `amount: number`). Two consequences:
 
-- **A money value off the API is a string until you make it one.** `Number(...)`
-  it at the boundary of anything that branches on its type -- an export, a
-  `typeof` check, a `.toFixed`. The transactions export now does; the split
-  branch beside it always did, which is precisely why split rows were the only
-  ones the reporter found intact.
-- **A test for a type-dependent branch uses the shape the API sends**, not the
-  shape the interface claims. `page.test.tsx` exports a fixture whose `amount`
-  is `'-67.9900'` for this reason. Where a fixture disagrees with the wire, the
-  suite is checking the type declaration rather than the code.
+- **A money value off the API is a string until you make it one.** `Number(...)` it at the boundary of anything that branches on its type -- an export, a `typeof` check, a `.toFixed`.
+- **A test for a type-dependent branch uses the shape the API sends**, not the shape the interface claims (`page.test.tsx` exports a fixture whose `amount` is `'-67.9900'` for this reason).
 
 ### Asynchronous data carries the request that produced it
 
-**Asynchronous data is not only a payload. It is the payload plus the complete
-request key that produced it.** A component holding `data` without knowing
-which request answered cannot tell "the report you are looking at" from "the
-report you were looking at a moment ago", and every action it offers is aimed
-at whichever of the two it happens to read.
+**Asynchronous data is not only a payload. It is the payload plus the complete request key that produced it.** A component holding `data` without knowing which request answered cannot tell "the report you are looking at" from "the report you were looking at a moment ago", and every action it offers is aimed at whichever of the two it happens to read.
 
-The request key is every selector that changes the *meaning* of the response,
-not merely its freshness. Typically: the scenario or strategy id, the account
-id, the date range, the reporting currency, the active filters, the locale
-where the server localizes its output, and the revision or version where one
-exists. If changing it would make the same payload mean something else, it is
-part of the key.
+The request key is every selector that changes the *meaning* of the response, not merely its freshness: the scenario or strategy id, the account id, the date range, the reporting currency, the active filters, the locale where the server localizes output, and the revision where one exists. If changing it would make the same payload mean something else, it is part of the key.
 
-**Stale data may stay on screen; it may not stay actionable.** Keeping the
-previous view during a load is often the better read -- a blank page loses the
-user's place. It is allowed while all of the following hold:
+**Stale data may stay on screen; it may not stay actionable.** Keeping the previous view during a load is often the better read. It is allowed while all of the following hold: it is visually marked as stale or loading; editable controls are disabled; mutations are disabled; no action can submit an id taken from the stale payload under the new selection; assistive technology is told the same thing the pixels say (`aria-busy`). Clearing the screen is not required. Non-actionable is.
 
-- it is visually marked as stale or loading;
-- editable controls are disabled;
-- mutations are disabled;
-- no action can submit an id taken from the stale payload under the new
-  selection;
-- assistive technology is told the same thing the pixels say (`aria-busy`, or
-  an equivalent that does not rely on the greyed-out styling alone).
+**A mutation captures an immutable origin key when it starts**, and its response is adopted only when `mutationOriginKey === currentRequestKey` *and* the entity the response describes is the one the mutation targeted. Derive that origin from the data the component was rendering, not from current React state read after the request began -- state has already moved by the time the response lands.
 
-Clearing the screen is not required. Non-actionable is.
+**A failed lookup is not an empty dataset.** A failed accounts request is not `accounts = []`, and a failed report is not a report of zeros -- rendering the failure as emptiness turns an outage into a plausible answer and leaves the save button live over prerequisites that never loaded. Five states stay distinguishable: loaded-and-empty, loading, failed, stale-previous, and current. Where a prerequisite failed, use the shared retryable error presentation, keep the stored ids, and disable the actions that depend on it.
 
-**A mutation captures an immutable origin key when it starts**, and its
-response is adopted only when
+**A dirty keyed form is data.** Changing the request key while a form has unsaved edits calls for a confirmation, a preserved draft, or an explicit save/discard flow; silently unmounting it is data loss. A form rendered for scenario A must also stop being editable once scenario B is the current selection -- two obligations, and meeting the second by discarding the first is not meeting both.
 
-```text
-mutationOriginKey === currentRequestKey
-```
-
-*and* the entity the response describes is the one the mutation targeted. A
-late response from scenario A must never replace scenario B merely by arriving
-last. Derive that origin from the data the component was rendering, not from
-current React state read after the request began -- state has already moved by
-the time the response lands, which is the whole problem.
-
-**A failed lookup is not an empty dataset.** A failed accounts request is not
-`accounts = []`, a failed securities request is not `securities = []`, and a
-failed report is not a report of zeros. Rendering the failure as emptiness
-turns an outage into a plausible answer, and leaves the save button live over
-prerequisites that never loaded. Five states have to stay distinguishable:
-loaded-and-empty, loading, failed, stale-previous, and current. Where a
-prerequisite failed, use the shared retryable error presentation, keep the
-stored ids, and disable the actions that depend on it.
-
-**A dirty keyed form is data.** Changing the request key while a form has
-unsaved edits calls for a confirmation, a preserved draft, or an explicit
-save/discard flow; silently unmounting it is data loss, and remounting it under
-a new key is the same loss with extra steps. A form rendered for scenario A
-must also stop being editable once scenario B is the current selection -- those
-are two obligations, and meeting the second by discarding the first is not
-meeting both.
-
-Regression tests for this class need deferred promises, and must assert on what
-the user *can do*, not only on what is rendered (`docs/testing-contract.md`
-carries the wider list of adversarial inputs, including the asynchronous ones):
+Regression tests for this class need deferred promises, and must assert on what the user *can do*, not only on what is rendered (`docs/testing-contract.md` carries the wider adversarial list):
 
 | Case | Assertion |
 | --- | --- |
@@ -1123,271 +342,81 @@ carries the wider list of adversarial inputs, including the asynchronous ones):
 | Form dirty, user selects B | confirmation is asked for, or the draft survives |
 | Save on the default selection, nothing else happens | the response is adopted |
 
-**Both sides of that comparison must come from the same place.** The origin
-key a mutation captures and the key the loader is holding have to be produced
-by one expression, not by two that agree in the cases you happened to think
-about. Take the origin from what the loader actually stamped -- `dataKey` on
-`useReportData` -- and never rebuild it out of the rendered payload's fields.
-The GEM report built its page key from a `strategyId` *state* that stays unset
-until the user picks from a switcher, and the save's origin key from
-`data.strategy.id`, which is always a real id: the two could never match on
-the ordinary single-scenario path, so every settings save was discarded as
-belonging to a selection nobody was on, with no refetch behind it. A key
-comparison that silently drops the common case looks exactly like one that
-works.
+**Both sides of that comparison must come from the same place.** The origin key a mutation captures and the key the loader is holding have to be produced by one expression -- take the origin from what the loader actually stamped (`dataKey` on `useReportData`), never rebuild it from the rendered payload's fields. The GEM report built its page key from a `strategyId` *state* unset until the user picks from a switcher, and the save's origin from `data.strategy.id`, always a real id: they could never match on the ordinary path, so every save was discarded with no refetch behind it. A key comparison that silently drops the common case looks exactly like one that works.
 
 ### A busy flag shared by nesting operations is a counter, not a boolean
 
-One mutation can start another -- "save and carry on" runs the deferred
-scenario create from inside the settings save's own `onSaved`. With a single
-boolean the inner operation sets it, the outer one's `finally` runs
-immediately afterwards and clears it, and the page goes live over a request
-still on the wire: a second create can be started, and a late response can be
-adopted under a newer selection. Whichever finishes first speaks for both.
-
-Count the operations in flight and derive the flag (`pending > 0`). Every
-begin needs exactly one end, on both the success and the failure path.
+One mutation can start another ("save and carry on" runs the deferred scenario create from inside the settings save's own `onSaved`). With a single boolean the inner sets it, the outer's `finally` clears it, and the page goes live over a request still on the wire. Count the operations in flight and derive the flag (`pending > 0`); every begin needs exactly one end, on both success and failure paths.
 
 ### Nothing interactive goes inside a `<button>` or an `<a>`
 
-The parser closes the outer element at the inner tag, so the click target ends
-wherever the nested control begins and the server's HTML stops matching what
-React builds -- a hydration mismatch. Fix it at the call site by making the
-two **siblings**: give the card a wrapper that carries the border and hover,
-and put the navigation button and the nested control inside it side by side.
-
-Do not fix it by demoting the inner control to a focusable `<span>`. A span's
-implicit role is generic, screen readers drop its `aria-label`, and the result
-is a tab stop that announces nothing -- which is how `InfoTooltip` came to be
-a `<button>` in the first place. Trading one defect for the other just moves
-it.
-
-`ui-conventions.test.ts` scans for this, and it is the kind of rule only a
-scan can hold: neither file is wrong on its own. Changing a shared component's
-trigger element is a change to every call site, so the guard is what tells you
-which ones.
+The parser closes the outer element at the inner tag, so the click target ends where the nested control begins and the server's HTML stops matching React's -- a hydration mismatch. Fix it at the call site by making the two **siblings**: a wrapper carrying the border and hover, with the navigation button and the nested control side by side. Do not demote the inner control to a focusable `<span>` -- its implicit role is generic, screen readers drop its `aria-label`, and the result is a tab stop announcing nothing. `ui-conventions.test.ts` scans for this; changing a shared component's trigger element is a change to every call site, and the guard tells you which.
 
 ### A short-range portfolio change is measured from the prior close
 
-On `1d`, `1w` and `mtd` the Change and Change % measure from the close of the
-last trading day *before* the window, so a chart showing a week from Aug 5
-measures from Aug 4 and includes Aug 5's own movement. That is the convention
-every quote source reports a daily move against. The longer ranges measure from
-their first point instead -- their window opens on a calendar date whose first
-point already *is* that day's close, so there is nothing earlier to reach for.
-Which ranges are which lives in `PRIOR_CLOSE_BASELINE_RANGES`.
+On `1d`, `1w` and `mtd` the Change and Change % measure from the close of the last trading day *before* the window -- the convention every quote source reports against. The longer ranges measure from their first point (their window opens on a day whose first point already is that day's close). Which ranges are which lives in `PRIOR_CLOSE_BASELINE_RANGES`.
 
-This was briefly a user preference (`portfolio_change_baseline`, added by
-migration 152 and dropped by 153). It was removed because the prior close is
-the right answer rather than a taste, and a settings row asking the user to
-adjudicate it made the figure harder to trust, not easier. `usesPriorCloseBaseline`
-now takes the range and nothing else; if you find yourself adding a second
-argument to it, the question to ask first is whether the alternative is
-actually defensible.
+This was briefly a user preference (migration 152, dropped by 153); it was removed because the prior close is the right answer rather than a taste. `usesPriorCloseBaseline` takes the range and nothing else -- if you find yourself adding a second argument, first ask whether the alternative is actually defensible.
 
-Both halves of the decision come from **one hook**,
-`hooks/usePortfolioChangeBaseline.ts`, which returns `usesPriorClose` and the
-`priorClose` together; the arithmetic and the range set live once in
-`components/investments/portfolio-change-baseline.ts`. The Investments-page
-chart and the Portfolio Value report both go through them, and a new surface
-showing the same figure must too, rather than deciding for itself or
-subtracting `points[0]`. Deciding *whether* a prior close applies in one place
-and reading the close in another is the specific bug the single hook prevents:
-while the two are out of step the card shows one under the rules of the other,
-and nothing about it looks wrong.
-
-The baseline is looked up for the **first point on screen**, never for the
-requested window start: on a weekend or a holiday the 1D chart shows the last
-session rather than today, and the day before *that* is the close the change
-belongs to. A baseline that has not loaded, or could not be established, makes
-the change **unknown** -- both cards read N/A. It never falls back to the
-first-point change, which would put a different number under the same label.
+Both halves come from **one hook**, `hooks/usePortfolioChangeBaseline.ts` (`usesPriorClose` and the `priorClose` together); the arithmetic and range set live once in `components/investments/portfolio-change-baseline.ts`. Deciding *whether* a prior close applies in one place and reading the close in another is the specific bug the single hook prevents. The baseline is looked up for the **first point on screen**, never the requested window start (on a weekend the 1D chart shows the last session). A baseline that has not loaded makes the change **unknown** -- both cards read N/A, never the first-point change.
 
 ### The window a price chart requests is not the period its range names
 
-`resolveRangePreset` answers "what period is the user asking about", and ten
-reports depend on that answer -- a spending report's 3M window must not quietly
-start a day early. A *price* chart asks a narrower question: **which close is
-the series measured from**, so the figure beside it matches what every other
-quote source reports for the same period. Those are different questions, so
-they have different functions:
-`components/investments/portfolio-range-window.ts` holds the second one as a
-table (`PORTFOLIO_WINDOW_STARTS`), and the Portfolio Value report, the
-Investments chart and the dashboard widget all resolve through
-`usePortfolioRangeWindow`. Do not reach for `resolveRangePreset` directly in a
-fourth portfolio surface, and do not "fix" a range by editing the shared
-resolver.
+`resolveRangePreset` answers "what period is the user asking about", and ten reports depend on that answer. A *price* chart asks a narrower question -- **which close is the series measured from** -- so it has its own function: `components/investments/portfolio-range-window.ts` holds the table (`PORTFOLIO_WINDOW_STARTS`), and the Portfolio Value report, the Investments chart and the dashboard widget resolve through `usePortfolioRangeWindow`. Do not reach for `resolveRangePreset` in a fourth portfolio surface, and do not "fix" a range by editing the shared resolver.
 
-The rules are not uniform, and that is the point -- each was set to match the
-platform being compared against, not derived from a principle:
+The rules are not uniform -- each matches the platform being compared against:
 
-- **3M, 6M, 1Y, 2Y, 5Y** open on the calendar day *before* the period, so 1Y on
-  12 Aug 2026 opens on 11 Aug 2025. A rule naming an exact day ignores month
-  alignment, and 2Y follows the calendar rather than a 730-day count, which
-  differ in any window containing a leap day.
-- **YTD** opens on the year's first *trading* day. The daily series values every
-  calendar day at the latest close at or before it, so 1 January plots
-  December's close and a market holiday is indistinguishable from a flat
-  session there. `netWorthApi.getFirstPricedDay` answers it from
-  `security_prices`, whose rows exist only for days a price was struck. A null
-  answer is unknown, not "1 January is a trading day": the window keeps its
-  calendar boundary rather than claiming a trading day nobody observed.
-- **1M** keeps its window and collapses its first *day* to that day's close
-  (`trimIntradayToFirstDayClose`), because it is an intraday chart and opening
-  partway through the session a month ago mixes a mid-session price into a
-  series of closes. 1D deliberately still opens at the open; 1W and MTD are
-  measured from the prior close already, so collapsing their first day would
-  only throw away detail.
+- **3M, 6M, 1Y, 2Y, 5Y** open on the calendar day *before* the period (2Y follows the calendar, not a 730-day count).
+- **YTD** opens on the year's first *trading* day (`netWorthApi.getFirstPricedDay` answers from `security_prices`). A null answer keeps the calendar boundary rather than claiming a trading day nobody observed.
+- **1M** keeps its window and collapses its first *day* to that day's close (`trimIntradayToFirstDayClose`) -- it is an intraday chart, and opening mid-session a month ago mixes a mid-session price into a series of closes. 1D deliberately opens at the open; 1W and MTD are measured from the prior close already.
 
-Both intraday adjustments live inside `trimIntradayPoints`, which every
-intraday render site already calls -- a shaping step applied at three of four
-call sites is a chart that disagrees with itself depending on which path drew
-it.
+Both intraday adjustments live inside `trimIntradayPoints`, which every intraday render site calls -- a shaping step applied at three of four call sites is a chart that disagrees with itself.
 
-**A range served monthly cannot honour a day-precision rule.** 2Y and 5Y use
-month buckets on the report and the widget, so their first point is a
-month-end close and moving the window by a day changes nothing visible. Switch
-the range to daily if the exact opening close matters; do not prepend a single
-daily point to a monthly series, which is the sampling splice
-`docs/time-series-contract.md` section 1.2 exists to stop.
+**A range served monthly cannot honour a day-precision rule.** 2Y and 5Y use month buckets, so their first point is a month-end close. Switch the range to daily if the exact opening close matters; do not prepend a single daily point to a monthly series (the sampling splice `docs/time-series-contract.md` section 1.2 exists to stop).
 
-Relatedly, `mtd` is a chart range with no backend series of its own: its window
-is 1 to 31 days long, so it rides on the rolling 1M series and is trimmed to the
-month client-side. Both halves go through `portfolio-chart-utils.tsx` --
-`intradayRangeParam` before every intraday request, `trimIntradayPoints` on
-every response, including the sessionStorage-cached one and the per-security
-breakdown. Sending `mtd` verbatim is a 400 from `IntradayValueQueryDto`'s enum,
-which surfaces as the chart's generic "couldn't load" fallback and so reads as
-an outage rather than as a missing case; a response used untrimmed puts last
-month's bars in a month-to-date chart, where they can become its high or low.
-A guard test asserts every member of `INTRADAY_RANGES` maps onto a range the
-endpoint accepts, so a fourth one cannot be added without a mapping.
+`mtd` is a chart range with no backend series of its own: it rides on the rolling 1M series and is trimmed client-side. Both halves go through `portfolio-chart-utils.tsx` -- `intradayRangeParam` before every intraday request, `trimIntradayPoints` on every response, including the sessionStorage-cached one and the per-security breakdown. Sending `mtd` verbatim is a 400 from `IntradayValueQueryDto`'s enum; a response used untrimmed puts last month's bars in a month-to-date chart. A guard test asserts every member of `INTRADAY_RANGES` maps onto a range the endpoint accepts.
 
 ### A loan's payment, payoff and remaining interest are decided once -- `deriveLoanFigures`
 
-Three figures appear on every amortizing-debt surface (the loan detail page's
-summary cards, the transactions Details sidebar), and each one has a state that
-is neither a number nor "unknown":
+Three figures appear on every amortizing-debt surface (the loan detail page's summary cards, the transactions Details sidebar), and each has a state that is neither a number nor "unknown":
 
-- A **settled** debt owes nothing, so its remaining interest is a known **zero**
-  and its payoff is "Paid off" -- not `null`, which reports a finished mortgage
-  as one that could not be worked out. Settled means *nothing outstanding*
-  (`-balance <= 0.01`), so an overpaid loan sitting in credit is settled too;
-  `Math.abs(balance) <= 0.01` read that credit as debt of the same size.
-- A projection that hits its horizon without paying off (`paidOff` false) has no
-  payoff date, and its accumulated interest is the interest over that horizon --
-  a subtotal. Both figures are unknown; printing the horizon's number under
-  "Est. Remaining Interest" is a total's label over a partial sum.
+- A **settled** debt owes nothing: remaining interest is a known **zero** and the payoff is "Paid off" -- not `null`. Settled means *nothing outstanding* (`-balance <= 0.01`), so an overpaid loan in credit is settled too (`Math.abs` read that credit as debt).
+- A projection that hits its horizon without paying off (`paidOff` false) has no payoff date, and its accumulated interest is a subtotal -- both figures are unknown; printing the horizon's number under "Est. Remaining Interest" is a total's label over a partial sum.
 
-`lib/loan-figures.ts` makes that decision once and both surfaces render its
-output. The data behind it comes from `hooks/useLoanProjection.ts` (which fetches
-the account's history) or from a `baseline` the caller already has -- but never
-from a second copy of the branching. A failed history load is `status: 'error'`
-with every figure unknown, never an empty history, which would project a
-plausible payoff date from no payments at all.
+`lib/loan-figures.ts` makes the decision once and both surfaces render its output. The data comes from `hooks/useLoanProjection.ts` or a `baseline` the caller already has -- never a second copy of the branching. A failed history load is `status: 'error'` with every figure unknown, never an empty history (which would project a plausible payoff from no payments at all).
 
 ### An unknown value must not render as a measured zero
 
-The server goes to real trouble to send `null` rather than `0` for anything it
-could not work out (`docs/financial-calculation-contract.md`), and the last
-hundred pixels are where that gets thrown away:
+The server sends `null` rather than `0` for anything it could not work out (`docs/financial-calculation-contract.md`), and the last hundred pixels are where that gets thrown away:
 
-- **`connectNulls` on a line chart** draws a straight segment through the gap.
-  It is indistinguishable from measured data, and a tooltip saying "unknown"
-  under the cursor does not undo it. Default to `connectNulls={false}`.
-- **A bar, gauge or meter at zero width** beside an "unknown" label reads as a
-  measured zero to everyone who looks at the shape rather than the number.
-  Draw a distinct no-data treatment, or nothing at all -- not an empty fill.
-- **A row that disappears** when its value is `null` conflates "not
-  applicable" with "could not be computed". Where the payload can tell those
-  apart -- a configured tax rate with an uncomputable tax, say -- render the
-  row with an unknown marker rather than dropping it.
-- **`?? 0`, `|| 0`, `?? 1` on an API value** is the same mistake in arithmetic
-  form. Guard with an `isKnown()`-style check first; a fallback inside a
-  `reduce` that a guard already covers is dead code at best and a silent
-  subtotal at worst.
+- **`connectNulls` on a line chart** draws a measured-looking segment through the gap. Default to `connectNulls={false}`.
+- **A bar, gauge or meter at zero width** beside an "unknown" label reads as a measured zero. Draw a distinct no-data treatment, or nothing.
+- **A row that disappears** when its value is `null` conflates "not applicable" with "could not be computed" -- where the payload can tell them apart, render the row with an unknown marker.
+- **`?? 0`, `|| 0`, `?? 1` on an API value** is the same mistake in arithmetic form. Guard with an `isKnown()`-style check first.
 
-Whoever adds the `null` on the server owns how it looks. A component test
-asserting the gap, the marker or the absent fill is what keeps it.
+Whoever adds the `null` on the server owns how it looks; a component test asserting the gap, marker or absent fill is what keeps it.
 
-**A missing exchange rate is the same class, and it used to be the worst case
-of it.** `useExchangeRates().convert` / `convertToDefault` /
-`convertWithRateMap` return `number | null`; they previously returned the amount
-*unconverted*, so a 100.00 USD balance with no USD→EUR rate was formatted as
-"100.00 EUR" and summed into Assets, Liabilities and Net Worth. Silent,
-unbounded, one instance per unconverted account, and able to reverse a trend.
+**A missing exchange rate is the same class.** `useExchangeRates().convert` / `convertToDefault` / `convertWithRateMap` return `number | null`; they previously returned the amount *unconverted*, so a 100.00 USD balance with no rate was formatted as "100.00 EUR" and summed into Net Worth. Pick the treatment from what the figure is:
 
-Pick the treatment from what the figure is:
+- **An aggregate** uses `sumConverted` / `combineTotals` (`lib/currency-total.ts`), which keep the subtotal and the missing currencies together, rendered through `PartialTotal`. Incompleteness is a union: net worth built from a complete asset total and a partial liability total is partial.
+- **A single displayed value** shows an unknown marker, or nothing. Never the unconverted number beside the target currency's symbol.
+- **A chart series** uses `null` and `connectNulls={false}`; a bar, slice or gauge cannot say "unknown", so an unconvertible component leaves the chart.
+- **A cumulative series** (a running balance, a forecast) is withheld whole: one missing rate invalidates every point after it, so `buildForecast` returns no points and names the currencies; `buildMultiAccountForecast` withholds every line and the total together.
+- **A summary over a series** (`computeBalanceSummary`) refuses when any point is unknown -- "minimum" and "goes negative" are claims about all of it.
 
-- **An aggregate** uses `sumConverted` / `combineTotals`
-  (`lib/currency-total.ts`), which keep the subtotal and the missing currencies
-  together, and renders through `PartialTotal`. Incompleteness is a union: net
-  worth built from a complete asset total and a partial liability total is
-  partial.
-- **A single displayed value** shows an unknown marker, or nothing. Never the
-  unconverted number beside the target currency's symbol -- "≈" does not make a
-  euro figure an approximate zloty one.
-- **A chart series** uses `null` and `connectNulls={false}`. A bar, slice or
-  gauge cannot say "unknown", so an unconvertible component leaves the chart
-  rather than appearing at an arbitrary size.
-- **A cumulative series** (a running balance, a forecast) is withheld whole:
-  one missing rate invalidates every point after it, so `buildForecast` returns
-  no points and names the currencies. A short series there is not a partial
-  answer, it is a wrong one. `buildMultiAccountForecast` withholds every line
-  and the total together for the same reason -- the accounts that *did* convert
-  are not a smaller forecast, they are a total labelled as something it is not.
-- **A summary over a series** (`computeBalanceSummary`) refuses when any point
-  is unknown. "Minimum" and "goes negative" are claims about all of it.
-
-Same currency is 1:1 *by definition* and stays a known conversion -- keep it
-distinguishable from the missing case, and keep a real zero rendering as a
-number.
+Same currency is 1:1 *by definition* and stays a known conversion -- keep it distinguishable from the missing case, and keep a real zero rendering as a number.
 
 ## `accountsApi.getAll()` is not "the user's accounts"
 
-In own context the endpoint returns a **union**: accounts the caller owns, plus
-accounts another owner shared with them jointly. The two are told apart by
-`account.isJoint` -- true means the row belongs to someone else and is only
-shown natively because a grant says so (`ownerLabel` names the owner). Any
-screen that treats the list as "mine" is wrong for whichever half it forgot.
+In own context the endpoint returns a **union**: accounts the caller owns, plus accounts another owner shared with them jointly, told apart by `account.isJoint` (true means the row belongs to someone else; `ownerLabel` names the owner). Any screen treating the list as "mine" is wrong for whichever half it forgot.
 
-Filter to `!a.isJoint` before offering an account as something to **give away,
-delegate, or otherwise re-share**. A delegate must not be able to pass on the
-access they were given, so the Edit Access modal
-(`components/settings/DelegateAccessModal.tsx`) derives `grantableAccounts` and
-uses it for the grouping, the empty state, the baseline diff and the save
-payload -- not just for the rows it draws. The server refuses a non-owned
-account too (`setGrants` -> 403), which is why an unfiltered list is not merely
-untidy: every toggle on it is one whose save cannot succeed.
-
-The converse is not true. An account the caller owns and has shared *out*
-carries `jointGranteeCount`, is still theirs, and stays assignable.
+Filter to `!a.isJoint` before offering an account as something to **give away, delegate, or otherwise re-share** -- a delegate must not pass on the access they were given. The Edit Access modal (`components/settings/DelegateAccessModal.tsx`) derives `grantableAccounts` and uses it for the grouping, the empty state, the baseline diff and the save payload -- not just the rows it draws. The server refuses a non-owned account too (`setGrants` -> 403), so every toggle on an unfiltered list is one whose save cannot succeed. The converse is not true: an account the caller owns and has shared *out* carries `jointGranteeCount` and stays assignable.
 
 ### On a joint row, *every* picker reads the owner's list -- and creation is off
 
-A joint row belongs to the sharing owner and may only carry the owner's
-reference ids, so `TransactionForm` derives `effectiveCategories` /
-`effectivePayees` from the grant-gated reference-data endpoint. The rule is that
-**everything** downstream reads those, not the caller's own `categories`: the
-option list, the income/expense sign lookups, and the split editor. Three sites
-still read `categories`, and each failed differently and quietly -- the sign
-lookup could not resolve an owner id, so choosing an income category left the
-amount negative; `SplitEditor` was handed the caller's list, so the owner's
-split lines resolved to nothing and any pick wrote one of the caller's ids onto
-the owner's row. Split mode is blocked on the *mode button* for a joint account,
-which is not the same as being unreachable: opening a split row that already
-lives there puts the form straight into it.
+A joint row may only carry the owner's reference ids, so `TransactionForm` derives `effectiveCategories` / `effectivePayees` from the grant-gated reference-data endpoint, and **everything** downstream reads those, not the caller's own `categories`: the option list, the income/expense sign lookups, and the split editor (three sites still read `categories` and each failed quietly -- a pick in `SplitEditor` wrote one of the caller's ids onto the owner's row). Split mode being blocked on the *mode button* is not the same as unreachable: opening a split row that already lives there puts the form straight into it.
 
-Creation is a separate question with a blunter answer: **do not offer it.**
-`categoriesApi.create` writes to the caller's ledger and there is no client path
-that creates on someone else's, so "+ Create" on a joint account made the
-category in the wrong place and put an id the owner does not own on the form.
-The delegation carries a `categoriesCanCreate` capability with nothing on the
-client to drive yet; until an owner-scoped create exists, withhold the creator
-(`jointSafeCategoryCreator`) rather than gate the button on a flag the code
-cannot honour. Withholding it is also what makes the rule hold everywhere at
-once -- the Category field, the transfer form's, and every split line take the
-same optional prop, so there is one decision rather than four.
+Creation gets a blunter answer: **do not offer it.** `categoriesApi.create` writes to the caller's ledger, so "+ Create" on a joint account made the category in the wrong place. Until an owner-scoped create exists, withhold the creator (`jointSafeCategoryCreator`) rather than gate the button on a `categoriesCanCreate` flag the code cannot honour -- withholding is also what makes the rule hold everywhere at once, since the Category field, the transfer form's, and every split line take the same optional prop.
 
 ## Form Patterns
 
@@ -1397,7 +426,7 @@ Supporting hooks: `useFormSubmitRef` (expose submit via ref), `useFormDirtyNotif
 
 ## Internationalization (i18n)
 
-All user-facing strings go through `next-intl` -- no hardcoded literals. Read them with `useTranslations('namespace')`; catalogs live in `src/i18n/messages/{locale}/{namespace}.json` (locales `de`, `en`, `en-US`, `en-CA`, `en-GB`, `es`, `fr`, `hi`, `id`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `pt-BR`, `ru`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`, `xx`; the `en-*` locales are lean regional variants holding only the strings that differ from `en`; register new namespaces in `src/i18n/messages.ts`). Use `t.rich` for embedded markup and `t.raw` for template strings. Adding or changing a string means updating every locale -- the parity test `src/i18n/messages.parity.test.ts` fails otherwise -- then regenerating the pseudo-locale with `npm run i18n:pseudo`. The language is a user preference (`LanguageSelector` in Settings -> Preferences). Full contributor flow: `src/i18n/messages/README.md`.
+All user-facing strings go through `next-intl` -- no hardcoded literals. Read them with `useTranslations('namespace')`; catalogs live in `src/i18n/messages/{locale}/{namespace}.json` (locales `de`, `en`, `en-US`, `en-CA`, `en-GB`, `es`, `fr`, `hi`, `id`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `pt-BR`, `ru`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`, `xx`; the `en-*` locales are lean regional variants holding only the strings that differ from `en`; register new namespaces in `src/i18n/messages.ts`). Use `t.rich` for embedded markup and `t.raw` for template strings. Adding or changing a string means updating every locale (`src/i18n/messages.parity.test.ts` fails otherwise), then `npm run i18n:pseudo`. The language is a user preference (`LanguageSelector` in Settings -> Preferences). Full contributor flow: `src/i18n/messages/README.md`.
 
 ## React Testing (act() Pattern)
 
@@ -1430,17 +459,17 @@ await waitFor(() => expect(screen.getByText('Error message')).toBeInTheDocument(
 
 Never use synchronous `act(() => {...})` for calls that trigger async side-effects — always `await act(async () => {...})`.
 
-**`vitest run` does not show you the warnings.** The default reporter buffers console output and prints it only for failing tests, so a suite full of act warnings looks spotless locally and prints eighty of them in CI. Use `npx vitest run --reporter=verbose` when checking for them, and grep for `not wrapped in act`.
+**`vitest run` does not show you the warnings.** The default reporter buffers console output and prints it only for failing tests. Use `npx vitest run --reporter=verbose` and grep for `not wrapped in act`.
 
-**A store reset in a file's `afterEach` runs while the tree is still mounted.** Testing Library registers its `cleanup` at import time and vitest runs after-hooks in reverse registration order, so the file's own hook goes first. Writing to a Zustand store there re-renders the mounted component outside act, once per selector it reads through -- `SecurityDetailHeader` emitted three warnings in every one of its tests for exactly this. Call `cleanup()` at the top of the hook; a second cleanup afterwards is a no-op. `src/test/test-hygiene.test.ts` scans for it.
+**A store reset in a file's `afterEach` runs while the tree is still mounted.** Testing Library registers its `cleanup` at import time and vitest runs after-hooks in reverse registration order, so the file's own hook goes first, and a Zustand write there re-renders the mounted component outside act. Call `cleanup()` at the top of the hook. `src/test/test-hygiene.test.ts` scans for it.
 
-**Three quieter sources of the same warning**, all of which show up as "an update to X inside a test was not wrapped in act":
+**Three quieter sources of the same warning:**
 
-- A **synchronous `render(...)` of a component that fetches on mount** -- even in a test that only asserts on static copy, and even when the fetch is a stubbed `mockResolvedValue([])`. `GemStrategyHeader`'s tests were clean-looking for this reason; the switcher beside the title loads saved reports. Give the file one `await act(async () => { render(...) })` helper and use it everywhere, not only in the tests that await something.
-- An **awaited handler behind a click**: `fireEvent.click` is act-wrapped, but the `finally { setBusy(false) }` after an `await` lands in a later microtask. Wrap that click in `await act(async () => ...)`.
-- A **bare `await new Promise(r => setTimeout(r, n))`** used to let a `requestAnimationFrame` run. Whatever rAF you were waiting on is inside act; the ones beside it are not. Put the wait inside `await act(async () => { ... })`.
+- A **synchronous `render(...)` of a component that fetches on mount** -- even in a test that only asserts static copy, and even with a stubbed `mockResolvedValue([])`. Give the file one `await act(async () => { render(...) })` helper and use it everywhere.
+- An **awaited handler behind a click**: `fireEvent.click` is act-wrapped, but the `finally { setBusy(false) }` after an `await` lands in a later microtask. Wrap the click in `await act(async () => ...)`.
+- A **bare `await new Promise(r => setTimeout(r, n))`** used to let a `requestAnimationFrame` run -- put the wait inside `await act(async () => { ... })`.
 
-**A mocked hook must return a stable object if the real one does.** `useRouter()` returns the same router every render; a mock written as `useRouter: () => ({ push: vi.fn(), ... })` returns a new one per call. Every `useCallback([router])` then changes identity each render, every effect depending on such a callback re-runs each render, and an effect that also sets state loops forever. The Transactions page made **83 `transactions.getAll` calls in 300ms** under its own local mock -- invisible except as a slow test file and sixteen act warnings from updates still landing after the test had ended. The mock in `src/test/setup.ts` builds one router for the run; a file overriding it to observe `push` must do the same (build it lazily inside the factory -- `vi.mock` is hoisted above the `const mockPush` it closes over). The same reasoning applies to any mocked hook returning an object or array.
+**A mocked hook must return a stable object if the real one does.** `useRouter()` returns the same router every render; a mock written as `useRouter: () => ({ push: vi.fn(), ... })` returns a new one per call, so every `useCallback([router])` changes identity each render and an effect that also sets state loops forever (the Transactions page made 83 `getAll` calls in 300ms under its own local mock). The mock in `src/test/setup.ts` builds one router for the run; a file overriding it to observe `push` must do the same (build it lazily inside the factory -- `vi.mock` is hoisted above the `const mockPush` it closes over). Applies to any mocked hook returning an object or array.
 
 ## Testing Conventions
 
@@ -1452,145 +481,41 @@ Never use synchronous `act(() => {...})` for calls that trigger async side-effec
 
 ## Theme
 
-`ThemeContext` provides `theme` (light/dark/system), `resolvedTheme`, and `setTheme()`, plus `colorTheme`/`setColorTheme()` for the colour palette (`src/lib/color-themes.ts`). Both persisted to localStorage; applies `dark` class (Tailwind dark mode strategy) and a `data-theme` attribute (`default` = no attribute) to `<html>`; listens for system preference changes via `matchMedia`. Custom theme variables in `globals.css` `@theme` block; dark variant `@variant dark (&:where(.dark, .dark *))`.
+`ThemeContext` provides `theme` (light/dark/system), `resolvedTheme`, and `setTheme()`, plus `colorTheme`/`setColorTheme()` for the colour palette (`src/lib/color-themes.ts`). Both persisted to localStorage; applies `dark` class and a `data-theme` attribute (`default` = no attribute) to `<html>`; listens for system preference changes via `matchMedia`. Custom theme variables in `globals.css` `@theme` block; dark variant `@variant dark (&:where(.dark, .dark *))`.
 
-Colour themes are pure CSS variable overrides in `src/app/themes.css` (`html[data-theme="..."]` redefines the gray/blue ramps etc. -- Tailwind v4 utilities compile to `var(--color-*)` so no component changes are needed). Chart colours go through `src/lib/chart-colors.ts`, which exposes `var(--chart-*)` strings for Recharts props; never hardcode hex colours in charts, and never theme user-chosen entity colours (tags, categories, payees).
+Colour themes are pure CSS variable overrides in `src/app/themes.css` (`html[data-theme="..."]` redefines the gray/blue ramps; Tailwind v4 utilities compile to `var(--color-*)` so no component changes are needed). Chart colours go through `src/lib/chart-colors.ts`, which exposes `var(--chart-*)` strings for Recharts props; never hardcode hex colours in charts, and never theme user-chosen entity colours (tags, categories, payees).
 
 ### The boot surfaces read the theme from cookies, not from localStorage
 
-`ThemeProvider` returns `null` until it has read localStorage, so everything
-inside it ships as an empty body and nothing the provider renders can decide
-what the first paint looks like. The surfaces that paint before hydration --
-the server-stamped `dark` class and `data-theme` attribute in `layout.tsx`,
-the boot splash (`components/layout/BootSplash.tsx`, hidden by
-`BootSplashHider` once the app mounts -- *hidden*, never removed: the splash
-is a React-rendered node, and detaching a React-owned node outside React
-crashes the reconciler on the next client-side navigation, sending every
-page to the error boundary), the `theme-color` viewport meta,
-and the PWA manifest's splash palette (`app/manifest.webmanifest/route.ts`)
--- read the `monize-resolved-theme` and `monize-color-theme` cookies that
-`ThemeContext` mirrors on every change (`src/lib/pwa-theme.ts` owns the names
-and fallback colours). A non-CSS consumer needing a palette's actual hex goes
-through `THEME_SWATCHES` (`src/lib/theme-swatches.ts`), never a literal; the
-service worker's offline fallback cannot import either, so
-`components/providers/OfflineFallbackSync.tsx` posts it the localized copy
-and computed page colours, and `src/test/sw-offline.test.ts` holds sw.js's
-built-in fallbacks equal to the catalog and `pwa-theme` constants. The
-manifest link is hand-written in `layout.tsx` with
-`crossorigin="use-credentials"` because a manifest fetch carries no cookies
-without it -- Next's static manifest file convention cannot express that,
-which is why the route handler exists instead. The link's href also encodes
-the theme as query parameters: an installed app's manifest update check
-re-fetches the URL it was installed with, possibly without credentials, so
-the query keeps a cookieless check resolving the installed theme (cookies,
-when present, win). The manifest pins `id: '/'` so every URL variant is the
-same app. The OS bakes the splash colours in at install time and refreshes
-them lazily (days, or a reinstall), so a theme change reaching the OS splash
-is expected to lag; the boot splash is the surface that follows it
-immediately.
+`ThemeProvider` returns `null` until it has read localStorage, so nothing it renders can decide the first paint. The surfaces that paint before hydration -- the server-stamped `dark` class and `data-theme` attribute in `layout.tsx`, the boot splash (`components/layout/BootSplash.tsx`, hidden by `BootSplashHider` once the app mounts -- *hidden*, never removed: detaching a React-owned node outside React crashes the reconciler on the next client-side navigation), the `theme-color` viewport meta, and the PWA manifest's splash palette (`app/manifest.webmanifest/route.ts`) -- read the `monize-resolved-theme` and `monize-color-theme` cookies that `ThemeContext` mirrors on every change (`src/lib/pwa-theme.ts` owns the names and fallback colours).
 
-**A palette needs a dark block, or dark mode renders its light colours.** A
-theme's `html[data-theme]` block has specificity (0,1,1) and the `.dark`
-defaults in `globals.css` have (0,1,0), so a theme that sets `--chart-*` in
-its light block wins in dark mode too -- and those values were picked to sit
-on white paper. That is what "the dark themes look washed out" was: fourteen
-of fifteen palettes drawing light-tuned chart colours on a dark card. Every
-such theme now carries an `html.dark[data-theme='x']` block (0,2,1), and
-`src/test/theme-contrast.test.ts` fails when one is missing or partial.
+A non-CSS consumer needing a palette's actual hex goes through `THEME_SWATCHES` (`src/lib/theme-swatches.ts`), never a literal; the service worker's offline fallback cannot import either, so `components/providers/OfflineFallbackSync.tsx` posts it the localized copy and computed page colours, and `src/test/sw-offline.test.ts` holds sw.js's built-in fallbacks equal to the catalog and `pwa-theme` constants. The manifest link is hand-written in `layout.tsx` with `crossorigin="use-credentials"` (a manifest fetch carries no cookies without it, which Next's static manifest convention cannot express -- hence the route handler). The link's href also encodes the theme as query parameters so a cookieless manifest update check still resolves the installed theme (cookies, when present, win); the manifest pins `id: '/'`. The OS bakes splash colours in at install time and refreshes lazily; the boot splash is the surface that follows a theme change immediately.
 
-The same test holds the contrast floors -- body text, muted text, links and
-every chart token against the surface they sit on, per theme and mode, plus a
-minimum page/card/border separation in dark mode. Shortfalls that predate it
-are listed in a shrink-only `KNOWN_CONTRAST_DEBT`; genuine design exceptions
-(midnight is black-on-black by intent, separated by its border) are listed
-separately in `DELIBERATE`, so the two never blur together.
-Values must be literal 6-digit hex: `resolvePdfColor` accepts nothing else and
-silently falls back to grey. `frontend/scripts/derive-dark-palette.mjs` generates a
-starting point for a new palette; the test, not the script, is the authority.
+**A palette needs a dark block, or dark mode renders its light colours.** A theme's `html[data-theme]` block (0,1,1) beats the `.dark` defaults (0,1,0), so light-tuned values win in dark mode too. Every such theme carries an `html.dark[data-theme='x']` block (0,2,1), and `src/test/theme-contrast.test.ts` fails when one is missing or partial.
 
-**The gray ramp is the theme, and it is generated.** Cards, pages, borders
-and most text all read from the gray ramp, so it covers nearly every pixel,
-while the accent shows up only on buttons, links and chart series. Themes
-whose ramps were near-neutral therefore looked interchangeable no matter how
-distinct their accents were -- and a first attempt at fixing it by tinting
-`--color-white` a percent or two did not move anything, because at that
-lightness sRGB has almost no chroma to give.
+The same test holds the contrast floors -- body text, muted text, links and every chart token against their surfaces, per theme and mode, plus a minimum page/card/border separation in dark mode. Pre-existing shortfalls live in a shrink-only `KNOWN_CONTRAST_DEBT`; genuine design exceptions (midnight is black-on-black by intent) in `DELIBERATE`. Values must be literal 6-digit hex: `resolvePdfColor` accepts nothing else and silently falls back to grey. `frontend/scripts/derive-dark-palette.mjs` generates a starting point; the test, not the script, is the authority.
 
-So the ramps come from `frontend/scripts/derive-theme-ramp.mjs`: one lightness
-curve shared by every theme, with each theme setting its own hue and
-intensity. Three consequences worth knowing before editing a palette by hand.
-Contrast is a property of the curve rather than of each value, so it is
-checked once. Chroma is spent as a *share of what the hue can hold* rather
-than as a flat number, because the gamut is wildly asymmetric near white --
-at L 0.95 a green carries about four times the chroma of a blue, so a flat
-target tints the warm themes hard and leaves the cool ones looking untouched.
-And themes that shift hue between their light and dark ends (parchment over
-navy) concentrate the shift in the midtones and damp chroma across it, so the
-ramp does not detour through a colour the theme never chose.
+**The gray ramp is the theme, and it is generated.** Cards, pages, borders and most text read from the gray ramp (nearly every pixel), while the accent shows only on buttons, links and chart series -- so near-neutral ramps made themes interchangeable. The ramps come from `frontend/scripts/derive-theme-ramp.mjs`: one lightness curve shared by every theme, each theme setting hue and intensity. Consequences: contrast is a property of the curve, checked once; chroma is spent as a *share of what the hue can hold* (the gamut near white is wildly asymmetric -- a flat target tints warm themes hard and leaves cool ones untouched); hue-shifting themes concentrate the shift in the midtones.
 
-**Intensity is not a tuning knob, it is half the identity.** A version that
-varied only the hue flattened every palette into the same theme at a
-different angle, and a human reported both costs: palettes whose hues sat
-close became indistinguishable (gruvbox and solarized read as one cream,
-newspaper and burgundy as one pink), and MS Money -- whose character is *pale*
-parchment with navy text and a green accent -- became a yellow theme wearing
-MS Money's accent. Cream and parchment is a crowded, legitimate family that
-hue alone cannot separate; its members are told apart by how strongly the
-paper is tinted and by where the ramp's dark end goes.
+**Intensity is not a tuning knob, it is half the identity.** Hue alone cannot separate the cream/parchment family (gruvbox vs solarized, MS Money's pale parchment); members are told apart by how strongly the paper is tinted and where the ramp's dark end goes. `theme-swatches.test.ts` therefore measures **perceptual distance** between every pair of tinted papers rather than comparing hex strings (the reported collisions differed in every byte and measured 0.0032 in OKLab); floors are set below the achievable minimum for eleven themes on one hue wheel.
 
-That is why `theme-swatches.test.ts` measures **perceptual distance** between
-every pair of tinted papers rather than comparing hex strings. Byte-equality
-is far too weak a test for "these look the same": the reported collisions
-differed in every byte, and the closest measured 0.0032 in OKLab. Eleven
-tinted themes on one hue wheel do have a bounded best case, so the floors are
-set below the achievable minimum rather than at some ideal.
+Three themes are deliberately ungenerated and near-neutral: `default`, `midnight` (black AMOLED by design) and `highcontrast` (maximum luminance contrast). That policy is asserted, so the exceptions read as decisions.
 
-Three themes are deliberately ungenerated and near-neutral: `default` (the
-stock identity), `midnight` (a black AMOLED palette by design) and
-`highcontrast`, whose whole point is maximum luminance contrast. That policy
-is asserted, so the exceptions read as decisions.
+**An accessibility theme is exempt from what it actually guarantees, and no more.** `colorblind`'s promise is its Okabe-Ito CHART palette, not its chrome -- leaving its greys stock made it byte-identical to `default` on every chartless screen. Its ramp is generated now; `highcontrast` stays exempt because *its* promise is about luminance, which chroma really would spend.
 
-**An accessibility theme is exempt from what it actually guarantees, and no
-more.** `colorblind` was on that list too, on the reasoning that chroma
-"spends CVD budget". That is true of the CHART palette, which is the promise,
-and false of the chrome: surfaces are not data. Leaving its greys stock made
-it byte-identical to `default` on every screen without a chart -- every grey
-token matched to the byte, and the dark link accent differed by 0.069 -- so a
-user picking it saw no change at all until they opened a report. Its ramp is
-generated now and only its Okabe-Ito charts are hand-picked. `highcontrast`
-stays exempt because *its* promise is about luminance, which chroma really
-would spend.
+**Two themes that share a strategy need different jobs, not different hexes.** `highcontrast` and `midnight` were both a black page under a near-black card and read as one theme. Midnight optimises for OLED (unlit blacks, quiet borders); highcontrast for visible STRUCTURE (a panel edge you cannot locate is the accessibility failure), so its card sits well clear of its page with a bright border -- which is also why it no longer needs the `card-vs-page` exemption midnight still carries.
 
-**Two themes that share a strategy need different jobs, not different hexes.**
-`highcontrast` and `midnight` were both a black page under a near-black card
-(#0a0a0a and #0c0c0c) and read as one theme in dark mode. The fix was not to
-nudge a value but to separate what they optimise for: midnight is for an OLED
-panel, where every black pixel is unlit and borders stay quiet, and
-highcontrast is for visible STRUCTURE, where a panel edge you cannot locate is
-the accessibility failure. Its card now sits well clear of its page with a
-much brighter border -- which is also why it no longer needs the
-`card-vs-page` exemption midnight still carries.
+Changing the curve is a change to every theme at once -- expect the guard to name chart colours and accents that need re-seating, and re-seat them rather than widening the debt register.
 
-Changing the curve is a change to every theme at once, which is the point --
-but it moves every value sitting on those surfaces too, so expect the guard
-to name chart colours and accents that need re-seating, and re-seat them
-rather than widening the debt register.
+**A theme preview is a copy of the stylesheet, and copies rot.** A browser only computes the *active* theme's custom properties, so the picker's swatches live in `src/lib/theme-swatches.ts`. `theme-swatches.test.ts` parses the CSS through the same cascade the contrast guard uses (`src/test/theme-css.ts`) and fails when a swatch disagrees with the token it claims to show, or when two themes end up with identical swatches.
 
-**A theme preview is a copy of the stylesheet, and copies rot.** A browser
-only computes the *active* theme's custom properties, so the picker's swatches
-live in `src/lib/theme-swatches.ts`. `theme-swatches.test.ts` parses the CSS
-through the same cascade the contrast guard uses (`src/test/theme-css.ts`) and
-fails when a swatch disagrees with the token it claims to show, or when two
-themes end up with identical swatches -- a preview that cannot tell two
-palettes apart is the problem it was built to solve.
+**A hand-rolled CSS bar is a chart.** `chartColors` is not only for Recharts props -- a `<div>` bar, and the amount printed beside it, take the tokens through `style={{ backgroundColor }}` / `style={{ color }}`. `bg-green-400 dark:bg-green-500` stays Tailwind green on every other theme. To emphasise one bar among many, vary `opacity` on the same token rather than picking a second shade -- opacity moves toward the card in both modes.
 
-**A hand-rolled CSS bar is a chart.** `chartColors` is not only for Recharts props -- a `<div>` bar, and the amount printed beside it, take the tokens through `style={{ backgroundColor }}` / `style={{ color }}`. Reaching for `bg-green-400 dark:bg-green-500` or `text-red-600 dark:text-red-400` instead looks right on the default palette and then stays Tailwind red/green on every other theme, which is exactly the thing that gets noticed. To emphasise one bar among many (a peak, a selection), vary `opacity` on the same token rather than picking a second shade -- opacity moves toward the card in both light and dark mode, so the emphasis reads the same way in each.
+**The tokens cover more than series colour.** `chartColors.grid` and `.axis` carry their own dark overrides (no `dark:stroke-*` needed). `chartColors.surface` is the card behind the chart -- use it for the ring around a marker dot (it must be the background, not white). `chartColors.neutral` is for unclassified data. `ui-conventions.test.ts` fails on any hex reaching a `fill`, `stroke` or `stopColor` in a component that imports recharts. Two deliberate non-targets: `summaryCards[].color` for the PDF export (`pdf-export.ts` parses hex; `var(...)` would be NaN), and colour on a *data* field, indistinguishable from the PDF case by regex. White drawn on top of a filled shape (label text in a coloured flag bubble) is contrast-on-fill and stays literal.
 
-**The tokens cover more than series colour.** `chartColors.grid` and `.axis` carry their own dark overrides, so a `CartesianGrid` using them needs no `dark:stroke-*` class beside it. `chartColors.surface` is the card behind the chart -- use it for the ring around a marker dot, which exists to separate the dot from the line beneath it and so must be the background, not white. `chartColors.neutral` is for unclassified data (an "Other" slice, an item with no colour). `ui-conventions.test.ts` fails on any hex reaching a `fill`, `stroke` or `stopColor` in a component that imports recharts. Two things it deliberately does not police: `summaryCards[].color` for the PDF export, where `pdf-export.ts` parses the string as hex and a `var(...)` would produce NaN, and colour on a *data* field (`color:` on a datum), which is indistinguishable from the PDF case by regex. White drawn on top of a filled shape -- label text inside a coloured flag bubble -- is contrast-on-fill and stays literal; `surface` there would be invisible in dark mode.
+**Spending is not an error: default a breakdown to `chartColors.primary`, not `chartColors.expense`.** Red is loud and spent deliberately (the Monthly Totals chart, where a loss month is the point). A routine breakdown (top categories, paid-from accounts, a seasonality strip) is a magnitude comparison, so its bars take the theme accent. Keep `chartColors.income` for genuine inflows so a refund is still distinguishable. `TopGroupsPanel` and `PayeeSeasonalityPanel` are the worked examples, each with a guard test asserting no `bg-`/`text-red|green-N` and no `var(--chart-expense)` survives. `income`/`expense` remain right for a chart genuinely *about* the in/out split.
 
-**Spending is not an error: default a breakdown to `chartColors.primary`, not `chartColors.expense`.** Red is loud and the app spends it deliberately -- the Monthly Totals chart, where a loss month is the point. A routine breakdown (top categories, paid-from accounts, a seasonality strip) is a magnitude comparison, so its bars take the theme accent, which re-colours per palette because `--chart-primary` follows the theme's blue ramp. Keep `chartColors.income` for genuine inflows so a refund is still distinguishable; that leaves red spent only where it means something. `TopGroupsPanel` and `PayeeSeasonalityPanel` are the worked examples, and both carry a guard test asserting no `bg-`/`text-red|green-N` and no `var(--chart-expense)` survives in their output. Note that `income`/`expense` remain right for a chart genuinely *about* the in/out split -- the rule is about breakdowns that merely happen to be negative.
-
-**A member series drawn beside a total takes `chartSeriesColorAsidePrimary`, not `chartSeriesColor`.** `--chart-1` is the theme accent in every palette in `themes.css`, and so is `--chart-primary` -- so a chart that draws an aggregate line in `chartColors.primary` and starts its members at palette slot 0 hands the first member the total's own colour, in the chart, the legend and the tooltip alike. The helper excludes that slot from the cycle rather than deferring it, because a modulo over the full palette gives it back on the tenth series: the same collision, arriving late. `CashFlowForecastChart`'s "Total of Accounts" line and its per-account lines are the worked example; `chart-colors.test.ts` pins both halves. Use plain `chartSeriesColor` where there is no primary series to collide with.
+**A member series drawn beside a total takes `chartSeriesColorAsidePrimary`, not `chartSeriesColor`.** `--chart-1` is the theme accent in every palette, and so is `--chart-primary` -- so a chart drawing an aggregate line in `chartColors.primary` and starting members at palette slot 0 hands the first member the total's own colour. The helper excludes that slot from the cycle rather than deferring it (a modulo over the full palette gives it back on the tenth series). `CashFlowForecastChart` is the worked example; `chart-colors.test.ts` pins both halves. Use plain `chartSeriesColor` where there is no primary series to collide with.
 
 ## Security Notes
 


### PR DESCRIPTION
Compress the five CLAUDE.md files from ~3,500 to ~1,400 lines by trimming
incident narratives down to short citations while preserving every rule,
helper/constant name, guard-test pointer, issue number, and contract-doc
reference. Section headings and named rules are kept stable since source
comments and guard specs cite them.

Verified against the checks that read these files:
- scripts/check-docs-manifests.mjs (paths in commands, npm scripts, tables)
- backend/src/common/doc-paths.spec.ts (every named path resolves)
- backend/src/common/db/lint-bans.spec.ts (banned DB primitives still
  documented in call form, no positive recommendations)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q8wsseAEWqjTNAssEa1Avw