### PR TITLE
Hide payee brand badges on mobile in the transactions register

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -103,6 +103,8 @@ Both are resolved server-side in one walk up the ancestry: read `category.effect
 
 `components/ui/BrandLogo.tsx` renders a cached favicon with the neutral badge fallback, and owns the one rule that matters: the bytes always come from our own backend, never a third party, so drawing a logo cannot leak which institutions or payees a user has. `InstitutionLogo` and `PayeeLogo` are thin wrappers naming the `/:id/logo` route, gated on `hasLogo` so icon-less rows issue no requests. A 404 lands on `onError` and shows the same badge. A third entity gets a wrapper, not a second component.
 
+**Hiding a logo responsively is spelled `max-sm:hidden`, never a bare `hidden`.** Tailwind emits `.hidden` *first* among the display utilities, so on the fallback badge -- whose own classes include `inline-flex` -- a caller's `hidden sm:inline-flex` never hides anything: the letter circles stayed visible on mobile while the favicons vanished. A `max-*` variant sorts after every base utility and wins below its breakpoint. The brand-logo guard in `ui-conventions.test.ts` fails on a bare `hidden` token in any logo call site's `className`.
+
 ### A status pill is `Badge`; table chrome is `Table.tsx`
 
 `components/ui/Badge.tsx` is the small status pill (previously hand-rolled ~50 times). Pass `variant` and `size`; pass `as="button"` where the pill is also a control, rather than nesting a button in a span. It deliberately does not absorb pills whose colour *means* something -- `CategoryPill`, `AccountTypePill` and `SCHEDULED_KIND_CHIP_CLASSES` are each already one source of truth, exempted by name.

--- a/frontend/src/components/payees/PayeeList.tsx
+++ b/frontend/src/components/payees/PayeeList.tsx
@@ -175,7 +175,7 @@ const PayeeRow = memo(function PayeeRow({
       <td className={`${cellPadding} whitespace-nowrap`}>
         <div className="flex flex-col items-start gap-0.5 sm:flex-row sm:items-center sm:gap-2">
           {density !== 'dense' && (
-            <PayeeLogo payee={payee} size={20} className="hidden sm:inline-flex" />
+            <PayeeLogo payee={payee} size={20} className="max-sm:hidden" />
           )}
           <button
             onClick={(e) => { e.stopPropagation(); onViewTransactions(payee); }}

--- a/frontend/src/components/transactions/PayeeInfoWidget.tsx
+++ b/frontend/src/components/transactions/PayeeInfoWidget.tsx
@@ -188,7 +188,7 @@ export function PayeeInfoWidget({
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 mb-6 lg:mb-0 lg:absolute lg:inset-x-0 lg:top-0 lg:bottom-6 lg:overflow-y-auto flex flex-col">
       <div className="flex items-start justify-between gap-2 mb-4">
         <div className="flex min-w-0 items-start gap-2.5">
-          <PayeeLogo payee={payee} size={28} className="mt-0.5" />
+          <PayeeLogo payee={payee} size={28} className="mt-0.5 max-sm:hidden" />
           <div className="min-w-0">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
             {payee.name}

--- a/frontend/src/components/transactions/TransactionRow.test.tsx
+++ b/frontend/src/components/transactions/TransactionRow.test.tsx
@@ -1040,6 +1040,28 @@ describe('TransactionRow payee brand icon', () => {
     expect(container.querySelector('td span[aria-hidden="true"]')).toBeNull();
   });
 
+  it('hides the favicon on phones with a variant, never a bare hidden', () => {
+    // `.hidden` is emitted before every other display utility, so on the
+    // fallback badge (whose own classes include `inline-flex`) a bare
+    // `hidden` loses and the letter circle stays visible on mobile. The
+    // reliable spelling is `max-sm:hidden` -- a variant sorts after the base
+    // utilities and wins below the breakpoint.
+    const { container } = renderRow({}, { payee: withLogo });
+    const img = container.querySelector('td img') as HTMLImageElement;
+    expect(img.classList.contains('max-sm:hidden')).toBe(true);
+    expect(img.classList.contains('hidden')).toBe(false);
+  });
+
+  it('hides the letter badge on phones with a variant, never a bare hidden', () => {
+    const { container } = renderRow(
+      {},
+      { payee: { ...withLogo, hasLogo: false } as Transaction['payee'] },
+    );
+    const badge = container.querySelector('td span[aria-hidden="true"]')!;
+    expect(badge.classList.contains('max-sm:hidden')).toBe(true);
+    expect(badge.classList.contains('hidden')).toBe(false);
+  });
+
   it('keeps the payee button\'s text to the name alone', () => {
     // The badge is a sibling of the button, never inside it: a glyph in there
     // changes what every textContent assertion over the cell reads.

--- a/frontend/src/components/transactions/TransactionRow.tsx
+++ b/frontend/src/components/transactions/TransactionRow.tsx
@@ -318,13 +318,14 @@ export const TransactionRow = memo(function TransactionRow({
           {/* Brand badge beside the name, never inside the button: the button's
               text is the payee name, and a decorative glyph in it changes what
               every textContent assertion reads. Hidden at dense, where the row
-              is one line of data and a 20px chip per row is noise. */}
+              is one line of data and a 20px chip per row is noise, and on
+              phones, where the payee column has no width to spare. */}
           {density !== 'dense' && payeeLabel && (
             <PayeeLogo
               payee={transaction.payee}
               name={payeeLabel}
               size={20}
-              className="hidden sm:inline-flex"
+              className="max-sm:hidden"
             />
           )}
           {transaction.payeeId && onPayeeClick ? (

--- a/frontend/src/test/ui-conventions.test.ts
+++ b/frontend/src/test/ui-conventions.test.ts
@@ -1463,15 +1463,30 @@ describe("a brand logo keeps the display mode its badge centres with", () => {
   /**
    * `BrandLogo`'s fallback badge centres its letter with `inline-flex` +
    * `items-center justify-center`. The caller's `className` is appended last,
-   * so a display utility in it wins: `hidden sm:block` on the payee list left
-   * every letter jammed against the top-left of its circle, which reads as a
-   * rendering fault rather than a class conflict. Responsive hiding is spelled
-   * `hidden sm:inline-flex`.
+   * but class-attribute order means nothing to CSS -- only stylesheet order
+   * decides, and Tailwind emits the display utilities in a fixed sequence with
+   * `.hidden` FIRST. Two mistakes follow from forgetting that:
+   *
+   * - `hidden sm:block` on the payee list left every letter jammed against
+   *   the top-left of its circle (`block` beat `inline-flex`), which reads as
+   *   a rendering fault rather than a class conflict.
+   * - `hidden sm:inline-flex` on the register never hid the badge on phones
+   *   at all: the badge's own base `inline-flex` beats the earlier-emitted
+   *   `hidden`, so the letter circles stayed visible on mobile.
+   *
+   * Responsive hiding of a logo is therefore spelled `max-sm:hidden` -- a
+   * variant sorts after every base utility, so it wins below the breakpoint
+   * and applies nothing above it.
    */
   const LOGO_TAGS = /<(?:BrandLogo|PayeeLogo|InstitutionLogo)\b[\s\S]{0,400}?\/>/g;
   /** A display utility, at any breakpoint, inside that element's className. */
   const DISPLAY_UTILITY =
     /className="[^"]*\b(?:[a-z]+:)?(?:block|grid|inline-block|flow-root)\b[^"]*"/;
+  /**
+   * A bare `hidden` token (no variant prefix) in that element's className --
+   * it sorts before the badge's own `inline-flex` and so never hides it.
+   */
+  const BARE_HIDDEN = /className="(?:[^"]*\s)?hidden(?:\s[^"]*)?"/;
 
   it("has no call site whose className overrides the badge's display", () => {
     const offenders: string[] = [];
@@ -1485,22 +1500,44 @@ describe("a brand logo keeps the display mode its badge centres with", () => {
     expect([...new Set(offenders)]).toEqual([]);
   });
 
+  it("has no call site trying to hide a logo with a bare `hidden`", () => {
+    const offenders: string[] = [];
+    for (const [path, content] of productionSources()) {
+      for (const match of content.matchAll(LOGO_TAGS)) {
+        if (BARE_HIDDEN.test(match[0])) {
+          offenders.push(path);
+        }
+      }
+    }
+    expect(
+      [...new Set(offenders)],
+      "a bare `hidden` loses to the badge's own `inline-flex`; spell responsive hiding `max-sm:hidden`",
+    ).toEqual([]);
+  });
+
   it("still finds the badge's centring, so the rule cannot pass by accident", () => {
     const brandLogo = sources["/src/components/ui/BrandLogo.tsx"];
     expect(brandLogo, "BrandLogo.tsx not found -- update this test").toBeTruthy();
     expect(brandLogo).toContain("inline-flex items-center justify-center");
   });
 
-  it("recognises the shape it is looking for", () => {
-    // Were the tag regex to stop matching, the scan above would police an
+  it("recognises the shapes it is looking for", () => {
+    // Were the tag regex to stop matching, the scans above would police an
     // empty set.
     const sample = '<PayeeLogo payee={p} size={20} className="hidden sm:block" />';
     const [found] = [...sample.matchAll(LOGO_TAGS)];
     expect(found).toBeTruthy();
     expect(DISPLAY_UTILITY.test(found[0])).toBe(true);
+    expect(BARE_HIDDEN.test(found[0])).toBe(true);
     expect(
-      DISPLAY_UTILITY.test('<PayeeLogo className="hidden sm:inline-flex" />'),
-    ).toBe(false);
+      BARE_HIDDEN.test('<PayeeLogo className="hidden sm:inline-flex" />'),
+    ).toBe(true);
+    expect(BARE_HIDDEN.test('<PayeeLogo className="hidden" />')).toBe(true);
+    // The sanctioned spelling: the variant prefix keeps `hidden` from being a
+    // bare token, and neither scan flags it.
+    const sanctioned = '<PayeeLogo className="mt-0.5 max-sm:hidden" />';
+    expect(DISPLAY_UTILITY.test(sanctioned)).toBe(false);
+    expect(BARE_HIDDEN.test(sanctioned)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: requested directly by the repository owner (no separate discussion/issue) — "When on mobile, don't show any favicons or letters in a circle for payees on the Transactions page".

## Summary

The register's payee badge was already spelled `hidden sm:inline-flex` with the intent of hiding it on phones, but Tailwind emits `.hidden` *first* among the display utilities, so on the fallback letter badge — whose own base classes include `inline-flex` — the caller's `hidden` loses and the letter circles stayed visible on mobile (favicons, with no competing base display class, were correctly hidden). The reliable spelling is `max-sm:hidden`: a variant sorts after every base utility, so it wins below the breakpoint and applies nothing above it.

- `TransactionRow`, `PayeeInfoWidget`, and `PayeeList` (same latent bug on the payees page) now use `max-sm:hidden`.
- The brand-logo guard in `ui-conventions.test.ts` — which previously *prescribed* the broken spelling — now fails on any bare `hidden` token in a logo call site's `className`.
- Two new `TransactionRow` tests pin `max-sm:hidden` (and the absence of bare `hidden`) on both the favicon and the letter badge; both fail against the original code.
- The rule is recorded in `frontend/CLAUDE.md`'s BrandLogo section.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. *(None — change was requested directly by the repo owner.)*
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes (full frontend suite: 723 files, 13,949 tests green; `tsc --noEmit` and ESLint clean).
- [x] All user-facing strings are translated for **every** locale (no user-facing strings were added or changed).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Authored with Claude Code at the repository owner's request; the compiled Tailwind utility order was verified against this project's actual `tailwindcss` build before changing the spelling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvRh5taij1gU9PvdXi3fet)_