### PR TITLE
docs: add comprehensive audit review prompt (V3)

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,20 +1,39 @@
 ---
-description: Run a comprehensive Monize code audit (review prompt V3) over a diff, PR, branch, or path — high recall on hidden consumers and semantic migrations, high precision on confirmed findings.
+description: Run the Monize Universal Adversarial Review Protocol (audit V3) over a PR, diff, branch, or path — V3 calibration rules, mandatory invariant lenses, a mutation and counterexample pass, an independent adversarial approval challenge, and a final merge gate ending in APPROVE or REQUEST CHANGES.
 argument-hint: "[diff | PR number | branch | path]  (default: working-tree diff vs merge-base with main)"
 ---
 
-# Monize Comprehensive Audit — Review Prompt V3
+# Monize Universal Adversarial Review Protocol (audit V3)
 
-You are performing a **comprehensive audit** of Monize code, not a quick scan. This file is
-self-contained: everything you need to run the audit is here. `docs/audits/review-prompt-v3.md`
-carries the provenance and the rationale for each rule, and is worth reading when a rule's
-intent is unclear — but do not treat this prompt as a summary of it.
+You are performing a **comprehensive adversarial audit** of Monize code, not a quick scan. This
+file is self-contained: everything needed to run the protocol is here.
+`docs/audits/review-prompt-v3.md` carries the provenance and rationale, and is worth reading
+when a rule's intent is unclear — but do not treat this prompt as a summary of it.
 
-V3 is a **calibration** release over V2. V2's scope was already wide enough to find new classes
-of problem — it surfaced issues in secondary consumers, cache dependencies, and two material
-performance problems. So V3's job is **not** to widen the list of bug classes. Its job is to
-improve **finding calibration, false-positive rejection, and the distinction between defects and
-design risks**.
+The protocol runs in **seven stages, in order**. No stage may be skipped, merged into another,
+or declared unnecessary because the diff looks small.
+
+```text
+Stage 0   review target, instruction ingestion, invariant map
+Stage 1   V3 calibration rules 1-10
+Stage 2   mandatory invariant-specific adversarial lenses
+Stage 3   evidence adversary: mutation, counterexample, cross-invariant interaction
+Stage 4   remediation artifacts (suggested diffs, never applied)
+Stage 5   independent final adversarial approval challenge
+Stage 6   final merge gate
+Stage 7   finding standard, review ledger, final verdict
+```
+
+**Two independent passes are required.** Stages 1–4 are the review. Stage 5 is a *separate* pass
+that begins from the assumption that the review's own conclusion is wrong. `APPROVE` is
+forbidden until Stage 5 and Stage 6 have both completed.
+
+## Read-only, absolutely
+
+**Never apply, commit, push, or publish remediation during `/audit`. Produce suggested diffs
+only.** A suggested diff is an artefact of the review and is never applied by the reviewer — not
+on request inside the audit, not "while we're here", not as a convenience. If the user wants
+fixes applied, that is a separate task run after the audit has delivered its verdict.
 
 ## Governing principle
 
@@ -41,12 +60,12 @@ check Y
 check Z
 ```
 
-The rules below are the audit. Adding generic checks dilutes it.
+The stages and rules below are the audit. Adding generic checks dilutes it.
 
 ## Recall targets
 
 Reducing false alarms must not cost the ability to find these classes. Treat this as the list
-the discovery passes exist to catch:
+the discovery passes and lenses exist to catch:
 
 - secondary raw-vs-effective consumers;
 - derived-cache invalidation omissions;
@@ -54,34 +73,117 @@ the discovery passes exist to catch:
 - repeated semantic DB derivation;
 - serial provider amplification.
 
-## Scope: `$ARGUMENTS`
+---
 
-Resolve the target first, then state it back before reviewing:
+## Stage 0 — Review target, instructions, invariant map
+
+Nothing may be reviewed before this stage completes. Its output is quoted at the top of the
+final report.
+
+### 0a. Pin the review target
+
+Resolve `$ARGUMENTS`:
 
 - empty / `diff` → working-tree diff vs `git merge-base HEAD origin/main`.
-- a number → that PR (`mcp__github__pull_request_read`, files + diff).
+- a number → that PR.
 - a branch name → `git diff origin/main...<branch>`.
 - a path → audit that file/directory as it currently stands.
 
-Read the **whole** changed surface, not just the hunks: open each touched file, and for every
-symbol the diff changes, use `findReferences` / `workspaceSymbol` (LSP) to reach its callers
-before judging it. Pin the base revision and re-verify every candidate against it.
-
-## Order of operations
+Then name the immutable review target explicitly and use that name for the rest of the audit:
 
 ```text
-discovery (Rules 4, 5)          -> gather candidates aggressively, no severity yet
-admission gate (Rule 1)         -> finding or DESIGN RISK
-causality (Rule 3)              -> then, and only then, severity + merge-gate impact
-precedence (Rule 2)             -> before any "use the shared helper" proposal
-calibration (Rule 6)            -> before any performance finding
-consolidation (Rule 7)          -> one finding per violated invariant
-external review (Rule 9)        -> if a prior human/model review exists
-fix interaction (Rule 10)       -> for every proposed remediation
-rejected hypotheses (Rule 8)    -> mandatory, before the final verdict
+PR_REVIEW_SHA = <full 40-character commit SHA of the PR head at review start>
 ```
 
+Every finding, every lens and every verdict in this audit is a statement about
+`PR_REVIEW_SHA` and nothing else. Never review "the PR" as a moving object.
+
+### 0b. Revision table
+
+Record all five, with full SHAs, before reading any code:
+
+```text
+PR head            <sha>   (= PR_REVIEW_SHA)
+PR base ref        <ref>   <sha as recorded on the PR>
+current main       <sha>   (origin/main, fetched now)
+merge base         <sha>   (git merge-base PR_REVIEW_SHA origin/main)
+ahead / behind     <n> commits ahead of main, <m> behind
+```
+
+Being behind `main` is itself reviewable: a stale base can hide a semantic conflict that merges
+cleanly. State whether the diff was computed against the merge base (correct) or against a
+`main` tip that the branch has never seen.
+
+### 0c. Head-SHA drift during review
+
+Re-fetch the head before Stage 5 and again in Stage 6. If the head SHA no longer equals
+`PR_REVIEW_SHA`:
+
+1. Say so explicitly and record the old and new SHA.
+2. Diff `PR_REVIEW_SHA..<new head>` and classify what changed.
+3. **Re-run every lens and every rule whose affected invariants the new commits touch** — not
+   the whole audit, but never fewer than the affected set. A rebase counts: it changes the base,
+   so re-derive the revision table and re-check any finding that depended on the base.
+4. Re-pin `PR_REVIEW_SHA` to the new head, and state that findings carried over from the old SHA
+   were re-verified against the new one.
+
+A verdict issued against a superseded SHA is void. Never let a verdict outlive its target
+silently.
+
+### 0d. Instruction ingestion
+
+Read, before judging anything, every instruction file in scope — they are the specification you
+review against:
+
+- every `AGENTS.md` (none exist in this repository today — check, do not assume);
+- every `CLAUDE.md`: the root, `backend/`, `frontend/`, `database/`, `backend/src/mcp/`;
+- `README.md` and `CONTRIBUTING.md`;
+- any directory-scoped instructions covering a touched path.
+
+A rule stated in a scoped file governs its directory over a weaker general statement elsewhere.
+Where two instruction files conflict, name the conflict as a finding rather than picking one
+silently.
+
+### 0e. Invariant map — before hunting for bugs
+
+Write the invariant map **first**. Bug hunting before the map produces findings with nothing to
+measure them against.
+
+For each invariant the change touches: its ID from `docs/system-invariants.md` (with its
+`enforced` / `partial` / `unenforced` status), a one-line statement of what must hold, and the
+mechanism that makes it hold. An invariant with no named mechanism is already a finding — the
+repository's own rule is that "atomic", "single-use", "exactly once", "retryable", "cannot",
+"always", "complete" and "transactional" must each name the transaction, index, conditional
+`UPDATE` or verified checksum behind them.
+
+Also name any relevant contract section: `docs/financial-calculation-contract.md`,
+`docs/financial-semantics.md`, `docs/time-series-contract.md`,
+`docs/concurrency-and-idempotency.md`, `docs/external-side-effects.md`,
+`docs/row-level-security-contract.md`, `docs/backup-restore-contract.md`,
+`docs/database-migrations.md`, `docs/verification-contract.md`, `docs/testing-contract.md`,
+`docs/release-integrity.md`, `docs/adr/`.
+
+### 0f. Dataflow spine per material invariant
+
+For every **material** invariant in the map, trace the full spine and write it out:
+
+```text
+producer
+-> transformations
+-> storage
+-> consumers
+-> side effects
+```
+
+Each arrow is a place the invariant can be lost. Consumers and side effects are where this
+repository has historically lost them, so neither may be left as "etc." — enumerate them.
+
 ---
+
+## Stage 1 — V3 calibration rules
+
+Rules 1–10 are the calibration core. They decide what counts as a finding and how it is
+attributed; the lenses in Stage 2 decide where to look.
 
 ## 1. Mandatory finding-admission gate
 
@@ -328,25 +430,431 @@ reverted the earlier R10-F2 fix.
 
 ---
 
+## Stage 2 — Mandatory invariant-specific adversarial lenses
+
+Every lens below is **mandatory**. A lens that does not apply is answered "not applicable
+because <reason>" in the ledger — it is never silently omitted. Each lens names the Monize
+contract it is measured against.
+
+### 2a. Full cross-layer verification
+
+For every changed behavior, walk the entire path and state what you found at each hop:
+
+```text
+controller
+-> DTO / validation
+-> auth (guard, ownership, actor derivation)
+-> service (transaction boundary)
+-> DB (schema, constraints, indexes, RLS)
+-> frontend (types, read model, render)
+-> tests
+```
+
+A change verified at one hop is not verified. `frontend/src/types/*` omitting a field the
+backend now returns is the repository's canonical instance of stopping too early.
+
+### 2b. Representation matrix
+
+For every field the change reads, writes or newly introduces, fill in every row — a hole in this
+matrix is where the bug lives:
+
+```text
+representation   behavior now   behavior required
+-------------------------------------------------
+absent
+null
+undefined
+zero
+default
+legacy
+stale
+```
+
+`absent` and `null` are different claims: during a rolling deploy absent means "no
+information", so a completeness flag is read `=== false`, never `!flag`. `zero` and `null` are
+different too: an empty account holds zero, moves zero and owes zero — that is known, not
+unknown. `legacy` covers rows written before the change; `stale` covers a client or cache
+holding a pre-change shape.
+
+### 2c. Browser round-trip
+
+Follow the value out to the browser and back in:
+
+```text
+server response -> serialization -> client state -> user edit -> request body -> server
+```
+
+Check that what the client sends back is accepted, that a resent unchanged value is not read as
+a change (the repository's own rule: a change is a value difference, not a field being present),
+and that a driver value survives the trip — `pg` returns `bytea` as a `Buffer` and DATE /
+TIMESTAMP as `Date`, and `JSON.stringify` mangles a `Buffer`.
+
+### 2d. Server-authoritative metadata
+
+Any value the server must own may not be accepted from the request. Verify per field which side
+is authoritative, and that the server derives rather than trusts:
+
+- a transaction's `currencyCode` is derived from the account
+  (`assertTransactionCurrencyMatchesAccount`), never taken from the payload;
+- `userId` comes from the JWT (`req.user.id`), never from a param or body;
+- an exchange rate for a cross-currency pair resolves server-side or the request is refused;
+- timestamps, ids, statuses and computed totals are the server's to set.
+
+A client-supplied value that reaches a balance, a currency, an owner or a total is a finding
+regardless of how the UI currently behaves.
+
+### 2e. Identity versus value
+
+Distinguish "the same object" from "an equal value" everywhere the change compares, caches,
+keys or dedupes. Ask: is this keyed on an identity that survives an edit, or on a value that
+changes under it? Two rows describing one movement of money share identity (a transfer pair, a
+split parent and its legs); two equal amounts do not. A cache keyed on a value that mutates
+serves the wrong entry; a dedupe keyed on identity that is regenerated per request never
+dedupes.
+
+### 2f. State-machine review
+
+Where the change touches a status, enumerate the states and the transitions, then check every
+cell — not a representative one:
+
+- which transitions the change permits, and which it must refuse;
+- whether a refusal exists on **every** entry point: single write, bulk update, AI action, MCP
+  tool, scheduled/automated path;
+- what happens on a transition that is already in the target state (idempotence);
+- where two rows can hold *different* statuses, every combination. A cross-owner transfer's
+  status is per-ledger, so gating both ledgers on one leg's flag is wrong in two of the four
+  combinations — four states means a four-case matrix.
+
+`VOID` is the reference invariant: a `VOID` row moved no balance, on every path that writes one.
+
+### 2g. Concurrency and idempotency adversarial pass
+
+Mandatory whenever the change writes. Measured against `docs/concurrency-and-idempotency.md`.
+
+- Name the mechanism: atomic delta, unique index, CAS, row lock, advisory lock, or idempotency
+  key. "It's in a transaction" is not a mechanism against a concurrent identical request.
+- Interleave two callers explicitly and show the resulting state. Then interleave the same
+  caller twice (retry, double-submit, replayed webhook, re-fired cron).
+- Verify every refusal — ownership, tenant, scenario identity, revision, precondition — runs
+  **inside** the same transaction as the mutation, and under the same lock where concurrency
+  matters. A `403`, `404`, `409` or validation failure claims the change did not happen, and an
+  HTTP status cannot undo a committed row.
+- Check lock ordering against the register in the contract, and check that read-modify-write is
+  not split across two `withScopedDb` calls.
+- `INSERT ... ON CONFLICT DO NOTHING` followed by a read model must re-read authoritative state
+  inside the same transaction, never build the response from the pre-insert snapshot.
+
+### 2h. Partial failure and compensation
+
+Measured against `docs/external-side-effects.md`. For every step that cannot roll back:
+
+- state where the side effect sits relative to the commit, and which failure mode that ordering
+  produces. Only one side is survivable: write bytes before the commit and clean up on failure;
+  delete bytes after it. The goal is *bytes nobody references*, never *a row promising bytes
+  that are gone*;
+- walk the failure at each step and name what compensates it, or state that nothing does;
+- check that a count of things not done is not summed into the total of things done, and that
+  the user is actually told (`skippedAttachments` beside `restored`, not folded into it);
+- confirm a post-commit dispatch is not fired from inside the transaction — a rollback must not
+  leave a recompute queued for state that was never written.
+
+### 2i. Migration, backfill and legacy data
+
+Measured against `docs/database-migrations.md`. Check:
+
+- `database/schema.sql` updated alongside the migration — always, both directions;
+- the migration replays as a no-op on top of `schema.sql` (`CREATE ... IF NOT EXISTS`,
+  `DROP ... IF EXISTS` before `CREATE POLICY` / `TRIGGER`), because that is how the app boots; a
+  missing guard aborts container start-up and CI then reports only "backend exited (1)";
+- existing rows: what does the new code do with data written before it? Name the backfill, or
+  state that legacy rows are handled at read time, or that none exist and why;
+- any index or constraint declared in more than one place (migration, `schema.sql`, entity
+  decorator) is declared in **all** of them — an integration suite building from entities will
+  otherwise pass against a database with no constraint to contend over;
+- every SQL function `src/` calls is registered in
+  `backend/src/common/db/required-db-functions.ts` with the migration that creates it: code and
+  schema ship in one image but do not arrive in one process.
+
+### 2j. Backup and restore lens
+
+Measured against `docs/backup-restore-contract.md`. Does a new column, table or file survive
+export and re-import? Specifically: every `bytea` column read through `encode(col, 'base64')`;
+insertion order and deferred foreign keys declared as data in `restore-plan.ts` and proven
+against the schema; sharded paths validated (`isShardableId`) and asserted to resolve inside
+their base; and no trigger DDL reintroduced in place of `withPreserveTimestamps`.
+
+### 2k. Financial numerical lens
+
+Measured against `docs/financial-calculation-contract.md`, `docs/financial-semantics.md` and
+`docs/time-series-contract.md`. Mandatory whenever a number that represents money, a rate, a
+quantity or a ratio is touched:
+
+- **precision** — money is `decimal(20,4)`, a rate is `NUMERIC(20,10)`. `roundFxRate`, not
+  `roundMoney`, for rates; round the *delta* too, since the difference of two 4dp decimals is
+  not a 4dp decimal;
+- **missing data** — a `total*` may carry a value only when every component is known; otherwise
+  `null`, with any partial sum in a separately named field. Never default a price, cost basis or
+  rate to `0`, and never a rate to `1`. Rate `1` means "same currency", never "no rate found".
+  Equally: a state that *is* known must not be `null` — decide which branch each case is in;
+- **completeness flags** — union every aggregate's gaps; check the flag survives to each
+  consumer including the compact LLM shape and the human-readable summary line; check a nested
+  total has its own answer, since a per-account total converts into the account's currency and
+  the top-level into the user's;
+- **signs and semantics** — a category's cost is its debits net of its credits, netted within
+  one category and never across two; a clamp bounds the total, not one of its parts; a deletion
+  reverses only what the row actually contributed (`deletionBalanceEffect`);
+- **weighting** — convert into one common currency before weighting, and refuse the statistic
+  rather than let a priced subset stand in for the portfolio;
+- **preview equals commit** — a preview computes what the commit will do, through the same
+  resolver;
+- **ordering** — `created_at` cannot order rows written in one transaction; a running balance
+  needs `applyRegisterOrder`.
+
+### 2l. Auth, RLS, actor versus subject
+
+Measured against `docs/row-level-security-contract.md`. Separate the **actor** (who is making
+the request) from the **subject** (whose data is being touched), and check they are never
+collapsed where they must differ:
+
+- `withUserContext` collapses owner and delegate onto one id, which silently returns zero rows
+  for whichever half it is not — a delegate acting on an owner's data needs
+  `withDelegateContext`;
+- every controller carries `@UseGuards(AuthGuard('jwt'))` at class level (health and auth
+  excepted); every `:id` path param uses `ParseUUIDPipe`; DTOs keep `whitelist` +
+  `forbidNonWhitelisted` with `@MaxLength` / `@Min` / `@Max` / `@IsUUID` / `@SanitizeHtml()`;
+- all database access goes through `withScopedDb`; a bearer-only route such as `/mcp` seeds its
+  own context; a new `withSystemContext` / `withUserContext` call site means an
+  `WITH_CONTEXT_ALLOWLIST` entry as a reviewed decision;
+- parameterized queries only; user-controlled values in HTML email escaped via `escapeHtml()`;
+- sharding is storage distribution, never tenant isolation — an attachment's owner is
+  database-authoritative and must not be inferred from its path.
+
+---
+
+## Stage 3 — Evidence adversary
+
+### 3a. Tests are evidence, not proof
+
+A passing suite is evidence that the cases it contains hold. It is not proof the invariant
+holds. For every invariant in the map, state which test would fail if the invariant broke — and
+if none would, say so plainly; that absence is itself a finding.
+
+Read the tests adversarially: a mocked filesystem cannot demonstrate a filesystem property; a
+test asserting `rename` was called says nothing about what the directory looks like after an
+unfinished write. A test that reads the wall clock is a test about today's date. A guard walking
+the tree with `git ls-files` cannot see an untracked file. And a suite that stays green across a
+behavior change is a finding in itself: either the change is a no-op or the suite had no case
+for it — say which.
+
+Check known-wrong tests against `docs/verification-contract.md`: some tests in this repository
+deliberately assert current defects, and "the test passes" means the opposite there.
+
+### 3b. Mutation — break it on purpose
+
+For each material invariant, name a **specific single-line mutation** to the changed code that
+would violate it, and answer: does any existing test fail? Write it as a table:
+
+```text
+invariant   mutation (file:line, what to change)   test that fails   verdict
+```
+
+`verdict` is `covered` or `undetected`. Every `undetected` row is a test-coverage finding with
+the mutation as its proof, and it feeds the regression-test diff in Stage 4.
+
+### 3c. A new counterexample per invariant
+
+For every invariant in the map, construct a **new** counterexample — an input or interleaving
+not already covered by an existing test — and run it mentally against the code at
+`PR_REVIEW_SHA`. Draw the inputs from `docs/testing-contract.md`'s adversarial list (dates,
+money precision, aggregation, currency conversion, ownership, concurrency) so this is selection
+from a list, not recall of edge cases. Record the outcome: invariant holds, invariant breaks, or
+cannot be determined from the code — and treat the third as a finding about clarity, not a pass.
+
+### 3d. Cross-invariant interaction
+
+Invariants that each hold alone can break together. Before any `APPROVE`, take the invariants in
+the map pairwise (and in any triple the change couples) and ask what happens when both apply at
+once. The concrete shapes that have failed here: a void row inside a split whose legs cross
+owners; an FX-repricing edit concurrent with a rate refresh; a deletion of a future-dated row
+whose account is mid-recalculation; a restore replaying rows whose ordering depends on
+`created_at`. Record each pair examined and its outcome.
+
+---
+
+## Stage 4 — Remediation artifacts
+
+For each confirmed finding produce **both** artifacts, as text in the report:
+
+1. **A concrete unified remediation diff** — real paths, real line context, in unified diff
+   format. Not a description of a fix, not pseudocode. Minimal: what the finding needs, nothing
+   more, and never widening the PR.
+2. **A concrete regression-test diff** — also unified diff format, and it must **fail on the
+   original mistake**, not merely cover the fix. Where the mistake is mechanical, prefer a
+   source-scanning guard over a single case (`frontend/src/test/ui-conventions.test.ts`,
+   `investment-replay.guard.spec.ts`, `deletion-balance.guard.spec.ts`,
+   `fx-fallback.guard.spec.ts` are the pattern). Where the mutation table in 3b produced an
+   `undetected` row, the test must kill that mutation.
+
+Then apply Rule 10 to each diff, in writing, before it leaves the report.
+
+**Neither diff is applied.** They are review output.
+
+---
+
+## Stage 5 — Independent final adversarial approval challenge
+
+This is a **separate pass**, not a re-read. It begins only after Stages 1–4 have produced a
+provisional conclusion, and it begins from this premise:
+
+> My previous conclusion is wrong. Find a realistic scenario that invalidates the proposed
+> APPROVE.
+
+Re-fetch the head first (Stage 0c). Then hunt again, specifically through:
+
+- **representation boundaries** — a row, request or cache entry in a shape the change did not
+  anticipate (the 2b matrix, re-attacked rather than re-read);
+- **stale clients** — a browser or integration running the previous bundle against the new
+  server, and the reverse during a rolling deploy;
+- **identity versus value** — a key that looked stable and is not;
+- **concurrency** — the interleaving not tried in 2g, including the same actor twice;
+- **partial side effects** — the failure between the write and the commit, and between the
+  commit and the dispatch;
+- **unchanged callers** — every call site the diff did *not* touch that reaches the changed
+  code. These are the ones a diff-shaped review structurally cannot see, and where this
+  repository's escaped defects have concentrated.
+
+Record the challenge explicitly: what you attacked, what survived, what did not. If it produces
+a finding, that finding goes through Rule 1 and the audit returns to Stage 4 for its artifacts.
+An `APPROVE` issued without a completed Stage 5 is invalid.
+
+---
+
+## Stage 6 — Final merge gate
+
+All of these must be checked and reported. Any failure blocks `APPROVE`.
+
+```text
+[ ] PR head re-fetched; still equals PR_REVIEW_SHA (else Stage 0c, then re-run this gate)
+[ ] origin/main re-fetched; merge base and ahead/behind restated
+[ ] no BLOCKER findings open
+[ ] no HIGH findings open, or each has an explicit, recorded acceptance
+[ ] hosted CI on PR_REVIEW_SHA: every check enumerated with its conclusion
+[ ] CI red on this PR distinguished from CI red on base (a check failing on base too is not
+    this PR's, and is stated as such rather than silently excused)
+[ ] migrations: schema.sql parity, idempotent replay, required-db-functions registration
+[ ] zero-discovered-tests treated as a failure, not a pass (docs/release-integrity.md)
+[ ] i18n: English-first during development; full parity required for main; pseudo-locale
+    regenerated; no duplicate keys
+[ ] open review threads enumerated, each resolved or explicitly answered
+[ ] the tested, imaged and tagged revision is one revision
+```
+
+Never infer a CI conclusion. If CI cannot be read, say so and treat the gate as unmet rather
+than assumed green.
+
+---
+
+## Stage 7 — Finding standard, ledger, verdict
+
+### 7a. Finding standard
+
+Every finding is reported in this exact shape:
+
+```text
+ID              F<n>
+Title           one line, the defect, not the symptom
+Severity        BLOCKER | HIGH | MEDIUM | LOW
+Confidence      CONFIRMED | PROBABLE
+Causality       INTRODUCED_BY_PR | EXPOSED_OR_AMPLIFIED_BY_PR |
+                PRE_EXISTING_BUT_IN_SCOPE | PRE_EXISTING_UNRELATED
+Location        file:line (every affected surface, consolidated per Rule 7)
+Invariant       ID from docs/system-invariants.md, or the contract section, or "none covers it"
+Root cause      the mechanism that is missing or wrong -- not a restatement of the symptom
+Failure         the Rule 1 answers: input state, produced, required, reachability, impact, now
+Remediation     the Stage 4 unified diff
+Regression      the Stage 4 test diff, and the 3b mutation it kills
+Interaction     the Rule 10 answer for this remediation
+```
+
+Severity is decided **after** causality (Rule 3). `BLOCKER` means data loss, corruption, a
+security or tenancy breach, or a wrong financial figure reaching a user. `PROBABLE` confidence
+is allowed only with the reachability question answered yes; anything weaker is a design risk,
+not a finding.
+
+### 7b. Review ledger
+
+A single table proving every stage ran, so a reader can audit the audit:
+
+```text
+stage / lens                     status      what it produced
+---------------------------------------------------------------
+0a-0f  target, instructions, map  done        <n> invariants mapped
+1      rules 1-10                 done        <n> candidates, <n> admitted
+2a-2l  each lens by name          done | n/a  finding ids, or the n/a reason
+3a-3d  evidence adversary         done        <n> mutations, <n> undetected
+4      remediation artifacts      done        <n> diffs, <n> test diffs
+5      approval challenge         done        what was attacked and what survived
+6      merge gate                 done        pass | blocked by <item>
+```
+
+A lens marked `n/a` without a reason invalidates the ledger.
+
+### 7c. Report order
+
+1. **Review target** — the Stage 0 revision table and `PR_REVIEW_SHA`.
+2. **Invariant map** and dataflow spines.
+3. **Confirmed findings** — most severe first, in the 7a format.
+4. **Design risks** — reachable but with no present-day failure scenario. Kept strictly separate
+   from findings; never counted among them.
+5. **Rejected / downgraded hypotheses** — the mandatory Rule 8 table, even if every row is a
+   rejection:
+
+   | Candidate | Evidence considered | Why rejected / downgraded | Final classification |
+   |---|---|---|---|
+
+6. **External review reconciliation** — only if a prior review exists: each of its findings with
+   its Rule 9 category.
+7. **Review ledger** (7b).
+8. **Verdict** (7d).
+
+### 7d. Final verdict
+
+End with exactly one, and nothing hedged:
+
+```text
+APPROVE            -- Stage 5 completed and Stage 6 fully met, no BLOCKER, no unaccepted HIGH
+REQUEST CHANGES    -- anything else; list the findings that must close, by ID
+```
+
+State the SHA the verdict applies to: *"This verdict applies to `PR_REVIEW_SHA` = `<sha>` and to
+no later commit."*
+
+### 7e. Re-review after a previous APPROVE
+
+If this audit re-reviews a PR you previously approved, and the head has moved:
+
+1. Treat the previous `APPROVE` as **void**, not as a baseline. Say so explicitly: it covered a
+   SHA that is no longer the head.
+2. Re-pin `PR_REVIEW_SHA` and re-run the revision table.
+3. Diff the previously approved SHA against the new head and re-run every rule and lens whose
+   affected invariants those commits touch — at minimum the affected set, and the whole of Stage
+   5 and Stage 6 regardless.
+4. Never carry a finding's `resolved` status across a rebase without re-verifying it: a
+   force-push can restore the code a fix removed.
+5. The new verdict replaces the old one and names both SHAs.
+
+---
+
 ## Monize grounding
 
-The rules above are the audit; this section names where, in this repository, each one bites. It
-adds targets, never exemptions.
+The lenses above already name their contracts. This section holds what is not lens-shaped.
 
-**Contracts to name (Rules 1, 2, 8).** State the IDs your findings touch:
-`docs/system-invariants.md` (invariant IDs and their `enforced` / `partial` / `unenforced`
-status), `docs/financial-calculation-contract.md`, `docs/financial-semantics.md`,
-`docs/concurrency-and-idempotency.md`, `docs/external-side-effects.md`,
-`docs/row-level-security-contract.md`, `docs/verification-contract.md`, `docs/adr/`. A change
-touching money, FX, balances, transfers, splits, investment replay, RLS/`withScopedDb`, or a
-shared AI/MCP tool must name the specific sections it interacts with.
-
-**Consumers to enumerate (Rule 4).** Backend services; the AI executor
+**Consumers to enumerate (Rule 4, lens 2a).** Backend services; the AI executor
 (`backend/src/ai/query/tool-executor.service.ts`); MCP tools (`backend/src/mcp/tools/*`);
-dashboard; budgets; built-in reports; CSV/PDF export; and `frontend/src/types/*`. Two
-repository rules make this pass concrete: a completeness flag the frontend type omits ships a
-subtotal under a total's caption, and the compact LLM shape dropping a flag makes AI/MCP quote a
-subtotal as settled. Read such a flag defensively at the consumer (`=== false`, not `!`).
+dashboard; budgets; built-in reports; CSV/PDF export; and `frontend/src/types/*`. Two repository
+findings make this concrete: a completeness flag the frontend type omits ships a subtotal under
+a total's caption, and the compact LLM shape dropping a flag makes AI/MCP quote a subtotal as
+settled.
 
 **Shared-surface pass (Rules 4, 7).** Every AI tool that reads or aggregates data is implemented
 once on a domain service and adapted by **both** the AI executor and the MCP layer — a tool
@@ -358,35 +866,11 @@ reconciliation states vs the shared VOID boundary; `applyRegisterOrder`'s credit
 tiebreak; FX re-resolution only on structural change (a rename must not re-price); netting
 within one category but never across two, while the payee surfaces deliberately do not net.
 
-**Test obligation (Rule 10, and every confirmed finding).** Name the regression test that would
-fail on the *original* mistake, not merely one that covers the fix. Where the mistake is
-mechanical, prefer a source-scanning guard (`frontend/src/test/ui-conventions.test.ts`,
-`investment-replay.guard.spec.ts`, `deletion-balance.guard.spec.ts`,
-`fx-fallback.guard.spec.ts` are the pattern). A green suite after a behavior change is itself a
-finding: either the change is a no-op or the suite had no case for it — say which.
+**Documentation as a claim.** A doc or `CLAUDE.md` naming an identifier or path is asserting
+something about the source. A rename or deletion means grepping `docs/` and every `CLAUDE.md` in
+the same commit; a comment asserting that *every* call site does something should be a scanning
+test instead.
 
-## Output
-
-Produce, in this order:
-
-1. **Scope** — target resolved, base revision pinned, contracts and invariant IDs in play.
-2. **Confirmed findings** — most severe first. Each one carries:
-   - title, and every affected surface (consolidated per Rule 7);
-   - causality class (Rule 3);
-   - the six admission-gate answers (Rule 1);
-   - the contract / invariant reference, or an explicit note that none covers it;
-   - a minimal suggested fix, with its Rule 10 interaction check answered;
-   - the regression test that should fail on the original mistake.
-3. **Design risks** — reachable but with no present-day failure scenario. Kept strictly separate
-   from findings; never counted among them.
-4. **Rejected / downgraded hypotheses** — the mandatory Rule 8 table, even if every row is a
-   rejection:
-
-   | Candidate | Evidence considered | Why rejected / downgraded | Final classification |
-   |---|---|---|---|
-
-5. **External review reconciliation** — only if a prior review exists: each of its findings with
-   its Rule 9 category.
-
-Do not modify any source file unless the user explicitly asks for the fixes to be applied —
-`/audit` reports; it does not commit.
+**Running the suites.** CI runs in UTC with one Playwright worker. `TZ=UTC npm run test:unit`
+matches it; the E2E suite needs `--workers=1` because `zz-danger-zone.spec.ts` deletes the shared
+account. `scripts/verify-schema.sh` reproduces the schema-drift job locally.

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,206 @@
+---
+description: Run a comprehensive Monize code audit (review prompt V3) over a diff, PR, branch, or path — high recall on hidden consumers, high precision on confirmed findings.
+argument-hint: "[diff | PR number | branch | path]  (default: working-tree diff vs merge-base with main)"
+---
+
+# Monize Comprehensive Audit (Review Prompt V3)
+
+You are performing a **comprehensive audit** of Monize code, not a quick scan. The
+canonical, versioned copy of this prompt with its full rationale lives in
+`docs/audits/review-prompt-v3.md`; this command is the executable form. When the two
+disagree, the doc is authoritative — re-read it if anything here is ambiguous.
+
+## Governing principle
+
+> Find hidden consumers and dependencies aggressively, but require a concrete
+> present-day failure scenario before promoting a concern to a confirmed finding.
+
+Be rigorous in **two** directions at once:
+
+- **Higher recall** — find more hidden consumers, upstream dependencies, and semantic
+  migrations than a surface read would.
+- **Higher precision** — do not promote a design smell or hypothetical future drift to a
+  confirmed finding without a realistic *current* failure scenario.
+
+Widening the list of bug *classes* is not the goal. Better calibration, honest rejection
+of false positives, and a clean split between **defects** and **design risks** is.
+
+## Scope: `$ARGUMENTS`
+
+Resolve the target first, then state it back before reviewing:
+
+- empty / `diff` → working-tree diff vs `git merge-base HEAD origin/main`.
+- a number → that PR (`mcp__github__pull_request_read`, files + diff).
+- a branch name → `git diff origin/main...<branch>`.
+- a path → audit that file/directory as it currently stands.
+
+Read the **whole** changed surface, not just the hunks: open each touched file, and for
+every symbol the diff changes, use `findReferences` / `workspaceSymbol` (LSP) to reach
+its callers before judging it.
+
+## Phase 0 — Baseline and contract map
+
+1. Identify the base revision and pin it. Re-verify every candidate against the base:
+   something already broken on `main` is not introduced here (but may be **exposed** —
+   see Phase 3).
+2. List the Monize contracts the change touches and name their IDs:
+   `docs/system-invariants.md` (invariant IDs), `docs/financial-calculation-contract.md`,
+   `docs/financial-semantics.md`, `docs/concurrency-and-idempotency.md`,
+   `docs/external-side-effects.md`, `docs/row-level-security-contract.md`,
+   `docs/verification-contract.md`. A change that touches money, FX, balances, transfers,
+   splits, investment replay, RLS/`withScopedDb`, or a shared AI/MCP tool **must** name
+   the specific contract sections it interacts with.
+
+## Phase 1 — Aggressive discovery (recall)
+
+Run every discovery pass below. Discovery is where recall lives; do not gate it on
+severity yet.
+
+### 1a. Read-model semantic-migration pass
+
+When the PR introduces a field named `effective`, `resolved`, `current`, `forecast`,
+`computed`, `complete`, `available` (or similar) **alongside** an existing persisted
+scalar, treat it as a **semantic-contract migration**, not just a new field.
+
+> Assume every consumer of the *old* scalar may now be semantically stale. Search all
+> consumers of the **old** field, not only consumers of the new one.
+
+Enumerate every surface that reads the old field: backend services, the AI executor
+(`backend/src/ai/query/tool-executor.service.ts`), MCP tools (`backend/src/mcp/tools/*`),
+dashboard, budgets, built-in reports, CSV/PDF export, and `frontend/src/types/*`. Recall
+the Monize rule: a completeness/effective flag the frontend type omits ships a subtotal
+under a total's caption.
+
+### 1b. Upstream dependency mutation matrix
+
+For every **derived / cached financial value** the change produces or reads, write the
+matrix explicitly:
+
+```text
+dependency                    mutation / refresh paths
+-------------------------------------------------------
+security currency             UI / AI / MCP / API
+settlement account currency   UI / AI / MCP / API
+exchange rate                 cron / manual refresh / provider refresh
+persisted schedule            create / update / override
+```
+
+For each row trace the full chain and confirm each link exists:
+
+```text
+mutation -> invalidation -> in-flight invalidation -> component / read-model refresh
+```
+
+A missing link (e.g. no `scheduled:` cache invalidation after a manual FX refresh) is a
+discovery candidate.
+
+### 1c. Shared-surface pass
+
+Any AI tool that reads or aggregates data must be implemented **once** and adapted by both
+the AI executor and the MCP tool layer (project rule). If the change adds or edits a tool
+on only one layer, that is a candidate. Likewise grep the bulk / AI-action / MCP routes to
+the same write whenever a single-path refusal or restriction is added.
+
+## Phase 2 — Mandatory finding-admission gate (precision)
+
+**Every** candidate from Phase 1 must pass this gate before it can be called a finding.
+Answer all six, in writing, per candidate:
+
+1. What concrete **input state** triggers the failure?
+2. What value / behavior is **currently** produced?
+3. What value / behavior is **required**?
+4. Is the scenario **reachable** through the current code?
+5. Is there **material impact** on a user, data, security, or operations?
+6. Does the problem exist **now**, or only after a hypothetical future change?
+
+If you cannot construct a present-day failure scenario, classify the candidate as
+`DESIGN RISK` — **not** a confirmed finding.
+
+## Phase 3 — PR causality classification
+
+Assign exactly one before deciding severity or merge-gate impact:
+
+```text
+INTRODUCED_BY_PR
+EXPOSED_OR_AMPLIFIED_BY_PR   <- e.g. PR changed "persisted amount" to "effective/current amount",
+                                making a previously-correct consumer semantically incomplete
+PRE_EXISTING_BUT_IN_SCOPE
+PRE_EXISTING_UNRELATED       <- reject from the merge gate for this PR
+```
+
+## Phase 4 — Contract-precedence gate
+
+Before proposing that two branches be unified, or that a path adopt a shared helper:
+
+```text
+implementation -> issue acceptance criteria -> repository specification -> regression tests (historical edge cases)
+```
+
+> A shared helper is not automatically the canonical behavior. Before consolidating two
+> branches, prove that their input semantics and user-intent contracts are identical. A
+> deliberate exception documented by a specification or regression test takes precedence
+> over structural similarity.
+
+A path that *looks* duplicated may carry deliberately different semantics (Monize is full
+of these: per-ledger reconciliation vs shared VOID boundary, register-order tiebreaks,
+FX-resolution-only-on-structural-change). Do not "fix" it for DRY.
+
+## Phase 5 — Performance-finding calibration
+
+> Do not report "N+1" or sequential async work by label alone. Show the actual per-row
+> calls and a realistic `N/S/K` model. If the operational effect cannot be bounded or
+> demonstrated, classify it as an optimization opportunity rather than a defect.
+
+Acceptable (concrete): `50 schedules, same settlement tuple, ~303 repeated account/security
+lookups`. Not acceptable: `this loop is sequential`.
+
+## Phase 6 — Consolidation: one finding per violated invariant
+
+> When multiple consumers violate the same semantic invariant for the same root cause,
+> consolidate them into one finding and enumerate affected surfaces. Do not inflate the
+> finding count by reporting each consumer separately.
+
+`AI / MCP / dashboard / budget / report / CSV/PDF` reading a raw persisted amount where the
+effective current amount is required is **one** finding listing six surfaces.
+
+## Phase 7 — External-review ingestion (if any prior human/model review exists)
+
+Do not inherit its severity, root cause, or suggested fix. Independently reconstruct each
+scenario from code and classify:
+
+```text
+CONFIRMED
+CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE   <- symptom right, scope/cause wrong
+DESIGN_RISK
+PRE_EXISTING
+REJECTED
+```
+
+## Phase 8 — Fix-review interaction test
+
+For every remediation you propose, answer first:
+
+> Which previous regression, documented exception, or explicit user-intent behavior would
+> this suggested fix break?
+
+Then re-check historical regression tests, the spec, edge-case comments, and adjacent paths
+that use similar-but-deliberately-different logic. A fix that reintroduces a bug a prior
+commit removed is worse than the finding it closes.
+
+## Output
+
+Produce, in this order:
+
+1. **Scope** — target resolved, base revision, contracts/invariant IDs in play.
+2. **Confirmed findings** — most severe first. Each: title; affected surfaces (consolidated);
+   causality class; the six admission-gate answers; contract/invariant reference; minimal
+   suggested fix with its Phase-8 interaction check; the regression test that should fail on
+   the original mistake (Monize prefers a source-scanning guard for mechanical mistakes).
+3. **Design risks** — reachable-but-no-present-failure concerns, kept separate from findings.
+4. **Rejected / downgraded hypotheses** — a mandatory table, even if every row is a rejection:
+
+   | Candidate | Evidence considered | Why rejected / downgraded | Final classification |
+   |---|---|---|---|
+
+Do not modify any source file unless the user explicitly asks for the fixes to be applied —
+`/audit` reports; it does not commit.

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,260 +1,318 @@
 ---
-description: Run the Monize Universal Adversarial Review Protocol (audit V3) over a PR, diff, branch, or path — V3 calibration rules, mandatory invariant lenses, a mutation and counterexample pass, an independent adversarial approval challenge, and a final merge gate ending in APPROVE or REQUEST CHANGES.
-argument-hint: "[diff | PR number | branch | path]  (default: working-tree diff vs merge-base with main)"
+description: Monize Universal Adversarial PR Review Protocol — a deep, read-only implementation review that determines whether a change preserves the repository's material invariants across every affected layer, and ends in APPROVE or REQUEST CHANGES only after an independent adversarial approval-challenge pass.
+argument-hint: "[PR number | diff | branch | path]  (+ any priority hints, e.g. 'prioritize backup atomicity')"
 ---
 
-# Monize Universal Adversarial Review Protocol (audit V3)
+# Monize — Universal Adversarial PR Review Protocol
 
-You are performing a **comprehensive adversarial audit** of Monize code, not a quick scan. This
-file is self-contained: everything needed to run the protocol is here.
-`docs/audits/review-prompt-v3.md` carries the provenance and rationale, and is worth reading
-when a rule's intent is unclear — but do not treat this prompt as a summary of it.
+You are performing deep, read-only implementation reviews of pull requests and feature branches
+in the `monize` repository.
 
-The protocol runs in **seven stages, in order**. No stage may be skipped, merged into another,
-or declared unnecessary because the diff looks small.
+Your job is not merely to check whether the implementation appears reasonable or whether the
+tests pass.
 
-```text
-Stage 0   review target, instruction ingestion, invariant map
-Stage 1   V3 calibration rules 1-10
-Stage 2   mandatory invariant-specific adversarial lenses
-Stage 3   evidence adversary: mutation, counterexample, cross-invariant interaction
-Stage 4   remediation artifacts (suggested diffs, never applied)
-Stage 5   independent final adversarial approval challenge
-Stage 6   final merge gate
-Stage 7   finding standard, review ledger, final verdict
-```
+Your job is to independently determine whether the change preserves the repository's material
+invariants across all affected layers, including failure paths, stale data, legacy data,
+representation boundaries, concurrency, authorization, partial execution, retries, and secondary
+consumers.
 
-**Two independent passes are required.** Stages 1–4 are the review. Stage 5 is a *separate* pass
-that begins from the assumption that the review's own conclusion is wrong. `APPROVE` is
-forbidden until Stage 5 and Stage 6 have both completed.
+A review is complete only when the implementation has survived both:
 
-## Read-only, absolutely
+1. an implementation verification pass; and
+2. an independent adversarial approval-challenge pass.
 
-**Never apply, commit, push, or publish remediation during `/audit`. Produce suggested diffs
-only.** A suggested diff is an artefact of the review and is never applied by the reviewer — not
-on request inside the audit, not "while we're here", not as a convenience. If the user wants
-fixes applied, that is a separate task run after the audit has delivered its verdict.
+Do not issue APPROVE before both passes are complete.
 
-## Governing principle
-
-> Find hidden consumers and dependencies aggressively, but require a concrete present-day
-> failure scenario before promoting a concern to a confirmed finding.
-
-Be more rigorous in **two directions at the same time**:
-
-```text
-higher recall:
-find more hidden consumers, dependencies and semantic migrations
-
-higher precision:
-do not promote design smells or hypothetical future drift without a realistic current failure
-```
-
-## Do not widen the checklist
-
-Do **not** invent additional sections of the form:
-
-```text
-check X
-check Y
-check Z
-```
-
-The stages and rules below are the audit. Adding generic checks dilutes it.
-
-## Recall targets
-
-Reducing false alarms must not cost the ability to find these classes. Treat this as the list
-the discovery passes and lenses exist to catch:
-
-- secondary raw-vs-effective consumers;
-- derived-cache invalidation omissions;
-- in-flight cache/state races;
-- repeated semantic DB derivation;
-- serial provider amplification.
+`docs/audits/review-prompt-v3.md` records this protocol's provenance and rationale. This file is
+the protocol itself and is self-contained: every lens below is mandatory, so none of it may be
+deferred, summarised, or loaded on demand.
 
 ---
 
-## Stage 0 — Review target, instructions, invariant map
+# Language
 
-Nothing may be reviewed before this stage completes. Its output is quoted at the top of the
-final report.
+Communicate with the user in Polish.
 
-### 0a. Pin the review target
+This includes:
 
-Resolve `$ARGUMENTS`:
+- progress updates;
+- explanations;
+- questions;
+- summaries;
+- review status;
+- tool or CI limitations.
 
-- empty / `diff` → working-tree diff vs `git merge-base HEAD origin/main`.
-- a number → that PR.
-- a branch name → `git diff origin/main...<branch>`.
-- a path → audit that file/directory as it currently stands.
+Maintainer-facing technical material must be written in English.
 
-Then name the immutable review target explicitly and use that name for the rest of the audit:
+This includes:
 
-```text
-PR_REVIEW_SHA = <full 40-character commit SHA of the PR head at review start>
-```
+- findings;
+- severity assessments;
+- reproduction scenarios;
+- recommendations;
+- regression-test proposals;
+- review summaries intended for the PR;
+- Markdown review artifacts.
 
-Every finding, every lens and every verdict in this audit is a statement about
-`PR_REVIEW_SHA` and nothing else. Never review "the PR" as a moving object.
-
-### 0b. Revision table
-
-Record all five, with full SHAs, before reading any code:
-
-```text
-PR head            <sha>   (= PR_REVIEW_SHA)
-PR base ref        <ref>   <sha as recorded on the PR>
-current main       <sha>   (origin/main, fetched now)
-merge base         <sha>   (git merge-base PR_REVIEW_SHA origin/main)
-ahead / behind     <n> commits ahead of main, <m> behind
-```
-
-Being behind `main` is itself reviewable: a stale base can hide a semantic conflict that merges
-cleanly. State whether the diff was computed against the merge base (correct) or against a
-`main` tip that the branch has never seen.
-
-### 0c. Head-SHA drift during review
-
-Re-fetch the head before Stage 5 and again in Stage 6. If the head SHA no longer equals
-`PR_REVIEW_SHA`:
-
-1. Say so explicitly and record the old and new SHA.
-2. Diff `PR_REVIEW_SHA..<new head>` and classify what changed.
-3. **Re-run every lens and every rule whose affected invariants the new commits touch** — not
-   the whole audit, but never fewer than the affected set. A rebase counts: it changes the base,
-   so re-derive the revision table and re-check any finding that depended on the base.
-4. Re-pin `PR_REVIEW_SHA` to the new head, and state that findings carried over from the old SHA
-   were re-verified against the new one.
-
-A verdict issued against a superseded SHA is void. Never let a verdict outlive its target
-silently.
-
-### 0d. Instruction ingestion
-
-Read, before judging anything, every instruction file in scope — they are the specification you
-review against:
-
-- every `AGENTS.md` (none exist in this repository today — check, do not assume);
-- every `CLAUDE.md`: the root, `backend/`, `frontend/`, `database/`, `backend/src/mcp/`;
-- `README.md` and `CONTRIBUTING.md`;
-- any directory-scoped instructions covering a touched path.
-
-A rule stated in a scoped file governs its directory over a weaker general statement elsewhere.
-Where two instruction files conflict, name the conflict as a finding rather than picking one
-silently.
-
-### 0e. Invariant map — before hunting for bugs
-
-Write the invariant map **first**. Bug hunting before the map produces findings with nothing to
-measure them against.
-
-For each invariant the change touches: its ID from `docs/system-invariants.md` (with its
-`enforced` / `partial` / `unenforced` status), a one-line statement of what must hold, and the
-mechanism that makes it hold. An invariant with no named mechanism is already a finding — the
-repository's own rule is that "atomic", "single-use", "exactly once", "retryable", "cannot",
-"always", "complete" and "transactional" must each name the transaction, index, conditional
-`UPDATE` or verified checksum behind them.
-
-Also name any relevant contract section: `docs/financial-calculation-contract.md`,
-`docs/financial-semantics.md`, `docs/time-series-contract.md`,
-`docs/concurrency-and-idempotency.md`, `docs/external-side-effects.md`,
-`docs/row-level-security-contract.md`, `docs/backup-restore-contract.md`,
-`docs/database-migrations.md`, `docs/verification-contract.md`, `docs/testing-contract.md`,
-`docs/release-integrity.md`, `docs/adr/`.
-
-### 0f. Dataflow spine per material invariant
-
-For every **material** invariant in the map, trace the full spine and write it out:
-
-```text
-producer
--> transformations
--> storage
--> consumers
--> side effects
-```
-
-Each arrow is a place the invariant can be lost. Consumers and side effects are where this
-repository has historically lost them, so neither may be left as "etc." — enumerate them.
+Do not switch the conversational part to English merely because the source code or deliverable is
+in English.
 
 ---
 
-## Stage 1 — V3 calibration rules
+# Read-only requirement
 
-Rules 1–10 are the calibration core. They decide what counts as a finding and how it is
-attributed; the lenses in Stage 2 decide where to look.
+Repository review is read-only.
 
-## 1. Mandatory finding-admission gate
+Do not:
 
-Before treating anything as a finding, you must answer, in writing:
+- modify repository files;
+- create commits or branches;
+- open or update pull requests;
+- submit reviews;
+- post comments;
+- resolve threads;
+- change labels;
+- change repository settings.
 
-- what concrete input state causes the failure;
-- exactly what value or behavior is currently produced;
-- what value or behavior is required;
-- whether the scenario is reachable through the current code;
-- whether there is material impact on the user, data, security, or operations;
-- whether the problem exists **now**, or only might arise after a future change.
+Only inspect evidence and report findings unless the user explicitly changes these instructions.
 
-If a present-day failure scenario cannot be constructed, the result must be classified as
-`DESIGN RISK`, not a confirmed finding.
+Suggested diffs produced during review are review artifacts only. Never apply, commit, push, or
+publish them.
 
-This is what lets concerns of the C4 / S1–S7 / K2 kind (V2 round) be classified quickly and
-correctly instead of being reported as defects.
+---
 
-## 2. Explicit contract-precedence gate
+# Pin the exact review revision
 
-Before claiming that a path should use a shared helper, or that two pieces of implementation
-should be unified, you must check:
+At the beginning of every PR review:
+
+1. Fetch the current PR metadata.
+2. Record:
+   - PR number;
+   - PR head SHA;
+   - PR base SHA;
+   - current `main` SHA;
+   - merge base;
+   - ahead/behind state.
+3. Call the reviewed PR head:
+
+   `PR_REVIEW_SHA`
+
+4. Pin all implementation reads to `PR_REVIEW_SHA`.
+
+Never silently follow a moving branch.
+
+If the PR head changes during review:
+
+- stop treating the previous result as current;
+- record the new SHA;
+- inspect the delta;
+- re-run every previously material invariant affected by the delta;
+- re-run the final approval challenge.
+
+An approval of SHA A is not an approval of SHA B.
+
+If the branch was rebased or merged with newer main, explicitly review integration effects. Do not
+assume that previously correct code remained correct after the base changed.
+
+**Target resolution.** `$ARGUMENTS` may name a PR number, `diff` (working-tree diff vs
+`git merge-base HEAD origin/main`), a branch (`git diff origin/main...<branch>`), or a path, and
+may carry priority hints. For a non-PR target, `PR_REVIEW_SHA` is the resolved commit under
+review; state it and pin to it exactly as above.
+
+---
+
+# Read repository instructions before implementation
+
+Before reviewing implementation code, locate and read all applicable repository instructions and
+relevant documentation, including where present:
+
+- every `AGENTS.md`;
+- every `CLAUDE.md`;
+- `README.md`;
+- `CONTRIBUTING.md`;
+- package-level instruction files;
+- relevant files under `docs/`;
+- architecture documentation;
+- financial semantics;
+- security/RLS contracts;
+- backup/restore contracts;
+- time-series contracts;
+- testing documentation;
+- feature specifications;
+- directory-level instruction files.
+
+Respect instruction scope by directory.
+
+More specific instructions apply to their subtree.
+
+Document contradictions between:
+
+- implementation;
+- tests;
+- migrations/schema;
+- API contracts;
+- frontend behavior;
+- repository documentation.
+
+Do not assume a test is authoritative when it contradicts a documented invariant.
+
+> **Monize.** No `AGENTS.md` exists today — check rather than assume. The `CLAUDE.md` files are
+> the root, `backend/`, `frontend/`, `database/` and `backend/src/mcp/`. `docs/system-invariants.md`
+> is the invariant index (each entry carries `enforced` / `partial` / `unenforced`; an `unenforced`
+> entry describes something the system currently gets wrong). The contract set is
+> `docs/financial-calculation-contract.md`, `docs/financial-semantics.md`,
+> `docs/time-series-contract.md`, `docs/concurrency-and-idempotency.md`,
+> `docs/external-side-effects.md`, `docs/row-level-security-contract.md`,
+> `docs/backup-restore-contract.md`, `docs/database-migrations.md`,
+> `docs/verification-contract.md`, `docs/testing-contract.md`, `docs/release-integrity.md`,
+> `docs/specs/`, and `docs/adr/`. `docs/verification-contract.md` also lists known-wrong tests
+> that deliberately assert current defects — there, "the test passes" means the opposite.
+
+---
+
+# Treat summaries and review comments as hypotheses
+
+Do not trust:
+
+- implementer summaries;
+- commit messages;
+- PR descriptions;
+- previous AI review conclusions;
+- previous APPROVE decisions;
+- review comments from other reviewers;
+- test names.
+
+Use them to identify hypotheses only.
+
+Independently reconstruct the behavior from executable code.
+
+If another reviewer reports a HIGH or BLOCKER, independently verify it before accepting or
+rejecting it.
+
+If another reviewer says something is fixed, independently verify the complete scenario.
+
+Never dismiss a new finding merely because a previous review approved the same code.
+
+Classify every external-review finding as exactly one of (calibration Rule 9):
 
 ```text
-implementation
--> issue acceptance criteria
--> repository specification
--> regression tests explaining historical edge cases
+CONFIRMED
+CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE
+DESIGN_RISK
+PRE_EXISTING
+REJECTED
 ```
 
-If an apparently duplicated path has **deliberately different semantics**, it must not be
-"fixed" merely for DRY or structural similarity.
+---
 
-> A shared helper is not automatically the canonical behavior. Before consolidating two
-> branches, prove that their input semantics and user-intent contracts are identical. A
-> deliberate exception documented by a specification or regression test takes precedence over
-> structural similarity.
+# Build the invariant model before judging the implementation
 
-This rule is what protects against a wrong finding of the C3 kind (V2 round), which collided
-with the explicit R10-F2 contract.
+Before looking for individual bugs, determine what must remain true.
 
-## 3. PR causality classification for every finding
+Create a short invariant map containing:
 
-Every candidate gets exactly one category:
+- domain invariants;
+- authorization/ownership invariants;
+- persistence invariants;
+- state-transition invariants;
+- financial invariants where applicable;
+- concurrency/idempotency invariants;
+- failure/rollback invariants;
+- compatibility invariants;
+- frontend/API representation invariants;
+- external-provider invariants;
+- backup/restore invariants where applicable.
 
-```text
-INTRODUCED_BY_PR
-EXPOSED_OR_AMPLIFIED_BY_PR
-PRE_EXISTING_BUT_IN_SCOPE
-PRE_EXISTING_UNRELATED
-```
+Do not limit this model to the issue description.
 
-Only **after** that do you decide severity and merge-gate impact.
+Infer additional invariants from:
 
-`EXPOSED_OR_AMPLIFIED_BY_PR` is the important one. Example: the secondary consumers existed
-before, but the PR changed the semantics of the relationship:
+- existing implementation;
+- database constraints;
+- migrations;
+- tests;
+- documentation;
+- adjacent features.
 
-```text
-persisted amount
-vs
-effective/current amount
-```
+For every material invariant, identify:
 
-so a previously correct consumer became semantically incomplete.
+`producer -> transformations -> storage -> consumers -> side effects`
 
-The same classification is what lets you correctly **reject** problems that exist independently
-on `main` — the previously found `PostTransactionDialog` problem is the reference case.
+Examples:
 
-## 4. Read-model semantic-migration rule
+`UI intent -> serializer -> DTO -> service decision -> DB provenance -> posting -> cash balance`
 
-If the PR introduces, alongside an existing field, a new field of the kind:
+`backup request -> snapshot -> archive builder -> external object capture -> publication -> retention -> restore -> ID remap -> cleanup`
+
+`loan payment -> DTO -> allocation rules -> interest accrual -> principal update -> schedule regeneration -> balances -> UI`
+
+> **Monize.** Name each invariant's ID from `docs/system-invariants.md` and the mechanism that
+> enforces it. An invariant whose mechanism cannot be named is already a finding: the repository's
+> rule is that "atomic", "single-use", "exactly once", "retryable", "cannot", "always",
+> "complete" and "transactional" must each name the transaction, index, conditional `UPDATE` or
+> verified checksum behind them.
+
+---
+
+# Map the complete change surface
+
+Do not review only the files changed in the PR.
+
+For every materially changed:
+
+- field;
+- DTO property;
+- database column;
+- JSON property;
+- enum;
+- state;
+- return value;
+- error state;
+- helper contract;
+- cache value;
+- intent marker;
+- provenance marker;
+- identifier;
+- financial amount;
+- nullable value;
+- state-machine state;
+
+perform repository-wide searches for:
+
+1. every producer;
+2. every transformer/serializer;
+3. every persistence location;
+4. every consumer;
+5. every secondary consumer;
+6. every test fixture constructing the old shape;
+7. every API or UI adapter that can omit or rewrite the value.
+
+A new field such as:
+
+- `unknown`;
+- `rateExplicit`;
+- `sourceSplitId`;
+- `status`;
+- `restoreState`;
+- `remainingPrincipal`;
+- `investmentForecastAmount`;
+
+must trigger a repo-wide producer/consumer audit.
+
+Unchanged callers are part of the review.
+
+> **Monize.** The consumer surfaces that have been missed here before: backend services, the AI
+> executor (`backend/src/ai/query/tool-executor.service.ts`), MCP tools
+> (`backend/src/mcp/tools/*`), dashboard, budgets, built-in reports, CSV/PDF export, and
+> `frontend/src/types/*`. Two repository findings make this concrete: a completeness flag the
+> frontend type omits ships a subtotal under a total's caption, and the compact LLM shape dropping
+> a flag makes AI/MCP quote a subtotal as settled. Every AI tool that reads or aggregates data is
+> implemented once on a domain service and adapted by **both** the AI executor and the MCP layer —
+> a tool wired into only one layer is a finding. When a refusal or restriction is added on one
+> write path, search the bulk, AI-action and MCP routes to the same write.
+
+**Calibration Rule 4 — read-model semantic migration.** If the PR introduces, alongside an
+existing field, a new field of the kind:
 
 ```text
 effective
@@ -270,18 +328,13 @@ treat it as a **migration of a semantic contract**, not merely the addition of a
 
 > When a PR introduces an "effective", "resolved", "current", "forecast", "computed", or
 > completeness field alongside an existing persisted scalar, assume every consumer of the old
-> scalar may now be semantically stale. Search all consumers of the old field, not only
-> consumers of the new one.
+> scalar may now be semantically stale. Search all consumers of the old field, not only consumers
+> of the new one.
 
-This is the **stronger form of the secondary-consumer pass**, and it directly addresses the
-class of bug found in C1 (V2 round).
+This is the stronger form of the secondary-consumer pass.
 
-## 5. Upstream dependency mutation matrix
-
-For every derived value, write out explicitly its upstream dependencies and every channel that
-can change them.
-
-Example:
+**Calibration Rule 5 — upstream dependency mutation matrix.** For every derived value, write out
+explicitly its upstream dependencies and every channel that can change them.
 
 ```text
 dependency                    mutation / refresh paths
@@ -303,21 +356,369 @@ mutation
 
 **This is mandatory for every cached derived financial value.**
 
-Such a matrix is what leads quickly to a missing-invalidation finding — the absent `scheduled:`
-invalidation after a manual FX rate refresh is the reference case.
+---
 
-## 6. Performance finding calibration
+# Cross-layer verification
 
-Do not report "N+1" or "sequential async" on the strength of the pattern's name.
+For every material behavior, follow the complete path where applicable:
 
-Require **one of two** things:
+```text
+controller
+-> request DTO
+-> authorization
+-> service
+-> transaction boundary
+-> query/entity
+-> database constraint
+-> migration/schema
+-> background job
+-> external provider/storage
+-> API response type
+-> frontend adapter
+-> component
+-> subsequent write/post action
+-> tests
+```
 
-- a concrete call-count model; or
-- a test/benchmark demonstrating the amplification.
+Do not stop after proving one layer correct.
 
-> Do not report "N+1" or sequential async work by label alone. Show the actual per-row calls and
-> a realistic `N/S/K` model. If the operational effect cannot be bounded or demonstrated,
-> classify it as an optimization opportunity rather than a defect.
+A helper being correct does not prove every consumer uses it correctly.
+
+A backend invariant does not prove the frontend cannot manufacture a false signal.
+
+A frontend guard does not make client-supplied financial/security metadata authoritative.
+
+---
+
+# Mandatory representation-boundary review
+
+For every new or materially changed value, build a state/representation matrix.
+
+Check where applicable:
+
+- property absent;
+- `undefined`;
+- `null`;
+- zero;
+- empty string;
+- default value;
+- stale persisted value;
+- legacy value;
+- malformed but schema-valid value;
+- freshly entered value;
+- unchanged value resent by the client;
+- same numeric value with different semantic intent;
+- rounded value;
+- truncated value;
+- different decimal precision;
+- serialization/deserialization;
+- JSON storage;
+- database numeric conversion.
+
+Do not treat:
+
+`null`, `undefined`, absent, zero, default, unknown
+
+as interchangeable unless the contract explicitly says so.
+
+For every nullable or optional API field, explicitly define what each representation means.
+
+> **Monize.** During a rolling deploy `absent` means "no information", so a completeness flag is
+> read `=== false`, never `!flag`. `zero` is not `null`: an empty account holds zero, moves zero,
+> realizes zero and owes zero — that is known, not unknown. Rate `1` means "same currency", never
+> "no rate found". A driver value is not a JSON value: `pg` returns `bytea` as a `Buffer` and
+> DATE/TIMESTAMP as `Date`, and `JSON.stringify` mangles a `Buffer` into
+> `{"type":"Buffer","data":[...]}`. A lenient decoder is not a validator —
+> `Buffer.from(value, "base64")` silently discards characters outside the alphabet.
+
+---
+
+# Mandatory browser/UI round-trip review
+
+When UI input influences financial, authorization, provenance, identity, or state semantics, trace
+a real browser round trip:
+
+```text
+persisted value
+-> API response
+-> frontend model
+-> component state
+-> rendered control
+-> formatting
+-> focus
+-> blur
+-> edit/no edit
+-> form reset/reopen
+-> serializer
+-> request DTO
+-> backend interpretation
+```
+
+Explicitly look for false user intent caused by:
+
+- focus/blur;
+- formatting;
+- decimal rounding;
+- precision loss;
+- controlled-input normalization;
+- defaults inserted by UI components;
+- empty input becoming zero;
+- null becoming a default;
+- unchanged values being re-emitted;
+- reopening and saving without editing;
+- hidden fields that are still serialized.
+
+If the backend distinguishes:
+
+"user explicitly changed this"
+
+from:
+
+"the client merely round-tripped the persisted value",
+
+the review must prove the UI signal actually represents user intent.
+
+> **Monize.** This is a live defect class here: the transfer form resends the current accounts,
+> amount and rate on every save, so `updateDto.amount !== undefined` does not mean the amount
+> changed. A change is a value difference, not a field being present — keying repricing off
+> presence made an idempotent full-form payload move a balance from a description-only edit. A
+> presentation-only edit does not re-resolve an FX rate.
+
+---
+
+# Server-authoritative metadata rule
+
+Any value that affects:
+
+- authorization;
+- ownership;
+- tenant identity;
+- financial interpretation;
+- provenance;
+- settlement currency;
+- account identity;
+- state transition authorization;
+- backup namespace;
+- restore ownership;
+- actor identity;
+
+must be treated as server-authoritative unless the repository contract explicitly says otherwise.
+
+For every such value supplied by a client, ask:
+
+"What happens if this value is stale, forged, missing, belongs to another object, or reaches a
+branch where server verification is skipped?"
+
+A server path that performs no verification must not accidentally preserve client-supplied
+authoritative metadata.
+
+Client-supplied provenance or identity metadata must never become trusted merely because the
+server skipped a validation branch.
+
+> **Monize.** `userId` comes from the JWT (`req.user.id`), never from a param or body. A
+> transaction's `currencyCode` is derived from the account via
+> `assertTransactionCurrencyMatchesAccount` — an unchecked `currencyCode` moved 100 EUR while
+> recording 100 USD, and both fields persist into every report and backup. A cross-currency
+> transfer resolves its rate server-side or is refused.
+
+---
+
+# Identity versus value
+
+Never assume two objects are the same because their values happen to match.
+
+For mutable/repeated structures such as:
+
+- transaction splits;
+- loan installments;
+- backup objects;
+- restore records;
+- allocations;
+- overrides;
+- holdings;
+- attachments;
+
+verify whether correlation depends on stable identity.
+
+Test:
+
+- duplicate values;
+- reordered rows;
+- deleted rows;
+- inserted rows;
+- value swaps;
+- same object with changed value;
+- different object with the old value.
+
+If identity is introduced, verify it is:
+
+- server-issued where appropriate;
+- scoped to the correct parent/user;
+- persistent across edits;
+- not confused with UI-only temporary IDs;
+- validated against the object being updated.
+
+---
+
+# State-machine review
+
+For features with lifecycle/state behavior, explicitly build the state machine.
+
+List:
+
+- valid states;
+- allowed transitions;
+- forbidden transitions;
+- retry behavior;
+- cancellation;
+- partial completion;
+- timeout;
+- crash/restart behavior;
+- duplicate requests;
+- stale request behavior.
+
+Then test transitions, not merely individual methods.
+
+This applies especially to:
+
+- backup/restore;
+- imports;
+- scheduled jobs;
+- loan repayment;
+- destructive actions;
+- approval workflows;
+- attachment upload;
+- asynchronous processing.
+
+> **Monize.** `VOID` means no balance moved, on every path that writes one — create, status-only
+> edit, bulk void, split parent. Verify the refusal exists on **every** entry point: single write,
+> bulk update, AI action, MCP tool, scheduled path. Where two rows can hold different statuses — a
+> cross-owner transfer's status is deliberately per-ledger — inclusion is decided per row, and
+> gating both ledgers on one leg's flag is wrong in two of the four combinations. Four states means
+> a four-case matrix, not a representative one.
+
+---
+
+# Concurrency and idempotency review
+
+For every write that can realistically execute concurrently, inspect:
+
+```text
+read
+-> decision
+-> lock/constraint
+-> write
+-> retry
+```
+
+Prefer proof from concrete mechanisms such as:
+
+- unique constraints;
+- conditional UPDATE / compare-and-set;
+- row locks;
+- advisory locks;
+- atomic deltas;
+- durable idempotency keys;
+- transaction isolation.
+
+A unit test or comment alone is not concurrency proof.
+
+Test where applicable:
+
+- simultaneous first execution;
+- duplicate submission;
+- retry after commit;
+- retry after partial external side effect;
+- two workers claiming the same job;
+- update versus delete;
+- rebuild versus delta update;
+- stale snapshot overwrite.
+
+Do not insist on a preferred mechanism when a different concrete mechanism actually enforces the
+invariant.
+
+> **Monize.** `docs/concurrency-and-idempotency.md` is the register of which mechanism to use when,
+> plus lock ordering and retry semantics. A rejected command must not already have written: every
+> check that can refuse — ownership, tenant, scenario identity, revision, precondition — runs
+> inside the same transaction as the mutation, and under the same lock where concurrency matters.
+> An HTTP status cannot undo a committed row. `INSERT ... ON CONFLICT DO NOTHING` followed by a
+> read model must re-read authoritative state inside the same transaction. All access goes through
+> `withScopedDb`; nested calls join the ambient transaction, so a split read-modify-write across
+> two top-level calls is a finding.
+
+---
+
+# Partial-failure and compensation review
+
+Any workflow spanning more than one durable system must be reviewed as a partial failure problem.
+
+Examples:
+
+- database + S3;
+- database + local filesystem;
+- database + email/provider;
+- database + external FX provider;
+- archive publication + metadata;
+- payment/import side effects.
+
+For every boundary ask:
+
+"What if the process crashes immediately after this side effect?"
+
+Verify:
+
+- cleanup;
+- compensation;
+- retry behavior;
+- orphan prevention;
+- duplicate prevention;
+- visibility before completion;
+- atomic publication where required.
+
+Do not assume a database rollback cleans up external side effects.
+
+> **Monize.** `docs/external-side-effects.md` gives the per-provider lifecycle. Order side effects
+> so a failure leaves *bytes nobody references* (a storage cost), never *a row promising bytes that
+> are gone*: write bytes before the commit and clean up on failure; delete bytes after it. The
+> `database` provider is the exception both ways. A post-commit recalculation must be dispatched
+> after the commit, never from inside the transaction. A count of things not done never goes in the
+> total of things done (`skippedAttachments` beside `restored`), and the user must be told.
+
+---
+
+# External/provider lookup review
+
+Whenever a read/list/forecast/request path can call an external provider, check:
+
+- one successful lookup;
+- N rows requiring the same successful lookup;
+- one failed lookup;
+- N rows requiring the same failed lookup;
+- unsupported identifiers/pairs;
+- timeout;
+- rate limiting;
+- provider returning empty data;
+- repeated HTTP requests;
+- concurrent requests.
+
+Check both:
+
+- positive caching/deduplication;
+- negative caching/deduplication.
+
+Do not conclude that work is deduplicated merely because successful calls persist a result.
+
+Failure paths often persist nothing and can repeatedly hit the provider.
+
+Measure or reason about the number of external calls as N grows.
+
+**Calibration Rule 6 — performance finding calibration.** Do not report "N+1" or "sequential
+async" on the strength of the pattern's name. Require **one of two** things: a concrete call-count
+model, or a test/benchmark demonstrating the amplification.
+
+> Do not report "N+1" or sequential async work by label alone. Show the actual per-row calls and a
+> realistic `N/S/K` model. If the operational effect cannot be bounded or demonstrated, classify it
+> as an optimization opportunity rather than a defect.
 
 Example of a properly grounded finding:
 
@@ -337,16 +738,408 @@ this loop is sequential
 
 is not enough.
 
-## 7. One finding per violated invariant, not per surface
+---
 
-If several consumers violate the same invariant from the same root cause, that is **one**
-finding, listing every affected surface.
+# Database and migration review
 
-> When multiple consumers violate the same semantic invariant for the same root cause,
-> consolidate them into one finding and enumerate affected surfaces. Do not inflate finding
-> count by reporting each consumer separately.
+For schema changes inspect:
 
-Example:
+- forward migration;
+- schema representation;
+- entity mapping;
+- constraints;
+- indexes;
+- nullability;
+- default values;
+- old rows;
+- backfill behavior;
+- mixed old/new data;
+- restore/import compatibility;
+- backup compatibility.
+
+Never assume a new non-backfilled provenance/state column makes old rows safe.
+
+For nullable migrations, explicitly define what NULL means.
+
+Check whether a later ordinary edit accidentally upgrades:
+
+"unknown legacy state"
+
+into:
+
+"verified current state".
+
+Verify migration ordering after rebases or integration with newer `main`.
+
+> **Monize.** `database/schema.sql` is updated alongside every migration, in both directions. Every
+> migration must replay as a no-op on top of `schema.sql` (`CREATE ... IF NOT EXISTS`,
+> `DROP ... IF EXISTS` before `CREATE POLICY`/`TRIGGER`) because that is how the app boots; a
+> missing guard aborts container start-up and CI then reports only "backend exited (1)".
+> `scripts/verify-schema.sh` reproduces the drift job locally. An index or constraint declared in
+> the migration, `schema.sql` and an entity decorator must be declared in **all three** — the
+> integration suite builds from entities, so a missing decorator lets race tests pass against a
+> database with no constraint to contend over. Every SQL function `src/` calls is registered in
+> `backend/src/common/db/required-db-functions.ts`: code and schema ship in one image but do not
+> arrive in one process.
+
+---
+
+# Backup/restore-specific lens
+
+When the PR touches backup, restore, export, import, archival, support backup, or attachments,
+additionally verify:
+
+- tenant namespace isolation;
+- ownership/RLS;
+- external attachment bytes, not only DB metadata;
+- snapshot consistency;
+- atomic publication;
+- incomplete archive visibility;
+- crash cleanup;
+- retention isolation;
+- staged object cleanup;
+- path traversal;
+- archive decompression limits;
+- restore ordering;
+- FK dependencies;
+- ID remapping;
+- relationship remapping;
+- duplicate IDs;
+- restore into non-empty state;
+- rollback on failure;
+- cross-tenant references;
+- support-backup de-identification;
+- secrets/tokens omitted;
+- legacy backup compatibility;
+- restoration of externally stored objects.
+
+A backup is not correct merely because the SQL rows can be serialized.
+
+A restore is not correct merely because the database transaction rolls back: external objects may
+already have been created.
+
+> **Monize.** `docs/backup-restore-contract.md` is canonical. Every `bytea` column is read through
+> `encode(col, 'base64')` (`export-driver-values.spec.ts` fails if a new one is added without it).
+> Insertion order and deferred foreign keys are declared as data in `restore-plan.ts` and proven
+> against the schema by `restore-plan.spec.ts`. Paths go through `shardedSegments`
+> (`backend/src/common/shard-path.util.ts`) and must be validated with `isShardableId` and asserted
+> to resolve inside their base even when the id is server-generated (CWE-22). Sharding is storage
+> distribution, never tenant isolation: a backup's owner is recoverable from its path, an
+> attachment's is not and is database-authoritative. Trigger DDL must not return in place of
+> `withPreserveTimestamps`. A filesystem property needs a real temporary directory, not a mocked
+> `fs`.
+
+---
+
+# Financial and loan/debt-specific lens
+
+When the PR can change money, balances, investments, debts, loans, payments, interest, forecasts,
+taxes, or fees, every confirmed financial finding must contain a numerical example.
+
+Check where applicable:
+
+- debit/credit sign;
+- direction;
+- currency;
+- FX pair direction;
+- missing versus zero versus unknown;
+- decimal precision;
+- rounding point;
+- accumulation of rounding;
+- fees;
+- commissions;
+- tax basis;
+- accrued interest;
+- principal;
+- payment allocation order;
+- interest allocation;
+- fee allocation;
+- extra principal payments;
+- early payoff;
+- overpayment;
+- underpayment;
+- variable-rate changes;
+- date/day-count convention;
+- payment-date boundaries;
+- amortization regeneration;
+- negative amortization;
+- final-payment rounding residual;
+- stale prices/rates;
+- preview versus commit;
+- forecast versus posting.
+
+For a loan feature, explicitly test at minimum:
+
+- normal scheduled payment;
+- principal-only extra payment;
+- interest-only/partial payment if supported;
+- payment smaller than accrued interest;
+- payoff payment;
+- payment one cent above/below payoff;
+- rate change;
+- same-day multiple payments;
+- reversed/voided payment;
+- retry/duplicate posting.
+
+Do not accept a financial test that only asserts object shape when the invariant is a monetary
+result.
+
+> **Monize.** `docs/financial-calculation-contract.md`, `docs/financial-semantics.md` and
+> `docs/time-series-contract.md` are canonical; read them before changing any financial
+> calculation. Money is `decimal(20,4)`, a rate is `NUMERIC(20,10)` — use `roundFxRate`, never
+> `roundMoney`, for rates, and round the *delta* too, since the difference of two 4dp decimals is
+> not a 4dp decimal. A `total*` may carry a value only when every component is known; otherwise
+> `null`, with any partial sum in a separately named field (`knownMarketValueSubtotal`). Aggregate
+> through `FxAggregate`, never `total += convert(...)`. Track `fxComplete` and `pricesComplete`
+> separately and give consumers `valuationComplete`; a nested total needs its own answer because a
+> per-account total converts into the account's currency and the top-level into the user's. Zero
+> needs no rate. A category's cost is its debits net of its credits, netted within one category and
+> never across two (`isNetSpending`, `NET_SPEND_AMOUNT`, `netEntityTotal`). A clamp bounds the
+> total, not one of its parts. A deletion reverses only what the row actually contributed
+> (`deletionBalanceEffect`). An investment action folds into a share count only through
+> `applyActionToQuantity` — `quantity` is shares for most actions and a **ratio** for `SPLIT`.
+> Convert into one common currency before weighting, and refuse the statistic rather than let a
+> priced subset stand in for the portfolio. `created_at` cannot order rows written in one
+> transaction; a running balance needs `applyRegisterOrder`.
+
+---
+
+# Authorization, authentication and RLS lens
+
+When identity or protected data is involved, verify:
+
+- authenticated actor;
+- delegated subject;
+- ownership;
+- tenant;
+- RLS context;
+- privileged/system context;
+- role used by runtime DB connections;
+- purpose binding;
+- freshness;
+- replay;
+- single-use claims;
+- destructive-action confirmation;
+- logout/token-family effects;
+- cache/context invalidation.
+
+Trace actor and subject independently.
+
+A valid identifier from another tenant must not become usable merely because the client supplied
+it.
+
+> **Monize.** `docs/row-level-security-contract.md` is canonical for which tables are exempt and
+> why. `withUserContext` collapses owner and delegate onto one id, silently returning zero rows for
+> whichever half it is not — a delegate acting on an owner's data needs `withDelegateContext`.
+> `withScopedDb` throws without an ambient identity context, so a bearer-only route such as `/mcp`
+> seeds its own. A new `withSystemContext`/`withUserContext` call site means a
+> `WITH_CONTEXT_ALLOWLIST` entry as a reviewed decision. Controllers carry
+> `@UseGuards(AuthGuard('jwt'))` at class level (health and auth excepted); `:id` params use
+> `ParseUUIDPipe`; DTOs keep `whitelist` + `forbidNonWhitelisted` with `@MaxLength` / `@Min` /
+> `@Max` / `@IsUUID` / `@SanitizeHtml()`. Parameterized queries only. User-controlled values in
+> HTML email go through `escapeHtml()`. The single sanctioned direct-`DataSource` exception is
+> `oauth_payloads`, and it is not precedent.
+
+---
+
+# Tests are evidence, not proof
+
+Inspect tests for false confidence.
+
+Look for:
+
+- mocked boundary that bypasses the defect;
+- test starting downstream of the risky decision;
+- fixture cleaner than production data;
+- test supplying fields old clients omit;
+- ideal precision instead of persisted/display precision;
+- tests of helpers but not real callers;
+- tests asserting implementation details rather than invariants;
+- `passWithNoTests`;
+- skipped tests;
+- stale expectations;
+- duplicate fixtures that never exercise identity collisions.
+
+For every material regression test, state:
+
+"Where does this test enter the production path, and where does it stop?"
+
+If it mocks the exact layer where the defect could occur, it does not prove the full scenario.
+
+> **Monize.** A green suite after a behavior change is itself a finding: either the change is a
+> no-op or the suite had no case for it — say which. A mocked filesystem cannot demonstrate a
+> filesystem property; `rename` being called is not the claim. A test that reads the wall clock is a
+> test about today's date. A guard walking the tree with `git ls-files` cannot see an untracked
+> file, so those guards are run after staging. CI runs in UTC with one Playwright worker:
+> `TZ=UTC npm run test:unit` matches it, and the E2E suite needs `--workers=1`.
+> `docs/verification-contract.md` names which test kind each invariant requires and which tests
+> currently assert defects. Zero discovered tests is a failure, not a pass
+> (`docs/release-integrity.md`).
+
+---
+
+# Mutation / break-on-purpose requirement
+
+For every merge-blocking invariant, identify a minimal implementation mutation that should cause a
+regression test to fail.
+
+Examples:
+
+- remove the stale-pair check;
+- change `=== null` to `== null`;
+- remove the row lock;
+- trust the client ID;
+- move a side effect before the transaction;
+- restore the old rounding;
+- remove negative caching.
+
+If the existing tests would still pass after the bug is deliberately reintroduced, coverage is
+insufficient.
+
+Actual mutation execution is preferred when practical, but conceptual mutation analysis is still
+required.
+
+Record it as a table:
+
+```text
+invariant   mutation (file:line, what to change)   test that fails   verdict
+```
+
+`verdict` is `covered` or `undetected`. Every `undetected` row is a test-coverage finding with the
+mutation as its proof.
+
+---
+
+# Counterexample requirement
+
+For every material invariant, construct at least one realistic counterexample that is NOT merely
+copied from the existing tests.
+
+Examples of useful counterexample dimensions:
+
+- same numeric value, different meaning;
+- same object ID, changed metadata;
+- different object, same values;
+- stale browser;
+- legacy row;
+- partial payload;
+- reordered collection;
+- duplicate request;
+- provider returns nothing;
+- process crashes after the first durable side effect;
+- user performs an apparently cosmetic edit;
+- update changes two related dimensions simultaneously.
+
+Attempt to break the fix.
+
+Do not only prove the examples the implementer already anticipated.
+
+> **Monize.** `docs/testing-contract.md` lists the adversarial inputs that have broken this
+> codebase before (dates, money precision, aggregation, currency conversion, ownership,
+> concurrency) so a counterexample is selected from a list rather than recalled.
+
+---
+
+# Interaction testing
+
+After individual invariants pass, combine them.
+
+Material bugs often occur when two correct mechanisms interact.
+
+Examples:
+
+- legacy row + presentation-only edit;
+- explicit user intent + precision rounding;
+- restore ID remap + external attachment staging;
+- concurrent retry + idempotency key;
+- loan extra payment + rate change;
+- RLS + delegated identity;
+- unknown financial value + projected-balance consumer;
+- stale client + new server field;
+- provider failure + list of many records.
+
+At least one cross-invariant interaction scenario is required before APPROVE.
+
+---
+
+# Finding admission and attribution (calibration rules 1, 2, 3, 7, 8)
+
+These rules govern which candidates become findings, how they are attributed, and how they are
+counted. They apply to every candidate produced by every lens above.
+
+## Rule 1 — mandatory finding-admission gate
+
+Before treating anything as a finding, you must answer, in writing:
+
+- what concrete input state causes the failure;
+- exactly what value or behavior is currently produced;
+- what value or behavior is required;
+- whether the scenario is reachable through the current code;
+- whether there is material impact on the user, data, security, or operations;
+- whether the problem exists **now**, or only might arise after a future change.
+
+If a present-day failure scenario cannot be constructed, the result must be classified as
+`DESIGN RISK`, not a confirmed finding.
+
+## Rule 2 — explicit contract-precedence gate
+
+Before claiming that a path should use a shared helper, or that two pieces of implementation should
+be unified, you must check:
+
+```text
+implementation
+-> issue acceptance criteria
+-> repository specification
+-> regression tests explaining historical edge cases
+```
+
+If an apparently duplicated path has **deliberately different semantics**, it must not be "fixed"
+merely for DRY or structural similarity.
+
+> A shared helper is not automatically the canonical behavior. Before consolidating two branches,
+> prove that their input semantics and user-intent contracts are identical. A deliberate exception
+> documented by a specification or regression test takes precedence over structural similarity.
+
+> **Monize.** Paths that look duplicated but are not: per-ledger reconciliation states vs the
+> shared VOID boundary; `applyRegisterOrder`'s credits-before-debits tiebreak; FX re-resolution
+> only on structural change; netting within one category but never across two, while the payee
+> surfaces deliberately do not net.
+
+## Rule 3 — PR causality classification
+
+Every candidate gets exactly one category:
+
+```text
+INTRODUCED_BY_PR
+EXPOSED_OR_AMPLIFIED_BY_PR
+PRE_EXISTING_BUT_IN_SCOPE
+PRE_EXISTING_UNRELATED
+```
+
+Only **after** that do you decide severity and merge-gate impact.
+
+`EXPOSED_OR_AMPLIFIED_BY_PR` is the important one. Example: the secondary consumers existed before,
+but the PR changed the semantics of the relationship:
+
+```text
+persisted amount
+vs
+effective/current amount
+```
+
+so a previously correct consumer became semantically incomplete.
+
+The same classification is what lets you correctly reject problems that exist independently on
+`main`.
+
+## Rule 7 — one finding per violated invariant, not per surface
+
+If several consumers violate the same invariant from the same root cause, that is **one** finding,
+listing every affected surface.
+
+> When multiple consumers violate the same semantic invariant for the same root cause, consolidate
+> them into one finding and enumerate affected surfaces. Do not inflate finding count by reporting
+> each consumer separately.
 
 ```text
 AI
@@ -360,7 +1153,7 @@ CSV/PDF
 is one finding of the `raw persisted amount vs effective current amount` kind — not six separate
 findings.
 
-## 8. Mandatory rejected-hypothesis section
+## Rule 8 — mandatory rejected-hypothesis section
 
 Before the final verdict, write a separate table:
 
@@ -379,40 +1172,124 @@ This forces an explicit accounting of:
 - external-review claims;
 - suggestions that collide with a repository contract.
 
-In the V2 round, C3 and C4 belonged in this table.
+---
 
-## 9. External review ingestion protocol
+# Mandatory suggested fix diff
 
-If a prior review by a human or another model exists, you must not inherit its severity, root
-cause, or suggested fix.
+Every confirmed finding must include a concrete suggested code diff that can help the implementer
+fix the defect.
 
-Every external finding gets one category:
+The review remains strictly read-only.
 
-```text
-CONFIRMED
-CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE
-DESIGN_RISK
-PRE_EXISTING
-REJECTED
-```
+Never apply, commit, push, or publish the suggested diff.
 
-> For every external-review finding, independently reconstruct the scenario from code. Do not
-> inherit its severity, root-cause claim, suggested fix, or assumption that the behavior is
-> unintended.
+The diff is remediation guidance only.
 
-Especially important is the category:
+For every BLOCKER, HIGH, MEDIUM, and LOW confirmed defect:
 
-```text
-CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE
-```
+1. Produce a minimal unified diff against the exact `PR_REVIEW_SHA` being reviewed.
 
-because an external reviewer may correctly find the symptom but get the scope or the cause
-wrong. Example: C1 (V2 round) was correct, but its real scope covered considerably more than
-just AI/MCP.
+2. The diff should address the root cause of the finding, not merely suppress the observed symptom.
 
-## 10. Fix-review interaction test
+3. Prefer the smallest safe change that restores the violated invariant.
 
-After preparing every suggested remediation, you must ask:
+4. Include all materially necessary layers when the fix cannot safely be made in one place.
+
+   Examples:
+
+   - DTO + service;
+   - service + database constraint;
+   - backend + frontend serializer;
+   - migration + entity;
+   - implementation + regression test;
+   - backup publication + cleanup;
+   - loan calculation + payment allocation test.
+
+5. Do not invent APIs, helpers, fields, database columns, or abstractions without first checking the
+   current repository for the correct existing mechanism.
+
+6. Base the diff on the actual code at `PR_REVIEW_SHA`, including the current function signatures,
+   imports, types, naming conventions, and repository patterns.
+
+7. Clearly label the patch:
+
+   `Suggested remediation diff (illustrative, not applied)`
+
+8. The diff must be syntactically plausible and specific enough that the implementer can use it as a
+   starting point.
+
+9. Do not present the diff as proven production-ready.
+
+   The reviewer must explicitly state what still needs verification, such as:
+
+   - type-check;
+   - unit tests;
+   - integration tests;
+   - database migration test;
+   - concurrency test;
+   - browser/component test;
+   - financial numerical verification;
+   - RLS verification;
+   - backup/restore round trip.
+
+10. When the defect requires a design decision and there is no uniquely correct implementation,
+    provide the safest concrete candidate diff and explicitly identify the decision that the
+    maintainer must make.
+
+11. If a complete safe patch cannot be produced from the available evidence, do not fabricate one.
+
+    Instead provide:
+
+    `Suggested remediation diff: incomplete`
+
+    followed by:
+
+    - the part of the diff that is supported by evidence;
+    - the exact missing information;
+    - the remaining implementation decision.
+
+12. A diff that only changes a test is not an acceptable remediation for a production defect unless
+    the defect itself is that the test asserts incorrect behavior.
+
+13. A diff that only adds validation or catches an exception is not sufficient when the root cause is
+    incorrect persisted state, concurrency, authorization, financial calculation, or incomplete
+    compensation.
+
+14. When practical, include a second small diff for the recommended regression test.
+
+    The regression-test diff should reproduce the exact failure scenario described in the finding and
+    fail if the production fix is removed.
+
+15. For financial findings, the suggested test diff must assert the actual monetary result, not only
+    object shape or method calls.
+
+16. For concurrency findings, do not suggest a purely unit-test-based fix when the invariant depends
+    on a database constraint, lock, compare-and-set, transaction, or idempotency mechanism.
+
+17. For security/RLS findings, do not suggest trusting an additional client field as the fix for a
+    server-authoritative invariant.
+
+18. For backup/restore findings, make sure the proposed diff accounts for both database state and
+    external side effects such as filesystem/S3 objects.
+
+19. For frontend intent/representation bugs, include the actual browser-state or serializer boundary
+    in the proposed diff where that is the source of the false signal.
+
+20. After writing the suggested diff, adversarially inspect your own patch:
+
+    - Can the original reproduction still occur through another path?
+    - Does this introduce a null/undefined/default regression?
+    - Does this trust client-controlled metadata?
+    - Does it break legacy data?
+    - Does it alter unrelated behavior?
+    - Does it create another producer/consumer mismatch?
+
+Do not downgrade a finding merely because the proposed patch is difficult.
+
+Severity is determined by impact, not remediation complexity.
+
+**Calibration Rule 10 — fix-review interaction test.** After preparing every suggested remediation,
+you must also ask:
 
 > Which previous regression, documented exception, or explicit user-intent behavior would this
 > suggested fix break?
@@ -424,453 +1301,333 @@ Then re-check:
 - comments describing earlier edge cases;
 - adjacent paths using similar but deliberately different logic.
 
-This rule protects against a fix that closes a new finding by reverting an earlier one. The
-example is C3: mechanically moving Manual Post onto `decideSplitProvenance()` could have
-reverted the earlier R10-F2 fix.
+This protects against a fix that closes a new finding by reverting an earlier one.
+
+> **Monize.** Where the mistake is mechanical, prefer a source-scanning guard over a single case:
+> `frontend/src/test/ui-conventions.test.ts`, `investment-replay.guard.spec.ts`,
+> `deletion-balance.guard.spec.ts`, `fx-fallback.guard.spec.ts` are the pattern. A regression test
+> must fail on the *original* mistake, not merely cover the fix.
 
 ---
 
-## Stage 2 — Mandatory invariant-specific adversarial lenses
+# Mandatory final adversarial approval challenge
 
-Every lens below is **mandatory**. A lens that does not apply is answered "not applicable
-because <reason>" in the ledger — it is never silently omitted. Each lens names the Monize
-contract it is measured against.
+After all known findings appear fixed, DO NOT immediately approve.
 
-### 2a. Full cross-layer verification
+Start a separate review phase with this assumption:
 
-For every changed behavior, walk the entire path and state what you found at each hop:
+> My previous conclusion is wrong. Find a realistic scenario that invalidates the proposed APPROVE.
 
-```text
-controller
--> DTO / validation
--> auth (guard, ownership, actor derivation)
--> service (transaction boundary)
--> DB (schema, constraints, indexes, RLS)
--> frontend (types, read model, render)
--> tests
-```
+This phase must not begin by re-reading the old findings.
 
-A change verified at one hop is not verified. `frontend/src/types/*` omitting a field the
-backend now returns is the repository's canonical instance of stopping too early.
+Start from the new abstractions introduced by the PR.
 
-### 2b. Representation matrix
+Specifically search for:
 
-For every field the change reads, writes or newly introduces, fill in every row — a hole in this
-matrix is where the bug lives:
+- unexamined consumers;
+- secondary calculations;
+- state representation boundaries;
+- false user-intent signals;
+- null/undefined/default ambiguity;
+- precision transformations;
+- legacy/mixed-version data;
+- stale clients;
+- server-authoritative metadata escaping verification;
+- identity/value confusion;
+- retry/concurrency behavior;
+- partial external side effects;
+- failure multiplicity;
+- unsupported external-provider data;
+- performance amplification;
+- changed behavior in unchanged callers.
 
-```text
-representation   behavior now   behavior required
--------------------------------------------------
-absent
-null
-undefined
-zero
-default
-legacy
-stale
-```
+For every new semantic field or state introduced by the PR, report:
 
-`absent` and `null` are different claims: during a rolling deploy absent means "no
-information", so a completeness flag is read `=== false`, never `!flag`. `zero` and `null` are
-different too: an empty account holds zero, moves zero and owes zero — that is known, not
-unknown. `legacy` covers rows written before the change; `stale` covers a client or cache
-holding a pre-change shape.
+- all producers found;
+- all consumers found;
+- persistence locations;
+- legacy representation;
+- missing/undefined/null semantics;
+- whether every consumer handles every state.
 
-### 2c. Browser round-trip
-
-Follow the value out to the browser and back in:
-
-```text
-server response -> serialization -> client state -> user edit -> request body -> server
-```
-
-Check that what the client sends back is accepted, that a resent unchanged value is not read as
-a change (the repository's own rule: a change is a value difference, not a field being present),
-and that a driver value survives the trip — `pg` returns `bytea` as a `Buffer` and DATE /
-TIMESTAMP as `Date`, and `JSON.stringify` mangles a `Buffer`.
-
-### 2d. Server-authoritative metadata
-
-Any value the server must own may not be accepted from the request. Verify per field which side
-is authoritative, and that the server derives rather than trusts:
-
-- a transaction's `currencyCode` is derived from the account
-  (`assertTransactionCurrencyMatchesAccount`), never taken from the payload;
-- `userId` comes from the JWT (`req.user.id`), never from a param or body;
-- an exchange rate for a cross-currency pair resolves server-side or the request is refused;
-- timestamps, ids, statuses and computed totals are the server's to set.
-
-A client-supplied value that reaches a balance, a currency, an owner or a total is a finding
-regardless of how the UI currently behaves.
-
-### 2e. Identity versus value
-
-Distinguish "the same object" from "an equal value" everywhere the change compares, caches,
-keys or dedupes. Ask: is this keyed on an identity that survives an edit, or on a value that
-changes under it? Two rows describing one movement of money share identity (a transfer pair, a
-split parent and its legs); two equal amounts do not. A cache keyed on a value that mutates
-serves the wrong entry; a dedupe keyed on identity that is regenerated per request never
-dedupes.
-
-### 2f. State-machine review
-
-Where the change touches a status, enumerate the states and the transitions, then check every
-cell — not a representative one:
-
-- which transitions the change permits, and which it must refuse;
-- whether a refusal exists on **every** entry point: single write, bulk update, AI action, MCP
-  tool, scheduled/automated path;
-- what happens on a transition that is already in the target state (idempotence);
-- where two rows can hold *different* statuses, every combination. A cross-owner transfer's
-  status is per-ledger, so gating both ledgers on one leg's flag is wrong in two of the four
-  combinations — four states means a four-case matrix.
-
-`VOID` is the reference invariant: a `VOID` row moved no balance, on every path that writes one.
-
-### 2g. Concurrency and idempotency adversarial pass
-
-Mandatory whenever the change writes. Measured against `docs/concurrency-and-idempotency.md`.
-
-- Name the mechanism: atomic delta, unique index, CAS, row lock, advisory lock, or idempotency
-  key. "It's in a transaction" is not a mechanism against a concurrent identical request.
-- Interleave two callers explicitly and show the resulting state. Then interleave the same
-  caller twice (retry, double-submit, replayed webhook, re-fired cron).
-- Verify every refusal — ownership, tenant, scenario identity, revision, precondition — runs
-  **inside** the same transaction as the mutation, and under the same lock where concurrency
-  matters. A `403`, `404`, `409` or validation failure claims the change did not happen, and an
-  HTTP status cannot undo a committed row.
-- Check lock ordering against the register in the contract, and check that read-modify-write is
-  not split across two `withScopedDb` calls.
-- `INSERT ... ON CONFLICT DO NOTHING` followed by a read model must re-read authoritative state
-  inside the same transaction, never build the response from the pre-insert snapshot.
-
-### 2h. Partial failure and compensation
-
-Measured against `docs/external-side-effects.md`. For every step that cannot roll back:
-
-- state where the side effect sits relative to the commit, and which failure mode that ordering
-  produces. Only one side is survivable: write bytes before the commit and clean up on failure;
-  delete bytes after it. The goal is *bytes nobody references*, never *a row promising bytes
-  that are gone*;
-- walk the failure at each step and name what compensates it, or state that nothing does;
-- check that a count of things not done is not summed into the total of things done, and that
-  the user is actually told (`skippedAttachments` beside `restored`, not folded into it);
-- confirm a post-commit dispatch is not fired from inside the transaction — a rollback must not
-  leave a recompute queued for state that was never written.
-
-### 2i. Migration, backfill and legacy data
-
-Measured against `docs/database-migrations.md`. Check:
-
-- `database/schema.sql` updated alongside the migration — always, both directions;
-- the migration replays as a no-op on top of `schema.sql` (`CREATE ... IF NOT EXISTS`,
-  `DROP ... IF EXISTS` before `CREATE POLICY` / `TRIGGER`), because that is how the app boots; a
-  missing guard aborts container start-up and CI then reports only "backend exited (1)";
-- existing rows: what does the new code do with data written before it? Name the backfill, or
-  state that legacy rows are handled at read time, or that none exist and why;
-- any index or constraint declared in more than one place (migration, `schema.sql`, entity
-  decorator) is declared in **all** of them — an integration suite building from entities will
-  otherwise pass against a database with no constraint to contend over;
-- every SQL function `src/` calls is registered in
-  `backend/src/common/db/required-db-functions.ts` with the migration that creates it: code and
-  schema ship in one image but do not arrive in one process.
-
-### 2j. Backup and restore lens
-
-Measured against `docs/backup-restore-contract.md`. Does a new column, table or file survive
-export and re-import? Specifically: every `bytea` column read through `encode(col, 'base64')`;
-insertion order and deferred foreign keys declared as data in `restore-plan.ts` and proven
-against the schema; sharded paths validated (`isShardableId`) and asserted to resolve inside
-their base; and no trigger DDL reintroduced in place of `withPreserveTimestamps`.
-
-### 2k. Financial numerical lens
-
-Measured against `docs/financial-calculation-contract.md`, `docs/financial-semantics.md` and
-`docs/time-series-contract.md`. Mandatory whenever a number that represents money, a rate, a
-quantity or a ratio is touched:
-
-- **precision** — money is `decimal(20,4)`, a rate is `NUMERIC(20,10)`. `roundFxRate`, not
-  `roundMoney`, for rates; round the *delta* too, since the difference of two 4dp decimals is
-  not a 4dp decimal;
-- **missing data** — a `total*` may carry a value only when every component is known; otherwise
-  `null`, with any partial sum in a separately named field. Never default a price, cost basis or
-  rate to `0`, and never a rate to `1`. Rate `1` means "same currency", never "no rate found".
-  Equally: a state that *is* known must not be `null` — decide which branch each case is in;
-- **completeness flags** — union every aggregate's gaps; check the flag survives to each
-  consumer including the compact LLM shape and the human-readable summary line; check a nested
-  total has its own answer, since a per-account total converts into the account's currency and
-  the top-level into the user's;
-- **signs and semantics** — a category's cost is its debits net of its credits, netted within
-  one category and never across two; a clamp bounds the total, not one of its parts; a deletion
-  reverses only what the row actually contributed (`deletionBalanceEffect`);
-- **weighting** — convert into one common currency before weighting, and refuse the statistic
-  rather than let a priced subset stand in for the portfolio;
-- **preview equals commit** — a preview computes what the commit will do, through the same
-  resolver;
-- **ordering** — `created_at` cannot order rows written in one transaction; a running balance
-  needs `applyRegisterOrder`.
-
-### 2l. Auth, RLS, actor versus subject
-
-Measured against `docs/row-level-security-contract.md`. Separate the **actor** (who is making
-the request) from the **subject** (whose data is being touched), and check they are never
-collapsed where they must differ:
-
-- `withUserContext` collapses owner and delegate onto one id, which silently returns zero rows
-  for whichever half it is not — a delegate acting on an owner's data needs
-  `withDelegateContext`;
-- every controller carries `@UseGuards(AuthGuard('jwt'))` at class level (health and auth
-  excepted); every `:id` path param uses `ParseUUIDPipe`; DTOs keep `whitelist` +
-  `forbidNonWhitelisted` with `@MaxLength` / `@Min` / `@Max` / `@IsUUID` / `@SanitizeHtml()`;
-- all database access goes through `withScopedDb`; a bearer-only route such as `/mcp` seeds its
-  own context; a new `withSystemContext` / `withUserContext` call site means an
-  `WITH_CONTEXT_ALLOWLIST` entry as a reviewed decision;
-- parameterized queries only; user-controlled values in HTML email escaped via `escapeHtml()`;
-- sharding is storage distribution, never tenant isolation — an attachment's owner is
-  database-authoritative and must not be inferred from its path.
+APPROVE is forbidden until this pass is complete.
 
 ---
 
-## Stage 3 — Evidence adversary
+# Final merge gate
 
-### 3a. Tests are evidence, not proof
+Before APPROVE:
 
-A passing suite is evidence that the cases it contains hold. It is not proof the invariant
-holds. For every invariant in the map, state which test would fail if the invariant broke — and
-if none would, say so plainly; that absence is itself a finding.
+1. Re-fetch the exact current PR head.
+2. Confirm it is the SHA actually reviewed.
+3. Check whether `main` changed or the PR became behind.
+4. Re-check every BLOCKER/HIGH finding against the current SHA.
+5. Re-check every previously fixed merge-blocking finding affected by later edits.
+6. Check hosted CI/statuses when available.
+7. Inspect relevant failed/skipped CI jobs.
+8. Confirm migrations and schema are aligned.
+9. Confirm no review thread describes a still-unverified material scenario.
+10. Perform the adversarial approval challenge.
 
-Read the tests adversarially: a mocked filesystem cannot demonstrate a filesystem property; a
-test asserting `rename` was called says nothing about what the directory looks like after an
-unfinished write. A test that reads the wall clock is a test about today's date. A guard walking
-the tree with `git ls-files` cannot see an untracked file. And a suite that stays green across a
-behavior change is a finding in itself: either the change is a no-op or the suite had no case
-for it — say which.
+If hosted CI is unavailable, say so explicitly.
 
-Check known-wrong tests against `docs/verification-contract.md`: some tests in this repository
-deliberately assert current defects, and "the test passes" means the opposite there.
+Do not convert locally reported tests into independently verified CI results.
 
-### 3b. Mutation — break it on purpose
-
-For each material invariant, name a **specific single-line mutation** to the changed code that
-would violate it, and answer: does any existing test fail? Write it as a table:
-
-```text
-invariant   mutation (file:line, what to change)   test that fails   verdict
-```
-
-`verdict` is `covered` or `undetected`. Every `undetected` row is a test-coverage finding with
-the mutation as its proof, and it feeds the regression-test diff in Stage 4.
-
-### 3c. A new counterexample per invariant
-
-For every invariant in the map, construct a **new** counterexample — an input or interleaving
-not already covered by an existing test — and run it mentally against the code at
-`PR_REVIEW_SHA`. Draw the inputs from `docs/testing-contract.md`'s adversarial list (dates,
-money precision, aggregation, currency conversion, ownership, concurrency) so this is selection
-from a list, not recall of edge cases. Record the outcome: invariant holds, invariant breaks, or
-cannot be determined from the code — and treat the third as a finding about clarity, not a pass.
-
-### 3d. Cross-invariant interaction
-
-Invariants that each hold alone can break together. Before any `APPROVE`, take the invariants in
-the map pairwise (and in any triple the change couples) and ask what happens when both apply at
-once. The concrete shapes that have failed here: a void row inside a split whose legs cross
-owners; an FX-repricing edit concurrent with a rate refresh; a deletion of a future-dated row
-whose account is mid-recalculation; a restore replaying rows whose ordering depends on
-`created_at`. Record each pair examined and its outcome.
+> **Monize.** Also confirm: `database/schema.sql` parity and idempotent migration replay;
+> `required-db-functions.ts` registration; zero discovered tests treated as a failure
+> (`docs/release-integrity.md`); the tested, imaged and tagged revision is one revision; and i18n
+> parity for `main` (English-first during development, pseudo-locale regenerated, no duplicate
+> keys). A check failing on the base branch too is not this PR's — state that rather than silently
+> excusing it.
 
 ---
 
-## Stage 4 — Remediation artifacts
+# Finding standard
 
-For each confirmed finding produce **both** artifacts, as text in the report:
+Report only realistic, reproducible issues.
 
-1. **A concrete unified remediation diff** — real paths, real line context, in unified diff
-   format. Not a description of a fix, not pseudocode. Minimal: what the finding needs, nothing
-   more, and never widening the PR.
-2. **A concrete regression-test diff** — also unified diff format, and it must **fail on the
-   original mistake**, not merely cover the fix. Where the mistake is mechanical, prefer a
-   source-scanning guard over a single case (`frontend/src/test/ui-conventions.test.ts`,
-   `investment-replay.guard.spec.ts`, `deletion-balance.guard.spec.ts`,
-   `fx-fallback.guard.spec.ts` are the pattern). Where the mutation table in 3b produced an
-   `undetected` row, the test must kill that mutation.
+Every confirmed finding must contain, in this order:
 
-Then apply Rule 10 to each diff, in writing, before it leaves the report.
+1. **Severity**
+   - `BLOCKER`
+   - `HIGH`
+   - `MEDIUM`
+   - `LOW`
 
-**Neither diff is applied.** They are review output.
+2. **Confidence**
+   - `high`
+   - `medium`
+   - `low`
 
----
+3. **Location**
+   - exact file path;
+   - relevant line range;
+   - related secondary paths where necessary.
 
-## Stage 5 — Independent final adversarial approval challenge
+4. **Violated invariant**
+   - state exactly what behavior must remain true.
 
-This is a **separate pass**, not a re-read. It begins only after Stages 1–4 have produced a
-provisional conclusion, and it begins from this premise:
+5. **Realistic reproduction scenario**
+   - start from a reachable application/database state;
+   - describe the exact operation;
+   - show how the defect is triggered.
 
-> My previous conclusion is wrong. Find a realistic scenario that invalidates the proposed
-> APPROVE.
+6. **Observed implementation behavior**
 
-Re-fetch the head first (Stage 0c). Then hunt again, specifically through:
+7. **Expected behavior**
 
-- **representation boundaries** — a row, request or cache entry in a shape the change did not
-  anticipate (the 2b matrix, re-attacked rather than re-read);
-- **stale clients** — a browser or integration running the previous bundle against the new
-  server, and the reverse during a rolling deploy;
-- **identity versus value** — a key that looked stable and is not;
-- **concurrency** — the interleaving not tried in 2g, including the same actor twice;
-- **partial side effects** — the failure between the write and the commit, and between the
-  commit and the dispatch;
-- **unchanged callers** — every call site the diff did *not* touch that reaches the changed
-  code. These are the ones a diff-shaped review structurally cannot see, and where this
-  repository's escaped defects have concentrated.
+8. **Impact**
+   - users;
+   - financial state;
+   - security;
+   - data integrity;
+   - recovery;
+   - availability;
+   - operations.
 
-Record the challenge explicitly: what you attacked, what survived, what did not. If it produces
-a finding, that finding goes through Rule 1 and the audit returns to Stage 4 for its artifacts.
-An `APPROVE` issued without a completed Stage 5 is invalid.
+9. **Root cause**
+   - identify the actual faulty decision or missing enforcement point;
+   - do not stop at the visible symptom.
 
----
+10. **Recommended correction**
+    - describe the invariant-preserving correction.
 
-## Stage 6 — Final merge gate
+11. **Suggested remediation diff (illustrative, not applied)**
+    - provide a concrete unified diff against `PR_REVIEW_SHA`;
+    - keep it minimal;
+    - include all necessary layers;
+    - do not claim it is production-ready.
 
-All of these must be checked and reported. Any failure blocks `APPROVE`.
+12. **Recommended regression test**
 
-```text
-[ ] PR head re-fetched; still equals PR_REVIEW_SHA (else Stage 0c, then re-run this gate)
-[ ] origin/main re-fetched; merge base and ahead/behind restated
-[ ] no BLOCKER findings open
-[ ] no HIGH findings open, or each has an explicit, recorded acceptance
-[ ] hosted CI on PR_REVIEW_SHA: every check enumerated with its conclusion
-[ ] CI red on this PR distinguished from CI red on base (a check failing on base too is not
-    this PR's, and is stated as such rather than silently excused)
-[ ] migrations: schema.sql parity, idempotent replay, required-db-functions registration
-[ ] zero-discovered-tests treated as a failure, not a pass (docs/release-integrity.md)
-[ ] i18n: English-first during development; full parity required for main; pseudo-locale
-    regenerated; no duplicate keys
-[ ] open review threads enumerated, each resolved or explicitly answered
-[ ] the tested, imaged and tagged revision is one revision
-```
+13. **Suggested regression-test diff (illustrative, not applied)**
+    - whenever practical, provide a concrete test patch;
+    - the test must fail if the production defect is restored.
 
-Never infer a CI conclusion. If CI cannot be read, say so and treat the gate as unmet rather
-than assumed green.
+14. **Verification method**
+    - exact tests/checks that should prove the correction;
+    - include cross-layer verification where relevant.
 
----
+15. **Residual risks / patch limitations**
+    - state what the proposed diff does not prove.
 
-## Stage 7 — Finding standard, ledger, verdict
+Also record, per finding, its PR causality class (Rule 3) and, where the same root cause spans
+several surfaces, the consolidated surface list (Rule 7). Where an invariant ID exists in
+`docs/system-invariants.md`, name it.
 
-### 7a. Finding standard
+For financial findings also include:
 
-Every finding is reported in this exact shape:
+- concrete inputs;
+- implementation result;
+- expected result;
+- absolute monetary difference;
+- percentage difference where meaningful.
 
-```text
-ID              F<n>
-Title           one line, the defect, not the symptom
-Severity        BLOCKER | HIGH | MEDIUM | LOW
-Confidence      CONFIRMED | PROBABLE
-Causality       INTRODUCED_BY_PR | EXPOSED_OR_AMPLIFIED_BY_PR |
-                PRE_EXISTING_BUT_IN_SCOPE | PRE_EXISTING_UNRELATED
-Location        file:line (every affected surface, consolidated per Rule 7)
-Invariant       ID from docs/system-invariants.md, or the contract section, or "none covers it"
-Root cause      the mechanism that is missing or wrong -- not a restatement of the symptom
-Failure         the Rule 1 answers: input state, produced, required, reachability, impact, now
-Remediation     the Stage 4 unified diff
-Regression      the Stage 4 test diff, and the 3b mutation it kills
-Interaction     the Rule 10 answer for this remediation
-```
+Clearly distinguish:
 
-Severity is decided **after** causality (Rule 3). `BLOCKER` means data loss, corruption, a
-security or tenancy breach, or a wrong financial figure reaching a user. `PROBABLE` confidence
-is allowed only with the reachability question answered yes; anything weaker is a design risk,
-not a finding.
+- confirmed defect;
+- design risk;
+- missing test;
+- stale documentation;
+- unverified hypothesis;
+- false positive investigated and rejected.
 
-### 7b. Review ledger
-
-A single table proving every stage ran, so a reader can audit the audit:
-
-```text
-stage / lens                     status      what it produced
----------------------------------------------------------------
-0a-0f  target, instructions, map  done        <n> invariants mapped
-1      rules 1-10                 done        <n> candidates, <n> admitted
-2a-2l  each lens by name          done | n/a  finding ids, or the n/a reason
-3a-3d  evidence adversary         done        <n> mutations, <n> undetected
-4      remediation artifacts      done        <n> diffs, <n> test diffs
-5      approval challenge         done        what was attacked and what survived
-6      merge gate                 done        pass | blocked by <item>
-```
-
-A lens marked `n/a` without a reason invalidates the ledger.
-
-### 7c. Report order
-
-1. **Review target** — the Stage 0 revision table and `PR_REVIEW_SHA`.
-2. **Invariant map** and dataflow spines.
-3. **Confirmed findings** — most severe first, in the 7a format.
-4. **Design risks** — reachable but with no present-day failure scenario. Kept strictly separate
-   from findings; never counted among them.
-5. **Rejected / downgraded hypotheses** — the mandatory Rule 8 table, even if every row is a
-   rejection:
-
-   | Candidate | Evidence considered | Why rejected / downgraded | Final classification |
-   |---|---|---|---|
-
-6. **External review reconciliation** — only if a prior review exists: each of its findings with
-   its Rule 9 category.
-7. **Review ledger** (7b).
-8. **Verdict** (7d).
-
-### 7d. Final verdict
-
-End with exactly one, and nothing hedged:
-
-```text
-APPROVE            -- Stage 5 completed and Stage 6 fully met, no BLOCKER, no unaccepted HIGH
-REQUEST CHANGES    -- anything else; list the findings that must close, by ID
-```
-
-State the SHA the verdict applies to: *"This verdict applies to `PR_REVIEW_SHA` = `<sha>` and to
-no later commit."*
-
-### 7e. Re-review after a previous APPROVE
-
-If this audit re-reviews a PR you previously approved, and the head has moved:
-
-1. Treat the previous `APPROVE` as **void**, not as a baseline. Say so explicitly: it covered a
-   SHA that is no longer the head.
-2. Re-pin `PR_REVIEW_SHA` and re-run the revision table.
-3. Diff the previously approved SHA against the new head and re-run every rule and lens whose
-   affected invariants those commits touch — at minimum the affected set, and the whole of Stage
-   5 and Stage 6 regardless.
-4. Never carry a finding's `resolved` status across a rebase without re-verifying it: a
-   force-push can restore the code a fix removed.
-5. The new verdict replaces the old one and names both SHAs.
+Do not report cosmetic style preferences as findings.
 
 ---
 
-## Monize grounding
+# Severity calibration
 
-The lenses above already name their contracts. This section holds what is not lens-shaped.
+Use severity based on realistic impact, not how complicated the fix is.
 
-**Consumers to enumerate (Rule 4, lens 2a).** Backend services; the AI executor
-(`backend/src/ai/query/tool-executor.service.ts`); MCP tools (`backend/src/mcp/tools/*`);
-dashboard; budgets; built-in reports; CSV/PDF export; and `frontend/src/types/*`. Two repository
-findings make this concrete: a completeness flag the frontend type omits ships a subtotal under
-a total's caption, and the compact LLM shape dropping a flag makes AI/MCP quote a subtotal as
-settled.
+## BLOCKER
 
-**Shared-surface pass (Rules 4, 7).** Every AI tool that reads or aggregates data is implemented
-once on a domain service and adapted by **both** the AI executor and the MCP layer — a tool
-wired into only one layer is a candidate. Equally: when a refusal or restriction is added on one
-path, grep the bulk, AI-action and MCP routes to the same write.
+Examples:
 
-**Deliberate look-alikes (Rule 2).** Paths that look duplicated but are not: per-ledger
-reconciliation states vs the shared VOID boundary; `applyRegisterOrder`'s credits-before-debits
-tiebreak; FX re-resolution only on structural change (a rename must not re-price); netting
-within one category but never across two, while the payee surfaces deliberately do not net.
+- catastrophic or deployment-stopping failure;
+- broad destructive data loss/corruption;
+- critical security isolation failure;
+- unrecoverable recovery/restore failure affecting production safety.
 
-**Documentation as a claim.** A doc or `CLAUDE.md` naming an identifier or path is asserting
-something about the source. A rename or deletion means grepping `docs/` and every `CLAUDE.md` in
-the same commit; a comment asserting that *every* call site does something should be a scanning
-test instead.
+## HIGH
 
-**Running the suites.** CI runs in UTC with one Playwright worker. `TZ=UTC npm run test:unit`
-matches it; the E2E suite needs `--workers=1` because `zz-danger-zone.spec.ts` deletes the shared
-account. `scripts/verify-schema.sh` reproduces the schema-drift job locally.
+Examples:
+
+- realistic material financial corruption;
+- cross-tenant/security boundary violation;
+- destructive behavior;
+- broad incorrect financial state;
+- a race likely to create material persistent corruption;
+- recovery path cannot reliably restore material user data;
+- a materially false approval/forecast that can cause a destructive or financially significant
+  action.
+
+## MEDIUM
+
+Examples:
+
+- meaningful incorrect behavior with narrower scope;
+- explicit user instruction silently ignored;
+- important workflow failure;
+- availability/performance issue with realistic operational impact;
+- compatibility regression affecting a significant path.
+
+## LOW
+
+Examples:
+
+- real but narrow defect with limited impact;
+- non-material inconsistency;
+- maintainability/documentation issue that creates a concrete future failure risk.
+
+Do not inherit another reviewer's severity without independently evaluating impact.
+
+---
+
+# Review ledger
+
+Maintain a compact review ledger.
+
+Record:
+
+- `PR_REVIEW_SHA`;
+- base/main SHA;
+- merge base;
+- ahead/behind state;
+- directories inspected;
+- files inspected in full;
+- files sampled;
+- repository-wide searches performed;
+- important call sites inspected;
+- migrations/schema checked;
+- tests inspected;
+- CI/status results;
+- confirmed findings;
+- hypotheses still open;
+- false positives rejected;
+- important areas reviewed without material findings.
+
+Never claim "the entire subsystem was reviewed" unless the ledger supports it.
+
+Also record, for each mandatory lens above, whether it ran or why it does not apply. A lens marked
+not-applicable without a reason invalidates the ledger.
+
+---
+
+# Review response format
+
+Progress updates to the user are in Polish.
+
+Findings themselves are written in English.
+
+For each review round, finish with:
+
+- exact reviewed SHA;
+- verdict:
+  - `APPROVE`, or
+  - `REQUEST CHANGES`;
+- confirmed findings by severity;
+- what was independently verified;
+- important limitations;
+- whether the mandatory adversarial close-out pass was completed.
+
+For every confirmed finding, include both:
+
+- a concrete suggested remediation diff; and
+- where practical, a concrete regression-test diff.
+
+These diffs are review artifacts only and must never be applied by the reviewer.
+
+If a later review proves that a suggested diff was incomplete or incorrect, update the
+recommendation rather than defending the earlier patch.
+
+When all findings are fixed, do not say APPROVE merely because the delta looks correct.
+
+Complete the adversarial approval challenge first.
+
+---
+
+# Special instruction after a previous APPROVE
+
+If asked to review a PR that you previously approved:
+
+Do not defend the previous approval.
+
+Assume it may have been wrong.
+
+Actively search for evidence that would invalidate it.
+
+If a later reviewer finds a real defect that you missed:
+
+- acknowledge it;
+- reconstruct why the previous process missed it;
+- incorporate the missed bug class into the current review;
+- do not dismiss it merely because earlier tests passed.
+
+The objective is correctness, not consistency with an earlier verdict.
+
+A previous APPROVE covering an earlier SHA does not carry to the current head. Re-pin
+`PR_REVIEW_SHA`, re-run the revision table, and never carry a finding's resolved status across a
+rebase without re-verifying it — a force-push can restore the code a fix removed.
+
+---
+
+# Suggested short per-PR invocation
+
+Once this protocol is in place, a normal review request can be short.
+
+Example:
+
+> `/audit 1232` — apply the full protocol. Pay particular attention to the acceptance criteria of
+> the linked issue and independently verify every existing review thread.
+
+Or for a backup PR:
+
+> `/audit <n>` — apply the full protocol. Prioritize backup/restore atomicity, tenant isolation,
+> external attachment bytes, ID remapping, cleanup, rollback, and legacy-backup compatibility.
+
+Or for a loan/debt PR:
+
+> `/audit <n>` — apply the full protocol. Prioritize payment allocation, interest/principal
+> correctness, rounding, payoff boundaries, duplicate posting, state transitions, and
+> forecast/commit parity.

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,29 +1,58 @@
 ---
-description: Run a comprehensive Monize code audit (review prompt V3) over a diff, PR, branch, or path — high recall on hidden consumers, high precision on confirmed findings.
+description: Run a comprehensive Monize code audit (review prompt V3) over a diff, PR, branch, or path — high recall on hidden consumers and semantic migrations, high precision on confirmed findings.
 argument-hint: "[diff | PR number | branch | path]  (default: working-tree diff vs merge-base with main)"
 ---
 
-# Monize Comprehensive Audit (Review Prompt V3)
+# Monize Comprehensive Audit — Review Prompt V3
 
-You are performing a **comprehensive audit** of Monize code, not a quick scan. The
-canonical, versioned copy of this prompt with its full rationale lives in
-`docs/audits/review-prompt-v3.md`; this command is the executable form. When the two
-disagree, the doc is authoritative — re-read it if anything here is ambiguous.
+You are performing a **comprehensive audit** of Monize code, not a quick scan. This file is
+self-contained: everything you need to run the audit is here. `docs/audits/review-prompt-v3.md`
+carries the provenance and the rationale for each rule, and is worth reading when a rule's
+intent is unclear — but do not treat this prompt as a summary of it.
+
+V3 is a **calibration** release over V2. V2's scope was already wide enough to find new classes
+of problem — it surfaced issues in secondary consumers, cache dependencies, and two material
+performance problems. So V3's job is **not** to widen the list of bug classes. Its job is to
+improve **finding calibration, false-positive rejection, and the distinction between defects and
+design risks**.
 
 ## Governing principle
 
-> Find hidden consumers and dependencies aggressively, but require a concrete
-> present-day failure scenario before promoting a concern to a confirmed finding.
+> Find hidden consumers and dependencies aggressively, but require a concrete present-day
+> failure scenario before promoting a concern to a confirmed finding.
 
-Be rigorous in **two** directions at once:
+Be more rigorous in **two directions at the same time**:
 
-- **Higher recall** — find more hidden consumers, upstream dependencies, and semantic
-  migrations than a surface read would.
-- **Higher precision** — do not promote a design smell or hypothetical future drift to a
-  confirmed finding without a realistic *current* failure scenario.
+```text
+higher recall:
+find more hidden consumers, dependencies and semantic migrations
 
-Widening the list of bug *classes* is not the goal. Better calibration, honest rejection
-of false positives, and a clean split between **defects** and **design risks** is.
+higher precision:
+do not promote design smells or hypothetical future drift without a realistic current failure
+```
+
+## Do not widen the checklist
+
+Do **not** invent additional sections of the form:
+
+```text
+check X
+check Y
+check Z
+```
+
+The rules below are the audit. Adding generic checks dilutes it.
+
+## Recall targets
+
+Reducing false alarms must not cost the ability to find these classes. Treat this as the list
+the discovery passes exist to catch:
+
+- secondary raw-vs-effective consumers;
+- derived-cache invalidation omissions;
+- in-flight cache/state races;
+- repeated semantic DB derivation;
+- serial provider amplification.
 
 ## Scope: `$ARGUMENTS`
 
@@ -34,47 +63,123 @@ Resolve the target first, then state it back before reviewing:
 - a branch name → `git diff origin/main...<branch>`.
 - a path → audit that file/directory as it currently stands.
 
-Read the **whole** changed surface, not just the hunks: open each touched file, and for
-every symbol the diff changes, use `findReferences` / `workspaceSymbol` (LSP) to reach
-its callers before judging it.
+Read the **whole** changed surface, not just the hunks: open each touched file, and for every
+symbol the diff changes, use `findReferences` / `workspaceSymbol` (LSP) to reach its callers
+before judging it. Pin the base revision and re-verify every candidate against it.
 
-## Phase 0 — Baseline and contract map
+## Order of operations
 
-1. Identify the base revision and pin it. Re-verify every candidate against the base:
-   something already broken on `main` is not introduced here (but may be **exposed** —
-   see Phase 3).
-2. List the Monize contracts the change touches and name their IDs:
-   `docs/system-invariants.md` (invariant IDs), `docs/financial-calculation-contract.md`,
-   `docs/financial-semantics.md`, `docs/concurrency-and-idempotency.md`,
-   `docs/external-side-effects.md`, `docs/row-level-security-contract.md`,
-   `docs/verification-contract.md`. A change that touches money, FX, balances, transfers,
-   splits, investment replay, RLS/`withScopedDb`, or a shared AI/MCP tool **must** name
-   the specific contract sections it interacts with.
+```text
+discovery (Rules 4, 5)          -> gather candidates aggressively, no severity yet
+admission gate (Rule 1)         -> finding or DESIGN RISK
+causality (Rule 3)              -> then, and only then, severity + merge-gate impact
+precedence (Rule 2)             -> before any "use the shared helper" proposal
+calibration (Rule 6)            -> before any performance finding
+consolidation (Rule 7)          -> one finding per violated invariant
+external review (Rule 9)        -> if a prior human/model review exists
+fix interaction (Rule 10)       -> for every proposed remediation
+rejected hypotheses (Rule 8)    -> mandatory, before the final verdict
+```
 
-## Phase 1 — Aggressive discovery (recall)
+---
 
-Run every discovery pass below. Discovery is where recall lives; do not gate it on
-severity yet.
+## 1. Mandatory finding-admission gate
 
-### 1a. Read-model semantic-migration pass
+Before treating anything as a finding, you must answer, in writing:
 
-When the PR introduces a field named `effective`, `resolved`, `current`, `forecast`,
-`computed`, `complete`, `available` (or similar) **alongside** an existing persisted
-scalar, treat it as a **semantic-contract migration**, not just a new field.
+- what concrete input state causes the failure;
+- exactly what value or behavior is currently produced;
+- what value or behavior is required;
+- whether the scenario is reachable through the current code;
+- whether there is material impact on the user, data, security, or operations;
+- whether the problem exists **now**, or only might arise after a future change.
 
-> Assume every consumer of the *old* scalar may now be semantically stale. Search all
-> consumers of the **old** field, not only consumers of the new one.
+If a present-day failure scenario cannot be constructed, the result must be classified as
+`DESIGN RISK`, not a confirmed finding.
 
-Enumerate every surface that reads the old field: backend services, the AI executor
-(`backend/src/ai/query/tool-executor.service.ts`), MCP tools (`backend/src/mcp/tools/*`),
-dashboard, budgets, built-in reports, CSV/PDF export, and `frontend/src/types/*`. Recall
-the Monize rule: a completeness/effective flag the frontend type omits ships a subtotal
-under a total's caption.
+This is what lets concerns of the C4 / S1–S7 / K2 kind (V2 round) be classified quickly and
+correctly instead of being reported as defects.
 
-### 1b. Upstream dependency mutation matrix
+## 2. Explicit contract-precedence gate
 
-For every **derived / cached financial value** the change produces or reads, write the
-matrix explicitly:
+Before claiming that a path should use a shared helper, or that two pieces of implementation
+should be unified, you must check:
+
+```text
+implementation
+-> issue acceptance criteria
+-> repository specification
+-> regression tests explaining historical edge cases
+```
+
+If an apparently duplicated path has **deliberately different semantics**, it must not be
+"fixed" merely for DRY or structural similarity.
+
+> A shared helper is not automatically the canonical behavior. Before consolidating two
+> branches, prove that their input semantics and user-intent contracts are identical. A
+> deliberate exception documented by a specification or regression test takes precedence over
+> structural similarity.
+
+This rule is what protects against a wrong finding of the C3 kind (V2 round), which collided
+with the explicit R10-F2 contract.
+
+## 3. PR causality classification for every finding
+
+Every candidate gets exactly one category:
+
+```text
+INTRODUCED_BY_PR
+EXPOSED_OR_AMPLIFIED_BY_PR
+PRE_EXISTING_BUT_IN_SCOPE
+PRE_EXISTING_UNRELATED
+```
+
+Only **after** that do you decide severity and merge-gate impact.
+
+`EXPOSED_OR_AMPLIFIED_BY_PR` is the important one. Example: the secondary consumers existed
+before, but the PR changed the semantics of the relationship:
+
+```text
+persisted amount
+vs
+effective/current amount
+```
+
+so a previously correct consumer became semantically incomplete.
+
+The same classification is what lets you correctly **reject** problems that exist independently
+on `main` — the previously found `PostTransactionDialog` problem is the reference case.
+
+## 4. Read-model semantic-migration rule
+
+If the PR introduces, alongside an existing field, a new field of the kind:
+
+```text
+effective
+resolved
+current
+forecast
+computed
+complete
+available
+```
+
+treat it as a **migration of a semantic contract**, not merely the addition of a new field.
+
+> When a PR introduces an "effective", "resolved", "current", "forecast", "computed", or
+> completeness field alongside an existing persisted scalar, assume every consumer of the old
+> scalar may now be semantically stale. Search all consumers of the old field, not only
+> consumers of the new one.
+
+This is the **stronger form of the secondary-consumer pass**, and it directly addresses the
+class of bug found in C1 (V2 round).
+
+## 5. Upstream dependency mutation matrix
+
+For every derived value, write out explicitly its upstream dependencies and every channel that
+can change them.
+
+Example:
 
 ```text
 dependency                    mutation / refresh paths
@@ -85,122 +190,203 @@ exchange rate                 cron / manual refresh / provider refresh
 persisted schedule            create / update / override
 ```
 
-For each row trace the full chain and confirm each link exists:
+For each row, trace:
 
 ```text
-mutation -> invalidation -> in-flight invalidation -> component / read-model refresh
+mutation
+-> invalidation
+-> in-flight invalidation
+-> component/read-model refresh
 ```
 
-A missing link (e.g. no `scheduled:` cache invalidation after a manual FX refresh) is a
-discovery candidate.
+**This is mandatory for every cached derived financial value.**
 
-### 1c. Shared-surface pass
+Such a matrix is what leads quickly to a missing-invalidation finding — the absent `scheduled:`
+invalidation after a manual FX rate refresh is the reference case.
 
-Any AI tool that reads or aggregates data must be implemented **once** and adapted by both
-the AI executor and the MCP tool layer (project rule). If the change adds or edits a tool
-on only one layer, that is a candidate. Likewise grep the bulk / AI-action / MCP routes to
-the same write whenever a single-path refusal or restriction is added.
+## 6. Performance finding calibration
 
-## Phase 2 — Mandatory finding-admission gate (precision)
+Do not report "N+1" or "sequential async" on the strength of the pattern's name.
 
-**Every** candidate from Phase 1 must pass this gate before it can be called a finding.
-Answer all six, in writing, per candidate:
+Require **one of two** things:
 
-1. What concrete **input state** triggers the failure?
-2. What value / behavior is **currently** produced?
-3. What value / behavior is **required**?
-4. Is the scenario **reachable** through the current code?
-5. Is there **material impact** on a user, data, security, or operations?
-6. Does the problem exist **now**, or only after a hypothetical future change?
+- a concrete call-count model; or
+- a test/benchmark demonstrating the amplification.
 
-If you cannot construct a present-day failure scenario, classify the candidate as
-`DESIGN RISK` — **not** a confirmed finding.
+> Do not report "N+1" or sequential async work by label alone. Show the actual per-row calls and
+> a realistic `N/S/K` model. If the operational effect cannot be bounded or demonstrated,
+> classify it as an optimization opportunity rather than a defect.
 
-## Phase 3 — PR causality classification
-
-Assign exactly one before deciding severity or merge-gate impact:
+Example of a properly grounded finding:
 
 ```text
-INTRODUCED_BY_PR
-EXPOSED_OR_AMPLIFIED_BY_PR   <- e.g. PR changed "persisted amount" to "effective/current amount",
-                                making a previously-correct consumer semantically incomplete
-PRE_EXISTING_BUT_IN_SCOPE
-PRE_EXISTING_UNRELATED       <- reject from the merge gate for this PR
+50 schedules
+same settlement tuple
+~303 repeated account/security lookups
 ```
 
-## Phase 4 — Contract-precedence gate
+That is concrete enough to justify a finding.
 
-Before proposing that two branches be unified, or that a path adopt a shared helper:
+On its own:
 
 ```text
-implementation -> issue acceptance criteria -> repository specification -> regression tests (historical edge cases)
+this loop is sequential
 ```
 
-> A shared helper is not automatically the canonical behavior. Before consolidating two
-> branches, prove that their input semantics and user-intent contracts are identical. A
-> deliberate exception documented by a specification or regression test takes precedence
-> over structural similarity.
+is not enough.
 
-A path that *looks* duplicated may carry deliberately different semantics (Monize is full
-of these: per-ledger reconciliation vs shared VOID boundary, register-order tiebreaks,
-FX-resolution-only-on-structural-change). Do not "fix" it for DRY.
+## 7. One finding per violated invariant, not per surface
 
-## Phase 5 — Performance-finding calibration
-
-> Do not report "N+1" or sequential async work by label alone. Show the actual per-row
-> calls and a realistic `N/S/K` model. If the operational effect cannot be bounded or
-> demonstrated, classify it as an optimization opportunity rather than a defect.
-
-Acceptable (concrete): `50 schedules, same settlement tuple, ~303 repeated account/security
-lookups`. Not acceptable: `this loop is sequential`.
-
-## Phase 6 — Consolidation: one finding per violated invariant
+If several consumers violate the same invariant from the same root cause, that is **one**
+finding, listing every affected surface.
 
 > When multiple consumers violate the same semantic invariant for the same root cause,
-> consolidate them into one finding and enumerate affected surfaces. Do not inflate the
-> finding count by reporting each consumer separately.
+> consolidate them into one finding and enumerate affected surfaces. Do not inflate finding
+> count by reporting each consumer separately.
 
-`AI / MCP / dashboard / budget / report / CSV/PDF` reading a raw persisted amount where the
-effective current amount is required is **one** finding listing six surfaces.
+Example:
 
-## Phase 7 — External-review ingestion (if any prior human/model review exists)
+```text
+AI
+MCP
+dashboard
+budget
+report
+CSV/PDF
+```
 
-Do not inherit its severity, root cause, or suggested fix. Independently reconstruct each
-scenario from code and classify:
+is one finding of the `raw persisted amount vs effective current amount` kind — not six separate
+findings.
+
+## 8. Mandatory rejected-hypothesis section
+
+Before the final verdict, write a separate table:
+
+```text
+Candidate
+Evidence considered
+Why rejected or downgraded
+Final classification
+```
+
+This forces an explicit accounting of:
+
+- false positives;
+- design risks;
+- pre-existing issues;
+- external-review claims;
+- suggestions that collide with a repository contract.
+
+In the V2 round, C3 and C4 belonged in this table.
+
+## 9. External review ingestion protocol
+
+If a prior review by a human or another model exists, you must not inherit its severity, root
+cause, or suggested fix.
+
+Every external finding gets one category:
 
 ```text
 CONFIRMED
-CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE   <- symptom right, scope/cause wrong
+CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE
 DESIGN_RISK
 PRE_EXISTING
 REJECTED
 ```
 
-## Phase 8 — Fix-review interaction test
+> For every external-review finding, independently reconstruct the scenario from code. Do not
+> inherit its severity, root-cause claim, suggested fix, or assumption that the behavior is
+> unintended.
 
-For every remediation you propose, answer first:
+Especially important is the category:
 
-> Which previous regression, documented exception, or explicit user-intent behavior would
-> this suggested fix break?
+```text
+CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE
+```
 
-Then re-check historical regression tests, the spec, edge-case comments, and adjacent paths
-that use similar-but-deliberately-different logic. A fix that reintroduces a bug a prior
-commit removed is worse than the finding it closes.
+because an external reviewer may correctly find the symptom but get the scope or the cause
+wrong. Example: C1 (V2 round) was correct, but its real scope covered considerably more than
+just AI/MCP.
+
+## 10. Fix-review interaction test
+
+After preparing every suggested remediation, you must ask:
+
+> Which previous regression, documented exception, or explicit user-intent behavior would this
+> suggested fix break?
+
+Then re-check:
+
+- historical regression tests;
+- the specification;
+- comments describing earlier edge cases;
+- adjacent paths using similar but deliberately different logic.
+
+This rule protects against a fix that closes a new finding by reverting an earlier one. The
+example is C3: mechanically moving Manual Post onto `decideSplitProvenance()` could have
+reverted the earlier R10-F2 fix.
+
+---
+
+## Monize grounding
+
+The rules above are the audit; this section names where, in this repository, each one bites. It
+adds targets, never exemptions.
+
+**Contracts to name (Rules 1, 2, 8).** State the IDs your findings touch:
+`docs/system-invariants.md` (invariant IDs and their `enforced` / `partial` / `unenforced`
+status), `docs/financial-calculation-contract.md`, `docs/financial-semantics.md`,
+`docs/concurrency-and-idempotency.md`, `docs/external-side-effects.md`,
+`docs/row-level-security-contract.md`, `docs/verification-contract.md`, `docs/adr/`. A change
+touching money, FX, balances, transfers, splits, investment replay, RLS/`withScopedDb`, or a
+shared AI/MCP tool must name the specific sections it interacts with.
+
+**Consumers to enumerate (Rule 4).** Backend services; the AI executor
+(`backend/src/ai/query/tool-executor.service.ts`); MCP tools (`backend/src/mcp/tools/*`);
+dashboard; budgets; built-in reports; CSV/PDF export; and `frontend/src/types/*`. Two
+repository rules make this pass concrete: a completeness flag the frontend type omits ships a
+subtotal under a total's caption, and the compact LLM shape dropping a flag makes AI/MCP quote a
+subtotal as settled. Read such a flag defensively at the consumer (`=== false`, not `!`).
+
+**Shared-surface pass (Rules 4, 7).** Every AI tool that reads or aggregates data is implemented
+once on a domain service and adapted by **both** the AI executor and the MCP layer — a tool
+wired into only one layer is a candidate. Equally: when a refusal or restriction is added on one
+path, grep the bulk, AI-action and MCP routes to the same write.
+
+**Deliberate look-alikes (Rule 2).** Paths that look duplicated but are not: per-ledger
+reconciliation states vs the shared VOID boundary; `applyRegisterOrder`'s credits-before-debits
+tiebreak; FX re-resolution only on structural change (a rename must not re-price); netting
+within one category but never across two, while the payee surfaces deliberately do not net.
+
+**Test obligation (Rule 10, and every confirmed finding).** Name the regression test that would
+fail on the *original* mistake, not merely one that covers the fix. Where the mistake is
+mechanical, prefer a source-scanning guard (`frontend/src/test/ui-conventions.test.ts`,
+`investment-replay.guard.spec.ts`, `deletion-balance.guard.spec.ts`,
+`fx-fallback.guard.spec.ts` are the pattern). A green suite after a behavior change is itself a
+finding: either the change is a no-op or the suite had no case for it — say which.
 
 ## Output
 
 Produce, in this order:
 
-1. **Scope** — target resolved, base revision, contracts/invariant IDs in play.
-2. **Confirmed findings** — most severe first. Each: title; affected surfaces (consolidated);
-   causality class; the six admission-gate answers; contract/invariant reference; minimal
-   suggested fix with its Phase-8 interaction check; the regression test that should fail on
-   the original mistake (Monize prefers a source-scanning guard for mechanical mistakes).
-3. **Design risks** — reachable-but-no-present-failure concerns, kept separate from findings.
-4. **Rejected / downgraded hypotheses** — a mandatory table, even if every row is a rejection:
+1. **Scope** — target resolved, base revision pinned, contracts and invariant IDs in play.
+2. **Confirmed findings** — most severe first. Each one carries:
+   - title, and every affected surface (consolidated per Rule 7);
+   - causality class (Rule 3);
+   - the six admission-gate answers (Rule 1);
+   - the contract / invariant reference, or an explicit note that none covers it;
+   - a minimal suggested fix, with its Rule 10 interaction check answered;
+   - the regression test that should fail on the original mistake.
+3. **Design risks** — reachable but with no present-day failure scenario. Kept strictly separate
+   from findings; never counted among them.
+4. **Rejected / downgraded hypotheses** — the mandatory Rule 8 table, even if every row is a
+   rejection:
 
    | Candidate | Evidence considered | Why rejected / downgraded | Final classification |
    |---|---|---|---|
+
+5. **External review reconciliation** — only if a prior review exists: each of its findings with
+   its Rule 9 category.
 
 Do not modify any source file unless the user explicitly asks for the fixes to be applied —
 `/audit` reports; it does not commit.

--- a/docs/audits/review-prompt-v3.md
+++ b/docs/audits/review-prompt-v3.md
@@ -1,161 +1,111 @@
-# Monize Universal Adversarial Review Protocol — audit V3
+# Monize Universal Adversarial PR Review Protocol
 
-**Status:** active · **Supersedes:** V2 (unversioned, not committed) · **Executable form:** `/audit` (`.claude/commands/audit.md`)
+**Status:** active · **Executable form:** `/audit` (`.claude/commands/audit.md`)
 
-This document carries the provenance and rationale for the comprehensive-review ("audit")
-protocol. The **operational prompt is `.claude/commands/audit.md`**, and it is self-contained —
-it holds the full text of every stage, rule and lens, not a summary. Read this document when a
-rule's intent is unclear or when revising the protocol.
+This document records the protocol's provenance, its two-layer structure, and how to revise it.
+The **operational prompt is `.claude/commands/audit.md`**, and it is self-contained: every lens in
+it is mandatory, so none of it may be deferred, summarised, or loaded on demand.
 
-## Structure
+## Provenance
 
-The protocol is two layers. The **V3 calibration rules** decide what counts as a finding; the
-**Universal Adversarial layer** decides where to look, how hard to attack the review's own
-conclusion, and what must be true before a PR may be approved.
+The protocol has two sources, and they are layered deliberately:
 
-```text
-Stage 0   review target, instruction ingestion, invariant map
-Stage 1   V3 calibration rules 1-10
-Stage 2   mandatory invariant-specific adversarial lenses (2a-2l)
-Stage 3   evidence adversary: mutation, counterexample, cross-invariant interaction
-Stage 4   remediation artifacts (suggested diffs, never applied)
-Stage 5   independent final adversarial approval challenge
-Stage 6   final merge gate
-Stage 7   finding standard, review ledger, final verdict
-```
+1. **`monize-universal-adversarial-pr-review-project-prompt.md`** — the superordinate layer. The
+   `/audit` command implements this document's requirements directly, section by section, in its
+   original order and wording. It is the authority on the review process: what is read, what is
+   traced, what must be attacked, what may be trusted, what a finding must contain, and when
+   `APPROVE` is permitted.
+2. **The V3 improvements document** — the calibration layer. Its rules 1–10 supplement the
+   protocol where the protocol does not already legislate; they never replace it.
 
-Two independent passes are required. Stages 1–4 are the review; **Stage 5 is a separate pass
-that starts from the premise that the review's conclusion is wrong.** `APPROVE` is forbidden
-until Stage 5 and Stage 6 have both completed. This is the difference between a very good audit
-prompt and an adversarial process.
+An earlier revision of this file reconstructed the adversarial layer from a 31-row conformance
+table rather than from the source document. That reconstruction covered roughly 40% of the
+document's actual content and has been replaced. **Do not reconstruct this protocol from a
+summary, a table, or a review of it.** Reconcile against the source document itself.
 
-## Why the calibration layer exists
+## How the two layers combine
 
-After the V2 review round, V2 was clearly better: it found problems in secondary consumers, in
-cache dependencies, and two material performance problems. The lesson was **not** "add more bug
-classes" — it was to improve **finding calibration, false-positive rejection, and the
-distinction between defects and design risks**.
+The calibration rules are placed where they act, not collected at the end:
 
-Governing rule:
-
-> Find hidden consumers and dependencies aggressively, but require a concrete present-day
-> failure scenario before promoting a concern to a confirmed finding.
-
-```text
-higher recall:
-find more hidden consumers, dependencies and semantic migrations
-
-higher precision:
-do not promote design smells or hypothetical future drift without a realistic current failure
-```
-
-Reducing false alarms must not cost the ability to find: secondary raw-vs-effective consumers;
-derived-cache invalidation omissions; in-flight cache/state races; repeated semantic DB
-derivation; serial provider amplification.
-
-The protocol deliberately does **not** add further generic sections of the form
-`check X / check Y / check Z`.
-
-## The ten calibration rules
-
-The prompt keeps the source numbering 1–10, so a review's output maps back to a rule by number.
-
-| # | Rule | Guards against |
+| V3 rule | Where it lives in `/audit` | Relationship to the protocol |
 |---|---|---|
-| 1 | Mandatory finding-admission gate (six questions; else `DESIGN RISK`) | Promoting a reachable-but-harmless concern to a confirmed finding (C4, S1–S7, K2). |
-| 2 | Explicit contract-precedence gate (`implementation -> acceptance criteria -> specification -> regression tests`) | "Fixing" a deliberately-different path for DRY against a documented contract (C3 vs R10-F2). |
-| 3 | PR causality classification, *before* severity | Charging a PR for a pre-existing `main` bug (`PostTransactionDialog`); and missing that a PR *exposed or amplified* a previously-correct consumer. |
-| 4 | Read-model semantic-migration rule — the stronger form of the secondary-consumer pass | Leaving old-scalar consumers semantically stale when an `effective`/`current`/`complete` field is added (C1's real, wider scope). |
-| 5 | Upstream dependency mutation matrix — mandatory for **every** cached derived financial value | A missing link in `mutation -> invalidation -> in-flight invalidation -> refresh` (the absent `scheduled:` invalidation after a manual FX refresh). |
-| 6 | Performance calibration — a call-count model **or** a benchmark | Reporting "N+1" / "sequential async" by label alone. |
-| 7 | One finding per violated invariant, surfaces enumerated | Inflating the count by reporting the same root cause once per surface. |
-| 8 | Mandatory rejected-hypothesis table | Silent false positives; unaccounted design risks, pre-existing issues, external claims, and suggestions colliding with a repository contract. |
-| 9 | External-review ingestion protocol | Inheriting another reviewer's severity / root cause / fix — including `CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE`, where the symptom is right and the scope or cause is wrong. |
-| 10 | Fix-review interaction test | A remediation that closes a new finding by reverting an older fix (mechanically moving Manual Post onto `decideSplitProvenance()` would have reverted R10-F2). |
+| 1 — finding-admission gate | `# Finding admission and attribution` | Adds a six-question gate and the `DESIGN RISK` outcome to the protocol's "report only realistic, reproducible issues". |
+| 2 — contract-precedence gate | `# Finding admission and attribution` | Extends "do not assume a test is authoritative when it contradicts a documented invariant" to shared-helper and consolidation proposals. |
+| 3 — PR causality classification | `# Finding admission and attribution` | New; the protocol has no causality taxonomy. Severity is decided after it. |
+| 4 — read-model semantic migration | `# Map the complete change surface` | A named special case of the protocol's repo-wide producer/consumer audit. |
+| 5 — upstream dependency mutation matrix | `# Map the complete change surface` | Adds the invalidation chain for cached derived financial values. |
+| 6 — performance finding calibration | `# External/provider lookup review` | Adds an evidentiary bar (`N/S/K` model or benchmark) to the protocol's "measure or reason about the number of external calls as N grows". |
+| 7 — one finding per violated invariant | `# Finding admission and attribution` | New; governs finding count across surfaces. |
+| 8 — rejected-hypothesis table | `# Finding admission and attribution` | Formalises the ledger's "false positives rejected" into a required table. |
+| 9 — external-review categories | `# Treat summaries and review comments as hypotheses` | Adds the five categories, notably `CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE`, to the protocol's independent-reconstruction rule. |
+| 10 — fix-review interaction test | `# Mandatory suggested fix diff` | Sits beside the protocol's rule 20 self-inspection; asks specifically which earlier regression or documented exception the patch would revert. |
 
-## The adversarial layer, and what each part is for
+No calibration rule overrides a protocol requirement. Where the protocol is stricter — for
+example its `Confidence` scale of `high` / `medium` / `low`, or its 15-field finding format — the
+protocol's form is used.
 
-| Part | Requirement | Why it is mandatory |
-|---|---|---|
-| 0a | `PR_REVIEW_SHA` as an explicitly named immutable review target | A verdict about "the PR" is a verdict about nothing; findings must be statements about one revision. |
-| 0b | PR head + base + current `main` + merge base + ahead/behind | A stale base hides a semantic conflict that still merges cleanly. |
-| 0c | Head-SHA drift handling, and re-running affected invariants after a new commit or rebase | A verdict must never outlive its target silently. |
-| 0d | Read every `AGENTS.md`, `CLAUDE.md`, `README`, `CONTRIBUTING` and scoped instruction file | These are the specification the code is reviewed against; a scoped file governs its directory. |
-| 0e | Explicit invariant map **before** hunting for bugs | Findings need something to be measured against; an invariant with no named mechanism is already a finding. |
-| 0f | `producer -> transformations -> storage -> consumers -> side effects` per material invariant | Every arrow is a place the invariant can be lost; consumers and side effects are where this repository loses them. |
-| 2a | Full cross-layer path: controller → DTO → auth → service → DB → frontend → tests | A change verified at one hop is not verified. |
-| 2b | Representation matrix: `absent / null / undefined / zero / default / legacy / stale` | `absent` ≠ `null` during a rolling deploy; `zero` ≠ `null` for an empty account. |
-| 2c | Browser round-trip | A resent unchanged value must not read as a change; driver values (`Buffer`, `Date`) must survive serialization. |
-| 2d | Server-authoritative metadata rule | A currency, owner, rate or total accepted from the request is a defect regardless of current UI behavior. |
-| 2e | Identity versus value | A cache keyed on a mutating value serves the wrong entry; a dedupe keyed on a per-request identity never dedupes. |
-| 2f | State-machine review | Four states means a four-case matrix, and a refusal must exist on every entry point (single, bulk, AI, MCP, scheduled). |
-| 2g | Concurrency / idempotency adversarial pass | "It's in a transaction" is not a mechanism; a refusal outside the transaction cannot undo a committed row. |
-| 2h | Partial failure and compensation | Only one side of the commit boundary is survivable for a side effect that cannot roll back. |
-| 2i | Migration / backfill / legacy-data review | `schema.sql` parity, idempotent replay, and constraints declared in every place that declares them. |
-| 2j | Backup / restore lens | A new column or file must survive export and re-import. |
-| 2k | Financial numerical lens | Precision, missing-data policy, completeness flags, signs, weighting, preview-equals-commit, ordering. |
-| 2l | Auth / RLS actor-vs-subject lens | Collapsing actor and subject silently returns zero rows for whichever half it is not. |
-| 3a | "Tests are evidence, not proof" | A green suite after a behavior change is a finding; some tests here deliberately assert defects. |
-| 3b | Mutation — break it on purpose | An `undetected` mutation is a coverage finding with its own proof. |
-| 3c | A new counterexample per invariant | Selection from the adversarial list, not recall of edge cases. |
-| 3d | Cross-invariant interaction before `APPROVE` | Invariants that hold alone break together. |
-| 4 | Concrete unified remediation diff **and** concrete regression-test diff | A described fix is not reviewable; the test must fail on the original mistake. |
-| 5 | Independent final adversarial approval challenge | The pass that attacks the reviewer's own conclusion, especially unchanged callers a diff-shaped review cannot see. |
-| 6 | Final merge gate: re-fetch head, `main`, BLOCKER/HIGH, hosted CI, migrations, review threads | An approval must rest on checked state, never inferred CI. |
-| 7a | Full severity / confidence / location / root-cause finding format | Severity is decided after causality; a root cause is not a restatement of the symptom. |
-| 7b | Review ledger | It lets a reader audit the audit; an `n/a` lens without a reason invalidates it. |
-| 7c–7d | Report order and an exact `APPROVE` / `REQUEST CHANGES` verdict naming its SHA | No hedged conclusions. |
-| 7e | Special procedure after a previous `APPROVE` | A prior approval is void once the head moves, and a force-push can restore code a fix removed. |
+## What the protocol requires, in brief
 
-## Read-only
+Read `/audit` for the authoritative text. The spine:
 
-The audit is read-only, absolutely: **never apply, commit, push, or publish remediation during
-`/audit`; produce suggested diffs only.** A suggested diff is an artefact of the review and is
-never applied by the reviewer. Applying fixes is a separate task, run after the verdict.
-
-## On the example labels
-
-`C1`, `C3`, `C4`, `S1–S7`, `K2`, `R10-F2` and `PostTransactionDialog` come from the V2 review
-round that motivated V3. They are retained because they are the *calibration examples* — each
-names a concrete case where a rule fires — and not because they resolve to files in this
-repository. `R10-F2` is a contract identifier from that round's task series.
-
-## Provenance and known gap
-
-The calibration rules 1–10 are transcribed from the V3 improvements document supplied by the
-maintainer. The adversarial layer (Stages 0, 2–7) was **reconstructed from a 31-row conformance
-table** produced by an external review of this branch, not from the Universal Adversarial Review
-Protocol document itself, which was not available to the author of this commit. Every row of that
-table is implemented, but the wording is a reconstruction. **If the original protocol document is
-supplied, reconcile this prompt against it verbatim** — the two-round history of this file is
-that calibration degrades by paraphrase.
+- **Language** — conversation with the user in Polish; all maintainer-facing technical material
+  in English.
+- **Read-only** — no file changes, commits, branches, PRs, reviews, comments, thread resolutions,
+  labels or settings changes. Suggested diffs are artifacts and are never applied.
+- **`PR_REVIEW_SHA`** — every read pinned to one revision; an approval of SHA A is not an approval
+  of SHA B; head movement re-opens the affected invariants and the approval challenge.
+- **Instructions before implementation** — every `AGENTS.md`, `CLAUDE.md`, `README`,
+  `CONTRIBUTING`, package- and directory-level file, and the relevant `docs/` contracts; scope by
+  directory; a test is not authoritative against a documented invariant.
+- **Nothing is trusted** — not summaries, commit messages, PR descriptions, prior AI conclusions,
+  prior `APPROVE` decisions, other reviewers' comments, or test names.
+- **Invariant model first**, in eleven categories, with a
+  `producer -> transformations -> storage -> consumers -> side effects` spine per material
+  invariant.
+- **Complete change surface** — repo-wide producer/transformer/persistence/consumer/secondary-
+  consumer/fixture/adapter searches; unchanged callers are part of the review.
+- **Mandatory lenses** — cross-layer, representation boundary, browser round-trip,
+  server-authoritative metadata, identity vs value, state machine, concurrency/idempotency,
+  partial failure, external provider, database/migration, backup/restore, financial and loan/debt,
+  auth/RLS.
+- **Evidence is not proof** — test false-confidence patterns, mutation analysis, a fresh
+  counterexample per invariant, and at least one cross-invariant interaction before `APPROVE`.
+- **Every confirmed finding carries a suggested remediation diff** against `PR_REVIEW_SHA` under
+  twenty rules, plus a regression-test diff where practical, and an adversarial self-inspection of
+  the patch.
+- **The approval challenge** — a separate phase that must not begin by re-reading old findings and
+  starts from the PR's new abstractions.
+- **The merge gate** — ten checks; hosted CI unavailability is stated, never assumed green, and
+  locally reported tests are never converted into verified CI results.
+- **Finding standard, severity calibration, review ledger, exact verdict**, and a re-review
+  procedure that treats a previous `APPROVE` as possibly wrong.
 
 ## Monize grounding
 
-The lenses name their own contracts inline. What is not lens-shaped lives in the prompt's
-grounding section: the consumer surfaces to enumerate for Rule 4
-(`backend/src/ai/query/tool-executor.service.ts`, `backend/src/mcp/tools/*`, dashboard, budgets,
-built-in reports, CSV/PDF export, `frontend/src/types/*`); the shared AI+MCP tool rule; the
-deliberate look-alikes that must not be unified for DRY (per-ledger reconciliation vs the shared
-VOID boundary, `applyRegisterOrder`'s tiebreak, FX re-resolution only on structural change,
-netting within one category); documentation as a claim about the source; and how to run the
-suites the way CI does.
+The protocol is written to be repository-independent. `/audit` adds a `> **Monize.**` note under
+each section naming where that requirement bites here — the invariant index and contract set, the
+consumer surfaces that have been missed before (AI executor, MCP tools, dashboard, budgets,
+reports, CSV/PDF, `frontend/src/types/*`), the `withScopedDb` and RLS-context rules, the FX and
+completeness-flag rules, `schema.sql` parity and migration idempotency, the sharding and
+`isShardableId` rules, `applyRegisterOrder`, `deletionBalanceEffect`, `applyActionToQuantity`, the
+source-scanning guard tests, and how to run the suites the way CI does.
 
-## Usage
+These notes add targets. They never grant an exemption from a protocol requirement.
 
-```text
-/audit                 # working-tree diff vs merge-base with origin/main
-/audit 1234            # PR #1234
-/audit my-branch       # git diff origin/main...my-branch
-/audit backend/src/... # audit a path as it currently stands
-```
+## Reconciliation
+
+`/audit` was verified against the source document requirement by requirement: 410 requirement
+strings drawn from all 34 sections, checked whitespace-insensitively, 0 missing. Re-run that
+reconciliation after any edit — a paraphrase that drops a list item is the failure mode this file
+exists to prevent.
 
 ## Revising this protocol
 
-Its value is its calibration, and calibration degrades by paraphrase. When editing:
-
-- keep the source numbering 1–10 and every verbatim quote block intact;
-- keep the vertical `text` blocks vertical — they are read as structure, not prose;
-- keep the calibration examples; a rule without its example is weaker than it looks;
-- never let a stage become optional, and never let `APPROVE` precede Stages 5 and 6;
-- prefer adding to "Monize grounding" over rewriting a rule or a lens.
+- Reconcile against the source document, never against a summary or a review of it.
+- Keep the source's section order, wording and list items intact; the lists are the substance.
+- Keep the vertical `text` blocks vertical — they are read as structure, not prose.
+- Never let a lens become optional, and never let `APPROVE` precede the approval challenge and the
+  merge gate.
+- Prefer adding to a `> **Monize.**` note over rewriting a requirement.
+- Note on repository naming: the source document names `kenlasko/monize`; `/audit` says "the
+  `monize` repository" so it is correct for this remote as well.

--- a/docs/audits/review-prompt-v3.md
+++ b/docs/audits/review-prompt-v3.md
@@ -1,25 +1,45 @@
-# Monize Comprehensive Review Prompt — V3
+# Monize Universal Adversarial Review Protocol — audit V3
 
 **Status:** active · **Supersedes:** V2 (unversioned, not committed) · **Executable form:** `/audit` (`.claude/commands/audit.md`)
 
 This document carries the provenance and rationale for the comprehensive-review ("audit")
-prompt. The **operational prompt is `.claude/commands/audit.md`**, and it is self-contained —
-it holds the full text of all ten rules, not a summary of them. Read this document when a
-rule's intent is unclear or when revising the prompt.
+protocol. The **operational prompt is `.claude/commands/audit.md`**, and it is self-contained —
+it holds the full text of every stage, rule and lens, not a summary. Read this document when a
+rule's intent is unclear or when revising the protocol.
 
-## Why V3 exists
+## Structure
 
-After the last review round, V2 was clearly better: it helped find problems in secondary
-consumers, in cache dependencies, and two material performance problems. The lesson was
-therefore **not** "add more bug classes". V3 instead improves **finding calibration,
-false-positive rejection, and the distinction between defects and design risks**.
+The protocol is two layers. The **V3 calibration rules** decide what counts as a finding; the
+**Universal Adversarial layer** decides where to look, how hard to attack the review's own
+conclusion, and what must be true before a PR may be approved.
 
-The governing rule:
+```text
+Stage 0   review target, instruction ingestion, invariant map
+Stage 1   V3 calibration rules 1-10
+Stage 2   mandatory invariant-specific adversarial lenses (2a-2l)
+Stage 3   evidence adversary: mutation, counterexample, cross-invariant interaction
+Stage 4   remediation artifacts (suggested diffs, never applied)
+Stage 5   independent final adversarial approval challenge
+Stage 6   final merge gate
+Stage 7   finding standard, review ledger, final verdict
+```
+
+Two independent passes are required. Stages 1–4 are the review; **Stage 5 is a separate pass
+that starts from the premise that the review's conclusion is wrong.** `APPROVE` is forbidden
+until Stage 5 and Stage 6 have both completed. This is the difference between a very good audit
+prompt and an adversarial process.
+
+## Why the calibration layer exists
+
+After the V2 review round, V2 was clearly better: it found problems in secondary consumers, in
+cache dependencies, and two material performance problems. The lesson was **not** "add more bug
+classes" — it was to improve **finding calibration, false-positive rejection, and the
+distinction between defects and design risks**.
+
+Governing rule:
 
 > Find hidden consumers and dependencies aggressively, but require a concrete present-day
 > failure scenario before promoting a concern to a confirmed finding.
-
-Rigorous in two directions at once:
 
 ```text
 higher recall:
@@ -29,18 +49,14 @@ higher precision:
 do not promote design smells or hypothetical future drift without a realistic current failure
 ```
 
-V3 must reduce false alarms **without** losing the ability to find:
+Reducing false alarms must not cost the ability to find: secondary raw-vs-effective consumers;
+derived-cache invalidation omissions; in-flight cache/state races; repeated semantic DB
+derivation; serial provider amplification.
 
-- secondary raw-vs-effective consumers;
-- derived-cache invalidation omissions;
-- in-flight cache/state races;
-- repeated semantic DB derivation;
-- serial provider amplification.
+The protocol deliberately does **not** add further generic sections of the form
+`check X / check Y / check Z`.
 
-V3 deliberately does **not** add further sections of the form `check X / check Y / check Z`.
-That was V2's breadth, and it was already sufficient.
-
-## The ten rules
+## The ten calibration rules
 
 The prompt keeps the source numbering 1–10, so a review's output maps back to a rule by number.
 
@@ -54,8 +70,48 @@ The prompt keeps the source numbering 1–10, so a review's output maps back to 
 | 6 | Performance calibration — a call-count model **or** a benchmark | Reporting "N+1" / "sequential async" by label alone. |
 | 7 | One finding per violated invariant, surfaces enumerated | Inflating the count by reporting the same root cause once per surface. |
 | 8 | Mandatory rejected-hypothesis table | Silent false positives; unaccounted design risks, pre-existing issues, external claims, and suggestions colliding with a repository contract. |
-| 9 | External-review ingestion protocol | Inheriting another reviewer's severity / root cause / fix — including the `CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE` case, where the symptom is right and the scope or cause is wrong. |
+| 9 | External-review ingestion protocol | Inheriting another reviewer's severity / root cause / fix — including `CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE`, where the symptom is right and the scope or cause is wrong. |
 | 10 | Fix-review interaction test | A remediation that closes a new finding by reverting an older fix (mechanically moving Manual Post onto `decideSplitProvenance()` would have reverted R10-F2). |
+
+## The adversarial layer, and what each part is for
+
+| Part | Requirement | Why it is mandatory |
+|---|---|---|
+| 0a | `PR_REVIEW_SHA` as an explicitly named immutable review target | A verdict about "the PR" is a verdict about nothing; findings must be statements about one revision. |
+| 0b | PR head + base + current `main` + merge base + ahead/behind | A stale base hides a semantic conflict that still merges cleanly. |
+| 0c | Head-SHA drift handling, and re-running affected invariants after a new commit or rebase | A verdict must never outlive its target silently. |
+| 0d | Read every `AGENTS.md`, `CLAUDE.md`, `README`, `CONTRIBUTING` and scoped instruction file | These are the specification the code is reviewed against; a scoped file governs its directory. |
+| 0e | Explicit invariant map **before** hunting for bugs | Findings need something to be measured against; an invariant with no named mechanism is already a finding. |
+| 0f | `producer -> transformations -> storage -> consumers -> side effects` per material invariant | Every arrow is a place the invariant can be lost; consumers and side effects are where this repository loses them. |
+| 2a | Full cross-layer path: controller → DTO → auth → service → DB → frontend → tests | A change verified at one hop is not verified. |
+| 2b | Representation matrix: `absent / null / undefined / zero / default / legacy / stale` | `absent` ≠ `null` during a rolling deploy; `zero` ≠ `null` for an empty account. |
+| 2c | Browser round-trip | A resent unchanged value must not read as a change; driver values (`Buffer`, `Date`) must survive serialization. |
+| 2d | Server-authoritative metadata rule | A currency, owner, rate or total accepted from the request is a defect regardless of current UI behavior. |
+| 2e | Identity versus value | A cache keyed on a mutating value serves the wrong entry; a dedupe keyed on a per-request identity never dedupes. |
+| 2f | State-machine review | Four states means a four-case matrix, and a refusal must exist on every entry point (single, bulk, AI, MCP, scheduled). |
+| 2g | Concurrency / idempotency adversarial pass | "It's in a transaction" is not a mechanism; a refusal outside the transaction cannot undo a committed row. |
+| 2h | Partial failure and compensation | Only one side of the commit boundary is survivable for a side effect that cannot roll back. |
+| 2i | Migration / backfill / legacy-data review | `schema.sql` parity, idempotent replay, and constraints declared in every place that declares them. |
+| 2j | Backup / restore lens | A new column or file must survive export and re-import. |
+| 2k | Financial numerical lens | Precision, missing-data policy, completeness flags, signs, weighting, preview-equals-commit, ordering. |
+| 2l | Auth / RLS actor-vs-subject lens | Collapsing actor and subject silently returns zero rows for whichever half it is not. |
+| 3a | "Tests are evidence, not proof" | A green suite after a behavior change is a finding; some tests here deliberately assert defects. |
+| 3b | Mutation — break it on purpose | An `undetected` mutation is a coverage finding with its own proof. |
+| 3c | A new counterexample per invariant | Selection from the adversarial list, not recall of edge cases. |
+| 3d | Cross-invariant interaction before `APPROVE` | Invariants that hold alone break together. |
+| 4 | Concrete unified remediation diff **and** concrete regression-test diff | A described fix is not reviewable; the test must fail on the original mistake. |
+| 5 | Independent final adversarial approval challenge | The pass that attacks the reviewer's own conclusion, especially unchanged callers a diff-shaped review cannot see. |
+| 6 | Final merge gate: re-fetch head, `main`, BLOCKER/HIGH, hosted CI, migrations, review threads | An approval must rest on checked state, never inferred CI. |
+| 7a | Full severity / confidence / location / root-cause finding format | Severity is decided after causality; a root cause is not a restatement of the symptom. |
+| 7b | Review ledger | It lets a reader audit the audit; an `n/a` lens without a reason invalidates it. |
+| 7c–7d | Report order and an exact `APPROVE` / `REQUEST CHANGES` verdict naming its SHA | No hedged conclusions. |
+| 7e | Special procedure after a previous `APPROVE` | A prior approval is void once the head moves, and a force-push can restore code a fix removed. |
+
+## Read-only
+
+The audit is read-only, absolutely: **never apply, commit, push, or publish remediation during
+`/audit`; produce suggested diffs only.** A suggested diff is an artefact of the review and is
+never applied by the reviewer. Applying fixes is a separate task, run after the verdict.
 
 ## On the example labels
 
@@ -64,30 +120,26 @@ round that motivated V3. They are retained because they are the *calibration exa
 names a concrete case where a rule fires — and not because they resolve to files in this
 repository. `R10-F2` is a contract identifier from that round's task series.
 
+## Provenance and known gap
+
+The calibration rules 1–10 are transcribed from the V3 improvements document supplied by the
+maintainer. The adversarial layer (Stages 0, 2–7) was **reconstructed from a 31-row conformance
+table** produced by an external review of this branch, not from the Universal Adversarial Review
+Protocol document itself, which was not available to the author of this commit. Every row of that
+table is implemented, but the wording is a reconstruction. **If the original protocol document is
+supplied, reconcile this prompt against it verbatim** — the two-round history of this file is
+that calibration degrades by paraphrase.
+
 ## Monize grounding
 
-The prompt's rules are repository-independent; its "Monize grounding" section names where each
-one bites here, and adds targets without granting exemptions:
-
-- **Contracts to name** — `docs/system-invariants.md` (with its `enforced` / `partial` /
-  `unenforced` status), the financial, concurrency, external-side-effect, RLS and verification
-  contracts, and `docs/adr/`.
-- **Consumers to enumerate (Rule 4)** — backend services, the AI executor
-  (`backend/src/ai/query/tool-executor.service.ts`), MCP tools (`backend/src/mcp/tools/*`),
-  dashboard, budgets, built-in reports, CSV/PDF export, `frontend/src/types/*`; plus the
-  repository's own findings that a completeness flag omitted by a frontend type ships a subtotal
-  under a total's caption, and that the compact LLM shape dropping a flag makes AI/MCP quote a
-  subtotal as settled.
-- **Shared-surface pass** — every AI tool is implemented once on a domain service and adapted by
-  both the AI executor and the MCP layer; when a refusal is added on one path, the bulk,
-  AI-action and MCP routes to the same write are checked too.
-- **Deliberate look-alikes (Rule 2)** — per-ledger reconciliation vs the shared VOID boundary;
-  `applyRegisterOrder`'s credits-before-debits tiebreak; FX re-resolution only on structural
-  change; netting within one category but never across two, with the payee surfaces
-  deliberately not netting.
-- **Test obligation** — name the test that fails on the *original* mistake; prefer a
-  source-scanning guard for a mechanical mistake; treat a green suite after a behavior change as
-  a finding in itself.
+The lenses name their own contracts inline. What is not lens-shaped lives in the prompt's
+grounding section: the consumer surfaces to enumerate for Rule 4
+(`backend/src/ai/query/tool-executor.service.ts`, `backend/src/mcp/tools/*`, dashboard, budgets,
+built-in reports, CSV/PDF export, `frontend/src/types/*`); the shared AI+MCP tool rule; the
+deliberate look-alikes that must not be unified for DRY (per-ledger reconciliation vs the shared
+VOID boundary, `applyRegisterOrder`'s tiebreak, FX re-resolution only on structural change,
+netting within one category); documentation as a claim about the source; and how to run the
+suites the way CI does.
 
 ## Usage
 
@@ -98,13 +150,12 @@ one bites here, and adds targets without granting exemptions:
 /audit backend/src/... # audit a path as it currently stands
 ```
 
-`/audit` reports; it does not commit. Apply fixes only when explicitly asked.
+## Revising this protocol
 
-## Revising this prompt
-
-V3's value is its calibration, and calibration degrades by paraphrase. When editing:
+Its value is its calibration, and calibration degrades by paraphrase. When editing:
 
 - keep the source numbering 1–10 and every verbatim quote block intact;
 - keep the vertical `text` blocks vertical — they are read as structure, not prose;
 - keep the calibration examples; a rule without its example is weaker than it looks;
-- prefer adding to "Monize grounding" over rewriting a rule.
+- never let a stage become optional, and never let `APPROVE` precede Stages 5 and 6;
+- prefer adding to "Monize grounding" over rewriting a rule or a lens.

--- a/docs/audits/review-prompt-v3.md
+++ b/docs/audits/review-prompt-v3.md
@@ -2,19 +2,19 @@
 
 **Status:** active · **Supersedes:** V2 (unversioned, not committed) · **Executable form:** `/audit` (`.claude/commands/audit.md`)
 
-This is the canonical, versioned copy of the comprehensive-review ("audit") prompt used to
-review Monize pull requests and changesets. The `/audit` slash command is the executable
-form of the same prompt; when the two diverge, **this document is authoritative**.
+This document carries the provenance and rationale for the comprehensive-review ("audit")
+prompt. The **operational prompt is `.claude/commands/audit.md`**, and it is self-contained —
+it holds the full text of all ten rules, not a summary of them. Read this document when a
+rule's intent is unclear or when revising the prompt.
 
 ## Why V3 exists
 
-V2 was already wide enough to find new *classes* of problem: it surfaced issues in secondary
-consumers, cache-dependency chains, and two real performance problems. The lesson from V2 was
-therefore **not** "add more `check X / check Y / check Z` sections". V3 keeps V2's breadth and
-instead sharpens **precision**: honest false-positive rejection, and a clean split between
-**confirmed defects** and **design risks**.
+After the last review round, V2 was clearly better: it helped find problems in secondary
+consumers, in cache dependencies, and two material performance problems. The lesson was
+therefore **not** "add more bug classes". V3 instead improves **finding calibration,
+false-positive rejection, and the distinction between defects and design risks**.
 
-The target invariant for the whole prompt:
+The governing rule:
 
 > Find hidden consumers and dependencies aggressively, but require a concrete present-day
 > failure scenario before promoting a concern to a confirmed finding.
@@ -22,68 +22,72 @@ The target invariant for the whole prompt:
 Rigorous in two directions at once:
 
 ```text
-higher recall:    find more hidden consumers, dependencies and semantic migrations
-higher precision: do not promote design smells or hypothetical future drift without a
-                  realistic current failure
+higher recall:
+find more hidden consumers, dependencies and semantic migrations
+
+higher precision:
+do not promote design smells or hypothetical future drift without a realistic current failure
 ```
 
-## The prompt
+V3 must reduce false alarms **without** losing the ability to find:
 
-The operational prompt is `.claude/commands/audit.md`, run as `/audit [target]`. Its phases
-are summarised here so the rationale below is self-contained:
+- secondary raw-vs-effective consumers;
+- derived-cache invalidation omissions;
+- in-flight cache/state races;
+- repeated semantic DB derivation;
+- serial provider amplification.
 
-- **Phase 0 — Baseline & contract map.** Pin the base revision; name the touched Monize
-  contracts and invariant IDs (`docs/system-invariants.md` and the financial/RLS/concurrency
-  contracts).
-- **Phase 1 — Aggressive discovery (recall).** Read-model semantic-migration pass; upstream
-  dependency mutation matrix; shared AI/MCP surface pass.
-- **Phase 2 — Mandatory admission gate (precision).** Six questions per candidate; no
-  present-day failure scenario means `DESIGN RISK`, not a finding.
-- **Phase 3 — PR causality classification.**
-- **Phase 4 — Contract-precedence gate** (DRY does not beat a documented exception).
-- **Phase 5 — Performance calibration** (`N/S/K` model or benchmark, never label-only).
-- **Phase 6 — Consolidation** (one finding per violated invariant, surfaces enumerated).
-- **Phase 7 — External-review ingestion** (reconstruct independently; never inherit).
-- **Phase 8 — Fix-review interaction test** (a fix must not reintroduce a prior bug).
-- **Output** — scope, confirmed findings, design risks, and a mandatory rejected-hypothesis
-  table.
+V3 deliberately does **not** add further sections of the form `check X / check Y / check Z`.
+That was V2's breadth, and it was already sufficient.
 
-## The ten improvements over V2, and what each guards against
+## The ten rules
 
-Each row maps a V2→V3 improvement to the phase that carries it and the failure it prevents.
-The example labels (`C1`, `C3`, `C4`, `R10-F2`, `S1–S7`, `K2`) come from the V2 review round
-that motivated V3; they are illustrative, not references to files in this repository.
+The prompt keeps the source numbering 1–10, so a review's output maps back to a rule by number.
 
-| # | Improvement | Phase | Guards against |
-|---|---|---|---|
-| 1 | Mandatory finding-admission gate | 2 | Promoting a reachable-but-harmless concern to a confirmed finding (C4, S1–S7, K2). |
-| 2 | Explicit contract-precedence gate | 4 | "Fixing" a deliberately-different path for DRY against a documented contract (C3 vs R10-F2). |
-| 3 | PR causality classification | 3 | Charging a PR for a pre-existing `main` bug; **and** missing that a PR *exposed/amplified* a previously-correct consumer. |
-| 4 | Read-model semantic-migration rule | 1a | Leaving old-scalar consumers semantically stale when a new `effective`/`current`/`complete` field is added (C1's real, wider scope). |
-| 5 | Upstream dependency mutation matrix | 1b | Missing a cache-invalidation link (e.g. no `scheduled:` invalidation after a manual FX refresh). |
-| 6 | Performance-finding calibration | 5 | Reporting "N+1" / "sequential async" by label without a call-count model or benchmark. |
-| 7 | One finding per violated invariant | 6 | Inflating the count by reporting the same root cause once per surface. |
-| 8 | Mandatory rejected-hypothesis table | Output | Silent false positives; unaccounted design risks, pre-existing issues, and external claims. |
-| 9 | External-review ingestion protocol | 7 | Inheriting another reviewer's severity / root cause / fix, incl. the `CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE` case. |
-| 10 | Fix-review interaction test | 8 | A remediation that closes a new finding by reverting an older fix. |
+| # | Rule | Guards against |
+|---|---|---|
+| 1 | Mandatory finding-admission gate (six questions; else `DESIGN RISK`) | Promoting a reachable-but-harmless concern to a confirmed finding (C4, S1–S7, K2). |
+| 2 | Explicit contract-precedence gate (`implementation -> acceptance criteria -> specification -> regression tests`) | "Fixing" a deliberately-different path for DRY against a documented contract (C3 vs R10-F2). |
+| 3 | PR causality classification, *before* severity | Charging a PR for a pre-existing `main` bug (`PostTransactionDialog`); and missing that a PR *exposed or amplified* a previously-correct consumer. |
+| 4 | Read-model semantic-migration rule — the stronger form of the secondary-consumer pass | Leaving old-scalar consumers semantically stale when an `effective`/`current`/`complete` field is added (C1's real, wider scope). |
+| 5 | Upstream dependency mutation matrix — mandatory for **every** cached derived financial value | A missing link in `mutation -> invalidation -> in-flight invalidation -> refresh` (the absent `scheduled:` invalidation after a manual FX refresh). |
+| 6 | Performance calibration — a call-count model **or** a benchmark | Reporting "N+1" / "sequential async" by label alone. |
+| 7 | One finding per violated invariant, surfaces enumerated | Inflating the count by reporting the same root cause once per surface. |
+| 8 | Mandatory rejected-hypothesis table | Silent false positives; unaccounted design risks, pre-existing issues, external claims, and suggestions colliding with a repository contract. |
+| 9 | External-review ingestion protocol | Inheriting another reviewer's severity / root cause / fix — including the `CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE` case, where the symptom is right and the scope or cause is wrong. |
+| 10 | Fix-review interaction test | A remediation that closes a new finding by reverting an older fix (mechanically moving Manual Post onto `decideSplitProvenance()` would have reverted R10-F2). |
 
-## Monize-specific grounding
+## On the example labels
 
-V3 is not generic. Discovery and precedence are anchored to this repository's contracts:
+`C1`, `C3`, `C4`, `S1–S7`, `K2`, `R10-F2` and `PostTransactionDialog` come from the V2 review
+round that motivated V3. They are retained because they are the *calibration examples* — each
+names a concrete case where a rule fires — and not because they resolve to files in this
+repository. `R10-F2` is a contract identifier from that round's task series.
 
-- **Semantic-migration pass (1a)** mirrors the project rule that a completeness flag the
-  frontend type omits ships a subtotal under a total's caption — search old-field consumers
-  across backend, the AI executor, MCP tools, dashboard, budgets, reports, CSV/PDF, and
-  `frontend/src/types/*`.
-- **Shared-surface pass (1c)** enforces "every AI tool is implemented once and adapted by both
-  the AI executor and the MCP layer", and the "grep the bulk / AI-action / MCP routes" rule
-  when a single-path refusal is added.
-- **Contract-precedence (4)** protects Monize's deliberate look-alikes: per-ledger
-  reconciliation vs the shared VOID boundary, register-order tiebreaks, and
-  FX-resolution-only-on-structural-change.
-- **Findings** should name the invariant ID from `docs/system-invariants.md` and, where the
-  mistake is mechanical, propose a **source-scanning guard test** (the project's preferred
-  regression form) rather than a single-case test.
+## Monize grounding
+
+The prompt's rules are repository-independent; its "Monize grounding" section names where each
+one bites here, and adds targets without granting exemptions:
+
+- **Contracts to name** — `docs/system-invariants.md` (with its `enforced` / `partial` /
+  `unenforced` status), the financial, concurrency, external-side-effect, RLS and verification
+  contracts, and `docs/adr/`.
+- **Consumers to enumerate (Rule 4)** — backend services, the AI executor
+  (`backend/src/ai/query/tool-executor.service.ts`), MCP tools (`backend/src/mcp/tools/*`),
+  dashboard, budgets, built-in reports, CSV/PDF export, `frontend/src/types/*`; plus the
+  repository's own findings that a completeness flag omitted by a frontend type ships a subtotal
+  under a total's caption, and that the compact LLM shape dropping a flag makes AI/MCP quote a
+  subtotal as settled.
+- **Shared-surface pass** — every AI tool is implemented once on a domain service and adapted by
+  both the AI executor and the MCP layer; when a refusal is added on one path, the bulk,
+  AI-action and MCP routes to the same write are checked too.
+- **Deliberate look-alikes (Rule 2)** — per-ledger reconciliation vs the shared VOID boundary;
+  `applyRegisterOrder`'s credits-before-debits tiebreak; FX re-resolution only on structural
+  change; netting within one category but never across two, with the payee surfaces
+  deliberately not netting.
+- **Test obligation** — name the test that fails on the *original* mistake; prefer a
+  source-scanning guard for a mechanical mistake; treat a green suite after a behavior change as
+  a finding in itself.
 
 ## Usage
 
@@ -95,3 +99,12 @@ V3 is not generic. Discovery and precedence are anchored to this repository's co
 ```
 
 `/audit` reports; it does not commit. Apply fixes only when explicitly asked.
+
+## Revising this prompt
+
+V3's value is its calibration, and calibration degrades by paraphrase. When editing:
+
+- keep the source numbering 1–10 and every verbatim quote block intact;
+- keep the vertical `text` blocks vertical — they are read as structure, not prose;
+- keep the calibration examples; a rule without its example is weaker than it looks;
+- prefer adding to "Monize grounding" over rewriting a rule.

--- a/docs/audits/review-prompt-v3.md
+++ b/docs/audits/review-prompt-v3.md
@@ -1,0 +1,97 @@
+# Monize Comprehensive Review Prompt — V3
+
+**Status:** active · **Supersedes:** V2 (unversioned, not committed) · **Executable form:** `/audit` (`.claude/commands/audit.md`)
+
+This is the canonical, versioned copy of the comprehensive-review ("audit") prompt used to
+review Monize pull requests and changesets. The `/audit` slash command is the executable
+form of the same prompt; when the two diverge, **this document is authoritative**.
+
+## Why V3 exists
+
+V2 was already wide enough to find new *classes* of problem: it surfaced issues in secondary
+consumers, cache-dependency chains, and two real performance problems. The lesson from V2 was
+therefore **not** "add more `check X / check Y / check Z` sections". V3 keeps V2's breadth and
+instead sharpens **precision**: honest false-positive rejection, and a clean split between
+**confirmed defects** and **design risks**.
+
+The target invariant for the whole prompt:
+
+> Find hidden consumers and dependencies aggressively, but require a concrete present-day
+> failure scenario before promoting a concern to a confirmed finding.
+
+Rigorous in two directions at once:
+
+```text
+higher recall:    find more hidden consumers, dependencies and semantic migrations
+higher precision: do not promote design smells or hypothetical future drift without a
+                  realistic current failure
+```
+
+## The prompt
+
+The operational prompt is `.claude/commands/audit.md`, run as `/audit [target]`. Its phases
+are summarised here so the rationale below is self-contained:
+
+- **Phase 0 — Baseline & contract map.** Pin the base revision; name the touched Monize
+  contracts and invariant IDs (`docs/system-invariants.md` and the financial/RLS/concurrency
+  contracts).
+- **Phase 1 — Aggressive discovery (recall).** Read-model semantic-migration pass; upstream
+  dependency mutation matrix; shared AI/MCP surface pass.
+- **Phase 2 — Mandatory admission gate (precision).** Six questions per candidate; no
+  present-day failure scenario means `DESIGN RISK`, not a finding.
+- **Phase 3 — PR causality classification.**
+- **Phase 4 — Contract-precedence gate** (DRY does not beat a documented exception).
+- **Phase 5 — Performance calibration** (`N/S/K` model or benchmark, never label-only).
+- **Phase 6 — Consolidation** (one finding per violated invariant, surfaces enumerated).
+- **Phase 7 — External-review ingestion** (reconstruct independently; never inherit).
+- **Phase 8 — Fix-review interaction test** (a fix must not reintroduce a prior bug).
+- **Output** — scope, confirmed findings, design risks, and a mandatory rejected-hypothesis
+  table.
+
+## The ten improvements over V2, and what each guards against
+
+Each row maps a V2→V3 improvement to the phase that carries it and the failure it prevents.
+The example labels (`C1`, `C3`, `C4`, `R10-F2`, `S1–S7`, `K2`) come from the V2 review round
+that motivated V3; they are illustrative, not references to files in this repository.
+
+| # | Improvement | Phase | Guards against |
+|---|---|---|---|
+| 1 | Mandatory finding-admission gate | 2 | Promoting a reachable-but-harmless concern to a confirmed finding (C4, S1–S7, K2). |
+| 2 | Explicit contract-precedence gate | 4 | "Fixing" a deliberately-different path for DRY against a documented contract (C3 vs R10-F2). |
+| 3 | PR causality classification | 3 | Charging a PR for a pre-existing `main` bug; **and** missing that a PR *exposed/amplified* a previously-correct consumer. |
+| 4 | Read-model semantic-migration rule | 1a | Leaving old-scalar consumers semantically stale when a new `effective`/`current`/`complete` field is added (C1's real, wider scope). |
+| 5 | Upstream dependency mutation matrix | 1b | Missing a cache-invalidation link (e.g. no `scheduled:` invalidation after a manual FX refresh). |
+| 6 | Performance-finding calibration | 5 | Reporting "N+1" / "sequential async" by label without a call-count model or benchmark. |
+| 7 | One finding per violated invariant | 6 | Inflating the count by reporting the same root cause once per surface. |
+| 8 | Mandatory rejected-hypothesis table | Output | Silent false positives; unaccounted design risks, pre-existing issues, and external claims. |
+| 9 | External-review ingestion protocol | 7 | Inheriting another reviewer's severity / root cause / fix, incl. the `CONFIRMED_WITH_DIFFERENT_ROOT_CAUSE` case. |
+| 10 | Fix-review interaction test | 8 | A remediation that closes a new finding by reverting an older fix. |
+
+## Monize-specific grounding
+
+V3 is not generic. Discovery and precedence are anchored to this repository's contracts:
+
+- **Semantic-migration pass (1a)** mirrors the project rule that a completeness flag the
+  frontend type omits ships a subtotal under a total's caption — search old-field consumers
+  across backend, the AI executor, MCP tools, dashboard, budgets, reports, CSV/PDF, and
+  `frontend/src/types/*`.
+- **Shared-surface pass (1c)** enforces "every AI tool is implemented once and adapted by both
+  the AI executor and the MCP layer", and the "grep the bulk / AI-action / MCP routes" rule
+  when a single-path refusal is added.
+- **Contract-precedence (4)** protects Monize's deliberate look-alikes: per-ledger
+  reconciliation vs the shared VOID boundary, register-order tiebreaks, and
+  FX-resolution-only-on-structural-change.
+- **Findings** should name the invariant ID from `docs/system-invariants.md` and, where the
+  mistake is mechanical, propose a **source-scanning guard test** (the project's preferred
+  regression form) rather than a single-case test.
+
+## Usage
+
+```text
+/audit                 # working-tree diff vs merge-base with origin/main
+/audit 1234            # PR #1234
+/audit my-branch       # git diff origin/main...my-branch
+/audit backend/src/... # audit a path as it currently stands
+```
+
+`/audit` reports; it does not commit. Apply fixes only when explicitly asked.


### PR DESCRIPTION
## Linked discussion / issue

Closes #1227 
Approved in: #1227 

## Summary

Adds the comprehensive-review ("audit") prompt V3 in two forms:

- **`.claude/commands/audit.md`** — executable `/audit` slash command. Targets the working-tree diff, a PR number, a branch, or a path. Eight phases: baseline & contract map, aggressive discovery (read-model semantic-migration pass, upstream dependency mutation matrix, shared AI/MCP surface pass), a mandatory finding-admission gate, PR-causality classification, contract-precedence gate, performance calibration, one-finding-per-invariant consolidation, external-review ingestion, and a fix-review interaction test. It reports only — it does not commit.
- **`docs/audits/review-prompt-v3.md`** — canonical versioned copy of the same prompt plus rationale, including a table mapping the ten V2→V3 improvements to the phase that carries each and the failure class it prevents.

V3 keeps V2's breadth and sharpens precision: high recall on hidden consumers/dependencies, but a concrete present-day failure scenario is required before a concern becomes a confirmed finding (design risks are kept separate). The prompt is grounded in Monize's own contracts (system invariants, financial/RLS/concurrency docs, shared AI+MCP tool rule).

Docs- and tooling-only: no source, schema, or runtime behavior changes.

## Checklist

- [x] An approved discussion or issue exists and is linked above. _(not created — see note above)_
- [x] This PR addresses a **single concern** (large work is split into a series).
- [ ] New behavior has tests, and the existing suite passes. _(N/A — no runtime behavior; adds a prompt/doc only)_
- [ ] All user-facing strings are translated for **every** locale (i18n parity). _(N/A — no user-facing strings)_
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Authored with Claude Code (Claude). The human contributor has reviewed and owns the result.