### PR TITLE
Show favourite reports at the top of the report switcher (#1224)

### DIFF
--- a/frontend/src/components/reports/ReportSwitcher.test.tsx
+++ b/frontend/src/components/reports/ReportSwitcher.test.tsx
@@ -232,6 +232,23 @@ describe('ReportSwitcher', () => {
     ).toBeNull();
   });
 
+  it('orders the Favourites section by REPORT_CATEGORIES, not by insertion order', async () => {
+    // favouriteReportIds lists networth before spending, but the source claims
+    // the top section reads in REPORT_CATEGORIES order (spending before
+    // networth) -- guard that claim so a future reorder cannot pass silently.
+    setFavouriteReportIds(['net-worth', 'spending-by-category']);
+    await openSwitcher('monthly-comparison');
+    const favourites = screen.getByRole('group', { name: 'Favourites' });
+    const names = within(favourites)
+      .getAllByRole('menuitem')
+      .map((item) => item.textContent ?? '');
+    const spendingIdx = names.findIndex((n) => /Spending by Category/.test(n));
+    const netWorthIdx = names.findIndex((n) => /Net Worth Over Time/.test(n));
+    expect(spendingIdx).toBeGreaterThanOrEqual(0);
+    expect(netWorthIdx).toBeGreaterThanOrEqual(0);
+    expect(spendingIdx).toBeLessThan(netWorthIdx);
+  });
+
   it('still filters a favourite by its own category name', async () => {
     setFavouriteReportIds(['savings-rate']);
     await openSwitcher('monthly-comparison');

--- a/frontend/src/components/reports/ReportSwitcher.test.tsx
+++ b/frontend/src/components/reports/ReportSwitcher.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, fireEvent, act, within } from '@/test/render';
 import { ReportSwitcher } from './ReportSwitcher';
 import { customReportsApi } from '@/lib/custom-reports';
 import { investmentReportsApi } from '@/lib/investment-reports';
+import { usePreferencesStore } from '@/store/preferencesStore';
+import type { UserPreferences } from '@/types/auth';
 
 vi.mock('@/lib/custom-reports', () => ({
   customReportsApi: { getAll: vi.fn() },
@@ -11,6 +13,14 @@ vi.mock('@/lib/custom-reports', () => ({
 vi.mock('@/lib/investment-reports', () => ({
   investmentReportsApi: { getAll: vi.fn() },
 }));
+
+// The built-in favourites live in the reactive preferences store; only
+// `favouriteReportIds` is read here, so the rest of the object is cast in.
+function setFavouriteReportIds(ids: string[]) {
+  usePreferencesStore.setState({
+    preferences: { favouriteReportIds: ids } as UserPreferences,
+  });
+}
 
 const push = vi.fn();
 
@@ -39,6 +49,9 @@ describe('ReportSwitcher', () => {
     vi.clearAllMocks();
     getCustom.mockResolvedValue([]);
     getInvestment.mockResolvedValue([]);
+    // No favourites by default, so the section-order tests see only the
+    // category sections. Reset explicitly -- the store is a singleton.
+    setFavouriteReportIds([]);
   });
 
   it('groups the reports by section, in the order the Reports page lists them', async () => {
@@ -132,5 +145,104 @@ describe('ReportSwitcher', () => {
       screen.getByRole('menuitem', { name: /Dividend Yield & Growth/ }),
     ).toBeInTheDocument();
     expect(screen.queryByRole('menuitem', { name: /Savings Rate/ })).toBeNull();
+  });
+
+  it('lifts favourite built-in reports into a Favourites section at the top', async () => {
+    setFavouriteReportIds(['savings-rate', 'net-worth']);
+    await openSwitcher('monthly-comparison');
+
+    // Favourites is the first section the caret shows.
+    const sections = screen
+      .getAllByRole('group')
+      .map((group) => group.getAttribute('aria-label'));
+    expect(sections[0]).toBe('Favourites');
+
+    const favourites = screen.getByRole('group', { name: 'Favourites' });
+    expect(
+      within(favourites).getByRole('menuitem', { name: /Savings Rate/ }),
+    ).toBeInTheDocument();
+    expect(
+      within(favourites).getByRole('menuitem', { name: /Net Worth Over Time/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a favourite once -- not also under its own category', async () => {
+    setFavouriteReportIds(['savings-rate']);
+    await openSwitcher('monthly-comparison');
+
+    // Savings Rate is a Budget report; favouriting it moves it out of Budget.
+    const budget = screen.getByRole('group', { name: 'Budget' });
+    expect(
+      within(budget).queryByRole('menuitem', { name: /Savings Rate/ }),
+    ).toBeNull();
+    // And it appears exactly once across the whole menu.
+    expect(screen.getAllByRole('menuitem', { name: /Savings Rate/ })).toHaveLength(
+      1,
+    );
+  });
+
+  it('lifts favourite custom and investment reports into Favourites', async () => {
+    getCustom.mockResolvedValue([
+      { id: 'c1', name: 'Groceries Deep Dive', isFavourite: true },
+      { id: 'c2', name: 'Utilities', isFavourite: false },
+    ] as unknown as Awaited<ReturnType<typeof customReportsApi.getAll>>);
+    getInvestment.mockResolvedValue([
+      { id: 'i1', name: 'RRSP Holdings', isFavourite: true },
+    ] as unknown as Awaited<ReturnType<typeof investmentReportsApi.getAll>>);
+
+    await openSwitcher();
+    const favourites = screen.getByRole('group', { name: 'Favourites' });
+    expect(
+      within(favourites).getByRole('menuitem', { name: /Groceries Deep Dive/ }),
+    ).toBeInTheDocument();
+    expect(
+      within(favourites).getByRole('menuitem', { name: /RRSP Holdings/ }),
+    ).toBeInTheDocument();
+
+    // The non-favourite custom report stays under its own section.
+    const custom = screen.getByRole('group', { name: 'Custom' });
+    expect(
+      within(custom).getByRole('menuitem', { name: /Utilities/ }),
+    ).toBeInTheDocument();
+    expect(
+      within(custom).queryByRole('menuitem', { name: /Groceries Deep Dive/ }),
+    ).toBeNull();
+  });
+
+  it('reorders immediately when a favourite is toggled', async () => {
+    await openSwitcher('monthly-comparison');
+    // Nothing starred yet, so no Favourites section.
+    expect(screen.queryByRole('group', { name: 'Favourites' })).toBeNull();
+
+    // Toggling a favourite anywhere updates the reactive preference, and the
+    // open menu reorders without reopening.
+    await act(async () => {
+      usePreferencesStore
+        .getState()
+        .updatePreferences({ favouriteReportIds: ['spending-by-category'] });
+    });
+
+    const favourites = screen.getByRole('group', { name: 'Favourites' });
+    expect(
+      within(favourites).getByRole('menuitem', { name: /Spending by Category/ }),
+    ).toBeInTheDocument();
+    const spending = screen.getByRole('group', { name: 'Spending' });
+    expect(
+      within(spending).queryByRole('menuitem', { name: /Spending by Category/ }),
+    ).toBeNull();
+  });
+
+  it('still filters a favourite by its own category name', async () => {
+    setFavouriteReportIds(['savings-rate']);
+    await openSwitcher('monthly-comparison');
+    fireEvent.change(screen.getByPlaceholderText('Filter reports...'), {
+      target: { value: 'budget' },
+    });
+    // Savings Rate sits in Favourites now, but its searchText still carries its
+    // Budget category, so a category search finds it.
+    const favourites = screen.getByRole('group', { name: 'Favourites' });
+    expect(
+      within(favourites).getByRole('menuitem', { name: /Savings Rate/ }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/reports/ReportSwitcher.tsx
+++ b/frontend/src/components/reports/ReportSwitcher.tsx
@@ -22,7 +22,12 @@ interface ReportSwitcherProps {
  *
  * Fifty-odd reports are too many to read as one column, so the menu is grouped
  * by the section the Reports page files each under, in the same order its
- * filter chips use.
+ * filter chips use. The reports the user has starred are lifted into a
+ * "Favourites" section above those, so the ones they open most are the first
+ * thing the caret shows -- and because favourite status is read live (built-ins
+ * from the reactive preference, saved reports from their own flag), toggling a
+ * star reorders the menu without a reload. A favourite is shown once, at the
+ * top; its category section keeps only the remaining reports.
  *
  * Picking a report navigates, and the route is built here rather than by each
  * caller: an id in this menu *is* a path under `/reports/`, and two call sites
@@ -36,20 +41,36 @@ export function ReportSwitcher({ currentId }: ReportSwitcherProps) {
   const items = useMemo<EntitySwitcherItem[]>(() => {
     const label = (category: string) =>
       t(`page.categories.${category}` as Parameters<typeof t>[0]);
+    const favouritesLabel = t('detailHeader.favourites');
+    const toItem = (
+      report: (typeof reports)[number],
+      group: string,
+    ): EntitySwitcherItem => ({
+      id: report.id,
+      primary: report.name,
+      // The section is the heading above the row, so repeating it beside the
+      // name would say the same thing twice. A favourite is searchable by its
+      // own category too, so typing "spending" still finds a starred spending
+      // report sitting in the Favourites section.
+      group,
+      searchText: `${report.name} ${label(report.category)}`,
+    });
     // Ordered section by section: `EntitySwitcher` takes the order of the
-    // sections from the order their first item appears in.
-    return REPORT_CATEGORIES.flatMap((category) =>
+    // sections from the order their first item appears in, so the Favourites
+    // rows come first by being emitted first -- each in REPORT_CATEGORIES order
+    // so the top section reads in the same order as the rest of the menu.
+    const favourites = REPORT_CATEGORIES.flatMap((category) =>
       reports
-        .filter((report) => report.category === category)
-        .map((report) => ({
-          id: report.id,
-          primary: report.name,
-          // The section is the heading above the row, so repeating it beside
-          // the name would say the same thing twice.
-          group: label(category),
-          searchText: `${report.name} ${label(category)}`,
-        })),
+        .filter((report) => report.category === category && report.isFavourite)
+        .map((report) => toItem(report, favouritesLabel)),
     );
+    // The remaining (non-favourite) reports, filed under their own section.
+    const rest = REPORT_CATEGORIES.flatMap((category) =>
+      reports
+        .filter((report) => report.category === category && !report.isFavourite)
+        .map((report) => toItem(report, label(category))),
+    );
+    return [...favourites, ...rest];
   }, [reports, t]);
 
   return (

--- a/frontend/src/components/reports/useReportCatalog.ts
+++ b/frontend/src/components/reports/useReportCatalog.ts
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { customReportsApi } from '@/lib/custom-reports';
 import { investmentReportsApi } from '@/lib/investment-reports';
+import { usePreferencesStore } from '@/store/preferencesStore';
 import { createLogger } from '@/lib/logger';
 import {
   builtInReports,
@@ -20,6 +21,13 @@ export interface ReportCatalogEntry {
   id: string;
   name: string;
   category: ReportCategory;
+  /**
+   * Whether the user has starred this report. Built-ins read it from the
+   * reactive `favouriteReportIds` preference, so toggling a favourite anywhere
+   * reorders the switcher on the next render; a saved report carries its own
+   * `isFavourite`.
+   */
+  isFavourite: boolean;
 }
 
 /**
@@ -34,11 +42,14 @@ export interface ReportCatalogEntry {
  */
 export function useReportCatalog(): { reports: readonly ReportCatalogEntry[] } {
   const t = useTranslations('reports');
+  const favouriteReportIds = usePreferencesStore(
+    (s) => s.preferences?.favouriteReportIds,
+  );
   const [customNames, setCustomNames] = useState<
-    readonly { id: string; name: string }[]
+    readonly { id: string; name: string; isFavourite: boolean }[]
   >([]);
   const [investmentNames, setInvestmentNames] = useState<
-    readonly { id: string; name: string }[]
+    readonly { id: string; name: string; isFavourite: boolean }[]
   >([]);
 
   useEffect(() => {
@@ -47,14 +58,26 @@ export function useReportCatalog(): { reports: readonly ReportCatalogEntry[] } {
       .getAll()
       .then((reports) => {
         if (!active) return;
-        setCustomNames(reports.map((r) => ({ id: r.id, name: r.name })));
+        setCustomNames(
+          reports.map((r) => ({
+            id: r.id,
+            name: r.name,
+            isFavourite: r.isFavourite,
+          })),
+        );
       })
       .catch((error) => logger.error('Failed to load custom reports:', error));
     investmentReportsApi
       .getAll()
       .then((reports) => {
         if (!active) return;
-        setInvestmentNames(reports.map((r) => ({ id: r.id, name: r.name })));
+        setInvestmentNames(
+          reports.map((r) => ({
+            id: r.id,
+            name: r.name,
+            isFavourite: r.isFavourite,
+          })),
+        );
       })
       .catch((error) =>
         logger.error('Failed to load investment reports:', error),
@@ -70,19 +93,22 @@ export function useReportCatalog(): { reports: readonly ReportCatalogEntry[] } {
         id: report.id,
         name: t(`page.names.${report.id}` as Parameters<typeof t>[0]),
         category: report.category,
+        isFavourite: (favouriteReportIds ?? []).includes(report.id),
       })),
       ...customNames.map((report) => ({
         id: `custom/${report.id}`,
         name: report.name,
         category: 'custom' as ReportCategory,
+        isFavourite: report.isFavourite,
       })),
       ...investmentNames.map((report) => ({
         id: `investment/${report.id}`,
         name: report.name,
         category: 'investment' as ReportCategory,
+        isFavourite: report.isFavourite,
       })),
     ],
-    [customNames, investmentNames, t],
+    [customNames, investmentNames, favouriteReportIds, t],
   );
 
   return { reports };

--- a/frontend/src/i18n/messages/de/reports.json
+++ b/frontend/src/i18n/messages/de/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Zurück zu Berichten",
     "switchReport": "Zu einem anderen Bericht wechseln",
     "switchPlaceholder": "Berichte filtern...",
-    "switchNoMatches": "Keine Berichte gefunden"
+    "switchNoMatches": "Keine Berichte gefunden",
+    "favourites": "Favoriten"
   },
   "reportPage": {
     "notFound": "Bericht nicht gefunden",

--- a/frontend/src/i18n/messages/en-US/reports.json
+++ b/frontend/src/i18n/messages/en-US/reports.json
@@ -19,5 +19,8 @@
   },
   "investmentReportForm": {
     "labelFavourite": "Add to favorites"
+  },
+  "detailHeader": {
+    "favourites": "Favorites"
   }
 }

--- a/frontend/src/i18n/messages/en/reports.json
+++ b/frontend/src/i18n/messages/en/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Back to Reports",
     "switchReport": "Switch to another report",
     "switchPlaceholder": "Filter reports...",
-    "switchNoMatches": "No reports match"
+    "switchNoMatches": "No reports match",
+    "favourites": "Favourites"
   },
   "reportPage": {
     "notFound": "Report Not Found",

--- a/frontend/src/i18n/messages/es/reports.json
+++ b/frontend/src/i18n/messages/es/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Volver a informes",
     "switchReport": "Cambiar a otro informe",
     "switchPlaceholder": "Filtrar informes...",
-    "switchNoMatches": "Ningún informe coincide"
+    "switchNoMatches": "Ningún informe coincide",
+    "favourites": "Favoritos"
   },
   "reportPage": {
     "notFound": "Informe no encontrado",

--- a/frontend/src/i18n/messages/fr/reports.json
+++ b/frontend/src/i18n/messages/fr/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Retour aux rapports",
     "switchReport": "Passer à un autre rapport",
     "switchPlaceholder": "Filtrer les rapports...",
-    "switchNoMatches": "Aucun rapport ne correspond"
+    "switchNoMatches": "Aucun rapport ne correspond",
+    "favourites": "Favoris"
   },
   "reportPage": {
     "notFound": "Rapport introuvable",

--- a/frontend/src/i18n/messages/hi/reports.json
+++ b/frontend/src/i18n/messages/hi/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "रिपोर्ट पर वापस जाएँ",
     "switchReport": "किसी दूसरी रिपोर्ट पर जाएँ",
     "switchPlaceholder": "रिपोर्ट छाँटें...",
-    "switchNoMatches": "कोई रिपोर्ट मेल नहीं खाती"
+    "switchNoMatches": "कोई रिपोर्ट मेल नहीं खाती",
+    "favourites": "पसंदीदा"
   },
   "reportPage": {
     "notFound": "रिपोर्ट नहीं मिली",

--- a/frontend/src/i18n/messages/id/reports.json
+++ b/frontend/src/i18n/messages/id/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Kembali ke Laporan",
     "switchReport": "Pindah ke laporan lain",
     "switchPlaceholder": "Saring laporan...",
-    "switchNoMatches": "Tidak ada laporan yang cocok"
+    "switchNoMatches": "Tidak ada laporan yang cocok",
+    "favourites": "Favorit"
   },
   "reportPage": {
     "notFound": "Laporan Tidak Ditemukan",

--- a/frontend/src/i18n/messages/it/reports.json
+++ b/frontend/src/i18n/messages/it/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Torna ai report",
     "switchReport": "Passa a un altro report",
     "switchPlaceholder": "Filtra report...",
-    "switchNoMatches": "Nessun report corrisponde"
+    "switchNoMatches": "Nessun report corrisponde",
+    "favourites": "Preferiti"
   },
   "reportPage": {
     "notFound": "Report non trovato",

--- a/frontend/src/i18n/messages/ja/reports.json
+++ b/frontend/src/i18n/messages/ja/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "レポートに戻る",
     "switchReport": "別のレポートに切り替える",
     "switchPlaceholder": "レポートを絞り込む...",
-    "switchNoMatches": "一致するレポートはありません"
+    "switchNoMatches": "一致するレポートはありません",
+    "favourites": "お気に入り"
   },
   "reportPage": {
     "notFound": "レポートが見つかりません",

--- a/frontend/src/i18n/messages/ko/reports.json
+++ b/frontend/src/i18n/messages/ko/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "보고서로 돌아가기",
     "switchReport": "다른 보고서로 이동",
     "switchPlaceholder": "보고서 검색...",
-    "switchNoMatches": "일치하는 보고서가 없습니다"
+    "switchNoMatches": "일치하는 보고서가 없습니다",
+    "favourites": "즐겨찾기"
   },
   "reportPage": {
     "notFound": "보고서를 찾을 수 없음",

--- a/frontend/src/i18n/messages/nl/reports.json
+++ b/frontend/src/i18n/messages/nl/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Terug naar rapporten",
     "switchReport": "Naar een ander rapport gaan",
     "switchPlaceholder": "Rapporten filteren...",
-    "switchNoMatches": "Geen rapporten gevonden"
+    "switchNoMatches": "Geen rapporten gevonden",
+    "favourites": "Favorieten"
   },
   "reportPage": {
     "notFound": "Rapport niet gevonden",

--- a/frontend/src/i18n/messages/pl/reports.json
+++ b/frontend/src/i18n/messages/pl/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Powrót do raportów",
     "switchReport": "Przejdź do innego raportu",
     "switchPlaceholder": "Filtruj raporty...",
-    "switchNoMatches": "Brak dopasowanych raportów"
+    "switchNoMatches": "Brak dopasowanych raportów",
+    "favourites": "Ulubione"
   },
   "reportPage": {
     "notFound": "Nie znaleziono raportu",

--- a/frontend/src/i18n/messages/pt-BR/reports.json
+++ b/frontend/src/i18n/messages/pt-BR/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Voltar aos Relatórios",
     "switchReport": "Mudar para outro relatório",
     "switchPlaceholder": "Filtrar relatórios...",
-    "switchNoMatches": "Nenhum relatório corresponde"
+    "switchNoMatches": "Nenhum relatório corresponde",
+    "favourites": "Favoritos"
   },
   "reportPage": {
     "notFound": "Relatório Não Encontrado",

--- a/frontend/src/i18n/messages/pt/reports.json
+++ b/frontend/src/i18n/messages/pt/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Voltar aos Relatórios",
     "switchReport": "Mudar para outro relatório",
     "switchPlaceholder": "Filtrar relatórios...",
-    "switchNoMatches": "Nenhum relatório corresponde"
+    "switchNoMatches": "Nenhum relatório corresponde",
+    "favourites": "Favoritos"
   },
   "reportPage": {
     "notFound": "Relatório Não Encontrado",

--- a/frontend/src/i18n/messages/reports.favourites-group.test.ts
+++ b/frontend/src/i18n/messages/reports.favourites-group.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+
+// The report switcher lifts starred reports into a "Favourites" section whose
+// group identity IS the translated `detailHeader.favourites` string, and
+// EntitySwitcher merges any items that share a group string into one section.
+// So if a locale ever translated `detailHeader.favourites` to the same text as
+// one of its `page.categories.*` labels, that category's non-favourite reports
+// would collapse under the Favourites heading. No shipped locale does this
+// today; this guard keeps a future translation edit from introducing it
+// silently (a machine-checkable rule beats a comment).
+
+type ReportsCatalog = {
+  detailHeader?: { favourites?: string };
+  page?: { categories?: Record<string, string> };
+};
+
+const catalogs = import.meta.glob<{ default: ReportsCatalog }>(
+  '@/i18n/messages/*/reports.json',
+  { eager: true },
+);
+
+const base = Object.entries(catalogs).find(([path]) =>
+  path.includes('/en/reports.json'),
+)?.[1].default;
+
+function localeOf(path: string): string {
+  return path.split('/').slice(-2, -1)[0];
+}
+
+describe('report switcher Favourites group label', () => {
+  it('resolves an en base with categories to compare against', () => {
+    expect(base?.page?.categories).toBeTruthy();
+  });
+
+  for (const [path, mod] of Object.entries(catalogs)) {
+    const locale = localeOf(path);
+    it(`${locale}: Favourites label collides with no category label`, () => {
+      const catalog = mod.default;
+      // Lean regional variants ship only overrides, so the effective value is the
+      // locale's own string when present, else the en base's -- exactly what the
+      // running app renders after next-intl merges them.
+      const favourites =
+        catalog.detailHeader?.favourites ?? base?.detailHeader?.favourites;
+      const categories = {
+        ...(base?.page?.categories ?? {}),
+        ...(catalog.page?.categories ?? {}),
+      };
+      expect(favourites).toBeTruthy();
+      expect(Object.values(categories)).not.toContain(favourites);
+    });
+  }
+});

--- a/frontend/src/i18n/messages/ru/reports.json
+++ b/frontend/src/i18n/messages/ru/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Назад к отчётам",
     "switchReport": "Перейти к другому отчёту",
     "switchPlaceholder": "Фильтр отчётов...",
-    "switchNoMatches": "Нет подходящих отчётов"
+    "switchNoMatches": "Нет подходящих отчётов",
+    "favourites": "Избранное"
   },
   "reportPage": {
     "notFound": "Отчёт не найден",

--- a/frontend/src/i18n/messages/tr/reports.json
+++ b/frontend/src/i18n/messages/tr/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Raporlara Geri Dön",
     "switchReport": "Başka bir rapora geç",
     "switchPlaceholder": "Raporları filtrele...",
-    "switchNoMatches": "Eşleşen rapor yok"
+    "switchNoMatches": "Eşleşen rapor yok",
+    "favourites": "Favoriler"
   },
   "reportPage": {
     "notFound": "Rapor Bulunamadı",

--- a/frontend/src/i18n/messages/uk/reports.json
+++ b/frontend/src/i18n/messages/uk/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Назад до звітів",
     "switchReport": "Перейти до іншого звіту",
     "switchPlaceholder": "Фільтр звітів...",
-    "switchNoMatches": "Немає відповідних звітів"
+    "switchNoMatches": "Немає відповідних звітів",
+    "favourites": "Обране"
   },
   "reportPage": {
     "notFound": "Звіт не знайдено",

--- a/frontend/src/i18n/messages/vi/reports.json
+++ b/frontend/src/i18n/messages/vi/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "Quay lại báo cáo",
     "switchReport": "Chuyển sang báo cáo khác",
     "switchPlaceholder": "Lọc báo cáo...",
-    "switchNoMatches": "Không có báo cáo nào khớp"
+    "switchNoMatches": "Không có báo cáo nào khớp",
+    "favourites": "Yêu thích"
   },
   "reportPage": {
     "notFound": "Không tìm thấy báo cáo",

--- a/frontend/src/i18n/messages/xx/reports.json
+++ b/frontend/src/i18n/messages/xx/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "[XX-Back to Reports-XX]",
     "switchReport": "[XX-Switch to another report-XX]",
     "switchPlaceholder": "[XX-Filter reports...-XX]",
-    "switchNoMatches": "[XX-No reports match-XX]"
+    "switchNoMatches": "[XX-No reports match-XX]",
+    "favourites": "[XX-Favourites-XX]"
   },
   "reportPage": {
     "notFound": "[XX-Report Not Found-XX]",

--- a/frontend/src/i18n/messages/zh-CN/reports.json
+++ b/frontend/src/i18n/messages/zh-CN/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "返回报告",
     "switchReport": "切换到其他报告",
     "switchPlaceholder": "筛选报告...",
-    "switchNoMatches": "没有匹配的报告"
+    "switchNoMatches": "没有匹配的报告",
+    "favourites": "收藏"
   },
   "reportPage": {
     "notFound": "未找到报告",

--- a/frontend/src/i18n/messages/zh-TW/reports.json
+++ b/frontend/src/i18n/messages/zh-TW/reports.json
@@ -128,7 +128,8 @@
     "backToReports": "返回報表",
     "switchReport": "切換到其他報表",
     "switchPlaceholder": "篩選報表...",
-    "switchNoMatches": "沒有符合的報表"
+    "switchNoMatches": "沒有符合的報表",
+    "favourites": "我的最愛"
   },
   "reportPage": {
     "notFound": "找不到報表",

--- a/frontend/src/lib/custom-reports.test.ts
+++ b/frontend/src/lib/custom-reports.test.ts
@@ -73,4 +73,65 @@ describe('customReportsApi', () => {
     expect(apiClient.get).not.toHaveBeenCalled();
     expect(second).toEqual(first);
   });
+
+  // Issue #1224 requirement 3: a favourite change is reflected in the switcher's
+  // order immediately -- even for the report the user starred and then navigated
+  // straight to, while the PATCH is still on the wire. The switcher reads getAll
+  // through the shared cache, so the toggle must patch that cache up front.
+  it('reflects a favourite toggle in the cache before the request settles', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: [
+        { id: 'r-1', name: 'A', isFavourite: false },
+        { id: 'r-2', name: 'B', isFavourite: false },
+      ],
+    });
+    await customReportsApi.getAll();
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+
+    // Hold the PATCH open to observe the in-flight window.
+    let resolvePatch!: (value: unknown) => void;
+    vi.mocked(apiClient.patch).mockReturnValue(
+      new Promise((resolve) => {
+        resolvePatch = resolve;
+      }) as never,
+    );
+    const toggle = customReportsApi.toggleFavourite('r-1', true);
+
+    // A read racing the in-flight toggle sees the new favourite, from cache,
+    // without a fresh request.
+    vi.mocked(apiClient.get).mockClear();
+    const midFlight = await customReportsApi.getAll();
+    expect(apiClient.get).not.toHaveBeenCalled();
+    expect(midFlight.find((r) => r.id === 'r-1')?.isFavourite).toBe(true);
+    expect(midFlight.find((r) => r.id === 'r-2')?.isFavourite).toBe(false);
+
+    // Once the server answers, the optimistic copy is dropped: the next read
+    // reconciles against the server.
+    resolvePatch({ data: { id: 'r-1', isFavourite: true } });
+    await toggle;
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: [{ id: 'r-1', isFavourite: true }],
+    });
+    await customReportsApi.getAll();
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the optimistic favourite and rethrows when the toggle fails', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: [{ id: 'r-1', name: 'A', isFavourite: false }],
+    });
+    await customReportsApi.getAll();
+
+    vi.mocked(apiClient.patch).mockRejectedValue(new Error('boom'));
+    await expect(customReportsApi.toggleFavourite('r-1', true)).rejects.toThrow('boom');
+
+    // The optimistic value is gone: the next read refetches server truth.
+    vi.mocked(apiClient.get).mockClear();
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: [{ id: 'r-1', isFavourite: false }],
+    });
+    const after = await customReportsApi.getAll();
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+    expect(after.find((r) => r.id === 'r-1')?.isFavourite).toBe(false);
+  });
 });

--- a/frontend/src/lib/custom-reports.ts
+++ b/frontend/src/lib/custom-reports.ts
@@ -8,6 +8,11 @@ import {
 } from '@/types/custom-report';
 import { getCached, setCache, invalidateCache } from './apiCache';
 
+// The saved-reports list lives under one cache key; keep the key and TTL in one
+// place so getAll and the optimistic favourite patch below cannot drift.
+const REPORTS_CACHE_KEY = 'reports:all';
+const REPORTS_CACHE_TTL = 300_000; // 5 minutes
+
 export interface ExecuteReportParams {
   timeframeType?: TimeframeType;
   startDate?: string;
@@ -24,10 +29,10 @@ export const customReportsApi = {
 
   // Get all custom reports for the current user
   getAll: async (): Promise<CustomReport[]> => {
-    const cached = getCached<CustomReport[]>('reports:all');
+    const cached = getCached<CustomReport[]>(REPORTS_CACHE_KEY);
     if (cached) return cached;
     const response = await apiClient.get<CustomReport[]>('/reports/custom');
-    setCache('reports:all', response.data, 300_000);
+    setCache(REPORTS_CACHE_KEY, response.data, REPORTS_CACHE_TTL);
     return response.data;
   },
 
@@ -61,10 +66,31 @@ export const customReportsApi = {
 
   // Toggle favourite status
   toggleFavourite: async (id: string, isFavourite: boolean): Promise<CustomReport> => {
-    const response = await apiClient.patch<CustomReport>(`/reports/custom/${id}`, {
-      isFavourite,
-    });
-    invalidateCache('reports:');
-    return response.data;
+    // Reflect the new favourite in the shared list cache the moment the toggle
+    // starts, so a surface re-reading getAll before the request settles -- the
+    // report switcher mounting as the user navigates straight to the report they
+    // just starred -- already shows the new order (issue #1224). The
+    // invalidateCache below drops this optimistic copy once the server answers,
+    // on either path, so the next read reconciles against the server.
+    const cached = getCached<CustomReport[]>(REPORTS_CACHE_KEY);
+    if (cached) {
+      setCache(
+        REPORTS_CACHE_KEY,
+        cached.map((report) =>
+          report.id === id ? { ...report, isFavourite } : report,
+        ),
+        REPORTS_CACHE_TTL,
+      );
+    }
+    try {
+      const response = await apiClient.patch<CustomReport>(`/reports/custom/${id}`, {
+        isFavourite,
+      });
+      invalidateCache('reports:');
+      return response.data;
+    } catch (error) {
+      invalidateCache('reports:');
+      throw error;
+    }
   },
 };

--- a/frontend/src/lib/investment-reports.test.ts
+++ b/frontend/src/lib/investment-reports.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import apiClient from './api';
-import { getCached } from './apiCache';
+import { getCached, setCache, invalidateCache } from './apiCache';
 import { investmentReportsApi } from './investment-reports';
 
 vi.mock('./api', () => ({
@@ -76,5 +76,40 @@ describe('investmentReportsApi', () => {
     vi.mocked(apiClient.patch).mockResolvedValue({ data: { id: 'r1' } });
     await investmentReportsApi.toggleFavourite('r1', true);
     expect(apiClient.patch).toHaveBeenCalledWith('/reports/investment/r1', { isFavourite: true });
+  });
+
+  // Issue #1224 requirement 3: reflect the favourite change in the shared list
+  // cache up front, so the switcher mounting mid-flight reads the new order.
+  it('toggleFavourite optimistically patches the cached list up front', async () => {
+    vi.mocked(getCached).mockReturnValue([
+      { id: 'r1', isFavourite: false },
+      { id: 'r2', isFavourite: false },
+    ] as never);
+    vi.mocked(apiClient.patch).mockResolvedValue({ data: { id: 'r1', isFavourite: true } });
+    await investmentReportsApi.toggleFavourite('r1', true);
+    expect(setCache).toHaveBeenCalledWith(
+      'investment-reports:all',
+      [
+        { id: 'r1', isFavourite: true },
+        { id: 'r2', isFavourite: false },
+      ],
+      300_000,
+    );
+    expect(invalidateCache).toHaveBeenCalledWith('investment-reports:');
+  });
+
+  it('toggleFavourite skips the optimistic patch when nothing is cached', async () => {
+    vi.mocked(getCached).mockReturnValue(undefined);
+    vi.mocked(apiClient.patch).mockResolvedValue({ data: { id: 'r1' } });
+    await investmentReportsApi.toggleFavourite('r1', true);
+    expect(setCache).not.toHaveBeenCalled();
+    expect(invalidateCache).toHaveBeenCalledWith('investment-reports:');
+  });
+
+  it('toggleFavourite drops the optimistic value and rethrows on failure', async () => {
+    vi.mocked(getCached).mockReturnValue([{ id: 'r1', isFavourite: false }] as never);
+    vi.mocked(apiClient.patch).mockRejectedValue(new Error('boom'));
+    await expect(investmentReportsApi.toggleFavourite('r1', true)).rejects.toThrow('boom');
+    expect(invalidateCache).toHaveBeenCalledWith('investment-reports:');
   });
 });

--- a/frontend/src/lib/investment-reports.ts
+++ b/frontend/src/lib/investment-reports.ts
@@ -7,6 +7,11 @@ import {
 } from '@/types/investment-report';
 import { getCached, setCache, invalidateCache } from './apiCache';
 
+// The saved investment-reports list lives under one cache key; keep the key and
+// TTL in one place so getAll and the optimistic favourite patch cannot drift.
+const INVESTMENT_REPORTS_CACHE_KEY = 'investment-reports:all';
+const INVESTMENT_REPORTS_CACHE_TTL = 300_000; // 5 minutes
+
 export interface ExecuteInvestmentReportParams {
   asOfDate?: string;
   /**
@@ -24,10 +29,10 @@ export const investmentReportsApi = {
   },
 
   getAll: async (): Promise<InvestmentReport[]> => {
-    const cached = getCached<InvestmentReport[]>('investment-reports:all');
+    const cached = getCached<InvestmentReport[]>(INVESTMENT_REPORTS_CACHE_KEY);
     if (cached) return cached;
     const response = await apiClient.get<InvestmentReport[]>('/reports/investment');
-    setCache('investment-reports:all', response.data, 300_000);
+    setCache(INVESTMENT_REPORTS_CACHE_KEY, response.data, INVESTMENT_REPORTS_CACHE_TTL);
     return response.data;
   },
 
@@ -62,10 +67,31 @@ export const investmentReportsApi = {
   },
 
   toggleFavourite: async (id: string, isFavourite: boolean): Promise<InvestmentReport> => {
-    const response = await apiClient.patch<InvestmentReport>(`/reports/investment/${id}`, {
-      isFavourite,
-    });
-    invalidateCache('investment-reports:');
-    return response.data;
+    // Reflect the new favourite in the shared list cache the moment the toggle
+    // starts, so a surface re-reading getAll before the request settles -- the
+    // report switcher mounting as the user navigates straight to the report they
+    // just starred -- already shows the new order (issue #1224). The
+    // invalidateCache below drops this optimistic copy once the server answers,
+    // on either path, so the next read reconciles against the server.
+    const cached = getCached<InvestmentReport[]>(INVESTMENT_REPORTS_CACHE_KEY);
+    if (cached) {
+      setCache(
+        INVESTMENT_REPORTS_CACHE_KEY,
+        cached.map((report) =>
+          report.id === id ? { ...report, isFavourite } : report,
+        ),
+        INVESTMENT_REPORTS_CACHE_TTL,
+      );
+    }
+    try {
+      const response = await apiClient.patch<InvestmentReport>(`/reports/investment/${id}`, {
+        isFavourite,
+      });
+      invalidateCache('investment-reports:');
+      return response.data;
+    } catch (error) {
+      invalidateCache('investment-reports:');
+      throw error;
+    }
   },
 };


### PR DESCRIPTION
<!-- Before opening this PR, please read CONTRIBUTING.md. Monize follows a propose-first workflow: open a Discussion and get the approach approved before writing code. -->

## Linked discussion / issue

Closes #1224
Approved in: https://github.com/kenlasko/monize/issues/1224 (label: `approved-to-build`)

## Summary

The report switcher (the caret beside a report's title on every report detail
page) listed all ~50 reports grouped by section, with no priority for the ones
a user has starred. This PR lifts favourites into a **"Favourites"** section
above the category sections, so the reports opened most often are the first
thing the caret shows.

- **Favourites first, remaining below.** `useReportCatalog` now exposes
  `isFavourite` per entry, and `ReportSwitcher` emits favourites first (in
  `REPORT_CATEGORIES` order), then the non-favourites under their own sections.
  A favourite is shown once, at the top; its category section keeps only the
  remaining reports. `searchText` still carries each report's category, so a
  category search finds a starred report sitting in Favourites.
- **Reflected immediately (requirement 3).** Built-in favourites read the
  reactive `favouriteReportIds` preference. For saved (custom/investment)
  reports, `toggleFavourite` now optimistically patches the shared
  `reports:all` / `investment-reports:all` cache the moment the toggle starts,
  so a switcher mounting mid-flight (starring a report, then navigating
  straight to it before the PATCH settles) already shows the new order.
  `invalidateCache` runs on both success and failure, so the next read
  reconciles against the server. The cache key and TTL are pulled into one
  constant per client so `getAll` and the patch cannot drift.
- **i18n.** New key `reports.detailHeader.favourites`, pseudo-locale
  regenerated, and translated across all locales (`en-US` uses "Favorites").

### Tests
- `ReportSwitcher`: favourites lifted to a top section, no duplication in the
  category section, custom/investment favourites, category-name search of a
  lifted favourite, immediate reordering on preference change, and a guard that
  the Favourites section is ordered by `REPORT_CATEGORIES` (not insertion order).
- API clients: optimistic-cache race + failure rollback for both
  `customReportsApi` and `investmentReportsApi`.
- A locale guard fails if any locale ever translates `detailHeader.favourites`
  to one of its `page.categories.*` labels (which would collapse that category
  under the Favourites heading, since the group key is the translated string).

`EntitySwitcher` (shared) was left untouched. Scope is limited to the reports
switcher and the reports API clients.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Implemented with Claude Code. Two code-review passes were run against the change;
the confirmed finding (saved-report favourites could be stale after a fast
navigation) is fixed by the optimistic cache patch described above. I have
reviewed and own the result.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)