### PR TITLE
Report membership follows investment provenance, not account type (#1257)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,13 +326,21 @@ real ledger from fifteen report queries: salary paid into a brokerage's cash
 side vanished from Cash Flow, Income by Source, spending, tax and the
 Uncategorized list (issue #1257). It never described the rows it was meant to
 remove either: the cash leg a BUY/SELL/DIVIDEND posts lives in that same cash
-account, carries no category and no transfer flag.
+account, carries no category and no transfer flag -- and when the action names an
+explicit `fundingAccountId`, that leg lands in an *ordinary* account where no
+account-type predicate could ever see it, reporting an investment purchase as
+spending nobody did.
 
 What a row *is* decides it, and the predicate is written once in
 `backend/src/common/investment-filter.util.ts` -- `investmentExclusionSql` for
 raw SQL, `applyInvestmentTransactionFilters` for a QueryBuilder, both built from
 the same fragments so the two dialects cannot drift. Use those; never spell an
 account-type or sub-type exclusion by hand.
+An investment line embedded in a split is the case a transaction-level linkage
+check alone gets wrong (its `transaction_id` is null; the split carries the cash),
+so it is excluded by both of its representations -- the split's `kind` and an
+`investment_transactions` row pointing at the split -- and **at split-row
+granularity**: excluding the parent would take the ordinary sibling line with it.
 `backend/src/common/investment-filter.guard.spec.ts` fails on either shape and
 on a built-in-report ledger query that carries no exclusion, and
 `backend/test/integration/report-investment-cash.integration.spec.ts` holds the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,10 +359,13 @@ on a built-in-report ledger query that carries no exclusion, and
 behaviour against a real database. That guard's transfer-only exemption is
 positive proof, never the presence of the token -- the monthly breakdown reads
 ordinary rows *and* categorized transfer outflows, so a substring match exempted
-a split-joining query from the whole scan. **`backend/src/reports/`, the
-user-defined custom report engine, is the one ledger reader still outside all of
-this**, which is why INV-REPORT-001 is `partial`; a known-gap block in that guard
-spec fails when it is migrated, so the catalog cannot go stale. The same rule governs what "Uncategorized"
+a split-joining query from the whole scan. The custom report engine
+(`backend/src/reports/`) aggregates hydrated entities in TypeScript, so it uses
+the same rule's other dialect -- `ordinarySplitLines` and
+`reportableTransactionAmount`, which live beside the SQL -- and its own scans
+check the loop rather than a query string. The two dialects differ by exactly one
+clause on purpose: the SQL drops transfer children, while a custom report keeps
+its own `includeTransfers` decision. The same rule governs what "Uncategorized"
 means: an auto-generated trade leg is not a row the user forgot to file, and a
 bulk update filtered to uncategorized must not reach it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,18 @@ check alone gets wrong (its `transaction_id` is null; the split carries the cash
 so it is excluded by both of its representations -- the split's `kind` and an
 `investment_transactions` row pointing at the split -- and **at split-row
 granularity**: excluding the parent would take the ordinary sibling line with it.
+
+**A report that reads only the parent row cannot exclude a line, so it excludes
+an amount.** `t.amount` on a split parent is the sum of every child, so Spending
+by Payee, Recurring Expenses, Bill Payment History and the Uncategorized list all
+reported a `-560` parent made of `-60` groceries and a `-500` embedded BUY as
+`560` of spending. They derive their figure through
+`reportableTransactionAmountSql` -- the children that are neither transfer nor
+investment, `NULL` when the row represents no ordinary cash at all. Duplicate
+Transactions is the one exception and says so in its SQL (`PARENT-IDENTITY
+REPORT`): its subject is the stored row, not its cash meaning. The guard checks
+the *representation*, not the presence of a token, because a parent-only query
+that reached for the no-splits variant is exactly the defect.
 `backend/src/common/investment-filter.guard.spec.ts` fails on either shape and
 on a built-in-report ledger query that carries no exclusion, and
 `backend/test/integration/report-investment-cash.integration.spec.ts` holds the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,7 +356,13 @@ that reached for the no-splits variant is exactly the defect.
 `backend/src/common/investment-filter.guard.spec.ts` fails on either shape and
 on a built-in-report ledger query that carries no exclusion, and
 `backend/test/integration/report-investment-cash.integration.spec.ts` holds the
-behaviour against a real database. The same rule governs what "Uncategorized"
+behaviour against a real database. That guard's transfer-only exemption is
+positive proof, never the presence of the token -- the monthly breakdown reads
+ordinary rows *and* categorized transfer outflows, so a substring match exempted
+a split-joining query from the whole scan. **`backend/src/reports/`, the
+user-defined custom report engine, is the one ledger reader still outside all of
+this**, which is why INV-REPORT-001 is `partial`; a known-gap block in that guard
+spec fails when it is migrated, so the catalog cannot go stale. The same rule governs what "Uncategorized"
 means: an auto-generated trade leg is not a row the user forgot to file, and a
 bulk update filtered to uncategorized must not reach it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,6 +317,29 @@ A refund, return, chargeback or cashback filed against an expense category is a 
 
 Dropping the sign filter means income now reaches the aggregate and has to leave by a different door: a bucket whose net is not spending is not a row in a spending report -- one predicate, not a per-call-site `> 0`. Netting is **within** one category, never across two; both halves come from the same filtered aggregate. (The payee surfaces are deliberately unchanged: `PayeeInfoWidget` prints received credits as their own line beside the spend, so netting them into the headline would count them twice.)
 
+### An INVESTMENT account is a pair, so account type is never the report's filter
+
+`INVESTMENT` is the `account_type` of *both* halves of a linked pair -- the
+`INVESTMENT_CASH` sleeve holding ordinary money and the `INVESTMENT_BROKERAGE`
+sleeve holding securities -- so `AND a.account_type != 'INVESTMENT'` deleted a
+real ledger from fifteen report queries: salary paid into a brokerage's cash
+side vanished from Cash Flow, Income by Source, spending, tax and the
+Uncategorized list (issue #1257). It never described the rows it was meant to
+remove either: the cash leg a BUY/SELL/DIVIDEND posts lives in that same cash
+account, carries no category and no transfer flag.
+
+What a row *is* decides it, and the predicate is written once in
+`backend/src/common/investment-filter.util.ts` -- `investmentExclusionSql` for
+raw SQL, `applyInvestmentTransactionFilters` for a QueryBuilder, both built from
+the same fragments so the two dialects cannot drift. Use those; never spell an
+account-type or sub-type exclusion by hand.
+`backend/src/common/investment-filter.guard.spec.ts` fails on either shape and
+on a built-in-report ledger query that carries no exclusion, and
+`backend/test/integration/report-investment-cash.integration.spec.ts` holds the
+behaviour against a real database. The same rule governs what "Uncategorized"
+means: an auto-generated trade leg is not a row the user forgot to file, and a
+bulk update filtered to uncategorized must not reach it.
+
 ## Environment
 
 Key env vars (see `.env.example` for full list):

--- a/backend/src/ai/forecast/forecast-aggregator.service.ts
+++ b/backend/src/ai/forecast/forecast-aggregator.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, Inject, Logger, forwardRef } from "@nestjs/common";
 import { DataSource } from "typeorm";
 import { withScopedDb } from "../../common/db/scoped-db";
-import { investmentLinkedTransactionExclusion } from "../../common/investment-filter.util";
+import {
+  investmentLinkedTransactionExclusion,
+  reportableTransactionAmountSql,
+} from "../../common/investment-filter.util";
 import { Transaction } from "../../transactions/entities/transaction.entity";
 import { ScheduledTransaction } from "../../scheduled-transactions/entities/scheduled-transaction.entity";
 import { AccountsService } from "../../accounts/accounts.service";
@@ -61,6 +64,14 @@ export interface ForecastAggregates {
 }
 
 export { RecurringCharge };
+
+/**
+ * The forecast trains on one row per payment and joins no splits, so a split
+ * parent's own amount -- the sum of every line, an embedded investment line
+ * included -- is not what the household spent. A -60 grocery split beside a -500
+ * embedded BUY taught the baseline 560 of monthly spending (re-audit).
+ */
+const REPORTABLE_TX_AMOUNT = reportableTransactionAmountSql("t");
 
 @Injectable()
 export class ForecastAggregatorService {
@@ -127,11 +138,11 @@ export class ForecastAggregatorService {
         .addSelect("COALESCE(cat.name, 'Uncategorized')", "categoryName")
         .addSelect("COALESCE(cat.isIncome, false)", "isIncome")
         .addSelect(
-          "SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END)",
+          `SUM(CASE WHEN ${REPORTABLE_TX_AMOUNT} > 0 THEN ${REPORTABLE_TX_AMOUNT} ELSE 0 END)`,
           "income",
         )
         .addSelect(
-          "SUM(CASE WHEN t.amount < 0 THEN ABS(t.amount) ELSE 0 END)",
+          `SUM(CASE WHEN ${REPORTABLE_TX_AMOUNT} < 0 THEN ABS(${REPORTABLE_TX_AMOUNT}) ELSE 0 END)`,
           "expenses",
         )
         .where("t.userId = :userId", { userId })
@@ -253,12 +264,12 @@ export class ForecastAggregatorService {
         .getRepository(Transaction)
         .createQueryBuilder("t")
         .select("TO_CHAR(t.transactionDate, 'YYYY-MM')", "month")
-        .addSelect("SUM(t.amount)", "total")
+        .addSelect(`SUM(${REPORTABLE_TX_AMOUNT})`, "total")
         .addSelect("COUNT(DISTINCT t.payeeName)", "sourceCount")
         .where("t.userId = :userId", { userId })
         .andWhere("t.transactionDate >= :startDate", { startDate })
         .andWhere("t.transactionDate <= :endDate", { endDate })
-        .andWhere("t.amount > 0")
+        .andWhere(`${REPORTABLE_TX_AMOUNT} > 0`)
         .andWhere("t.status != 'VOID'")
         .andWhere("t.isTransfer = false")
         .andWhere("t.parentTransactionId IS NULL")

--- a/backend/src/ai/forecast/forecast-aggregator.service.ts
+++ b/backend/src/ai/forecast/forecast-aggregator.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject, Logger, forwardRef } from "@nestjs/common";
 import { DataSource } from "typeorm";
 import { withScopedDb } from "../../common/db/scoped-db";
+import { investmentLinkedTransactionExclusion } from "../../common/investment-filter.util";
 import { Transaction } from "../../transactions/entities/transaction.entity";
 import { ScheduledTransaction } from "../../scheduled-transactions/entities/scheduled-transaction.entity";
 import { AccountsService } from "../../accounts/accounts.service";
@@ -142,9 +143,7 @@ export class ForecastAggregatorService {
         // Exclude investment-linked cash transactions so BUY/SELL/DIVIDEND
         // side-effects don't skew the historical income/expense baseline
         // used to train the forecast.
-        .andWhere(
-          "NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = t.id)",
-        )
+        .andWhere(investmentLinkedTransactionExclusion("t"))
         .groupBy("TO_CHAR(t.transactionDate, 'YYYY-MM')")
         .addGroupBy("cat.name")
         .addGroupBy("cat.isIncome")
@@ -265,9 +264,7 @@ export class ForecastAggregatorService {
         .andWhere("t.parentTransactionId IS NULL")
         // Exclude investment-linked cash credits (SELL / DIVIDEND) so
         // they don't inflate the income baseline.
-        .andWhere(
-          "NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = t.id)",
-        )
+        .andWhere(investmentLinkedTransactionExclusion("t"))
         .groupBy("TO_CHAR(t.transactionDate, 'YYYY-MM')")
         .orderBy("month", "ASC")
         .getRawMany(),

--- a/backend/src/built-in-reports/anomaly-reports.service.ts
+++ b/backend/src/built-in-reports/anomaly-reports.service.ts
@@ -10,6 +10,20 @@ import {
 } from "./dto";
 import { formatDateYMD } from "../common/date-utils";
 import { roundMoney, sumMoney, toMoneyNumber } from "../common/round.util";
+import { investmentExclusionSql } from "../common/investment-filter.util";
+
+/**
+ * Investment scope is LINKAGE, never account type (INV-REPORT-001, issue #1257):
+ * the cash sleeve of an INVESTMENT account holds ordinary money, while the cash
+ * leg a trade generated is not spending or income. Both halves of the predicate,
+ * and why the account type cannot express either, live in
+ * `common/investment-filter.util.ts`.
+ */
+const INVESTMENT_EXCLUSION = investmentExclusionSql({
+  accountAlias: "a",
+  transactionAlias: "t",
+  splitAlias: "ts",
+});
 
 @Injectable()
 export class AnomalyReportsService {
@@ -51,7 +65,7 @@ export class AnomalyReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION}
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
       ORDER BY t.transaction_date
     `;

--- a/backend/src/built-in-reports/comparison-reports.service.ts
+++ b/backend/src/built-in-reports/comparison-reports.service.ts
@@ -11,6 +11,20 @@ import {
   DaySpending,
   CategoryWeekendWeekday,
 } from "./dto";
+import { investmentExclusionSql } from "../common/investment-filter.util";
+
+/**
+ * Investment scope is LINKAGE, never account type (INV-REPORT-001, issue #1257):
+ * the cash sleeve of an INVESTMENT account holds ordinary money, while the cash
+ * leg a trade generated is not spending or income. Both halves of the predicate,
+ * and why the account type cannot express either, live in
+ * `common/investment-filter.util.ts`.
+ */
+const INVESTMENT_EXCLUSION = investmentExclusionSql({
+  accountAlias: "a",
+  transactionAlias: "t",
+  splitAlias: "ts",
+});
 
 @Injectable()
 export class ComparisonReportsService {
@@ -46,7 +60,7 @@ export class ComparisonReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION}
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
       GROUP BY EXTRACT(YEAR FROM t.transaction_date), EXTRACT(MONTH FROM t.transaction_date), t.currency_code
       ORDER BY year, month
@@ -141,7 +155,7 @@ export class ComparisonReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION}
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
     `;
 

--- a/backend/src/built-in-reports/data-quality-reports.service.ts
+++ b/backend/src/built-in-reports/data-quality-reports.service.ts
@@ -10,7 +10,10 @@ import {
   DuplicateGroup,
   DuplicateTransactionItem,
 } from "./dto";
-import { investmentExclusionSql } from "../common/investment-filter.util";
+import {
+  investmentExclusionSql,
+  reportableTransactionAmountSql,
+} from "../common/investment-filter.util";
 
 /**
  * Investment scope is LINKAGE, never account type (INV-REPORT-001, issue #1257):
@@ -23,6 +26,15 @@ const INVESTMENT_EXCLUSION_NO_SPLITS = investmentExclusionSql({
   accountAlias: "a",
   transactionAlias: "t",
 });
+
+/**
+ * "Uncategorized" means ordinary cash the user has not filed, so the figure is
+ * the ordinary part of the row and a parent whose only lines are an embedded
+ * investment or a transfer represents none: NULL, and the `IS NOT NULL`
+ * predicate drops it (branch audit F-RPT-001). Without this a `-500` embedded
+ * BUY passthrough was listed as money the user forgot to categorize.
+ */
+const REPORTABLE_TX_AMOUNT = reportableTransactionAmountSql("t");
 
 @Injectable()
 export class DataQualityReportsService {
@@ -46,7 +58,7 @@ export class DataQualityReportsService {
         t.id,
         t.transaction_date,
         t.currency_code,
-        t.amount,
+        ${REPORTABLE_TX_AMOUNT} as amount,
         COALESCE(p.name, t.payee_name) as payee_name,
         t.description,
         a.name as account_name,
@@ -60,6 +72,7 @@ export class DataQualityReportsService {
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
         AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
+        AND ${REPORTABLE_TX_AMOUNT} IS NOT NULL
         AND t.category_id IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM transaction_splits ts
@@ -117,10 +130,10 @@ export class DataQualityReportsService {
       SELECT
         t.currency_code,
         COUNT(*) as total_count,
-        COUNT(*) FILTER (WHERE t.amount < 0) as expense_count,
-        COALESCE(SUM(ABS(t.amount)) FILTER (WHERE t.amount < 0), 0) as expense_total,
-        COUNT(*) FILTER (WHERE t.amount > 0) as income_count,
-        COALESCE(SUM(t.amount) FILTER (WHERE t.amount > 0), 0) as income_total
+        COUNT(*) FILTER (WHERE ${REPORTABLE_TX_AMOUNT} < 0) as expense_count,
+        COALESCE(SUM(ABS(${REPORTABLE_TX_AMOUNT})) FILTER (WHERE ${REPORTABLE_TX_AMOUNT} < 0), 0) as expense_total,
+        COUNT(*) FILTER (WHERE ${REPORTABLE_TX_AMOUNT} > 0) as income_count,
+        COALESCE(SUM(${REPORTABLE_TX_AMOUNT}) FILTER (WHERE ${REPORTABLE_TX_AMOUNT} > 0), 0) as income_total
       FROM transactions t
       LEFT JOIN accounts a ON a.id = t.account_id
       WHERE t.user_id = $1
@@ -129,6 +142,7 @@ export class DataQualityReportsService {
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
         AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
+        AND ${REPORTABLE_TX_AMOUNT} IS NOT NULL
         AND t.category_id IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM transaction_splits ts
@@ -235,6 +249,13 @@ export class DataQualityReportsService {
         -- the user at a row they cannot act on here. Same exclusion as the rest
         -- of this service.
         AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
+        -- PARENT-IDENTITY REPORT: this detector's subject is the stored row, not
+        -- its cash meaning, so it deliberately compares t.amount rather than the
+        -- reportable ordinary amount every other query here derives (branch
+        -- audit DR-001). A split parent the user entered twice IS a duplicate,
+        -- and the remedy is deleting one whole transaction -- a per-child figure
+        -- would name a row nobody can delete. Which is also why it needs no
+        -- split-provenance clause: a row it admits is one the user owns.
       ORDER BY t.transaction_date ASC, t.amount ASC
     `;
 

--- a/backend/src/built-in-reports/data-quality-reports.service.ts
+++ b/backend/src/built-in-reports/data-quality-reports.service.ts
@@ -10,6 +10,19 @@ import {
   DuplicateGroup,
   DuplicateTransactionItem,
 } from "./dto";
+import { investmentExclusionSql } from "../common/investment-filter.util";
+
+/**
+ * Investment scope is LINKAGE, never account type (INV-REPORT-001, issue #1257):
+ * the cash sleeve of an INVESTMENT account holds ordinary money, while the cash
+ * leg a trade generated is not spending or income. Both halves of the predicate,
+ * and why the account type cannot express either, live in
+ * `common/investment-filter.util.ts`.
+ */
+const INVESTMENT_EXCLUSION_NO_SPLITS = investmentExclusionSql({
+  accountAlias: "a",
+  transactionAlias: "t",
+});
 
 @Injectable()
 export class DataQualityReportsService {
@@ -46,7 +59,7 @@ export class DataQualityReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
         AND t.category_id IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM transaction_splits ts
@@ -115,7 +128,7 @@ export class DataQualityReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
         AND t.category_id IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM transaction_splits ts
@@ -216,6 +229,12 @@ export class DataQualityReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
+        -- The cash leg of a trade is owned by its investment transaction and
+        -- cannot be edited or deleted from the cash register, so offering two
+        -- identical legs (two partial fills at one price) as duplicates points
+        -- the user at a row they cannot act on here. Same exclusion as the rest
+        -- of this service.
+        AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
       ORDER BY t.transaction_date ASC, t.amount ASC
     `;
 

--- a/backend/src/built-in-reports/data-quality-reports.service.ts
+++ b/backend/src/built-in-reports/data-quality-reports.service.ts
@@ -126,14 +126,13 @@ export class DataQualityReportsService {
       accountId: row.account_id,
     }));
 
-    let summaryQuery = `
+    // The reportable amount is derived ONCE, in a CTE: six of these in one
+    // aggregate is six correlated sub-queries per split parent, and the six
+    // answers have to be the same number anyway.
+    let summarySource = `
       SELECT
         t.currency_code,
-        COUNT(*) as total_count,
-        COUNT(*) FILTER (WHERE ${REPORTABLE_TX_AMOUNT} < 0) as expense_count,
-        COALESCE(SUM(ABS(${REPORTABLE_TX_AMOUNT})) FILTER (WHERE ${REPORTABLE_TX_AMOUNT} < 0), 0) as expense_total,
-        COUNT(*) FILTER (WHERE ${REPORTABLE_TX_AMOUNT} > 0) as income_count,
-        COALESCE(SUM(${REPORTABLE_TX_AMOUNT}) FILTER (WHERE ${REPORTABLE_TX_AMOUNT} > 0), 0) as income_total
+        ${REPORTABLE_TX_AMOUNT} as amount
       FROM transactions t
       LEFT JOIN accounts a ON a.id = t.account_id
       WHERE t.user_id = $1
@@ -142,7 +141,6 @@ export class DataQualityReportsService {
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
         AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
-        AND ${REPORTABLE_TX_AMOUNT} IS NOT NULL
         AND t.category_id IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM transaction_splits ts
@@ -153,11 +151,26 @@ export class DataQualityReportsService {
 
     const summaryParams: string[] = [userId, endDate];
     if (startDate) {
-      summaryQuery += ` AND t.transaction_date >= $3`;
+      summarySource += ` AND t.transaction_date >= $3`;
       summaryParams.push(startDate);
     }
 
-    summaryQuery += ` GROUP BY t.currency_code`;
+    // `amount IS NOT NULL` is the same predicate the list applies: a row whose
+    // only lines are an embedded investment or a transfer represents no ordinary
+    // cash, so it is not something the user forgot to categorize.
+    const summaryQuery = `
+      WITH reportable AS (${summarySource})
+      SELECT
+        currency_code,
+        COUNT(*) as total_count,
+        COUNT(*) FILTER (WHERE amount < 0) as expense_count,
+        COALESCE(SUM(ABS(amount)) FILTER (WHERE amount < 0), 0) as expense_total,
+        COUNT(*) FILTER (WHERE amount > 0) as income_count,
+        COALESCE(SUM(amount) FILTER (WHERE amount > 0), 0) as income_total
+      FROM reportable
+      WHERE amount IS NOT NULL
+      GROUP BY currency_code
+    `;
 
     interface RawSummary {
       currency_code: string;

--- a/backend/src/built-in-reports/income-reports.service.ts
+++ b/backend/src/built-in-reports/income-reports.service.ts
@@ -14,6 +14,20 @@ import {
   IncomeVsExpensesResponse,
   MonthlyIncomeExpenseItem,
 } from "./dto";
+import { investmentExclusionSql } from "../common/investment-filter.util";
+
+/**
+ * Investment scope is LINKAGE, never account type (INV-REPORT-001, issue #1257):
+ * the cash sleeve of an INVESTMENT account holds ordinary money, while the cash
+ * leg a trade generated is not spending or income. Both halves of the predicate,
+ * and why the account type cannot express either, live in
+ * `common/investment-filter.util.ts`.
+ */
+const INVESTMENT_EXCLUSION = investmentExclusionSql({
+  accountAlias: "a",
+  transactionAlias: "t",
+  splitAlias: "ts",
+});
 
 @Injectable()
 export class IncomeReportsService {
@@ -47,7 +61,7 @@ export class IncomeReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION}
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
         AND NOT EXISTS (
           SELECT 1 FROM accounts ax
@@ -166,7 +180,7 @@ export class IncomeReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION}
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
         AND NOT EXISTS (
           SELECT 1 FROM accounts ax

--- a/backend/src/built-in-reports/monthly-category-breakdown.service.spec.ts
+++ b/backend/src/built-in-reports/monthly-category-breakdown.service.spec.ts
@@ -380,7 +380,14 @@ describe("MonthlyCategoryBreakdownService", () => {
 
     const sql = scopedManager.query.mock.calls[0][0];
     expect(sql).toContain("t.is_transfer = false");
-    expect(sql).toContain("a.account_type != 'INVESTMENT'");
+    // Investment scope is linkage, not account type (issue #1257): the cash
+    // sleeve of an INVESTMENT account holds ordinary money.
+    expect(sql).not.toContain("a.account_type != 'INVESTMENT'");
+    expect(sql).toContain(
+      "(a.account_sub_type IS NULL OR a.account_sub_type != 'INVESTMENT_BROKERAGE')",
+    );
+    expect(sql).toContain("it.transaction_id = t.id");
+    expect(sql).toContain("its.transaction_split_id = ts.id");
     expect(sql).toContain("asset_category_id");
     expect(sql).toContain("parent_transaction_id IS NULL");
   });

--- a/backend/src/built-in-reports/monthly-category-breakdown.service.ts
+++ b/backend/src/built-in-reports/monthly-category-breakdown.service.ts
@@ -82,8 +82,10 @@ export class MonthlyCategoryBreakdownService {
 
     // Aggregate deposits (amount > 0) and withdrawals (amount < 0) per
     // category, month and currency. Transfers, voided rows, child rows of a
-    // split, investment accounts and the synthetic asset-value-change category
-    // are excluded -- mirroring the other category reports.
+    // split, investment MOVEMENTS (the securities sleeve, a trade's generated
+    // cash leg, an embedded investment split line -- never an account's type)
+    // and the synthetic asset-value-change category are excluded -- mirroring
+    // the other category reports.
     let query = `
       SELECT
         TO_CHAR(t.transaction_date, 'YYYY-MM') as month,

--- a/backend/src/built-in-reports/monthly-category-breakdown.service.ts
+++ b/backend/src/built-in-reports/monthly-category-breakdown.service.ts
@@ -9,6 +9,20 @@ import {
   MonthlyBreakdownCategoryRow,
   MonthlyBreakdownTransferRow,
 } from "./dto";
+import { investmentExclusionSql } from "../common/investment-filter.util";
+
+/**
+ * Investment scope is LINKAGE, never account type (INV-REPORT-001, issue #1257):
+ * the cash sleeve of an INVESTMENT account holds ordinary money, while the cash
+ * leg a trade generated is not spending or income. Both halves of the predicate,
+ * and why the account type cannot express either, live in
+ * `common/investment-filter.util.ts`.
+ */
+const INVESTMENT_EXCLUSION = investmentExclusionSql({
+  accountAlias: "a",
+  transactionAlias: "t",
+  splitAlias: "ts",
+});
 
 /**
  * Raw per-(category, month, currency) aggregate. Deposits and withdrawals are
@@ -106,7 +120,7 @@ export class MonthlyCategoryBreakdownService {
         )
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION}
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
         AND NOT EXISTS (
           SELECT 1 FROM accounts ax

--- a/backend/src/built-in-reports/spending-reports.service.ts
+++ b/backend/src/built-in-reports/spending-reports.service.ts
@@ -19,7 +19,10 @@ import {
   MonthlySpendingItem,
   MonthlyCategorySpending,
 } from "./dto";
-import { investmentExclusionSql } from "../common/investment-filter.util";
+import {
+  investmentExclusionSql,
+  reportableTransactionAmountSql,
+} from "../common/investment-filter.util";
 
 /**
  * Investment scope is LINKAGE, never account type (INV-REPORT-001, issue #1257):
@@ -37,6 +40,13 @@ const INVESTMENT_EXCLUSION_NO_SPLITS = investmentExclusionSql({
   accountAlias: "a",
   transactionAlias: "t",
 });
+
+/**
+ * The ordinary cash the parent row represents. A payee total reads only the
+ * parent, so a split's embedded investment or transfer line has to come out of
+ * the amount rather than out of the row (branch audit F-RPT-001).
+ */
+const REPORTABLE_TX_AMOUNT = reportableTransactionAmountSql("t");
 
 /**
  * Spending in a category is the DEBITS NET OF THE CREDITS filed against it: a
@@ -229,12 +239,12 @@ export class SpendingReportsService {
         t.payee_id,
         t.payee_name,
         t.currency_code,
-        SUM(ABS(t.amount)) as total
+        SUM(ABS(${REPORTABLE_TX_AMOUNT})) as total
       FROM transactions t
       LEFT JOIN accounts a ON a.id = t.account_id
       WHERE t.user_id = $1
         AND t.transaction_date <= $2
-        AND t.amount < 0
+        AND ${REPORTABLE_TX_AMOUNT} < 0
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL

--- a/backend/src/built-in-reports/spending-reports.service.ts
+++ b/backend/src/built-in-reports/spending-reports.service.ts
@@ -19,6 +19,24 @@ import {
   MonthlySpendingItem,
   MonthlyCategorySpending,
 } from "./dto";
+import { investmentExclusionSql } from "../common/investment-filter.util";
+
+/**
+ * Investment scope is LINKAGE, never account type (INV-REPORT-001, issue #1257):
+ * the cash sleeve of an INVESTMENT account holds ordinary money, while the cash
+ * leg a trade generated is not spending or income. Both halves of the predicate,
+ * and why the account type cannot express either, live in
+ * `common/investment-filter.util.ts`.
+ */
+const INVESTMENT_EXCLUSION = investmentExclusionSql({
+  accountAlias: "a",
+  transactionAlias: "t",
+  splitAlias: "ts",
+});
+const INVESTMENT_EXCLUSION_NO_SPLITS = investmentExclusionSql({
+  accountAlias: "a",
+  transactionAlias: "t",
+});
 
 /**
  * Spending in a category is the DEBITS NET OF THE CREDITS filed against it: a
@@ -76,7 +94,7 @@ export class SpendingReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION}
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
         AND NOT EXISTS (
           SELECT 1 FROM accounts ax
@@ -220,7 +238,7 @@ export class SpendingReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
         AND NOT EXISTS (
           SELECT 1 FROM accounts ax
           WHERE ax.user_id = t.user_id
@@ -321,7 +339,7 @@ export class SpendingReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION}
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
         AND NOT EXISTS (
           SELECT 1 FROM accounts ax

--- a/backend/src/built-in-reports/tax-recurring-reports.service.ts
+++ b/backend/src/built-in-reports/tax-recurring-reports.service.ts
@@ -240,7 +240,7 @@ export class TaxRecurringReportsService {
         AND (COALESCE(p.name, t.payee_name) IS NOT NULL AND TRIM(COALESCE(p.name, t.payee_name)) != '')
       GROUP BY t.payee_id, LOWER(TRIM(COALESCE(p.name, t.payee_name))), COALESCE(p.name, t.payee_name), c.name, t.currency_code
       HAVING COUNT(*) >= $4
-      ORDER BY SUM(ABS(${REPORTABLE_TX_AMOUNT})) DESC
+      ORDER BY total_amount DESC
     `;
 
     interface RawRecurring {

--- a/backend/src/built-in-reports/tax-recurring-reports.service.ts
+++ b/backend/src/built-in-reports/tax-recurring-reports.service.ts
@@ -13,7 +13,10 @@ import {
 } from "./dto";
 import { formatDateYMD } from "../common/date-utils";
 import { roundMoney, sumMoney, toMoneyNumber } from "../common/round.util";
-import { investmentExclusionSql } from "../common/investment-filter.util";
+import {
+  investmentExclusionSql,
+  reportableTransactionAmountSql,
+} from "../common/investment-filter.util";
 
 /**
  * Investment scope is LINKAGE, never account type (INV-REPORT-001, issue #1257):
@@ -31,6 +34,15 @@ const INVESTMENT_EXCLUSION_NO_SPLITS = investmentExclusionSql({
   accountAlias: "a",
   transactionAlias: "t",
 });
+
+/**
+ * Recurrence and bill matching read one row per payment and never join splits,
+ * so the embedded investment or transfer part of a split parent comes out of the
+ * amount rather than out of the row -- and the amount is derived once, not per
+ * joined split line, so one payment stays one occurrence (branch audit
+ * F-RPT-001).
+ */
+const REPORTABLE_TX_AMOUNT = reportableTransactionAmountSql("t");
 
 @Injectable()
 export class TaxRecurringReportsService {
@@ -211,7 +223,7 @@ export class TaxRecurringReportsService {
         c.name as category_name,
         t.currency_code,
         COUNT(*)::int as occurrences,
-        SUM(ABS(t.amount)) as total_amount,
+        SUM(ABS(${REPORTABLE_TX_AMOUNT})) as total_amount,
         MAX(t.transaction_date) as last_transaction_date
       FROM transactions t
       LEFT JOIN payees p ON p.id = t.payee_id
@@ -220,7 +232,7 @@ export class TaxRecurringReportsService {
       WHERE t.user_id = $1
         AND t.transaction_date >= $2
         AND t.transaction_date <= $3
-        AND t.amount < 0
+        AND ${REPORTABLE_TX_AMOUNT} < 0
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
@@ -228,7 +240,7 @@ export class TaxRecurringReportsService {
         AND (COALESCE(p.name, t.payee_name) IS NOT NULL AND TRIM(COALESCE(p.name, t.payee_name)) != '')
       GROUP BY t.payee_id, LOWER(TRIM(COALESCE(p.name, t.payee_name))), COALESCE(p.name, t.payee_name), c.name, t.currency_code
       HAVING COUNT(*) >= $4
-      ORDER BY SUM(ABS(t.amount)) DESC
+      ORDER BY SUM(ABS(${REPORTABLE_TX_AMOUNT})) DESC
     `;
 
     interface RawRecurring {
@@ -389,7 +401,7 @@ export class TaxRecurringReportsService {
         t.id,
         t.transaction_date,
         t.currency_code,
-        ABS(t.amount) as amount,
+        ABS(${REPORTABLE_TX_AMOUNT}) as amount,
         LOWER(TRIM(COALESCE(p.name, t.payee_name))) as payee_name_normalized
       FROM transactions t
       LEFT JOIN payees p ON p.id = t.payee_id
@@ -400,6 +412,7 @@ export class TaxRecurringReportsService {
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
         AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
+        AND ${REPORTABLE_TX_AMOUNT} IS NOT NULL
     `;
 
     const params: (string | undefined)[] = [userId, endDate];

--- a/backend/src/built-in-reports/tax-recurring-reports.service.ts
+++ b/backend/src/built-in-reports/tax-recurring-reports.service.ts
@@ -13,6 +13,24 @@ import {
 } from "./dto";
 import { formatDateYMD } from "../common/date-utils";
 import { roundMoney, sumMoney, toMoneyNumber } from "../common/round.util";
+import { investmentExclusionSql } from "../common/investment-filter.util";
+
+/**
+ * Investment scope is LINKAGE, never account type (INV-REPORT-001, issue #1257):
+ * the cash sleeve of an INVESTMENT account holds ordinary money, while the cash
+ * leg a trade generated is not spending or income. Both halves of the predicate,
+ * and why the account type cannot express either, live in
+ * `common/investment-filter.util.ts`.
+ */
+const INVESTMENT_EXCLUSION = investmentExclusionSql({
+  accountAlias: "a",
+  transactionAlias: "t",
+  splitAlias: "ts",
+});
+const INVESTMENT_EXCLUSION_NO_SPLITS = investmentExclusionSql({
+  accountAlias: "a",
+  transactionAlias: "t",
+});
 
 @Injectable()
 export class TaxRecurringReportsService {
@@ -46,7 +64,7 @@ export class TaxRecurringReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION}
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
     `;
 
@@ -206,7 +224,7 @@ export class TaxRecurringReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
         AND (COALESCE(p.name, t.payee_name) IS NOT NULL AND TRIM(COALESCE(p.name, t.payee_name)) != '')
       GROUP BY t.payee_id, LOWER(TRIM(COALESCE(p.name, t.payee_name))), COALESCE(p.name, t.payee_name), c.name, t.currency_code
       HAVING COUNT(*) >= $4
@@ -381,7 +399,7 @@ export class TaxRecurringReportsService {
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND ${INVESTMENT_EXCLUSION_NO_SPLITS}
     `;
 
     const params: (string | undefined)[] = [userId, endDate];

--- a/backend/src/common/investment-filter.guard.spec.ts
+++ b/backend/src/common/investment-filter.guard.spec.ts
@@ -105,12 +105,73 @@ describe("investment scope is decided in one place", () => {
 });
 
 /**
- * The other half of the rule: every report query that reads the transaction
- * ledger has to apply the exclusion. A query restricted to `is_transfer = true`
- * is exempt by construction -- an investment cash leg is never a transfer -- and
- * that exemption is derived from the query itself rather than kept as a list of
- * file names a new query could quietly join.
+ * The other half of the rule, and the half a substring match cannot carry:
+ * every report query that reads the transaction ledger must apply the exclusion
+ * in the representation its own shape needs.
+ *
+ * A query that JOINS `transaction_splits` classifies each line, so the
+ * split-aware conjunction is enough. A query that reads only the parent cannot:
+ * `t.amount` on a split parent is the sum of ALL its children, and an embedded
+ * investment line's `transaction_id` is null, so the transaction-level linkage
+ * cannot see it -- that query has to derive its amount through
+ * `reportableTransactionAmountSql` (branch audit F-RPT-001). Accepting the
+ * substring `INVESTMENT_EXCLUSION` would pass a parent-only query that chose the
+ * `_NO_SPLITS` variant, which is exactly the defect.
+ *
+ * Two exemptions, both derived from the query rather than kept as a list of file
+ * names a new query could quietly join: one restricted to `is_transfer = true`
+ * (an investment cash leg is never a transfer), and one that declares itself a
+ * PARENT-IDENTITY REPORT, whose subject is the stored row rather than its cash
+ * meaning.
  */
+type QueryShape =
+  | "transfer-only"
+  | "parent-identity"
+  | "split-aware"
+  | "parent-only";
+
+export function classifyLedgerQuery(query: string): {
+  shape: QueryShape;
+  missing: string[];
+} {
+  if (/is_transfer\s*=\s*true/.test(query)) {
+    return { shape: "transfer-only", missing: [] };
+  }
+
+  const missing: string[] = [];
+  if (/PARENT-IDENTITY REPORT/.test(query)) {
+    if (!query.includes("INVESTMENT_EXCLUSION")) {
+      missing.push("an investment exclusion");
+    }
+    return { shape: "parent-identity", missing };
+  }
+
+  if (/JOIN transaction_splits/.test(query)) {
+    // The split-aware constant, not the _NO_SPLITS one: `${INVESTMENT_EXCLUSION}`
+    // ends at the closing brace.
+    if (!/\$\{INVESTMENT_EXCLUSION\}/.test(query)) {
+      missing.push("the split-aware INVESTMENT_EXCLUSION");
+    }
+    return { shape: "split-aware", missing };
+  }
+
+  if (!query.includes("INVESTMENT_EXCLUSION")) {
+    missing.push("an investment exclusion");
+  }
+  if (!query.includes("REPORTABLE_TX_AMOUNT")) {
+    missing.push("a reportable-amount derivation (reads t.amount on a parent)");
+  }
+  return { shape: "parent-only", missing };
+}
+
+/** Every `FROM transactions` query in a file, cut at its template literal's end. */
+function ledgerQueries(source: string): string[] {
+  return source
+    .split("FROM transactions")
+    .slice(1)
+    .map((segment) => segment.split("`")[0]);
+}
+
 describe("every built-in report query applies the investment exclusion", () => {
   const reportServices = readdirSync(join(SRC_ROOT, "built-in-reports"))
     .filter((f) => f.endsWith(".service.ts"))
@@ -120,23 +181,102 @@ describe("every built-in report query applies the investment exclusion", () => {
     expect(reportServices.length).toBeGreaterThan(5);
   });
 
-  it("applies it to every ledger query that is not transfer-only", () => {
-    const missing: string[] = [];
+  it("applies it in the representation each query's shape needs", () => {
+    const failures: string[] = [];
 
     for (const file of reportServices) {
-      const source = readFileSync(file, "utf8");
-      const segments = source.split("FROM transactions");
-      for (const segment of segments.slice(1)) {
-        // The query's own template literal ends at the next backtick.
-        const query = segment.split("`")[0];
-        if (/is_transfer\s*=\s*true/.test(query)) continue;
-        if (query.includes("INVESTMENT_EXCLUSION")) continue;
-        missing.push(
-          `${relative(SRC_ROOT, file)}: ${query.trim().split("\n")[0]}`,
+      for (const query of ledgerQueries(readFileSync(file, "utf8"))) {
+        const { missing } = classifyLedgerQuery(query);
+        if (missing.length === 0) continue;
+        failures.push(
+          `${relative(SRC_ROOT, file)}: ${query.trim().split("\n")[0]} -- missing ${missing.join(", ")}`,
         );
       }
     }
 
-    expect(missing).toEqual([]);
+    expect(failures).toEqual([]);
+  });
+
+  it("scans both shapes, so neither branch is vacuous", () => {
+    const shapes = new Set<QueryShape>();
+    for (const file of reportServices) {
+      for (const query of ledgerQueries(readFileSync(file, "utf8"))) {
+        shapes.add(classifyLedgerQuery(query).shape);
+      }
+    }
+
+    expect(shapes.has("split-aware")).toBe(true);
+    expect(shapes.has("parent-only")).toBe(true);
+  });
+});
+
+/**
+ * The classifier's own negative controls. The real-source scan above can only
+ * say "nothing is wrong today"; these say the scan would notice.
+ */
+describe("classifyLedgerQuery", () => {
+  const PARENT_ONLY = `
+      SELECT SUM(ABS(t.amount)) FROM transactions t
+      LEFT JOIN accounts a ON a.id = t.account_id
+      WHERE t.user_id = $1
+        AND \${INVESTMENT_EXCLUSION_NO_SPLITS}
+  `;
+
+  it("flags a parent-only query that reads t.amount with transaction-only provenance", () => {
+    const { shape, missing } = classifyLedgerQuery(PARENT_ONLY);
+
+    expect(shape).toBe("parent-only");
+    expect(missing).toEqual([
+      "a reportable-amount derivation (reads t.amount on a parent)",
+    ]);
+  });
+
+  it("accepts the same query once it derives the reportable amount", () => {
+    const fixed = PARENT_ONLY.replace(
+      "SUM(ABS(t.amount))",
+      "SUM(ABS(${REPORTABLE_TX_AMOUNT}))",
+    );
+
+    expect(classifyLedgerQuery(fixed).missing).toEqual([]);
+  });
+
+  it("flags a split-joining query that downgrades to the no-splits variant", () => {
+    const query = `
+      FROM transactions t
+      LEFT JOIN transaction_splits ts ON ts.transaction_id = t.id
+      WHERE t.user_id = $1
+        AND \${INVESTMENT_EXCLUSION_NO_SPLITS}
+    `;
+
+    const { shape, missing } = classifyLedgerQuery(query);
+
+    expect(shape).toBe("split-aware");
+    expect(missing).toEqual(["the split-aware INVESTMENT_EXCLUSION"]);
+  });
+
+  it("exempts a transfer-only rollup", () => {
+    const query = `
+      FROM transactions t
+      WHERE t.user_id = $1 AND t.is_transfer = true
+    `;
+
+    expect(classifyLedgerQuery(query)).toEqual({
+      shape: "transfer-only",
+      missing: [],
+    });
+  });
+
+  it("exempts a declared parent-identity report, but still wants an exclusion", () => {
+    const declared = `${PARENT_ONLY}\n-- PARENT-IDENTITY REPORT: stored row, not its cash meaning`;
+
+    expect(classifyLedgerQuery(declared)).toEqual({
+      shape: "parent-identity",
+      missing: [],
+    });
+    expect(
+      classifyLedgerQuery(
+        "FROM transactions t -- PARENT-IDENTITY REPORT: no exclusion at all",
+      ).missing,
+    ).toEqual(["an investment exclusion"]);
   });
 });

--- a/backend/src/common/investment-filter.guard.spec.ts
+++ b/backend/src/common/investment-filter.guard.spec.ts
@@ -330,38 +330,50 @@ describe("classifyLedgerQuery", () => {
 });
 
 /**
- * The register of what INV-REPORT-001 does NOT yet cover, which is why the
- * invariant's status is `partial` rather than `enforced`.
- *
- * `backend/src/reports/` executes user-defined custom reports over the same
- * ledger through hydrated TypeORM entities, and applies no investment
- * provenance at all: a free-standing BUY's generated cash leg is reported as
- * `Uncategorized` spending, and an embedded investment split child is counted
- * beside its ordinary sibling (re-audit F-CUSTOM-001). The behaviour predates
- * the #1257 work and is unchanged by it.
- *
- * The pin is written so it fails when the gap CLOSES: whoever migrates that
- * engine gets a red test naming the document to update, so the catalog cannot
- * keep describing a gap that is gone.
+ * The custom report engine reaches the same ledger through hydrated TypeORM
+ * entities and aggregates in TypeScript, so the raw-SQL fragments cannot reach
+ * it. It gets the same rule in the other dialect
+ * (`isEmbeddedInvestmentSplit` / `ordinarySplitLines` /
+ * `reportableTransactionAmount`), and these are its scans -- a report engine that
+ * classifies in a loop needs the loop checked, not a query string.
  */
-describe("known gap: the custom report engine", () => {
+describe("the custom report engine classifies by provenance", () => {
   const CUSTOM_REPORTS = join(SRC_ROOT, "reports", "reports.service.ts");
-  const PROVENANCE_MARKERS = [
-    "investment_transactions",
-    "applyInvestmentTransactionFilters",
-    "investmentExclusionSql",
-    "reportableTransactionAmountSql",
-  ];
+  const source = readFileSync(CUSTOM_REPORTS, "utf8");
 
-  it("still applies no investment provenance -- keep INV-REPORT-001 at `partial` until it does", () => {
-    const source = readFileSync(CUSTOM_REPORTS, "utf8");
-    const applied = PROVENANCE_MARKERS.filter((marker) =>
-      source.includes(marker),
-    );
+  it("excludes the sleeve and generated cash in its selector", () => {
+    expect(source).toContain("applyInvestmentTransactionFilters");
+    // The linked investment row is what makes the second representation of an
+    // embedded split readable in TypeScript.
+    expect(source).toContain("splits.investmentTransaction");
+  });
 
-    // When this fails because `applied` is no longer empty: the gap is closed.
-    // Update INV-REPORT-001 in docs/system-invariants.md to `enforced`, name the
-    // custom-report tests that prove it, and delete this block.
-    expect(applied).toEqual([]);
+  it("iterates split lines only through ordinarySplitLines", () => {
+    // The shape that counted a securities purchase as Uncategorized spending.
+    const bareIteration = /for\s*\(\s*const\s+\w+\s+of\s+tx\.splits\s*\)/g;
+
+    expect(source.match(bareIteration)).toBeNull();
+  });
+
+  it("asks for the reportable amount in every aggregator that reads a parent amount", () => {
+    // Bodies are cut at the next method signature at the same indentation --
+    // enough to attribute a `tx.amount` read to the aggregator that makes it.
+    const bodies = source
+      .split(/\n {2}private aggregate/)
+      .slice(1)
+      .map((chunk) => `aggregate${chunk.split("\n  private ")[0]}`);
+
+    expect(bodies.length).toBeGreaterThan(4);
+
+    const offenders = bodies
+      .filter((body) => /Number\(tx\.amount\)/.test(body))
+      .filter(
+        (body) =>
+          !body.includes("reportableTransactionAmount") &&
+          !body.includes("ordinarySplitLines"),
+      )
+      .map((body) => body.split("(")[0]);
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/backend/src/common/investment-filter.guard.spec.ts
+++ b/backend/src/common/investment-filter.guard.spec.ts
@@ -173,12 +173,32 @@ export function classifyLedgerQuery(query: string): {
   return { shape: "parent-only", missing };
 }
 
-/** Every `FROM transactions` query in a file, cut at its template literal's end. */
+/**
+ * Every template literal in a file that reads the transaction ledger, WHOLE.
+ *
+ * Cutting forward from `FROM transactions` to the end of the literal misses the
+ * SELECT list, and a query whose derivation appears only there -- the
+ * uncategorized summary, once it moved its amount into a CTE -- then reads as
+ * missing it. Backticks delimit the literals, so the odd chunks of a split on
+ * them are the literals themselves.
+ */
 function ledgerQueries(source: string): string[] {
   return source
-    .split("FROM transactions")
-    .slice(1)
-    .map((segment) => segment.split("`")[0]);
+    .split("`")
+    .filter(
+      (chunk, index) => index % 2 === 1 && chunk.includes("FROM transactions"),
+    )
+    .map((chunk) => chunk);
+}
+
+/** Enough of a query to recognise it in a failure message. */
+function firstMeaningfulLine(query: string): string {
+  return (
+    query
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.length > 0 && !line.startsWith("--")) ?? "(empty)"
+  );
 }
 
 describe("every built-in report query applies the investment exclusion", () => {
@@ -198,7 +218,7 @@ describe("every built-in report query applies the investment exclusion", () => {
         const { missing } = classifyLedgerQuery(query);
         if (missing.length === 0) continue;
         failures.push(
-          `${relative(SRC_ROOT, file)}: ${query.trim().split("\n")[0]} -- missing ${missing.join(", ")}`,
+          `${relative(SRC_ROOT, file)}: ${firstMeaningfulLine(query)} -- missing ${missing.join(", ")}`,
         );
       }
     }
@@ -217,7 +237,7 @@ describe("every built-in report query applies the investment exclusion", () => {
         const { shape } = classifyLedgerQuery(query);
         if (shape !== "split-aware") {
           exempted.push(
-            `${relative(SRC_ROOT, file)}: ${query.trim().split("\n")[0]} -- classified ${shape}`,
+            `${relative(SRC_ROOT, file)}: ${firstMeaningfulLine(query)} -- classified ${shape}`,
           );
         }
       }

--- a/backend/src/common/investment-filter.guard.spec.ts
+++ b/backend/src/common/investment-filter.guard.spec.ts
@@ -1,0 +1,142 @@
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative } from "path";
+
+const SRC_ROOT = join(__dirname, "..");
+
+/** The file that owns the rule. */
+const OWNER = "common/investment-filter.util.ts";
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "node_modules" || entry === "dist") continue;
+      out.push(...sourceFiles(full));
+      continue;
+    }
+    if (!entry.endsWith(".ts")) continue;
+    if (entry.endsWith(".spec.ts")) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Comments discuss the banned shapes on purpose (this file's own subjects are
+ * named in prose in several services), so the scan reads code only.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[ \t]*\/\/.*$/gm, "")
+    .replace(/--[^\n']*$/gm, "");
+}
+
+interface Occurrence {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function scan(files: string[], pattern: RegExp): Occurrence[] {
+  const found: Occurrence[] = [];
+  for (const file of files) {
+    const code = stripComments(readFileSync(file, "utf8"));
+    const lines = code.split("\n");
+    for (const [index, line] of lines.entries()) {
+      const match = line.match(pattern);
+      if (match) {
+        found.push({
+          file: relative(SRC_ROOT, file),
+          line: index + 1,
+          text: match[0].trim(),
+        });
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * A report's account scope is investment LINKAGE, never account type
+ * (INV-REPORT-001).
+ *
+ * An INVESTMENT account in Monize is a pair -- an `INVESTMENT_CASH` sleeve
+ * holding real money and an `INVESTMENT_BROKERAGE` sleeve holding securities --
+ * so `account_type != 'INVESTMENT'` removed an entire real ledger from fifteen
+ * report queries, and the cash legs it was meant to exclude were never
+ * described by it in the first place (issue #1257). The mistake is mechanical
+ * and was made independently in eight files, so it gets a scanning test:
+ * the predicate lives in `common/investment-filter.util.ts` and nowhere else.
+ */
+describe("investment scope is decided in one place", () => {
+  const files = sourceFiles(SRC_ROOT);
+
+  it("finds source files to scan", () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it("nothing excludes rows by account type", () => {
+    const hits = scan(
+      files,
+      /account_?[Tt]ype\s*(?:!=|<>)\s*['"]INVESTMENT['"]/,
+    );
+
+    expect(hits).toEqual([]);
+  });
+
+  it("the brokerage-sleeve exclusion is spelled only in the util", () => {
+    const hits = scan(files, /(?:!=|<>)\s*['"]INVESTMENT_BROKERAGE['"]/).filter(
+      (hit) => hit.file !== OWNER,
+    );
+
+    expect(hits).toEqual([]);
+  });
+
+  it("the investment-linkage exclusion is spelled only in the util", () => {
+    const hits = scan(
+      files,
+      /NOT EXISTS\s*\(\s*SELECT 1 FROM investment_transactions/,
+    ).filter((hit) => hit.file !== OWNER);
+
+    expect(hits).toEqual([]);
+  });
+});
+
+/**
+ * The other half of the rule: every report query that reads the transaction
+ * ledger has to apply the exclusion. A query restricted to `is_transfer = true`
+ * is exempt by construction -- an investment cash leg is never a transfer -- and
+ * that exemption is derived from the query itself rather than kept as a list of
+ * file names a new query could quietly join.
+ */
+describe("every built-in report query applies the investment exclusion", () => {
+  const reportServices = readdirSync(join(SRC_ROOT, "built-in-reports"))
+    .filter((f) => f.endsWith(".service.ts"))
+    .map((f) => join(SRC_ROOT, "built-in-reports", f));
+
+  it("finds the report services", () => {
+    expect(reportServices.length).toBeGreaterThan(5);
+  });
+
+  it("applies it to every ledger query that is not transfer-only", () => {
+    const missing: string[] = [];
+
+    for (const file of reportServices) {
+      const source = readFileSync(file, "utf8");
+      const segments = source.split("FROM transactions");
+      for (const segment of segments.slice(1)) {
+        // The query's own template literal ends at the next backtick.
+        const query = segment.split("`")[0];
+        if (/is_transfer\s*=\s*true/.test(query)) continue;
+        if (query.includes("INVESTMENT_EXCLUSION")) continue;
+        missing.push(
+          `${relative(SRC_ROOT, file)}: ${query.trim().split("\n")[0]}`,
+        );
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/backend/src/common/investment-filter.guard.spec.ts
+++ b/backend/src/common/investment-filter.guard.spec.ts
@@ -119,10 +119,17 @@ describe("investment scope is decided in one place", () => {
  * `_NO_SPLITS` variant, which is exactly the defect.
  *
  * Two exemptions, both derived from the query rather than kept as a list of file
- * names a new query could quietly join: one restricted to `is_transfer = true`
- * (an investment cash leg is never a transfer), and one that declares itself a
+ * names a new query could quietly join: one restricted to transfers (an
+ * investment cash leg is never a transfer), and one that declares itself a
  * PARENT-IDENTITY REPORT, whose subject is the stored row rather than its cash
  * meaning.
+ *
+ * "Restricted to transfers" is positive proof, not the presence of the token:
+ * the monthly category breakdown admits `is_transfer = false` rows AND, in an OR
+ * branch, categorized transfer outflows, so matching `is_transfer = true`
+ * anywhere exempted a split-joining ledger query from the whole scan -- deleting
+ * its exclusion would have left the guard green (re-audit F-GUARD-001). A query
+ * that mentions both forms is not restricted to either.
  */
 type QueryShape =
   | "transfer-only"
@@ -134,7 +141,9 @@ export function classifyLedgerQuery(query: string): {
   shape: QueryShape;
   missing: string[];
 } {
-  if (/is_transfer\s*=\s*true/.test(query)) {
+  const readsTransfers = /is_transfer\s*=\s*true/.test(query);
+  const readsNonTransfers = /is_transfer\s*=\s*false/.test(query);
+  if (readsTransfers && !readsNonTransfers) {
     return { shape: "transfer-only", missing: [] };
   }
 
@@ -197,6 +206,26 @@ describe("every built-in report query applies the investment exclusion", () => {
     expect(failures).toEqual([]);
   });
 
+  it("never exempts a query that joins split rows", () => {
+    // The shape F-GUARD-001 slipped through: a split-joining aggregate that
+    // mentions `is_transfer = true` in an OR branch is not transfer-only.
+    const exempted: string[] = [];
+
+    for (const file of reportServices) {
+      for (const query of ledgerQueries(readFileSync(file, "utf8"))) {
+        if (!/JOIN transaction_splits/.test(query)) continue;
+        const { shape } = classifyLedgerQuery(query);
+        if (shape !== "split-aware") {
+          exempted.push(
+            `${relative(SRC_ROOT, file)}: ${query.trim().split("\n")[0]} -- classified ${shape}`,
+          );
+        }
+      }
+    }
+
+    expect(exempted).toEqual([]);
+  });
+
   it("scans both shapes, so neither branch is vacuous", () => {
     const shapes = new Set<QueryShape>();
     for (const file of reportServices) {
@@ -254,6 +283,25 @@ describe("classifyLedgerQuery", () => {
     expect(missing).toEqual(["the split-aware INVESTMENT_EXCLUSION"]);
   });
 
+  it("does not exempt a mixed predicate that merely mentions a transfer", () => {
+    // The real monthly-category-breakdown shape: ordinary rows plus categorized
+    // transfer outflows, joined to splits.
+    const query = `
+      FROM transactions t
+      LEFT JOIN transaction_splits ts ON ts.transaction_id = t.id
+      WHERE t.user_id = $1
+        AND (
+          t.is_transfer = false
+          OR (t.is_transfer = true AND t.category_id IS NOT NULL AND t.amount < 0)
+        )
+    `;
+
+    const { shape, missing } = classifyLedgerQuery(query);
+
+    expect(shape).toBe("split-aware");
+    expect(missing).toEqual(["the split-aware INVESTMENT_EXCLUSION"]);
+  });
+
   it("exempts a transfer-only rollup", () => {
     const query = `
       FROM transactions t
@@ -278,5 +326,42 @@ describe("classifyLedgerQuery", () => {
         "FROM transactions t -- PARENT-IDENTITY REPORT: no exclusion at all",
       ).missing,
     ).toEqual(["an investment exclusion"]);
+  });
+});
+
+/**
+ * The register of what INV-REPORT-001 does NOT yet cover, which is why the
+ * invariant's status is `partial` rather than `enforced`.
+ *
+ * `backend/src/reports/` executes user-defined custom reports over the same
+ * ledger through hydrated TypeORM entities, and applies no investment
+ * provenance at all: a free-standing BUY's generated cash leg is reported as
+ * `Uncategorized` spending, and an embedded investment split child is counted
+ * beside its ordinary sibling (re-audit F-CUSTOM-001). The behaviour predates
+ * the #1257 work and is unchanged by it.
+ *
+ * The pin is written so it fails when the gap CLOSES: whoever migrates that
+ * engine gets a red test naming the document to update, so the catalog cannot
+ * keep describing a gap that is gone.
+ */
+describe("known gap: the custom report engine", () => {
+  const CUSTOM_REPORTS = join(SRC_ROOT, "reports", "reports.service.ts");
+  const PROVENANCE_MARKERS = [
+    "investment_transactions",
+    "applyInvestmentTransactionFilters",
+    "investmentExclusionSql",
+    "reportableTransactionAmountSql",
+  ];
+
+  it("still applies no investment provenance -- keep INV-REPORT-001 at `partial` until it does", () => {
+    const source = readFileSync(CUSTOM_REPORTS, "utf8");
+    const applied = PROVENANCE_MARKERS.filter((marker) =>
+      source.includes(marker),
+    );
+
+    // When this fails because `applied` is no longer empty: the gap is closed.
+    // Update INV-REPORT-001 in docs/system-invariants.md to `enforced`, name the
+    // custom-report tests that prove it, and delete this block.
+    expect(applied).toEqual([]);
   });
 });

--- a/backend/src/common/investment-filter.guard.spec.ts
+++ b/backend/src/common/investment-filter.guard.spec.ts
@@ -341,8 +341,12 @@ describe("the custom report engine classifies by provenance", () => {
   const CUSTOM_REPORTS = join(SRC_ROOT, "reports", "reports.service.ts");
   const source = readFileSync(CUSTOM_REPORTS, "utf8");
 
-  it("excludes the sleeve and generated cash in its selector", () => {
-    expect(source).toContain("applyInvestmentTransactionFilters");
+  it("excludes generated cash unconditionally, and the sleeve where it was not asked for", () => {
+    // The two fragments rather than the combined helper: a report that NAMES the
+    // brokerage account keeps its rows, because answering an explicitly scoped
+    // report with nothing is worse than showing what was asked for.
+    expect(source).toContain("investmentLinkedTransactionExclusion");
+    expect(source).toContain("brokerageExclusionForEntity");
     // The linked investment row is what makes the second representation of an
     // embedded split readable in TypeScript.
     expect(source).toContain("splits.investmentTransaction");

--- a/backend/src/common/investment-filter.util.spec.ts
+++ b/backend/src/common/investment-filter.util.spec.ts
@@ -1,4 +1,11 @@
-import { applyInvestmentTransactionFilters } from "./investment-filter.util";
+import {
+  applyInvestmentTransactionFilters,
+  brokerageExclusionForEntity,
+  brokerageExclusionForSql,
+  investmentExclusionSql,
+  investmentLinkedSplitExclusion,
+  investmentLinkedTransactionExclusion,
+} from "./investment-filter.util";
 
 describe("applyInvestmentTransactionFilters", () => {
   it("applies both subtype and NOT EXISTS filters with the default transaction alias", () => {
@@ -23,5 +30,100 @@ describe("applyInvestmentTransactionFilters", () => {
 
     expect(andWhere.mock.calls[1][0]).toContain("tx.id");
     expect(andWhere.mock.calls[1][0]).not.toContain("transaction.id");
+  });
+
+  it("is composed from the exported fragments, not a second copy of them", () => {
+    const andWhere = jest.fn().mockReturnThis();
+    const qb = { andWhere } as any;
+
+    applyInvestmentTransactionFilters(qb, "acc", "tx");
+
+    expect(andWhere.mock.calls[0][0]).toBe(brokerageExclusionForEntity("acc"));
+    expect(andWhere.mock.calls[1][0]).toBe(
+      investmentLinkedTransactionExclusion("tx"),
+    );
+  });
+});
+
+describe("brokerage exclusion dialects", () => {
+  it("differ only in the column name", () => {
+    expect(brokerageExclusionForEntity("a")).toBe(
+      "(a.accountSubType IS NULL OR a.accountSubType != 'INVESTMENT_BROKERAGE')",
+    );
+    expect(brokerageExclusionForSql("a")).toBe(
+      "(a.account_sub_type IS NULL OR a.account_sub_type != 'INVESTMENT_BROKERAGE')",
+    );
+    expect(
+      brokerageExclusionForEntity("a").replace(/accountSubType/g, "SUBTYPE"),
+    ).toBe(
+      brokerageExclusionForSql("a").replace(/account_sub_type/g, "SUBTYPE"),
+    );
+  });
+
+  // A NULL sub-type is a standalone investment account -- it IS its own cash
+  // side, so it must survive the filter.
+  it("keeps a NULL sub-type in scope", () => {
+    expect(brokerageExclusionForSql("a")).toContain("IS NULL OR");
+  });
+});
+
+describe("investmentExclusionSql", () => {
+  it("emits the brokerage, transaction and split clauses when all aliases are given", () => {
+    const sql = investmentExclusionSql({
+      accountAlias: "a",
+      transactionAlias: "t",
+      splitAlias: "ts",
+    });
+
+    expect(sql).toContain(brokerageExclusionForSql("a"));
+    expect(sql).toContain(investmentLinkedTransactionExclusion("t"));
+    expect(sql).toContain(investmentLinkedSplitExclusion("ts"));
+    expect(sql.match(/NOT EXISTS/g)).toHaveLength(2);
+  });
+
+  it("omits the split clause when the query joins no splits", () => {
+    const sql = investmentExclusionSql({
+      accountAlias: "a",
+      transactionAlias: "t",
+    });
+
+    expect(sql).not.toContain("transaction_split_id");
+    expect(sql.match(/NOT EXISTS/g)).toHaveLength(1);
+  });
+
+  it("omits the brokerage clause when no account alias is given", () => {
+    const sql = investmentExclusionSql({ transactionAlias: "t" });
+
+    expect(sql).not.toContain("account_sub_type");
+    expect(sql).toBe(investmentLinkedTransactionExclusion("t"));
+  });
+
+  it("carries no bound parameters, so a caller's $n numbering is unchanged", () => {
+    const sql = investmentExclusionSql({
+      accountAlias: "a",
+      transactionAlias: "t",
+      splitAlias: "ts",
+    });
+
+    expect(sql).not.toMatch(/\$\d/);
+  });
+
+  it("joins its clauses with AND", () => {
+    const sql = investmentExclusionSql({
+      accountAlias: "a",
+      transactionAlias: "t",
+      splitAlias: "ts",
+    });
+
+    expect(sql.match(/\bAND\b/g)).toHaveLength(2);
+  });
+
+  it("uses distinct sub-query aliases so both NOT EXISTS clauses can coexist", () => {
+    expect(investmentLinkedTransactionExclusion("t")).toContain(
+      "investment_transactions it ",
+    );
+    expect(investmentLinkedSplitExclusion("ts")).toContain(
+      "investment_transactions its ",
+    );
   });
 });

--- a/backend/src/common/investment-filter.util.spec.ts
+++ b/backend/src/common/investment-filter.util.spec.ts
@@ -1,6 +1,9 @@
 import { SplitKind } from "../transactions/entities/split-kind.enum";
 import {
   applyInvestmentTransactionFilters,
+  isEmbeddedInvestmentSplit,
+  ordinarySplitLines,
+  reportableTransactionAmount,
   brokerageExclusionForEntity,
   brokerageExclusionForSql,
   investmentExclusionSql,
@@ -150,5 +153,134 @@ describe("investmentExclusionSql", () => {
     expect(investmentLinkedSplitExclusion("ts")).toContain(
       "investment_transactions its ",
     );
+  });
+});
+
+/**
+ * The hydrated-entity dialect, used by the custom report engine. Same two
+ * questions as the SQL fragments: what a line is, and what ordinary cash a whole
+ * transaction represents.
+ */
+describe("isEmbeddedInvestmentSplit", () => {
+  it("recognises the declared kind", () => {
+    expect(
+      isEmbeddedInvestmentSplit({ amount: -500, kind: "investment" }),
+    ).toBe(true);
+    expect(isEmbeddedInvestmentSplit({ amount: -60, kind: "category" })).toBe(
+      false,
+    );
+  });
+
+  it("recognises a linked investment row on a line that does not declare itself", () => {
+    expect(
+      isEmbeddedInvestmentSplit({
+        amount: -500,
+        kind: "category",
+        investmentTransaction: { id: "inv-1" },
+      }),
+    ).toBe(true);
+  });
+
+  it("reads a line that hydrated neither field as ordinary", () => {
+    // A caller that did not join the relation still gets the `kind` half; a
+    // line with neither is an ordinary category line.
+    expect(isEmbeddedInvestmentSplit({ amount: -60 })).toBe(false);
+  });
+
+  it("uses the same kind value as the SQL fragment", () => {
+    expect(
+      isEmbeddedInvestmentSplit({ amount: -1, kind: SplitKind.INVESTMENT }),
+    ).toBe(true);
+  });
+});
+
+describe("reportableTransactionAmount", () => {
+  const investmentLine = { amount: -500, kind: SplitKind.INVESTMENT };
+  const groceries = { amount: -60, kind: SplitKind.CATEGORY };
+
+  it("returns a non-split row's own amount", () => {
+    expect(reportableTransactionAmount({ amount: -125, isSplit: false })).toBe(
+      -125,
+    );
+  });
+
+  it("returns the ordinary part of a mixed split, not the parent total", () => {
+    expect(
+      reportableTransactionAmount({
+        amount: -560,
+        isSplit: true,
+        splits: [groceries, investmentLine],
+      }),
+    ).toBe(-60);
+  });
+
+  it("returns null for a pure investment passthrough", () => {
+    // Not zero: the row represents no ordinary cash, which a caller drops
+    // rather than adding 0 to a bucket.
+    expect(
+      reportableTransactionAmount({
+        amount: -500,
+        isSplit: true,
+        splits: [investmentLine],
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps a transfer line, because that decision belongs to the caller", () => {
+    // The SQL twin drops transfer children; a custom report carries its own
+    // includeTransfers configuration, so this one leaves them alone.
+    expect(
+      reportableTransactionAmount({
+        amount: -260,
+        isSplit: true,
+        splits: [groceries, { amount: -200, kind: SplitKind.TRANSFER }],
+      }),
+    ).toBe(-260);
+  });
+
+  it("falls back to the parent amount when a split parent hydrated no lines", () => {
+    expect(
+      reportableTransactionAmount({ amount: -560, isSplit: true, splits: [] }),
+    ).toBe(-560);
+  });
+
+  it("sums in integer arithmetic, so 4dp lines do not drift", () => {
+    expect(
+      reportableTransactionAmount({
+        amount: -0.3,
+        isSplit: true,
+        splits: [{ amount: -0.1 }, { amount: -0.2 }],
+      }),
+    ).toBe(-0.3);
+  });
+
+  it("reads amounts that arrive as decimal strings", () => {
+    expect(
+      reportableTransactionAmount({
+        amount: "-560.0000",
+        isSplit: true,
+        splits: [
+          { amount: "-60.0000", kind: SplitKind.CATEGORY },
+          { amount: "-500.0000", kind: SplitKind.INVESTMENT },
+        ],
+      }),
+    ).toBe(-60);
+  });
+});
+
+describe("ordinarySplitLines", () => {
+  it("drops only the investment lines and keeps their siblings", () => {
+    const groceries = { amount: -60, kind: SplitKind.CATEGORY };
+    const transfer = { amount: -200, kind: SplitKind.TRANSFER };
+    const investment = { amount: -500, kind: SplitKind.INVESTMENT };
+
+    expect(
+      ordinarySplitLines({ splits: [groceries, transfer, investment] }),
+    ).toEqual([groceries, transfer]);
+  });
+
+  it("answers an empty list for a transaction with no splits", () => {
+    expect(ordinarySplitLines({})).toEqual([]);
+    expect(ordinarySplitLines({ splits: null })).toEqual([]);
   });
 });

--- a/backend/src/common/investment-filter.util.spec.ts
+++ b/backend/src/common/investment-filter.util.spec.ts
@@ -238,9 +238,25 @@ describe("reportableTransactionAmount", () => {
     ).toBe(-260);
   });
 
-  it("falls back to the parent amount when a split parent hydrated no lines", () => {
+  it("answers null for a hydrated split parent with no lines, as the SQL twin does", () => {
+    // `SUM` over no rows is NULL there, so it is null here.
     expect(
       reportableTransactionAmount({ amount: -560, isSplit: true, splits: [] }),
+    ).toBeNull();
+  });
+
+  it("falls back to the parent amount when the caller did not hydrate the lines", () => {
+    // Absent is not a fact about the transaction: answering null would hide real
+    // money from a caller that simply did not select splits.
+    expect(reportableTransactionAmount({ amount: -560, isSplit: true })).toBe(
+      -560,
+    );
+    expect(
+      reportableTransactionAmount({
+        amount: -560,
+        isSplit: true,
+        splits: null,
+      }),
     ).toBe(-560);
   });
 

--- a/backend/src/common/investment-filter.util.spec.ts
+++ b/backend/src/common/investment-filter.util.spec.ts
@@ -1,3 +1,4 @@
+import { SplitKind } from "../transactions/entities/split-kind.enum";
 import {
   applyInvestmentTransactionFilters,
   brokerageExclusionForEntity,
@@ -79,6 +80,7 @@ describe("investmentExclusionSql", () => {
     expect(sql).toContain(investmentLinkedTransactionExclusion("t"));
     expect(sql).toContain(investmentLinkedSplitExclusion("ts"));
     expect(sql.match(/NOT EXISTS/g)).toHaveLength(2);
+    expect(sql).toContain("ts.kind IS DISTINCT FROM 'investment'");
   });
 
   it("omits the split clause when the query joins no splits", () => {
@@ -115,7 +117,30 @@ describe("investmentExclusionSql", () => {
       splitAlias: "ts",
     });
 
-    expect(sql.match(/\bAND\b/g)).toHaveLength(2);
+    // brokerage, generated cash leg, embedded split kind, embedded split row.
+    expect(sql.match(/\bAND\b/g)).toHaveLength(3);
+  });
+
+  it("names the split kind from the enum, not a hand-written literal", () => {
+    expect(investmentLinkedSplitExclusion("ts")).toContain(
+      `IS DISTINCT FROM '${SplitKind.INVESTMENT}'`,
+    );
+  });
+
+  // A LEFT JOIN that matched no split leaves kind NULL, and `NULL != 'x'` is
+  // NULL -- read as false, which would drop every non-split row from the report.
+  it("compares the split kind with IS DISTINCT FROM, never !=", () => {
+    const clause = investmentLinkedSplitExclusion("ts");
+
+    expect(clause).toContain("ts.kind IS DISTINCT FROM");
+    expect(clause).not.toContain("ts.kind !=");
+  });
+
+  it("excludes an embedded investment split by both of its representations", () => {
+    const clause = investmentLinkedSplitExclusion("ts");
+
+    expect(clause).toContain("ts.kind");
+    expect(clause).toContain("its.transaction_split_id = ts.id");
   });
 
   it("uses distinct sub-query aliases so both NOT EXISTS clauses can coexist", () => {

--- a/backend/src/common/investment-filter.util.spec.ts
+++ b/backend/src/common/investment-filter.util.spec.ts
@@ -228,7 +228,8 @@ describe("reportableTransactionAmount", () => {
 
   it("keeps a transfer line, because that decision belongs to the caller", () => {
     // The SQL twin drops transfer children; a custom report carries its own
-    // includeTransfers configuration, so this one leaves them alone.
+    // includeTransfers configuration and narrows the lines itself before calling
+    // this, so this one leaves whatever it is given alone.
     expect(
       reportableTransactionAmount({
         amount: -260,

--- a/backend/src/common/investment-filter.util.ts
+++ b/backend/src/common/investment-filter.util.ts
@@ -16,8 +16,11 @@ import { roundMoney, sumMoney } from "./round.util";
  * Two layers, and neither substitutes for the other:
  *
  *  - `accountSubType != 'INVESTMENT_BROKERAGE'` keeps the securities sleeve's
- *    register out of a cash report. A standalone investment account (subtype
- *    NULL, as .mny imports produce) IS its own cash side, so it stays in.
+ *    register out of a cash report. A standalone investment account -- type
+ *    INVESTMENT with a NULL sub-type, which the ordinary account-create path
+ *    produces and which `net-worth.service.ts` and `monthly-comparison.service.ts`
+ *    already branch on -- IS its own cash side, so it stays in. (A .mny import is
+ *    NOT such a case: `map-reference.ts` always emits the CASH/BROKERAGE pair.)
  *  - `NOT EXISTS (investment_transactions ...)` catches the cash-side rows that
  *    BUY / SELL / DIVIDEND post into the linked cash account
  *    (`createCashTransactionInTransaction`). Those carry no category and no

--- a/backend/src/common/investment-filter.util.ts
+++ b/backend/src/common/investment-filter.util.ts
@@ -1,4 +1,5 @@
 import { SelectQueryBuilder } from "typeorm";
+import { SplitKind } from "../transactions/entities/split-kind.enum";
 
 /**
  * Which transaction rows are an investment movement rather than ordinary cash,
@@ -68,9 +69,30 @@ export function investmentLinkedTransactionExclusion(
   return `NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = ${transactionAlias}.id)`;
 }
 
-/** Excludes an investment line embedded in a split transaction. */
+/**
+ * Excludes an investment line embedded in a split transaction, by BOTH of the
+ * representations that describe one: the split's declared `kind`, and an
+ * `investment_transactions` row pointing at that split. `createEmbeddedForSplit`
+ * writes both (`transaction_id` stays null and the split amount IS the cash
+ * side), so either clause alone would be the whole answer today -- and either
+ * one alone becomes wrong the moment the two disagree: a split declared
+ * investment whose row has been removed, or a row pointing at a split that does
+ * not declare itself. `kind` also answers for free on the common path, before
+ * the sub-query runs.
+ *
+ * `IS DISTINCT FROM` rather than `!=` because a LEFT JOIN that matched no split
+ * leaves `kind` NULL, and `NULL != 'investment'` is NULL, which a WHERE clause
+ * reads as false -- that comparison would drop every non-split transaction from
+ * the report.
+ *
+ * Deliberately `includes VOID` rows: this reads what a row IS -- its identity --
+ * not what it moved.
+ */
 export function investmentLinkedSplitExclusion(splitAlias: string): string {
-  return `NOT EXISTS (SELECT 1 FROM investment_transactions its WHERE its.transaction_split_id = ${splitAlias}.id)`;
+  return [
+    `${splitAlias}.kind IS DISTINCT FROM '${SplitKind.INVESTMENT}'`,
+    `NOT EXISTS (SELECT 1 FROM investment_transactions its WHERE its.transaction_split_id = ${splitAlias}.id)`,
+  ].join("\n        AND ");
 }
 
 /**

--- a/backend/src/common/investment-filter.util.ts
+++ b/backend/src/common/investment-filter.util.ts
@@ -217,12 +217,12 @@ export function ordinarySplitLines<T extends SplitLineLike>(parent: {
  * which is different from representing zero.
  *
  * The SQL form also drops transfer children, because no built-in report that
- * uses it includes transfers. This one does not, and deliberately says nothing
- * about transfers at all: the custom report engine decides them at the PARENT
- * level from its own `includeTransfers` configuration, and a transfer split LINE
- * inside a non-transfer parent is counted there today. That is pre-existing
- * behaviour and a separate decision from investment provenance -- what this
- * function must not do is quietly make it, in either direction.
+ * uses it includes transfers. This one deliberately says nothing about them: a
+ * custom report carries its own `includeTransfers` configuration, so its engine
+ * narrows the lines it does not want (`narrowSplitLines`) BEFORE asking this
+ * function, and passes whatever is left. Investment provenance is a property of
+ * the data; which transfers to count is a property of the report, and this
+ * function must not quietly decide the second one in either direction.
  */
 export function reportableTransactionAmount(
   parent: SplitParentLike,

--- a/backend/src/common/investment-filter.util.ts
+++ b/backend/src/common/investment-filter.util.ts
@@ -96,6 +96,44 @@ export function investmentLinkedSplitExclusion(splitAlias: string): string {
 }
 
 /**
+ * The ordinary cash a single `transactions` row represents.
+ *
+ * A report that joins `transaction_splits` classifies each line on its own and
+ * needs nothing more. A report that reads only the parent -- Spending by Payee,
+ * Recurring Expenses, Bill Payment History, the Uncategorized list -- cannot:
+ * `t.amount` on a split parent is the sum of ALL its children, and an embedded
+ * investment line's `transaction_id` is null, so the linkage exclusion above
+ * cannot see it. Such a query admitted a `-560` parent made of `-60` groceries
+ * and a `-500` embedded BUY as `560` of spending (branch audit F-RPT-001).
+ *
+ * Excluding the whole parent instead is the opposite error -- it loses the `60`
+ * the user really did spend -- so the amount is derived at split-row
+ * granularity: the sum of the children that are neither a transfer nor an
+ * investment.
+ *
+ * NULL means "this row represents no ordinary cash at all" (a pure investment or
+ * transfer passthrough). Every arithmetic comparison against NULL is NULL, which
+ * a WHERE clause reads as false, so a caller filtering on `< 0` or `IS NOT NULL`
+ * drops those rows without a second predicate. A caller that must keep them --
+ * one whose subject is the stored row rather than its cash meaning -- says so.
+ */
+export function reportableTransactionAmountSql(
+  transactionAlias: string,
+  splitAlias: string = "reportable_split",
+): string {
+  return `CASE
+          WHEN ${transactionAlias}.is_split = true THEN (
+            SELECT SUM(${splitAlias}.amount)
+              FROM transaction_splits ${splitAlias}
+             WHERE ${splitAlias}.transaction_id = ${transactionAlias}.id
+               AND ${splitAlias}.transfer_account_id IS NULL
+               AND ${investmentLinkedSplitExclusion(splitAlias)}
+          )
+          ELSE ${transactionAlias}.amount
+        END`;
+}
+
+/**
  * The conjunction a raw-SQL report inserts in place of the old
  * `AND a.account_type != 'INVESTMENT'`. Carries no bound parameters, so a
  * call site's `$n` numbering is unaffected.

--- a/backend/src/common/investment-filter.util.ts
+++ b/backend/src/common/investment-filter.util.ts
@@ -1,30 +1,113 @@
 import { SelectQueryBuilder } from "typeorm";
 
 /**
- * Exclusion filters for investment cash-side transactions that would
- * otherwise leak into "spending" or "income" totals.
+ * Which transaction rows are an investment movement rather than ordinary cash,
+ * written once for every reader.
  *
- * Two layers:
- *  - `accountSubType != 'INVESTMENT_BROKERAGE'` keeps auto-generated
- *    brokerage cash movements out of the account set.
- *  - `NOT EXISTS (investment_transactions ...)` catches the cash-side
- *    transactions that BUY / SELL / DIVIDEND post into a linked
- *    non-investment cash account, which the subtype filter can't see.
+ * An INVESTMENT account in Monize is a PAIR (`accounts.service.ts`
+ * `createInvestmentAccountPair`): an `INVESTMENT_CASH` sleeve holding real
+ * money and an `INVESTMENT_BROKERAGE` sleeve holding securities, both carrying
+ * `account_type = 'INVESTMENT'`. So `account_type != 'INVESTMENT'` is not a
+ * filter on synthetic rows -- it deletes the cash sleeve's entire ledger,
+ * salary deposits included (issue #1257).
  *
- * Callers must have joined the account alias first. The transaction
- * alias defaults to `transaction` but can be overridden.
+ * Two layers, and neither substitutes for the other:
+ *
+ *  - `accountSubType != 'INVESTMENT_BROKERAGE'` keeps the securities sleeve's
+ *    register out of a cash report. A standalone investment account (subtype
+ *    NULL, as .mny imports produce) IS its own cash side, so it stays in.
+ *  - `NOT EXISTS (investment_transactions ...)` catches the cash-side rows that
+ *    BUY / SELL / DIVIDEND post into the linked cash account
+ *    (`createCashTransactionInTransaction`). Those carry no category and no
+ *    transfer flag, and the subtype filter cannot see them at all -- untreated
+ *    they leak into "spending" and "income" totals as uncategorised money.
+ *
+ * The split fragment is the same fact one level down: an investment embedded in
+ * a split (`transaction_splits.kind = 'investment'`) has `category_id IS NULL`,
+ * so a report grouping on `COALESCE(ts.category_id, t.category_id)` files that
+ * line under Uncategorized unless it is excluded here.
+ *
+ * A raw-SQL caller and a QueryBuilder caller need the same predicate spelled
+ * with different column names, so both are derived from one definition below
+ * rather than written twice.
+ */
+const BROKERAGE_SUB_TYPE = "INVESTMENT_BROKERAGE";
+
+/** The sub-type column, in each dialect that has to name it. */
+const SUB_TYPE_FIELD = {
+  /** TypeORM QueryBuilder: entity property names. */
+  entity: "accountSubType",
+  /** Raw SQL: physical column names. */
+  column: "account_sub_type",
+} as const;
+
+function brokerageExclusion(accountAlias: string, field: string): string {
+  return `(${accountAlias}.${field} IS NULL OR ${accountAlias}.${field} != '${BROKERAGE_SUB_TYPE}')`;
+}
+
+/** Brokerage-sleeve exclusion for a TypeORM QueryBuilder condition. */
+export function brokerageExclusionForEntity(accountAlias: string): string {
+  return brokerageExclusion(accountAlias, SUB_TYPE_FIELD.entity);
+}
+
+/** Brokerage-sleeve exclusion for raw SQL. */
+export function brokerageExclusionForSql(accountAlias: string): string {
+  return brokerageExclusion(accountAlias, SUB_TYPE_FIELD.column);
+}
+
+/**
+ * Excludes the cash leg an investment transaction generated. Identical in both
+ * dialects: it names a physical table and the transaction row's `id`.
+ *
+ * Deliberately `includes VOID` rows: this reads what a row IS -- its identity --
+ * not what it moved.
+ */
+export function investmentLinkedTransactionExclusion(
+  transactionAlias: string,
+): string {
+  return `NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = ${transactionAlias}.id)`;
+}
+
+/** Excludes an investment line embedded in a split transaction. */
+export function investmentLinkedSplitExclusion(splitAlias: string): string {
+  return `NOT EXISTS (SELECT 1 FROM investment_transactions its WHERE its.transaction_split_id = ${splitAlias}.id)`;
+}
+
+/**
+ * The conjunction a raw-SQL report inserts in place of the old
+ * `AND a.account_type != 'INVESTMENT'`. Carries no bound parameters, so a
+ * call site's `$n` numbering is unaffected.
+ *
+ * Omit `accountAlias` where the query has already scoped its accounts (or
+ * genuinely wants the brokerage sleeve in); omit `splitAlias` where the query
+ * does not join `transaction_splits`.
+ */
+export function investmentExclusionSql(opts: {
+  accountAlias?: string;
+  transactionAlias: string;
+  splitAlias?: string;
+}): string {
+  const clauses: string[] = [];
+  if (opts.accountAlias) {
+    clauses.push(brokerageExclusionForSql(opts.accountAlias));
+  }
+  clauses.push(investmentLinkedTransactionExclusion(opts.transactionAlias));
+  if (opts.splitAlias) {
+    clauses.push(investmentLinkedSplitExclusion(opts.splitAlias));
+  }
+  return clauses.join("\n        AND ");
+}
+
+/**
+ * The QueryBuilder form of the same two layers. Callers must have joined the
+ * account alias first. The transaction alias defaults to `transaction`.
  */
 export function applyInvestmentTransactionFilters<T extends object>(
   qb: SelectQueryBuilder<T>,
   accountAlias: string,
   transactionAlias: string = "transaction",
 ): SelectQueryBuilder<T> {
-  qb.andWhere(
-    `(${accountAlias}.accountSubType IS NULL OR ${accountAlias}.accountSubType != 'INVESTMENT_BROKERAGE')`,
-  );
-  qb.andWhere(
-    // includes VOID rows: records read -- identity, not effect.
-    `NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = ${transactionAlias}.id)`,
-  );
+  qb.andWhere(brokerageExclusionForEntity(accountAlias));
+  qb.andWhere(investmentLinkedTransactionExclusion(transactionAlias));
   return qb;
 }

--- a/backend/src/common/investment-filter.util.ts
+++ b/backend/src/common/investment-filter.util.ts
@@ -209,7 +209,7 @@ export function ordinarySplitLines<T extends SplitLineLike>(parent: {
 }
 
 /**
- * The TypeScript twin of `reportableTransactionAmountSql`, and the same NULL
+ * The TypeScript twin of `reportableTransactionAmountSql`, with the same NULL
  * semantics: `null` means the transaction represents no ordinary cash at all,
  * which is different from representing zero.
  *
@@ -222,8 +222,13 @@ export function ordinarySplitLines<T extends SplitLineLike>(parent: {
 export function reportableTransactionAmount(
   parent: SplitParentLike,
 ): number | null {
-  const lines = parent.splits ?? [];
-  if (!parent.isSplit || lines.length === 0) {
+  if (!parent.isSplit) return roundMoney(Number(parent.amount));
+  // `undefined` is "the caller did not hydrate the lines", which is not a fact
+  // about the transaction -- answering null there would hide real money from a
+  // caller that simply did not ask for splits. An EMPTY array is hydrated and
+  // says there are no lines, which is what the SQL twin's `SUM` over no rows
+  // answers: no ordinary cash.
+  if (parent.splits === undefined || parent.splits === null) {
     return roundMoney(Number(parent.amount));
   }
   const ordinary = ordinarySplitLines(parent);

--- a/backend/src/common/investment-filter.util.ts
+++ b/backend/src/common/investment-filter.util.ts
@@ -214,10 +214,12 @@ export function ordinarySplitLines<T extends SplitLineLike>(parent: {
  * which is different from representing zero.
  *
  * The SQL form also drops transfer children, because no built-in report that
- * uses it includes transfers. This one does not: a custom report carries its own
- * `includeTransfers` configuration, and that decision stays where the user made
- * it. So the two differ by exactly the transfer clause, and neither of them
- * decides investment provenance twice.
+ * uses it includes transfers. This one does not, and deliberately says nothing
+ * about transfers at all: the custom report engine decides them at the PARENT
+ * level from its own `includeTransfers` configuration, and a transfer split LINE
+ * inside a non-transfer parent is counted there today. That is pre-existing
+ * behaviour and a separate decision from investment provenance -- what this
+ * function must not do is quietly make it, in either direction.
  */
 export function reportableTransactionAmount(
   parent: SplitParentLike,

--- a/backend/src/common/investment-filter.util.ts
+++ b/backend/src/common/investment-filter.util.ts
@@ -1,5 +1,6 @@
 import { SelectQueryBuilder } from "typeorm";
 import { SplitKind } from "../transactions/entities/split-kind.enum";
+import { roundMoney, sumMoney } from "./round.util";
 
 /**
  * Which transaction rows are an investment movement rather than ordinary cash,
@@ -156,6 +157,78 @@ export function investmentExclusionSql(opts: {
     clauses.push(investmentLinkedSplitExclusion(opts.splitAlias));
   }
   return clauses.join("\n        AND ");
+}
+
+/* ------------------------------------------------------------------------- *
+ * The same rule for a caller holding hydrated entities rather than SQL.
+ *
+ * The custom report engine (`src/reports/`) reads the ledger through TypeORM
+ * entities and aggregates in TypeScript, so it cannot use the fragments above.
+ * These are the same two questions in the other dialect, kept in this file so
+ * the pair is read together: a line's provenance, and the ordinary cash a whole
+ * transaction represents.
+ *
+ * Deliberately structural rather than the entity types: this file is imported by
+ * `common/` consumers and the rule is about three fields, not about an entity
+ * (the same reasoning as `DeletableRow` in `deletion-balance.util.ts`).
+ * ------------------------------------------------------------------------- */
+
+/** A hydrated split line, as far as this rule is concerned. */
+export interface SplitLineLike {
+  amount: number | string;
+  kind?: string | null;
+  /** Hydrate `splits.investmentTransaction` to make this half readable. */
+  investmentTransaction?: { id: string } | null;
+}
+
+/** A hydrated transaction and its lines. */
+export interface SplitParentLike {
+  isSplit?: boolean | null;
+  amount: number | string;
+  splits?: SplitLineLike[] | null;
+}
+
+/**
+ * Both representations, as in `investmentLinkedSplitExclusion`: the declared
+ * kind and a linked investment row. A caller that did not hydrate the relation
+ * still gets the `kind` half.
+ */
+export function isEmbeddedInvestmentSplit(line: SplitLineLike): boolean {
+  return (
+    line.kind === SplitKind.INVESTMENT || line.investmentTransaction != null
+  );
+}
+
+/** The lines of a split that are not an embedded investment action. */
+export function ordinarySplitLines<T extends SplitLineLike>(parent: {
+  splits?: T[] | null;
+}): T[] {
+  return (parent.splits ?? []).filter(
+    (line) => !isEmbeddedInvestmentSplit(line),
+  );
+}
+
+/**
+ * The TypeScript twin of `reportableTransactionAmountSql`, and the same NULL
+ * semantics: `null` means the transaction represents no ordinary cash at all,
+ * which is different from representing zero.
+ *
+ * The SQL form also drops transfer children, because no built-in report that
+ * uses it includes transfers. This one does not: a custom report carries its own
+ * `includeTransfers` configuration, and that decision stays where the user made
+ * it. So the two differ by exactly the transfer clause, and neither of them
+ * decides investment provenance twice.
+ */
+export function reportableTransactionAmount(
+  parent: SplitParentLike,
+): number | null {
+  const lines = parent.splits ?? [];
+  if (!parent.isSplit || lines.length === 0) {
+    return roundMoney(Number(parent.amount));
+  }
+  const ordinary = ordinarySplitLines(parent);
+  if (ordinary.length === 0) return null;
+  return sumMoney(ordinary.map((line) => Number(line.amount)));
 }
 
 /**

--- a/backend/src/reports/reports.service.spec.ts
+++ b/backend/src/reports/reports.service.spec.ts
@@ -1687,7 +1687,11 @@ describe("ReportsService", () => {
         const andWhereCalls = qb.andWhere.mock.calls.map(
           (c: unknown[]) => c[0],
         );
-        expect(andWhereCalls).toContain("transaction.amount < 0");
+        // A split parent's own sign is the sum of its lines, so it passes this
+        // gate and is narrowed per line afterwards (audit F-CUSTOM-DIR-001).
+        expect(andWhereCalls).toContain(
+          "(transaction.isSplit = true OR transaction.amount < 0)",
+        );
       });
 
       it("applies direction filter for INCOME_ONLY", async () => {
@@ -1703,7 +1707,9 @@ describe("ReportsService", () => {
         const andWhereCalls = qb.andWhere.mock.calls.map(
           (c: unknown[]) => c[0],
         );
-        expect(andWhereCalls).toContain("transaction.amount > 0");
+        expect(andWhereCalls).toContain(
+          "(transaction.isSplit = true OR transaction.amount > 0)",
+        );
       });
 
       it("does not apply direction filter for BOTH", async () => {
@@ -1716,8 +1722,12 @@ describe("ReportsService", () => {
         const andWhereCalls = qb.andWhere.mock.calls.map(
           (c: unknown[]) => c[0],
         );
-        expect(andWhereCalls).not.toContain("transaction.amount > 0");
-        expect(andWhereCalls).not.toContain("transaction.amount < 0");
+        expect(andWhereCalls).not.toContain(
+          "(transaction.isSplit = true OR transaction.amount > 0)",
+        );
+        expect(andWhereCalls).not.toContain(
+          "(transaction.isSplit = true OR transaction.amount < 0)",
+        );
       });
 
       /**
@@ -1732,9 +1742,45 @@ describe("ReportsService", () => {
           "(account.accountSubType IS NULL OR account.accountSubType != 'INVESTMENT_BROKERAGE')";
         const linkageClause =
           "NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = transaction.id)";
+        const explicitClause =
+          "transaction.accountId IN (:...explicitReportAccountIds)";
 
         const andWheres = (qb: Record<string, jest.Mock>) =>
           qb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
+
+        /**
+         * The row-level sleeve exception is composed inside `Brackets`, so the
+         * clauses land on the inner builder the mock hands the factory. This
+         * collects them from every bracket the query built.
+         */
+        const bracketCalls = (
+          qb: Record<string, jest.Mock>,
+        ): Array<[string, Record<string, unknown> | undefined]> => {
+          const collected: Array<
+            [string, Record<string, unknown> | undefined]
+          > = [];
+          for (const [arg] of qb.andWhere.mock.calls) {
+            const factory = (arg as { whereFactory?: (qb: unknown) => void })
+              ?.whereFactory;
+            if (!factory) continue;
+            const record = (
+              clause: string,
+              params?: Record<string, unknown>,
+            ) => {
+              collected.push([clause, params]);
+              return inner;
+            };
+            const inner: Record<string, jest.Mock> = {
+              where: jest.fn().mockImplementation(record),
+              orWhere: jest.fn().mockImplementation(record),
+            };
+            factory(inner);
+          }
+          return collected;
+        };
+
+        const bracketClauses = (qb: Record<string, jest.Mock>): string[] =>
+          bracketCalls(qb).map(([clause]) => clause);
 
         it("always excludes the cash leg a trade generated", async () => {
           const { qb } = setupExecuteMocks({ filters: {} });
@@ -1744,7 +1790,7 @@ describe("ReportsService", () => {
           expect(andWheres(qb)).toContain(linkageClause);
         });
 
-        it("excludes the securities sleeve from an unscoped report", async () => {
+        it("excludes the securities sleeve outright from an unscoped report", async () => {
           const { qb } = setupExecuteMocks({ filters: {} });
 
           await service.execute("user-1", "report-1");
@@ -1752,39 +1798,63 @@ describe("ReportsService", () => {
           expect(andWheres(qb)).toContain(brokerageClause);
         });
 
-        it("keeps the sleeve when the report names accounts", async () => {
+        it("admits the sleeve only for the accounts a legacy filter names", async () => {
           const { qb } = setupExecuteMocks({
             filters: { accountIds: ["acc-1"] },
           });
 
           await service.execute("user-1", "report-1");
 
+          // Not an outright exclusion any more: a bracket that keeps the sleeve
+          // out EXCEPT for the named accounts.
           expect(andWheres(qb)).not.toContain(brokerageClause);
-          expect(andWheres(qb)).toContain(linkageClause);
+          expect(bracketClauses(qb)).toEqual(
+            expect.arrayContaining([brokerageClause, explicitClause]),
+          );
         });
 
-        it("keeps the sleeve when a filter group names accounts", async () => {
+        /**
+         * Conditions within a group are OR'd, so these two shapes mean opposite
+         * things about the sleeve and a whole-report boolean cannot tell them
+         * apart (audit F-CUSTOM-OR-001).
+         */
+        it("names the brokerage account from a mixed OR group", async () => {
           const { qb } = setupExecuteMocks({
             filters: {
               filterGroups: [
-                { conditions: [{ field: "account", value: ["acc-1"] }] },
+                {
+                  conditions: [
+                    { field: "account", value: ["brokerage-1"] },
+                    { field: "category", value: ["cat-1"] },
+                  ],
+                },
               ],
             },
           });
 
           await service.execute("user-1", "report-1");
 
-          expect(andWheres(qb)).not.toContain(brokerageClause);
+          const explicit = bracketCalls(qb).find(
+            ([clause]) => clause === explicitClause,
+          );
+          expect(explicit?.[1]).toEqual({
+            explicitReportAccountIds: ["brokerage-1"],
+          });
+          // ...and the sleeve is still excluded for every OTHER account, so the
+          // category arm cannot leak brokerage rows in.
+          expect(bracketClauses(qb)).toContain(brokerageClause);
         });
 
-        it("ignores a stale accountIds when filter groups are in charge", async () => {
-          // getFilteredTransactions applies the groups and ignores accountIds,
-          // so this report restricts nothing by account.
+        it("names no account when the group's account arm is empty", async () => {
           const { qb } = setupExecuteMocks({
             filters: {
-              accountIds: ["acc-1"],
               filterGroups: [
-                { conditions: [{ field: "category", value: ["cat-1"] }] },
+                {
+                  conditions: [
+                    { field: "account", value: [] },
+                    { field: "payee", value: ["payee-1"] },
+                  ],
+                },
               ],
             },
           });
@@ -1794,12 +1864,15 @@ describe("ReportsService", () => {
           expect(andWheres(qb)).toContain(brokerageClause);
         });
 
-        it("ignores an account condition carrying no values", async () => {
-          // What the filter builder saves for a half-finished condition: it adds
-          // no SQL, so it is not a scope.
+        it("ignores a stale accountIds when filter groups are in charge", async () => {
+          // getFilteredTransactions applies the groups and ignores accountIds,
+          // so this report names no account at all.
           const { qb } = setupExecuteMocks({
             filters: {
-              filterGroups: [{ conditions: [{ field: "account", value: [] }] }],
+              accountIds: ["acc-1"],
+              filterGroups: [
+                { conditions: [{ field: "category", value: ["cat-1"] }] },
+              ],
             },
           });
 

--- a/backend/src/reports/reports.service.spec.ts
+++ b/backend/src/reports/reports.service.spec.ts
@@ -1720,6 +1720,95 @@ describe("ReportsService", () => {
         expect(andWhereCalls).not.toContain("transaction.amount < 0");
       });
 
+      /**
+       * INV-REPORT-001 for the custom engine. Generated investment cash is
+       * never ordinary cash; the securities sleeve is dropped only from a report
+       * that did not ask for it, and "asked for it" has to mirror
+       * getFilteredTransactions' own precedence -- filter groups REPLACE the
+       * legacy filters, and a condition with no values restricts nothing.
+       */
+      describe("investment provenance", () => {
+        const brokerageClause =
+          "(account.accountSubType IS NULL OR account.accountSubType != 'INVESTMENT_BROKERAGE')";
+        const linkageClause =
+          "NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = transaction.id)";
+
+        const andWheres = (qb: Record<string, jest.Mock>) =>
+          qb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
+
+        it("always excludes the cash leg a trade generated", async () => {
+          const { qb } = setupExecuteMocks({ filters: {} });
+
+          await service.execute("user-1", "report-1");
+
+          expect(andWheres(qb)).toContain(linkageClause);
+        });
+
+        it("excludes the securities sleeve from an unscoped report", async () => {
+          const { qb } = setupExecuteMocks({ filters: {} });
+
+          await service.execute("user-1", "report-1");
+
+          expect(andWheres(qb)).toContain(brokerageClause);
+        });
+
+        it("keeps the sleeve when the report names accounts", async () => {
+          const { qb } = setupExecuteMocks({
+            filters: { accountIds: ["acc-1"] },
+          });
+
+          await service.execute("user-1", "report-1");
+
+          expect(andWheres(qb)).not.toContain(brokerageClause);
+          expect(andWheres(qb)).toContain(linkageClause);
+        });
+
+        it("keeps the sleeve when a filter group names accounts", async () => {
+          const { qb } = setupExecuteMocks({
+            filters: {
+              filterGroups: [
+                { conditions: [{ field: "account", value: ["acc-1"] }] },
+              ],
+            },
+          });
+
+          await service.execute("user-1", "report-1");
+
+          expect(andWheres(qb)).not.toContain(brokerageClause);
+        });
+
+        it("ignores a stale accountIds when filter groups are in charge", async () => {
+          // getFilteredTransactions applies the groups and ignores accountIds,
+          // so this report restricts nothing by account.
+          const { qb } = setupExecuteMocks({
+            filters: {
+              accountIds: ["acc-1"],
+              filterGroups: [
+                { conditions: [{ field: "category", value: ["cat-1"] }] },
+              ],
+            },
+          });
+
+          await service.execute("user-1", "report-1");
+
+          expect(andWheres(qb)).toContain(brokerageClause);
+        });
+
+        it("ignores an account condition carrying no values", async () => {
+          // What the filter builder saves for a half-finished condition: it adds
+          // no SQL, so it is not a scope.
+          const { qb } = setupExecuteMocks({
+            filters: {
+              filterGroups: [{ conditions: [{ field: "account", value: [] }] }],
+            },
+          });
+
+          await service.execute("user-1", "report-1");
+
+          expect(andWheres(qb)).toContain(brokerageClause);
+        });
+      });
+
       it("filters out transfers when includeTransfers is false", async () => {
         const { qb } = setupExecuteMocks({
           config: { ...defaultConfig, includeTransfers: false },

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -24,6 +24,7 @@ import {
   SortDirection,
 } from "./entities/custom-report.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
+import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
 import { Category } from "../categories/entities/category.entity";
 import { Payee } from "../payees/entities/payee.entity";
 import { CreateCustomReportDto } from "./dto/create-custom-report.dto";
@@ -231,12 +232,8 @@ export class ReportsService {
       report.config,
     );
     // A split parent reached the aggregators whatever its own sign, so its lines
-    // are narrowed to the requested direction here, where each line's own amount
-    // is readable.
-    const transactions = this.applyDirectionToSplitLines(
-      selected,
-      report.config.direction,
-    );
+    // are narrowed here, where each line's own amount and kind are readable.
+    const transactions = this.narrowSplitLines(selected, report.config);
 
     // Only fetch category/payee maps when the report groups by them (avoid over-fetching)
     const categoryMap = new Map<string, Category>();
@@ -388,27 +385,47 @@ export class ReportsService {
   }
 
   /**
-   * Narrows each split parent to the lines matching the requested direction, and
-   * drops a parent left with none.
+   * Narrows each split parent to the lines this report asked for, and drops a
+   * parent left with none.
    *
-   * Non-split rows were already filtered in SQL by their own amount. This runs
-   * BEFORE the aggregators ask for ordinary lines, so a mixed-sign split
-   * contributes exactly the lines the user asked to see -- which is also what
-   * the built-in split-row-granular reports do with the same rows.
+   * Two decisions the SQL could only make about the PARENT, and a split parent
+   * is not its lines:
+   *
+   * - **Direction.** `transaction.amount` is the sum of every line, so its sign
+   *   is nobody's direction: a -60 expense beside a +500 embedded SELL is a +440
+   *   parent (audit F-CUSTOM-DIR-001).
+   * - **Transfers.** `transaction.isTransfer` is false on a split parent that
+   *   carries a transfer LINE, so `includeTransfers: false` counted a -200
+   *   transfer inside a -260 parent as 260 of spending.
+   *
+   * Both are the user's own configuration, applied to the representation the
+   * decision belongs to -- which is what the built-in split-row-granular reports
+   * have always done with the same rows. Investment provenance is NOT decided
+   * here: the aggregators ask `ordinarySplitLines` for that, because it is a
+   * property of the data rather than of the report.
    */
-  private applyDirectionToSplitLines(
+  private narrowSplitLines(
     transactions: Transaction[],
-    direction: DirectionFilter,
+    config: ReportConfig,
   ): Transaction[] {
-    if (direction === DirectionFilter.BOTH) return transactions;
+    const narrowsDirection = config.direction !== DirectionFilter.BOTH;
+    if (!narrowsDirection && config.includeTransfers) return transactions;
 
-    const matches = (amount: number): boolean =>
-      direction === DirectionFilter.INCOME_ONLY ? amount > 0 : amount < 0;
+    const wanted = (split: TransactionSplit): boolean => {
+      if (!config.includeTransfers && split.transferAccountId != null) {
+        return false;
+      }
+      if (!narrowsDirection) return true;
+      const amount = Number(split.amount);
+      return config.direction === DirectionFilter.INCOME_ONLY
+        ? amount > 0
+        : amount < 0;
+    };
 
     return transactions.flatMap((tx) => {
       if (!tx.isSplit || !tx.splits || tx.splits.length === 0) return [tx];
 
-      const splits = tx.splits.filter((split) => matches(Number(split.amount)));
+      const splits = tx.splits.filter(wanted);
       if (splits.length === 0) return [];
 
       // A shallow copy: the entity is not re-saved, and the aggregators read

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -7,6 +7,11 @@ import { tr } from "../i18n/translate";
 import { Brackets, DataSource, Repository } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
 import {
+  applyInvestmentTransactionFilters,
+  ordinarySplitLines,
+  reportableTransactionAmount,
+} from "../common/investment-filter.util";
+import {
   CustomReport,
   TimeframeType,
   GroupByType,
@@ -391,6 +396,9 @@ export class ReportsService {
         .leftJoinAndSelect("transaction.payee", "payee")
         .leftJoinAndSelect("transaction.tags", "tags")
         .leftJoinAndSelect("transaction.splits", "splits")
+        // Hydrated so an embedded investment line is recognisable by BOTH of its
+        // representations, exactly as the raw-SQL reports recognise it.
+        .leftJoinAndSelect("splits.investmentTransaction", "splitInvestmentTx")
         .leftJoinAndSelect("splits.category", "splitCategory")
         .leftJoinAndSelect("splitCategory.parent", "splitCategoryParent")
         .leftJoinAndSelect("splits.tags", "splitTags")
@@ -410,6 +418,16 @@ export class ReportsService {
         .andWhere("transaction.transactionDate >= :startDate", { startDate })
         .andWhere("transaction.transactionDate <= :endDate", { endDate })
         .andWhere("transaction.status != 'VOID'");
+
+      // INV-REPORT-001: a custom report reads the same ledger as the built-in
+      // ones, so it owes the same answer. This half excludes the securities
+      // sleeve and the cash leg a free-standing trade generated -- including
+      // when an explicit funding account put that leg in an ordinary account,
+      // where no account-type predicate could see it. The embedded-split half
+      // cannot be done here (the parent is a real row carrying real ordinary
+      // cash beside the investment line), so it happens per line during
+      // aggregation.
+      applyInvestmentTransactionFilters(queryBuilder, "account", "transaction");
 
       // Advanced filter groups take precedence over legacy filters
       if (filters.filterGroups && filters.filterGroups.length > 0) {
@@ -660,7 +678,9 @@ export class ReportsService {
             ? transferPayeeLabel(tx.amount, tx.linkedTransaction.account.name)
             : undefined;
         if (tx.isSplit && tx.splits && tx.splits.length > 0) {
-          for (const split of tx.splits) {
+          // Only the lines that are ordinary cash: an embedded investment line
+          // is the trade's own cash side, not a row of this report.
+          for (const split of ordinarySplitLines(tx)) {
             result.push({
               id: tx.id,
               label:
@@ -706,7 +726,7 @@ export class ReportsService {
 
     for (const tx of transactions) {
       if (tx.isSplit && tx.splits && tx.splits.length > 0) {
-        for (const split of tx.splits) {
+        for (const split of ordinarySplitLines(tx)) {
           amounts.push(Math.abs(Number(split.amount)));
         }
       } else {
@@ -741,8 +761,10 @@ export class ReportsService {
 
     for (const tx of transactions) {
       if (tx.isSplit && tx.splits && tx.splits.length > 0) {
-        // Handle split transactions
-        for (const split of tx.splits) {
+        // Handle split transactions. An embedded investment line carries no
+        // category by definition, so counting it here filed a securities
+        // purchase under "Uncategorized" spending (re-audit F-CUSTOM-001).
+        for (const split of ordinarySplitLines(tx)) {
           const categoryId = split.categoryId || "uncategorized";
           const existing = dataMap.get(categoryId) || { sum: 0, count: 0 };
           existing.sum = roundMoney(
@@ -798,13 +820,18 @@ export class ReportsService {
     >();
 
     for (const tx of transactions) {
+      // `tx.amount` on a split parent is the sum of EVERY line, so a payee total
+      // has to ask for the ordinary part; `null` means this row represents no
+      // ordinary cash at all.
+      const reportable = reportableTransactionAmount(tx);
+      if (reportable === null) continue;
       const payeeId = tx.payeeId || "unknown";
       const existing = dataMap.get(payeeId) || {
         sum: 0,
         count: 0,
         payeeName: tx.payeeName ?? undefined,
       };
-      existing.sum = roundMoney(existing.sum + Math.abs(Number(tx.amount)));
+      existing.sum = roundMoney(existing.sum + Math.abs(reportable));
       existing.count += 1;
       if (!existing.payeeName && tx.payeeName) {
         existing.payeeName = tx.payeeName;
@@ -839,10 +866,14 @@ export class ReportsService {
     >();
 
     for (const tx of transactions) {
-      // Collect all tags: transaction-level + split-level
+      const reportable = reportableTransactionAmount(tx);
+      if (reportable === null) continue;
+      // Collect all tags: transaction-level + split-level. A tag on an embedded
+      // investment line describes the trade, not ordinary cash, so the lines
+      // that are not reportable do not open a bucket either.
       const allTags = [...(tx.tags || [])];
       if (tx.splits) {
-        for (const split of tx.splits) {
+        for (const split of ordinarySplitLines(tx)) {
           if (split.tags) {
             for (const tag of split.tags) {
               if (!allTags.some((t) => t.id === tag.id)) {
@@ -860,7 +891,7 @@ export class ReportsService {
           count: 0,
           tagName: "Untagged",
         };
-        existing.sum = roundMoney(existing.sum + Math.abs(Number(tx.amount)));
+        existing.sum = roundMoney(existing.sum + Math.abs(reportable));
         existing.count += 1;
         dataMap.set("untagged", existing);
       } else {
@@ -871,7 +902,7 @@ export class ReportsService {
             tagName: tag.name,
             color: tag.color ?? undefined,
           };
-          existing.sum = roundMoney(existing.sum + Math.abs(Number(tx.amount)));
+          existing.sum = roundMoney(existing.sum + Math.abs(reportable));
           existing.count += 1;
           dataMap.set(tag.id, existing);
         }
@@ -906,6 +937,8 @@ export class ReportsService {
     >();
 
     for (const tx of transactions) {
+      const reportable = reportableTransactionAmount(tx);
+      if (reportable === null) continue;
       const date = parseISO(tx.transactionDate);
       let key: string;
       let label: string;
@@ -930,7 +963,7 @@ export class ReportsService {
       }
 
       const existing = dataMap.get(key) || { sum: 0, count: 0, label };
-      existing.sum = roundMoney(existing.sum + Math.abs(Number(tx.amount)));
+      existing.sum = roundMoney(existing.sum + Math.abs(reportable));
       existing.count += 1;
       dataMap.set(key, existing);
     }

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -383,25 +383,33 @@ export class ReportsService {
   /**
    * Whether the report actually restricts itself to particular accounts.
    *
-   * Mirrors `getFilteredTransactions`' own precedence rather than checking both
-   * shapes: advanced filter groups REPLACE the legacy filters, so a report that
-   * has groups and a stale `accountIds` restricts nothing by account. And an
-   * account condition carrying no values adds no SQL at all -- which is what the
-   * filter builder saves for a half-finished condition -- so an empty one is not
-   * a scope either.
+   * Three ways to get this wrong, all of them ways to answer a report with rows
+   * it did not ask for or to drop rows it did:
+   *
+   * - Advanced filter groups REPLACE the legacy filters in
+   *   `getFilteredTransactions`, so a report holding groups and a stale
+   *   `accountIds` restricts nothing by account.
+   * - An account condition carrying no values adds no SQL at all (what the
+   *   filter builder saves for a half-finished condition), so it is not a scope.
+   * - Conditions WITHIN a group are OR'd. `[account = Chequing, payee = Acme]`
+   *   admits every account for that payee, so only a group whose conditions are
+   *   ALL account conditions restricts by account. Groups are AND'ed with each
+   *   other, so one such group is enough.
    */
   private namesAnyAccount(filters: CustomReport["filters"]): boolean {
     const groups = filters.filterGroups ?? [];
     if (groups.length > 0) {
-      return groups.some((group) =>
-        (group.conditions ?? []).some(
-          (condition) =>
-            condition.field === "account" &&
-            (Array.isArray(condition.value)
-              ? condition.value.length > 0
-              : Boolean(condition.value)),
-        ),
-      );
+      return groups.some((group) => {
+        const conditions = (group.conditions ?? []).filter((condition) =>
+          Array.isArray(condition.value)
+            ? condition.value.length > 0
+            : Boolean(condition.value),
+        );
+        return (
+          conditions.length > 0 &&
+          conditions.every((condition) => condition.field === "account")
+        );
+      });
     }
     return (filters.accountIds ?? []).length > 0;
   }

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -223,12 +223,19 @@ export class ReportsService {
     );
 
     // Query transactions with filters
-    const transactions = await this.getFilteredTransactions(
+    const selected = await this.getFilteredTransactions(
       userId,
       startDate,
       endDate,
       report.filters,
       report.config,
+    );
+    // A split parent reached the aggregators whatever its own sign, so its lines
+    // are narrowed to the requested direction here, where each line's own amount
+    // is readable.
+    const transactions = this.applyDirectionToSplitLines(
+      selected,
+      report.config.direction,
     );
 
     // Only fetch category/payee maps when the report groups by them (avoid over-fetching)
@@ -381,37 +388,69 @@ export class ReportsService {
   }
 
   /**
-   * Whether the report actually restricts itself to particular accounts.
+   * Narrows each split parent to the lines matching the requested direction, and
+   * drops a parent left with none.
    *
-   * Three ways to get this wrong, all of them ways to answer a report with rows
-   * it did not ask for or to drop rows it did:
-   *
-   * - Advanced filter groups REPLACE the legacy filters in
-   *   `getFilteredTransactions`, so a report holding groups and a stale
-   *   `accountIds` restricts nothing by account.
-   * - An account condition carrying no values adds no SQL at all (what the
-   *   filter builder saves for a half-finished condition), so it is not a scope.
-   * - Conditions WITHIN a group are OR'd. `[account = Chequing, payee = Acme]`
-   *   admits every account for that payee, so only a group whose conditions are
-   *   ALL account conditions restricts by account. Groups are AND'ed with each
-   *   other, so one such group is enough.
+   * Non-split rows were already filtered in SQL by their own amount. This runs
+   * BEFORE the aggregators ask for ordinary lines, so a mixed-sign split
+   * contributes exactly the lines the user asked to see -- which is also what
+   * the built-in split-row-granular reports do with the same rows.
    */
-  private namesAnyAccount(filters: CustomReport["filters"]): boolean {
+  private applyDirectionToSplitLines(
+    transactions: Transaction[],
+    direction: DirectionFilter,
+  ): Transaction[] {
+    if (direction === DirectionFilter.BOTH) return transactions;
+
+    const matches = (amount: number): boolean =>
+      direction === DirectionFilter.INCOME_ONLY ? amount > 0 : amount < 0;
+
+    return transactions.flatMap((tx) => {
+      if (!tx.isSplit || !tx.splits || tx.splits.length === 0) return [tx];
+
+      const splits = tx.splits.filter((split) => matches(Number(split.amount)));
+      if (splits.length === 0) return [];
+
+      // A shallow copy: the entity is not re-saved, and the aggregators read
+      // only `splits` plus the parent's own scalar fields.
+      return [{ ...tx, splits } as Transaction];
+    });
+  }
+
+  /**
+   * The accounts this report explicitly names.
+   *
+   * Not "does the report restrict itself to accounts": a boolean cannot express
+   * a mixed OR group, and both of its answers are wrong for one shape.
+   * Conditions WITHIN a group are OR'd, groups are AND'ed, so
+   * `[account = Brokerage, category = Salary]` explicitly asks for Brokerage
+   * rows while `[account = Chequing, payee = Acme]` asks for none -- and a single
+   * boolean that admits the first also admits the second (or refuses both).
+   * The ids let the caller ask the question per row instead.
+   *
+   * Advanced filter groups REPLACE the legacy filters in
+   * `getFilteredTransactions`, so a report holding groups and a stale
+   * `accountIds` names nothing; and a condition carrying no values (what the
+   * filter builder saves for a half-finished one) adds no SQL, so it names
+   * nothing either.
+   */
+  private explicitAccountIds(filters: CustomReport["filters"]): string[] {
     const groups = filters.filterGroups ?? [];
-    if (groups.length > 0) {
-      return groups.some((group) => {
-        const conditions = (group.conditions ?? []).filter((condition) =>
-          Array.isArray(condition.value)
-            ? condition.value.length > 0
-            : Boolean(condition.value),
-        );
-        return (
-          conditions.length > 0 &&
-          conditions.every((condition) => condition.field === "account")
-        );
-      });
-    }
-    return (filters.accountIds ?? []).length > 0;
+    const named =
+      groups.length > 0
+        ? groups.flatMap((group) =>
+            (group.conditions ?? [])
+              .filter((condition) => condition.field === "account")
+              .flatMap((condition) =>
+                Array.isArray(condition.value)
+                  ? condition.value.filter(Boolean)
+                  : condition.value
+                    ? [condition.value]
+                    : [],
+              ),
+          )
+        : (filters.accountIds ?? []);
+    return [...new Set(named)];
   }
 
   private async getFilteredTransactions(
@@ -462,13 +501,28 @@ export class ReportsService {
       queryBuilder.andWhere(
         investmentLinkedTransactionExclusion("transaction"),
       );
-      // The securities sleeve is dropped only from a report that did not ask for
-      // it. Built-in reports have no account picker, so there the sleeve is
-      // noise in a whole-ledger figure; here the user may have named that
-      // account, and answering an explicitly scoped report with nothing is worse
-      // than showing the rows they asked to see.
-      if (!this.namesAnyAccount(filters)) {
+      // The securities sleeve is noise in a whole-ledger figure -- built-in
+      // reports have no account picker, so they always drop it -- but here the
+      // user may have named that very account, and answering an explicitly
+      // scoped report with nothing is worse than showing the rows they asked to
+      // see. The exception is per ROW, not per report: a filter group reading
+      // `account = Brokerage OR category = Salary` names Brokerage, while
+      // `account = Chequing OR payee = Acme` does not name it, and a
+      // whole-report boolean cannot tell those apart (audit F-CUSTOM-OR-001).
+      const explicitAccountIds = this.explicitAccountIds(filters);
+      if (explicitAccountIds.length === 0) {
         queryBuilder.andWhere(brokerageExclusionForEntity("account"));
+      } else {
+        queryBuilder.andWhere(
+          new Brackets((scope) => {
+            scope
+              .where(brokerageExclusionForEntity("account"))
+              .orWhere(
+                "transaction.accountId IN (:...explicitReportAccountIds)",
+                { explicitReportAccountIds: explicitAccountIds },
+              );
+          }),
+        );
       }
       // The embedded-investment half cannot be expressed here at all: the parent
       // is a real row carrying real ordinary cash beside the investment line, so
@@ -507,11 +561,20 @@ export class ReportsService {
         }
       }
 
-      // Filter by direction
+      // Filter by direction. A split parent's own amount is the SUM of its
+      // lines, so its sign is not the direction of any particular line: a -60
+      // expense beside a +500 embedded SELL is a +440 parent, and rejecting it
+      // here threw away the expense before provenance ever ran (audit
+      // F-CUSTOM-DIR-001). Split parents therefore pass this gate and are
+      // narrowed per line in `applyDirectionToSplitLines`.
       if (config.direction === DirectionFilter.INCOME_ONLY) {
-        queryBuilder.andWhere("transaction.amount > 0");
+        queryBuilder.andWhere(
+          "(transaction.isSplit = true OR transaction.amount > 0)",
+        );
       } else if (config.direction === DirectionFilter.EXPENSES_ONLY) {
-        queryBuilder.andWhere("transaction.amount < 0");
+        queryBuilder.andWhere(
+          "(transaction.isSplit = true OR transaction.amount < 0)",
+        );
       }
 
       // Filter transfers

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -7,7 +7,8 @@ import { tr } from "../i18n/translate";
 import { Brackets, DataSource, Repository } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
 import {
-  applyInvestmentTransactionFilters,
+  brokerageExclusionForEntity,
+  investmentLinkedTransactionExclusion,
   ordinarySplitLines,
   reportableTransactionAmount,
 } from "../common/investment-filter.util";
@@ -379,6 +380,19 @@ export class ReportsService {
     return { startDate, endDate, label };
   }
 
+  /**
+   * Whether the report scopes itself to particular accounts, through either the
+   * legacy `accountIds` filter or an advanced filter group.
+   */
+  private namesAnyAccount(filters: CustomReport["filters"]): boolean {
+    if (filters.accountIds && filters.accountIds.length > 0) return true;
+    return (filters.filterGroups ?? []).some((group) =>
+      (group.conditions ?? []).some(
+        (condition) => condition.field === "account",
+      ),
+    );
+  }
+
   private async getFilteredTransactions(
     userId: string,
     startDate: string,
@@ -420,14 +434,24 @@ export class ReportsService {
         .andWhere("transaction.status != 'VOID'");
 
       // INV-REPORT-001: a custom report reads the same ledger as the built-in
-      // ones, so it owes the same answer. This half excludes the securities
-      // sleeve and the cash leg a free-standing trade generated -- including
-      // when an explicit funding account put that leg in an ordinary account,
-      // where no account-type predicate could see it. The embedded-split half
-      // cannot be done here (the parent is a real row carrying real ordinary
-      // cash beside the investment line), so it happens per line during
-      // aggregation.
-      applyInvestmentTransactionFilters(queryBuilder, "account", "transaction");
+      // ones, so it owes the same answer. The cash leg a free-standing trade
+      // generated is never ordinary cash -- including when an explicit funding
+      // account put that leg in an ordinary account, where no account-type
+      // predicate could see it.
+      queryBuilder.andWhere(
+        investmentLinkedTransactionExclusion("transaction"),
+      );
+      // The securities sleeve is dropped only from a report that did not ask for
+      // it. Built-in reports have no account picker, so there the sleeve is
+      // noise in a whole-ledger figure; here the user may have named that
+      // account, and answering an explicitly scoped report with nothing is worse
+      // than showing the rows they asked to see.
+      if (!this.namesAnyAccount(filters)) {
+        queryBuilder.andWhere(brokerageExclusionForEntity("account"));
+      }
+      // The embedded-investment half cannot be expressed here at all: the parent
+      // is a real row carrying real ordinary cash beside the investment line, so
+      // it is classified per line during aggregation.
 
       // Advanced filter groups take precedence over legacy filters
       if (filters.filterGroups && filters.filterGroups.length > 0) {

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -381,16 +381,29 @@ export class ReportsService {
   }
 
   /**
-   * Whether the report scopes itself to particular accounts, through either the
-   * legacy `accountIds` filter or an advanced filter group.
+   * Whether the report actually restricts itself to particular accounts.
+   *
+   * Mirrors `getFilteredTransactions`' own precedence rather than checking both
+   * shapes: advanced filter groups REPLACE the legacy filters, so a report that
+   * has groups and a stale `accountIds` restricts nothing by account. And an
+   * account condition carrying no values adds no SQL at all -- which is what the
+   * filter builder saves for a half-finished condition -- so an empty one is not
+   * a scope either.
    */
   private namesAnyAccount(filters: CustomReport["filters"]): boolean {
-    if (filters.accountIds && filters.accountIds.length > 0) return true;
-    return (filters.filterGroups ?? []).some((group) =>
-      (group.conditions ?? []).some(
-        (condition) => condition.field === "account",
-      ),
-    );
+    const groups = filters.filterGroups ?? [];
+    if (groups.length > 0) {
+      return groups.some((group) =>
+        (group.conditions ?? []).some(
+          (condition) =>
+            condition.field === "account" &&
+            (Array.isArray(condition.value)
+              ? condition.value.length > 0
+              : Boolean(condition.value)),
+        ),
+      );
+    }
+    return (filters.accountIds ?? []).length > 0;
   }
 
   private async getFilteredTransactions(

--- a/backend/src/transactions/transaction-analytics.service.spec.ts
+++ b/backend/src/transactions/transaction-analytics.service.spec.ts
@@ -279,7 +279,7 @@ describe("TransactionAnalyticsService", () => {
       // the account-detail category breakdown.
       expect(mockQueryBuilder.orWhere).toHaveBeenCalledWith(
         expect.stringContaining(
-          "transaction.isSplit = true AND transaction.isTransfer = false AND summaryAccount.accountType != 'INVESTMENT' AND splits.categoryId IS NULL",
+          "transaction.isSplit = true AND transaction.isTransfer = false AND splits.categoryId IS NULL",
         ),
       );
     });

--- a/backend/src/transactions/transaction-analytics.service.ts
+++ b/backend/src/transactions/transaction-analytics.service.ts
@@ -10,6 +10,7 @@ import {
   brokerageExclusionForEntity,
   investmentLinkedSplitExclusion,
   investmentLinkedTransactionExclusion,
+  reportableTransactionAmountSql,
 } from "../common/investment-filter.util";
 import {
   joinSplitsForAnalytics,
@@ -33,6 +34,14 @@ import {
   UNKNOWN_CATEGORY_LABEL,
 } from "../categories/category-name.util";
 import { roundMoney, sumMoney } from "../common/round.util";
+
+/**
+ * The ordinary-cash amount of one transaction, for the recurring-charge
+ * detector: it reads one row per payment and joins no splits, so a split
+ * parent's own amount (the sum of every line, embedded investment included) is
+ * not what recurred.
+ */
+const RECURRING_REPORTABLE_AMOUNT = reportableTransactionAmountSql("t");
 
 export interface FxFeeMonthlySummaryRow {
   /** Calendar month in 'YYYY-MM'. */
@@ -613,6 +622,13 @@ export class TransactionAnalyticsService {
     queryBuilder.andWhere(
       "(splits.transferAccountId IS NULL OR splits.id IS NULL)",
     );
+    // ...and an embedded investment line is the trade's own cash side, not
+    // ordinary cash. Unconditional, unlike excludeInvestmentLinked below: that
+    // flag is about whole rows a caller may want to see, while this line's
+    // amount would otherwise land in the NULL "Uncategorized" bucket of every
+    // grouped total -- whose drill-down (the register filtered to
+    // uncategorized) excludes it, so the two disagreed by the trade amount.
+    queryBuilder.andWhere(investmentLinkedSplitExclusion("splits"));
 
     // Optionally exclude cash-side transactions created as a side-effect
     // of an investment BUY/SELL/DIVIDEND. Those transactions live in the
@@ -1662,8 +1678,11 @@ export class TransactionAnalyticsService {
         .addSelect("chargePayee.id", "payeeId")
         .addSelect(categoryNameSelect, "categoryName")
         .addSelect("cat.id", "categoryId")
+        // A split parent's own amount is the sum of every line, so the charge
+        // has to be the ordinary part -- otherwise this answers 560 where the
+        // built-in Recurring Expenses report answers 60 for the same rows.
         .addSelect(
-          "ARRAY_AGG(ABS(t.amount) ORDER BY t.transactionDate ASC)",
+          `ARRAY_AGG(ABS(${RECURRING_REPORTABLE_AMOUNT}) ORDER BY t.transactionDate ASC)`,
           "amounts",
         )
         .addSelect(
@@ -1674,7 +1693,7 @@ export class TransactionAnalyticsService {
         .where("t.userId = :userId", { userId })
         .andWhere("t.transactionDate >= :startDate", { startDate })
         .andWhere("t.transactionDate <= :endDate", { endDate })
-        .andWhere("t.amount < 0")
+        .andWhere(`${RECURRING_REPORTABLE_AMOUNT} < 0`)
         .andWhere("t.status != 'VOID'")
         .andWhere("t.isTransfer = false")
         .andWhere("t.parentTransactionId IS NULL")

--- a/backend/src/transactions/transaction-analytics.service.ts
+++ b/backend/src/transactions/transaction-analytics.service.ts
@@ -5,7 +5,12 @@ import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { getAllCategoryIdsWithChildren } from "../common/category-tree.util";
-import { applyInvestmentTransactionFilters } from "../common/investment-filter.util";
+import {
+  applyInvestmentTransactionFilters,
+  brokerageExclusionForEntity,
+  investmentLinkedSplitExclusion,
+  investmentLinkedTransactionExclusion,
+} from "../common/investment-filter.util";
 import {
   joinSplitsForAnalytics,
   SPLIT_AMOUNT,
@@ -596,9 +601,7 @@ export class TransactionAnalyticsService {
     // counts/totals match the transaction list.
     queryBuilder.leftJoin("transaction.account", "summaryAccount");
 
-    queryBuilder.andWhere(
-      "(summaryAccount.accountSubType IS NULL OR summaryAccount.accountSubType != 'INVESTMENT_BROKERAGE')",
-    );
+    queryBuilder.andWhere(brokerageExclusionForEntity("summaryAccount"));
 
     // Always expand split transactions so mixed-sign splits are bucketed
     // into income/expense per split. A split parent carries `amount =
@@ -618,8 +621,7 @@ export class TransactionAnalyticsService {
     // leak into expense/income totals as "uncategorised" spending.
     if (excludeInvestmentLinked) {
       queryBuilder.andWhere(
-        // includes VOID rows: records read -- identity, not effect.
-        "NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = transaction.id)",
+        investmentLinkedTransactionExclusion("transaction"),
       );
     }
 
@@ -695,14 +697,18 @@ export class TransactionAnalyticsService {
                 new Brackets((unc) => {
                   unc
                     .where(
-                      "transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND summaryAccount.accountType != 'INVESTMENT'",
+                      `transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND ${investmentLinkedTransactionExclusion(
+                        "transaction",
+                      )}`,
                     )
                     // A split transaction counts as uncategorised when any of
                     // its non-transfer split lines has no category (transfer
                     // splits are already excluded by the base query), matching
                     // the category breakdown grouping.
                     .orWhere(
-                      "transaction.isSplit = true AND transaction.isTransfer = false AND summaryAccount.accountType != 'INVESTMENT' AND splits.categoryId IS NULL",
+                      `transaction.isSplit = true AND transaction.isTransfer = false AND splits.categoryId IS NULL AND ${investmentLinkedSplitExclusion(
+                        "splits",
+                      )}`,
                     );
                 }),
               );
@@ -1675,10 +1681,7 @@ export class TransactionAnalyticsService {
         .andWhere("(t.payeeId IS NOT NULL OR t.payeeName IS NOT NULL)")
         // Exclude investment-linked cash debits so regular BUY activity
         // isn't flagged as a subscription-like "recurring charge".
-        .andWhere(
-          // includes VOID rows: records read -- identity, not effect.
-          "NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = t.id)",
-        )
+        .andWhere(investmentLinkedTransactionExclusion("t"))
         .setParameters(
           options.uncategorizedLabel
             ? { uncategorizedLabel: options.uncategorizedLabel }

--- a/backend/src/transactions/transaction-bulk-update.service.spec.ts
+++ b/backend/src/transactions/transaction-bulk-update.service.spec.ts
@@ -3181,6 +3181,18 @@ describe("TransactionBulkUpdateService", () => {
       expect(mockWhereBuilder.where).toHaveBeenCalledWith(
         expect.stringContaining("transaction.categoryId IS NULL"),
       );
+      // This is a WRITE path: "select all uncategorized" must not reach the cash
+      // legs a trade owns, and the securities sleeve is not ordinary cash
+      // either. Membership is provenance, never the account's type (issue
+      // #1257) -- so neither predicate may drift back to accountType here.
+      const [uncategorizedClause] = mockWhereBuilder.where.mock.calls[0];
+      expect(uncategorizedClause).toContain(
+        "filterAccount.accountSubType != 'INVESTMENT_BROKERAGE'",
+      );
+      expect(uncategorizedClause).toContain(
+        "NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = transaction.id)",
+      );
+      expect(uncategorizedClause).not.toContain("accountType");
     });
 
     it("applies transfer category filter", async () => {

--- a/backend/src/transactions/transaction-bulk-update.service.ts
+++ b/backend/src/transactions/transaction-bulk-update.service.ts
@@ -17,6 +17,10 @@ import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { TransactionSplit } from "./entities/transaction-split.entity";
 import { TransactionSplitService } from "./transaction-split.service";
 import { Category } from "../categories/entities/category.entity";
+import {
+  brokerageExclusionForEntity,
+  investmentLinkedTransactionExclusion,
+} from "../common/investment-filter.util";
 import { Payee } from "../payees/entities/payee.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { AccountsService } from "../accounts/accounts.service";
@@ -1540,7 +1544,9 @@ export class TransactionBulkUpdateService {
             const method = hasCondition ? "orWhere" : "where";
             hasCondition = true;
             qb[method](
-              "transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND filterAccount.accountType != 'INVESTMENT'",
+              `transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND ${brokerageExclusionForEntity(
+                "filterAccount",
+              )} AND ${investmentLinkedTransactionExclusion("transaction")}`,
             );
           }
           if (hasTransfer) {

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -2590,8 +2590,13 @@ describe("TransactionsService", () => {
       // also matched so the list agrees with the account-detail breakdown.
       expect(mockQb.orWhere).toHaveBeenCalledWith(
         expect.stringContaining(
-          "transaction.isSplit = true AND transaction.isTransfer = false AND account.accountType != 'INVESTMENT' AND splits.categoryId IS NULL AND splits.transferAccountId IS NULL",
+          "transaction.isSplit = true AND transaction.isTransfer = false AND splits.categoryId IS NULL AND splits.transferAccountId IS NULL",
         ),
+      );
+      // An investment line embedded in a split has no category by definition,
+      // so it is not what "uncategorised" means (issue #1257).
+      expect(mockQb.orWhere).toHaveBeenCalledWith(
+        expect.stringContaining("its.transaction_split_id = splits.id"),
       );
     });
 

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -24,6 +24,11 @@ import { PayeesService } from "../payees/payees.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { TransactionSplitService } from "./transaction-split.service";
 import { applyRegisterOrder } from "./register-order";
+import {
+  brokerageExclusionForEntity,
+  investmentLinkedSplitExclusion,
+  investmentLinkedTransactionExclusion,
+} from "../common/investment-filter.util";
 import { transferPayeeLabel } from "./transfer-payee-label.util";
 import {
   assertVoidTransitionAllowedOnRow,
@@ -942,9 +947,7 @@ export class TransactionsService {
       );
 
       if (!includeInvestmentBrokerage) {
-        queryBuilder.andWhere(
-          "(account.accountSubType IS NULL OR account.accountSubType != 'INVESTMENT_BROKERAGE')",
-        );
+        queryBuilder.andWhere(brokerageExclusionForEntity("account"));
       }
 
       if (accountIds && accountIds.length > 0) {
@@ -1202,7 +1205,9 @@ export class TransactionsService {
               new Brackets((unc) => {
                 unc
                   .where(
-                    "transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND account.accountType != 'INVESTMENT'",
+                    `transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND ${investmentLinkedTransactionExclusion(
+                      "transaction",
+                    )}`,
                   )
                   // A split transaction is uncategorised when any of its
                   // non-transfer split lines has no category. Match those too so
@@ -1211,7 +1216,9 @@ export class TransactionsService {
                   // the matching (null-category) splits hydrate, giving the
                   // frontend a filtered partial total.
                   .orWhere(
-                    "transaction.isSplit = true AND transaction.isTransfer = false AND account.accountType != 'INVESTMENT' AND splits.categoryId IS NULL AND splits.transferAccountId IS NULL",
+                    `transaction.isSplit = true AND transaction.isTransfer = false AND splits.categoryId IS NULL AND splits.transferAccountId IS NULL AND ${investmentLinkedSplitExclusion(
+                      "splits",
+                    )}`,
                   );
               }),
             );
@@ -1284,9 +1291,7 @@ export class TransactionsService {
         .where(this.registerScope("t", userId, jointAccountIds));
 
       if (!includeInvestmentBrokerage) {
-        countQuery.andWhere(
-          "(a.accountSubType IS NULL OR a.accountSubType != 'INVESTMENT_BROKERAGE')",
-        );
+        countQuery.andWhere(brokerageExclusionForEntity("a"));
       }
       if (accountIds && accountIds.length > 0) {
         countQuery.andWhere("t.accountId IN (:...accountIds)", { accountIds });

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -1899,8 +1899,13 @@ export class TransactionsService {
         new Brackets((outer) => {
           let hasCondition = false;
           if (hasUncategorized) {
+            // The same meaning as the list's own uncategorized arm: a trade's
+            // cash leg is not a row the user forgot to file. Without this the
+            // running balance summed a row the list above it does not show.
             outer.where(
-              "bf.categoryId IS NULL AND bf.isSplit = false AND bf.isTransfer = false",
+              `bf.categoryId IS NULL AND bf.isSplit = false AND bf.isTransfer = false AND ${investmentLinkedTransactionExclusion(
+                "bf",
+              )}`,
             );
             hasCondition = true;
           }

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -1899,9 +1899,15 @@ export class TransactionsService {
         new Brackets((outer) => {
           let hasCondition = false;
           if (hasUncategorized) {
-            // The same meaning as the list's own uncategorized arm: a trade's
-            // cash leg is not a row the user forgot to file. Without this the
-            // running balance summed a row the list above it does not show.
+            // A trade's cash leg is not a row the user forgot to file, so the
+            // running balance must not sum a row the list above it does not
+            // show. This arm is NOT otherwise identical to the list's: the list
+            // also matches a split parent with an uncategorized child, and this
+            // one does not, so such a parent is missing from the prior-page sum
+            // (pre-existing, and not fixable by copying the branch --
+            // `computeSplitAwareSum` adds the WHOLE parent amount for a
+            // pure-uncategorized filter, which would be wrong in the other
+            // direction).
             outer.where(
               `bf.categoryId IS NULL AND bf.isSplit = false AND bf.isTransfer = false AND ${investmentLinkedTransactionExclusion(
                 "bf",

--- a/backend/test/integration/report-investment-cash.integration.spec.ts
+++ b/backend/test/integration/report-investment-cash.integration.spec.ts
@@ -35,6 +35,7 @@ import {
   InvestmentTransaction,
 } from "@/securities/entities/investment-transaction.entity";
 import { TransactionAnalyticsService } from "@/transactions/transaction-analytics.service";
+import { ForecastAggregatorService } from "@/ai/forecast/forecast-aggregator.service";
 import { ReportsService } from "@/reports/reports.service";
 import {
   CustomReport,
@@ -624,6 +625,52 @@ describe("built-in reports and investment cash accounts (integration)", () => {
       expect(result.data).toEqual([expect.objectContaining({ value: 60 })]);
     });
 
+    it("leaves a transfer split line out when the report excludes transfers", async () => {
+      // `transaction.isTransfer` is false on a split parent carrying a transfer
+      // LINE, so the parent-level filter never saw it and the -200 counted as
+      // spending.
+      const parent = await insertTransaction({
+        amount: -260,
+        isSplit: true,
+        categoryId: null,
+        payeeName: "Sleeve sweep",
+      });
+      await dataSource.manager.save([
+        dataSource.manager.create(TransactionSplit, {
+          transactionId: parent.id,
+          kind: SplitKind.CATEGORY,
+          categoryId: groceriesCategoryId,
+          amount: -60,
+        } as Partial<TransactionSplit>),
+        dataSource.manager.create(TransactionSplit, {
+          transactionId: parent.id,
+          kind: SplitKind.TRANSFER,
+          transferAccountId: chequingId,
+          amount: -200,
+        } as Partial<TransactionSplit>),
+      ]);
+      // The counterpart leg the transfer writer creates in the target account.
+      await insertTransaction({
+        accountId: chequingId,
+        amount: 200,
+        isTransfer: true,
+        categoryId: null,
+      });
+
+      const excluded = await runCustomReport({
+        groupBy: GroupByType.CATEGORY,
+        includeTransfers: false,
+      });
+      expect(excluded.summary.total).toBe(60);
+
+      // ...and the user can still ask for them.
+      const included = await runCustomReport({
+        groupBy: GroupByType.CATEGORY,
+        includeTransfers: true,
+      });
+      expect(included.summary.total).toBe(260);
+    });
+
     it("honours a brokerage account named inside a mixed OR group", async () => {
       // Conditions in a group are OR'd, so this filter explicitly asks for
       // brokerage rows. A whole-report boolean read it as "not an account
@@ -840,6 +887,55 @@ describe("built-in reports and investment cash accounts (integration)", () => {
       );
 
       expect(charges).toEqual([]);
+    });
+  });
+
+  /**
+   * The AI forecast trains on this baseline, and it reads one row per payment
+   * with no split join -- so a split parent's own amount taught it a household
+   * spend nobody made.
+   */
+  describe("forecast baseline", () => {
+    it("learns the ordinary part of a mixed split, not the parent total", async () => {
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: -500,
+      });
+      await insertSleeveSalary();
+
+      // `getMonthlyHistory` is private and the public entry point needs the
+      // accounts and analytics services; the SQL is the subject here, and only a
+      // real database can execute it.
+      const forecast = new ForecastAggregatorService(
+        dataSource,
+        {} as never,
+        {} as never,
+      );
+      const history = await withUserContext(userId, () =>
+        (
+          forecast as unknown as {
+            getMonthlyHistory: (
+              userId: string,
+              startDate: string,
+              endDate: string,
+            ) => Promise<
+              Array<{
+                month: string;
+                totalIncome: number;
+                totalExpenses: number;
+              }>
+            >;
+          }
+        ).getMonthlyHistory(userId, START, END),
+      );
+
+      expect(history).toEqual([
+        expect.objectContaining({
+          month: MONTH,
+          totalIncome: 1000,
+          totalExpenses: 60,
+        }),
+      ]);
     });
   });
 

--- a/backend/test/integration/report-investment-cash.integration.spec.ts
+++ b/backend/test/integration/report-investment-cash.integration.spec.ts
@@ -203,6 +203,78 @@ describe("built-in reports and investment cash accounts (integration)", () => {
   }
 
   /**
+   * A split parent in the cash sleeve carrying an embedded investment line,
+   * shaped as `createEmbeddedForSplit` writes it: the investment line has no
+   * category, its InvestmentTransaction points at the SPLIT (`transaction_id`
+   * stays null), and the parent's amount is the sum of all its children.
+   *
+   * `ordinaryAmount: 0` builds the pure passthrough -- a parent whose only line
+   * is the investment one, which `transaction-split.service` allows.
+   */
+  async function createEmbeddedInvestmentParent(options: {
+    date?: string;
+    ordinaryAmount?: number;
+    investmentAmount?: number;
+    payeeName?: string;
+  }): Promise<Transaction> {
+    const ordinary = options.ordinaryAmount ?? -60;
+    const investment = options.investmentAmount ?? -500;
+    const parent = await insertTransaction({
+      transactionDate: options.date ?? "2026-03-10",
+      amount: ordinary + investment,
+      isSplit: true,
+      categoryId: null,
+      payeeName: options.payeeName ?? "Brokerage statement",
+    });
+
+    const lines: TransactionSplit[] = [];
+    if (ordinary !== 0) {
+      lines.push(
+        dataSource.manager.create(TransactionSplit, {
+          transactionId: parent.id,
+          kind: SplitKind.CATEGORY,
+          categoryId: groceriesCategoryId,
+          amount: ordinary,
+        } as Partial<TransactionSplit>),
+      );
+    }
+    const investmentLine = dataSource.manager.create(TransactionSplit, {
+      transactionId: parent.id,
+      kind: SplitKind.INVESTMENT,
+      categoryId: null,
+      amount: investment,
+    } as Partial<TransactionSplit>);
+    lines.push(investmentLine);
+    await dataSource.manager.save(lines);
+
+    await dataSource.manager.save(
+      dataSource.manager.create(InvestmentTransaction, {
+        userId,
+        accountId: brokerageId,
+        transactionSplitId: investmentLine.id,
+        securityId,
+        action: InvestmentAction.BUY,
+        transactionDate: options.date ?? "2026-03-10",
+        quantity: 10,
+        price: Math.abs(investment) / 10,
+        commission: 0,
+        totalAmount: investment,
+        exchangeRate: 1,
+        status: TransactionStatus.UNRECONCILED,
+      } as Partial<InvestmentTransaction>),
+    );
+
+    return parent;
+  }
+
+  /** A date N whole months before today, for the reports that window on now(). */
+  function monthsBeforeToday(months: number): string {
+    const d = new Date();
+    d.setMonth(d.getMonth() - months);
+    return d.toISOString().slice(0, 10);
+  }
+
+  /**
    * The scenario from issue #1257: $1,000 of employment income paid straight
    * into the cash sleeve of an investment account.
    */
@@ -680,19 +752,89 @@ describe("built-in reports and investment cash accounts (integration)", () => {
     });
 
     it("does not count an investment line embedded in a split", async () => {
-      // Shaped as `createEmbeddedForSplit` writes it: the investment line
-      // carries no category and its InvestmentTransaction points at the split
-      // (`transaction_id` stays null, the parent's amount is the cash side).
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: -500,
+      });
+
+      const byCategory = await withUserContext(userId, () =>
+        spending.getSpendingByCategory(userId, START, END),
+      );
+
+      expect(byCategory.data).toEqual([
+        expect.objectContaining({ categoryId: groceriesCategoryId, total: 60 }),
+      ]);
+      expect(byCategory.totalSpending).toBe(60);
+
+      const cashFlow = await withUserContext(userId, () =>
+        income.getIncomeVsExpenses(userId, START, END),
+      );
+      expect(cashFlow.totals.expenses).toBe(60);
+    });
+
+    /**
+     * The reports that read only the parent row. `t.amount` there is the sum of
+     * ALL children and an embedded investment line's `transaction_id` is null,
+     * so the transaction-level linkage cannot see it: without a derived amount
+     * these reported the whole `-560` as ordinary cash (branch audit F-RPT-001).
+     * Excluding the parent instead would lose the 60 the user did spend, so both
+     * wrong answers are asserted against.
+     */
+    it("reports only the ordinary line of a mixed split by payee", async () => {
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: -500,
+        payeeName: "Brokerage statement",
+      });
+
+      const byPayee = await withUserContext(userId, () =>
+        spending.getSpendingByPayee(userId, START, END),
+      );
+
+      expect(byPayee.data).toEqual([
+        expect.objectContaining({
+          payeeName: "Brokerage statement",
+          total: 60,
+        }),
+      ]);
+      expect(byPayee.totalSpending).toBe(60);
+    });
+
+    it("does not call a pure embedded-investment passthrough uncategorized", async () => {
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: 0,
+        investmentAmount: -500,
+        payeeName: "Broker",
+      });
+      const unfiled = await insertTransaction({
+        amount: -25,
+        categoryId: null,
+        payeeName: "Unfiled sleeve fee",
+      });
+
+      const result = await withUserContext(userId, () =>
+        dataQuality.getUncategorizedTransactions(userId, START, END),
+      );
+
+      expect(result.transactions.map((t) => t.id)).toEqual([unfiled.id]);
+      expect(result.summary.totalCount).toBe(1);
+      expect(result.summary.expenseCount).toBe(1);
+      expect(result.summary.expenseTotal).toBe(25);
+    });
+
+    it("reports the ordinary part of a mixed uncategorized split, not the parent total", async () => {
+      // -60 unfiled ordinary cash beside a -500 embedded BUY: the row IS
+      // uncategorized, but for 60, not 560.
       const parent = await insertTransaction({
         amount: -560,
         isSplit: true,
         categoryId: null,
         payeeName: "Brokerage statement",
       });
-      const groceries = dataSource.manager.create(TransactionSplit, {
+      const unfiledLine = dataSource.manager.create(TransactionSplit, {
         transactionId: parent.id,
         kind: SplitKind.CATEGORY,
-        categoryId: groceriesCategoryId,
+        categoryId: null,
         amount: -60,
       } as Partial<TransactionSplit>);
       const investmentLine = dataSource.manager.create(TransactionSplit, {
@@ -701,7 +843,7 @@ describe("built-in reports and investment cash accounts (integration)", () => {
         categoryId: null,
         amount: -500,
       } as Partial<TransactionSplit>);
-      await dataSource.manager.save([groceries, investmentLine]);
+      await dataSource.manager.save([unfiledLine, investmentLine]);
       await dataSource.manager.save(
         dataSource.manager.create(InvestmentTransaction, {
           userId,
@@ -719,19 +861,85 @@ describe("built-in reports and investment cash accounts (integration)", () => {
         } as Partial<InvestmentTransaction>),
       );
 
-      const byCategory = await withUserContext(userId, () =>
-        spending.getSpendingByCategory(userId, START, END),
+      const result = await withUserContext(userId, () =>
+        dataQuality.getUncategorizedTransactions(userId, START, END),
       );
 
-      expect(byCategory.data).toEqual([
-        expect.objectContaining({ categoryId: groceriesCategoryId, total: 60 }),
+      expect(result.transactions).toEqual([
+        expect.objectContaining({ id: parent.id, amount: -60 }),
       ]);
-      expect(byCategory.totalSpending).toBe(60);
+      expect(result.summary.expenseTotal).toBe(60);
+    });
 
-      const cashFlow = await withUserContext(userId, () =>
-        income.getIncomeVsExpenses(userId, START, END),
+    it("does not learn recurring spending from embedded BUY cash", async () => {
+      // Dates are derived from today because getRecurringExpenses windows on
+      // now() -- a pinned month would fall out of range as the clock moves.
+      for (const months of [1, 2, 3]) {
+        await createEmbeddedInvestmentParent({
+          date: monthsBeforeToday(months),
+          ordinaryAmount: 0,
+          investmentAmount: -500,
+          payeeName: "Broker",
+        });
+      }
+
+      const result = await withUserContext(userId, () =>
+        taxRecurring.getRecurringExpenses(userId, 3),
       );
-      expect(cashFlow.totals.expenses).toBe(60);
+
+      expect(result.data).toEqual([]);
+      expect(result.summary.totalRecurring).toBe(0);
+    });
+
+    it("counts a mixed recurring parent at its ordinary amount", async () => {
+      for (const months of [1, 2, 3]) {
+        await createEmbeddedInvestmentParent({
+          date: monthsBeforeToday(months),
+          ordinaryAmount: -60,
+          investmentAmount: -500,
+          payeeName: "Brokerage statement",
+        });
+      }
+
+      const result = await withUserContext(userId, () =>
+        taxRecurring.getRecurringExpenses(userId, 3),
+      );
+
+      expect(result.data).toEqual([
+        expect.objectContaining({
+          payeeName: "Brokerage statement",
+          occurrences: 3,
+          totalAmount: 180,
+          averageAmount: 60,
+        }),
+      ]);
+    });
+
+    /**
+     * The declared exception (branch audit DR-001): the duplicate finder's
+     * subject is the stored row, so a split parent entered twice is a duplicate
+     * at its stored amount -- the remedy is deleting one whole transaction, and
+     * a per-child figure would name a row nobody can delete.
+     */
+    it("still reports a duplicated split parent at its stored amount", async () => {
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: -500,
+        payeeName: "Brokerage statement",
+      });
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: -500,
+        payeeName: "Brokerage statement",
+      });
+
+      const result = await withUserContext(userId, () =>
+        dataQuality.getDuplicateTransactions(userId, START, END),
+      );
+
+      expect(result.groups).toHaveLength(1);
+      expect(result.groups[0].transactions).toHaveLength(2);
+      expect(result.groups[0].transactions[0].amount).toBe(-560);
     });
   });
 });

--- a/backend/test/integration/report-investment-cash.integration.spec.ts
+++ b/backend/test/integration/report-investment-cash.integration.spec.ts
@@ -215,23 +215,57 @@ describe("built-in reports and investment cash accounts (integration)", () => {
     });
   }
 
-  /** A BUY funded from the sleeve, so its cash leg lands in the sleeve. */
+  /**
+   * A trade through the real writer. With no funding account the cash leg lands
+   * in the linked sleeve; with one it lands in that account instead -- which is
+   * how investment-generated cash reaches an ordinary chequing ledger, where no
+   * account-type predicate could ever have recognised it.
+   */
+  async function createTrade(
+    action: InvestmentAction,
+    overrides: {
+      date?: string;
+      quantity?: number;
+      price?: number;
+      fundingAccountId?: string;
+    } = {},
+  ): Promise<InvestmentTransaction> {
+    return withUserContext(userId, () =>
+      investments.create(userId, {
+        accountId: brokerageId,
+        action,
+        transactionDate: overrides.date ?? "2026-03-12",
+        securityId,
+        quantity: overrides.quantity ?? 10,
+        price: overrides.price ?? 50,
+        commission: 0,
+        ...(overrides.fundingAccountId
+          ? { fundingAccountId: overrides.fundingAccountId }
+          : {}),
+      } as any),
+    );
+  }
+
   async function createBuy(
     date = "2026-03-12",
     quantity = 10,
     price = 50,
   ): Promise<InvestmentTransaction> {
-    return withUserContext(userId, () =>
-      investments.create(userId, {
-        accountId: brokerageId,
-        action: InvestmentAction.BUY,
-        transactionDate: date,
-        securityId,
-        quantity,
-        price,
-        commission: 0,
-      } as any),
-    );
+    return createTrade(InvestmentAction.BUY, { date, quantity, price });
+  }
+
+  /** The cash row a trade generated, asserted to be where the test expects. */
+  async function generatedLeg(
+    trade: InvestmentTransaction,
+    expectedAccountId: string,
+  ): Promise<Transaction> {
+    const leg = await dataSource.manager.findOneOrFail(Transaction, {
+      where: { id: trade.transactionId as string },
+    });
+    expect(leg.accountId).toBe(expectedAccountId);
+    expect(leg.categoryId).toBeNull();
+    expect(leg.isTransfer).toBe(false);
+    return leg;
   }
 
   describe("the reported bug", () => {
@@ -315,6 +349,46 @@ describe("built-in reports and investment cash accounts (integration)", () => {
 
       const payees = result.data.map((row) => row.payeeName);
       expect(payees).toEqual(["Corner Store"]);
+    });
+  });
+
+  /**
+   * The Cash Flow page issues three requests -- the monthly aggregate, the
+   * inflow breakdown and the outflow breakdown -- and every one of them carried
+   * the account-type predicate. A per-query fix that left them disagreeing would
+   * show a chart and two tables that do not add up, so the reconciliation is
+   * asserted rather than assumed.
+   */
+  describe("the Cash Flow page's three queries", () => {
+    it("reconcile with each other over the same range", async () => {
+      await insertSleeveSalary();
+      await insertTransaction({
+        amount: -60,
+        categoryId: groceriesCategoryId,
+        payeeName: "Corner Store",
+      });
+      await insertTransaction({
+        accountId: chequingId,
+        amount: -40,
+        categoryId: groceriesCategoryId,
+        payeeName: "Bakery",
+      });
+      await createBuy();
+
+      const [cashFlow, bySource, byCategory] = await withUserContext(
+        userId,
+        async () =>
+          Promise.all([
+            income.getIncomeVsExpenses(userId, START, END),
+            income.getIncomeBySource(userId, START, END),
+            spending.getSpendingByCategory(userId, START, END),
+          ]),
+      );
+
+      expect(cashFlow.totals.income).toBe(1000);
+      expect(cashFlow.totals.expenses).toBe(100);
+      expect(bySource.totalIncome).toBe(cashFlow.totals.income);
+      expect(byCategory.totalSpending).toBe(cashFlow.totals.expenses);
     });
   });
 
@@ -461,6 +535,148 @@ describe("built-in reports and investment cash accounts (integration)", () => {
       );
 
       expect(result.groups).toEqual([]);
+    });
+
+    it("keeps a trade's cash leg out of an ordinary funding account's report", async () => {
+      // The inverse of issue #1257, same root: an explicit funding account puts
+      // generated investment cash in a CHEQUING ledger, where the old
+      // account-type predicate could not see it at all. Before the fix this
+      // month reported 1000 of expenses that nobody spent.
+      await insertTransaction({
+        accountId: chequingId,
+        amount: -60,
+        categoryId: groceriesCategoryId,
+        payeeName: "Corner Store",
+      });
+      const buy = await createTrade(InvestmentAction.BUY, {
+        quantity: 10,
+        price: 100,
+        fundingAccountId: chequingId,
+      });
+      const leg = await generatedLeg(buy, chequingId);
+      expect(Number(leg.amount)).toBe(-1000);
+
+      const cashFlow = await withUserContext(userId, () =>
+        income.getIncomeVsExpenses(userId, START, END),
+      );
+
+      expect(cashFlow.totals.expenses).toBe(60);
+      expect(cashFlow.totals.income).toBe(0);
+    });
+
+    it("keeps a dividend paid into an ordinary account out of income", async () => {
+      const dividend = await createTrade(InvestmentAction.DIVIDEND, {
+        quantity: 1,
+        price: 30,
+        fundingAccountId: chequingId,
+      });
+      const leg = await generatedLeg(dividend, chequingId);
+      expect(Number(leg.amount)).toBe(30);
+
+      const cashFlow = await withUserContext(userId, () =>
+        income.getIncomeVsExpenses(userId, START, END),
+      );
+      const bySource = await withUserContext(userId, () =>
+        income.getIncomeBySource(userId, START, END),
+      );
+
+      expect(cashFlow.totals.income).toBe(0);
+      expect(bySource.data).toEqual([]);
+      expect(bySource.totalIncome).toBe(0);
+    });
+
+    it("keeps a SELL's cash credit out of income", async () => {
+      await insertSleeveSalary();
+      const sell = await createTrade(InvestmentAction.SELL, {
+        quantity: 4,
+        price: 75,
+      });
+      const leg = await generatedLeg(sell, cashSleeveId);
+      expect(Number(leg.amount)).toBe(300);
+
+      const cashFlow = await withUserContext(userId, () =>
+        income.getIncomeVsExpenses(userId, START, END),
+      );
+
+      expect(cashFlow.totals.income).toBe(1000);
+    });
+
+    it("counts ordinary cash on a standalone investment account", async () => {
+      // A .mny import produces these: account_type INVESTMENT with no sub-type,
+      // holding both securities and its own cash. It IS the cash side, so the
+      // brokerage-sleeve exclusion must not reach it.
+      const standalone = await createTestAccount(dataSource, userId, {
+        name: "Legacy Brokerage",
+        openingBalance: 0,
+        currentBalance: 0,
+      });
+      await dataSource.manager.update(Account, standalone.id, {
+        accountType: AccountType.INVESTMENT,
+        accountSubType: null,
+      });
+      await insertTransaction({
+        accountId: standalone.id,
+        amount: 250,
+        categoryId: salaryCategoryId,
+        payeeName: "Acme Payroll",
+      });
+
+      const cashFlow = await withUserContext(userId, () =>
+        income.getIncomeVsExpenses(userId, START, END),
+      );
+
+      expect(cashFlow.totals.income).toBe(250);
+    });
+
+    it("still excludes a VOID row in the sleeve", async () => {
+      await insertSleeveSalary();
+      await insertTransaction({
+        amount: 5000,
+        categoryId: salaryCategoryId,
+        payeeName: "Voided bonus",
+        status: TransactionStatus.VOID,
+      });
+
+      const cashFlow = await withUserContext(userId, () =>
+        income.getIncomeVsExpenses(userId, START, END),
+      );
+
+      expect(cashFlow.totals.income).toBe(1000);
+    });
+
+    it("still excludes a transfer split line in the sleeve", async () => {
+      const parent = await insertTransaction({
+        amount: -260,
+        isSplit: true,
+        categoryId: null,
+        payeeName: "Sleeve sweep",
+      });
+      const groceries = dataSource.manager.create(TransactionSplit, {
+        transactionId: parent.id,
+        kind: SplitKind.CATEGORY,
+        categoryId: groceriesCategoryId,
+        amount: -60,
+      } as Partial<TransactionSplit>);
+      const transferOut = dataSource.manager.create(TransactionSplit, {
+        transactionId: parent.id,
+        kind: SplitKind.TRANSFER,
+        transferAccountId: chequingId,
+        amount: -200,
+      } as Partial<TransactionSplit>);
+      await dataSource.manager.save([groceries, transferOut]);
+      // The counterpart leg the transfer writer creates in the target account.
+      await insertTransaction({
+        accountId: chequingId,
+        amount: 200,
+        isTransfer: true,
+        categoryId: null,
+      });
+
+      const byCategory = await withUserContext(userId, () =>
+        spending.getSpendingByCategory(userId, START, END),
+      );
+
+      expect(byCategory.totalSpending).toBe(60);
     });
 
     it("does not count an investment line embedded in a split", async () => {

--- a/backend/test/integration/report-investment-cash.integration.spec.ts
+++ b/backend/test/integration/report-investment-cash.integration.spec.ts
@@ -34,6 +34,7 @@ import {
   InvestmentAction,
   InvestmentTransaction,
 } from "@/securities/entities/investment-transaction.entity";
+import { TransactionAnalyticsService } from "@/transactions/transaction-analytics.service";
 import { ReportsService } from "@/reports/reports.service";
 import {
   CustomReport,
@@ -80,6 +81,7 @@ describe("built-in reports and investment cash accounts (integration)", () => {
   let dataQuality: DataQualityReportsService;
   let breakdown: MonthlyCategoryBreakdownService;
   let customReports: ReportsService;
+  let analytics!: TransactionAnalyticsService;
   let investments: InvestmentTransactionsService;
   let dataSource: DataSource;
 
@@ -119,6 +121,7 @@ describe("built-in reports and investment cash accounts (integration)", () => {
     // `execute` uses neither the budgets service (only the BUDGET_VARIANCE
     // metric does) nor action history (only the writes do).
     customReports = new ReportsService(dataSource, {} as never, {} as never);
+    analytics = new TransactionAnalyticsService(dataSource);
   });
 
   afterAll(async () => {
@@ -632,6 +635,99 @@ describe("built-in reports and investment cash accounts (integration)", () => {
       // The two engines answer the same question about one ledger, so a
       // divergence here is the defect whichever side moved.
       expect(custom.summary.total).toBe(builtIn.totalSpending);
+    });
+  });
+
+  /**
+   * The register's own analytics read the same rows. Their grouped totals are
+   * drill-downs: a bucket links to the register filtered the same way, so a
+   * figure the filtered list cannot show is a dead end (found by /code-review
+   * over this branch).
+   */
+  describe("register analytics", () => {
+    it("does not file an embedded investment line under Uncategorized", async () => {
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: -500,
+      });
+
+      const grouped = await withUserContext(userId, () =>
+        analytics.getGroupedTotals(userId, {
+          groupBy: "category",
+          startDate: START,
+          endDate: END,
+        }),
+      );
+
+      // Exactly the groceries line: the -500 investment line would otherwise
+      // open an "Uncategorized" bucket whose drill-down is empty.
+      expect(grouped).toEqual([
+        expect.objectContaining({ id: groceriesCategoryId, total: -60 }),
+      ]);
+    });
+
+    it("agrees with its own summary about what the ordinary cash was", async () => {
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: -500,
+      });
+
+      const summary = await withUserContext(userId, () =>
+        analytics.getSummary(userId, undefined, START, END),
+      );
+
+      expect(summary.totalExpenses).toBe(60);
+      expect(summary.totalIncome).toBe(0);
+    });
+
+    it("detects a recurring charge at its ordinary amount, not the parent's", async () => {
+      // Three monthly mixed parents: 60 of ordinary spending each, beside a
+      // -500 embedded BUY. The AI assistant and MCP read this detector, and the
+      // built-in Recurring Expenses report answers 60 for the same rows.
+      for (const months of [1, 2, 3]) {
+        await createEmbeddedInvestmentParent({
+          date: monthsBeforeToday(months),
+          ordinaryAmount: -60,
+          investmentAmount: -500,
+          payeeName: "Brokerage statement",
+        });
+      }
+
+      const charges = await withUserContext(userId, () =>
+        analytics.getRecurringCharges(
+          userId,
+          monthsBeforeToday(6),
+          monthsBeforeToday(0),
+        ),
+      );
+
+      expect(charges).toEqual([
+        expect.objectContaining({ payeeName: "Brokerage statement" }),
+      ]);
+      // Every occurrence is the ordinary 60, never the parent's 560.
+      expect(charges[0].amounts).toEqual([60, 60, 60]);
+      expect(charges[0].currentAmount).toBe(60);
+    });
+
+    it("leaves a pure investment passthrough out of recurring charges", async () => {
+      for (const months of [1, 2, 3]) {
+        await createEmbeddedInvestmentParent({
+          date: monthsBeforeToday(months),
+          ordinaryAmount: 0,
+          investmentAmount: -500,
+          payeeName: "Broker",
+        });
+      }
+
+      const charges = await withUserContext(userId, () =>
+        analytics.getRecurringCharges(
+          userId,
+          monthsBeforeToday(6),
+          monthsBeforeToday(0),
+        ),
+      );
+
+      expect(charges).toEqual([]);
     });
   });
 

--- a/backend/test/integration/report-investment-cash.integration.spec.ts
+++ b/backend/test/integration/report-investment-cash.integration.spec.ts
@@ -659,7 +659,16 @@ describe("built-in reports and investment cash accounts (integration)", () => {
 
     it("keeps a SELL's cash credit out of income", async () => {
       await insertSleeveSalary();
+      // Buy before selling: a SELL with no holding behind it is a state the
+      // production writer would not have produced, so the fixture would not be
+      // evidence about a report.
+      await createTrade(InvestmentAction.BUY, {
+        date: "2026-03-05",
+        quantity: 10,
+        price: 50,
+      });
       const sell = await createTrade(InvestmentAction.SELL, {
+        date: "2026-03-12",
         quantity: 4,
         price: 75,
       });
@@ -671,6 +680,7 @@ describe("built-in reports and investment cash accounts (integration)", () => {
       );
 
       expect(cashFlow.totals.income).toBe(1000);
+      expect(cashFlow.totals.expenses).toBe(0);
     });
 
     it("counts ordinary cash on a standalone investment account", async () => {

--- a/backend/test/integration/report-investment-cash.integration.spec.ts
+++ b/backend/test/integration/report-investment-cash.integration.spec.ts
@@ -34,6 +34,15 @@ import {
   InvestmentAction,
   InvestmentTransaction,
 } from "@/securities/entities/investment-transaction.entity";
+import { ReportsService } from "@/reports/reports.service";
+import {
+  CustomReport,
+  DirectionFilter,
+  GroupByType,
+  MetricType,
+  ReportViewType,
+  TimeframeType,
+} from "@/reports/entities/custom-report.entity";
 import { withUserContext } from "@/common/db/with-context";
 import {
   createIntegrationModule,
@@ -70,6 +79,7 @@ describe("built-in reports and investment cash accounts (integration)", () => {
   let taxRecurring: TaxRecurringReportsService;
   let dataQuality: DataQualityReportsService;
   let breakdown: MonthlyCategoryBreakdownService;
+  let customReports: ReportsService;
   let investments: InvestmentTransactionsService;
   let dataSource: DataSource;
 
@@ -106,6 +116,9 @@ describe("built-in reports and investment cash accounts (integration)", () => {
     taxRecurring = new TaxRecurringReportsService(dataSource, currency);
     dataQuality = new DataQualityReportsService(dataSource, currency);
     breakdown = new MonthlyCategoryBreakdownService(dataSource, currency);
+    // `execute` uses neither the budgets service (only the BUDGET_VARIANCE
+    // metric does) nor action history (only the writes do).
+    customReports = new ReportsService(dataSource, {} as never, {} as never);
   });
 
   afterAll(async () => {
@@ -115,6 +128,7 @@ describe("built-in reports and investment cash accounts (integration)", () => {
   beforeEach(async () => {
     await cleanTables(dataSource, [
       "action_history",
+      "custom_reports",
       "holdings",
       "security_prices",
       "securities",
@@ -461,6 +475,163 @@ describe("built-in reports and investment cash accounts (integration)", () => {
       expect(cashFlow.totals.expenses).toBe(100);
       expect(bySource.totalIncome).toBe(cashFlow.totals.income);
       expect(byCategory.totalSpending).toBe(cashFlow.totals.expenses);
+    });
+  });
+
+  /**
+   * The user-defined custom report engine reads the same ledger through
+   * hydrated TypeORM entities and aggregates in TypeScript, so none of the SQL
+   * fragments reach it. It was the one report surface left outside
+   * INV-REPORT-001 (re-audit F-CUSTOM-001): a generated BUY leg was reported as
+   * `Uncategorized` spending, and an embedded investment line was counted beside
+   * its ordinary sibling.
+   */
+  describe("custom reports", () => {
+    async function runCustomReport(overrides: {
+      groupBy?: GroupByType;
+      metric?: MetricType;
+      direction?: DirectionFilter;
+      includeTransfers?: boolean;
+    }) {
+      const report = await dataSource.manager.save(
+        dataSource.manager.create(CustomReport, {
+          userId,
+          name: "Spending",
+          viewType: ReportViewType.TABLE,
+          timeframeType: TimeframeType.CUSTOM,
+          groupBy: overrides.groupBy ?? GroupByType.CATEGORY,
+          filters: {},
+          config: {
+            metric: overrides.metric ?? MetricType.TOTAL_AMOUNT,
+            includeTransfers: overrides.includeTransfers ?? false,
+            direction: overrides.direction ?? DirectionFilter.EXPENSES_ONLY,
+            customStartDate: START,
+            customEndDate: END,
+          },
+        } as Partial<CustomReport>),
+      );
+
+      return withUserContext(userId, () =>
+        customReports.execute(userId, report.id),
+      );
+    }
+
+    it("does not report a generated BUY leg as Uncategorized spending", async () => {
+      await insertTransaction({
+        amount: -60,
+        categoryId: groceriesCategoryId,
+        payeeName: "Corner Store",
+      });
+      await createBuy();
+
+      const result = await runCustomReport({ groupBy: GroupByType.CATEGORY });
+
+      expect(result.data).toEqual([
+        expect.objectContaining({ id: groceriesCategoryId, value: 60 }),
+      ]);
+      expect(result.summary.total).toBe(60);
+    });
+
+    it("does not report a generated leg in an ordinary funding account either", async () => {
+      await insertTransaction({
+        accountId: chequingId,
+        amount: -40,
+        categoryId: groceriesCategoryId,
+        payeeName: "Bakery",
+      });
+      await createTrade(InvestmentAction.BUY, {
+        quantity: 10,
+        price: 100,
+        fundingAccountId: chequingId,
+      });
+
+      const result = await runCustomReport({ groupBy: GroupByType.CATEGORY });
+
+      expect(result.summary.total).toBe(40);
+    });
+
+    it("counts only the ordinary line of a mixed split, grouped by category", async () => {
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: -500,
+      });
+
+      const result = await runCustomReport({ groupBy: GroupByType.CATEGORY });
+
+      // Not 560, and not 0: the groceries line survives its investment sibling.
+      expect(result.data).toEqual([
+        expect.objectContaining({ id: groceriesCategoryId, value: 60 }),
+      ]);
+      expect(result.summary.total).toBe(60);
+    });
+
+    it("counts only the ordinary line when grouped by payee, month and tag", async () => {
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: -500,
+        payeeName: "Brokerage statement",
+      });
+
+      for (const groupBy of [
+        GroupByType.PAYEE,
+        GroupByType.MONTH,
+        GroupByType.TAG,
+      ]) {
+        const result = await runCustomReport({ groupBy });
+        expect(result.summary.total).toBe(60);
+      }
+    });
+
+    it("omits a pure embedded-investment passthrough entirely", async () => {
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: 0,
+        investmentAmount: -500,
+        payeeName: "Broker",
+      });
+
+      for (const groupBy of [
+        GroupByType.CATEGORY,
+        GroupByType.PAYEE,
+        GroupByType.MONTH,
+        GroupByType.TAG,
+        GroupByType.NONE,
+      ]) {
+        const result = await runCustomReport({ groupBy });
+        expect(result.data).toEqual([]);
+      }
+    });
+
+    it("lists the ordinary lines of a mixed split without aggregating", async () => {
+      await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: -500,
+        payeeName: "Brokerage statement",
+      });
+
+      const result = await runCustomReport({
+        groupBy: GroupByType.NONE,
+        metric: MetricType.NONE,
+      });
+
+      expect(result.data).toEqual([expect.objectContaining({ value: 60 })]);
+    });
+
+    it("still counts ordinary cash in the sleeve, and agrees with the built-in report", async () => {
+      await insertTransaction({
+        amount: -60,
+        categoryId: groceriesCategoryId,
+        payeeName: "Corner Store",
+      });
+      await createBuy();
+
+      const custom = await runCustomReport({ groupBy: GroupByType.CATEGORY });
+      const builtIn = await withUserContext(userId, () =>
+        spending.getSpendingByCategory(userId, START, END),
+      );
+
+      // The two engines answer the same question about one ledger, so a
+      // divergence here is the defect whichever side moved.
+      expect(custom.summary.total).toBe(builtIn.totalSpending);
     });
   });
 

--- a/backend/test/integration/report-investment-cash.integration.spec.ts
+++ b/backend/test/integration/report-investment-cash.integration.spec.ts
@@ -233,6 +233,7 @@ describe("built-in reports and investment cash accounts (integration)", () => {
     ordinaryAmount?: number;
     investmentAmount?: number;
     payeeName?: string;
+    action?: InvestmentAction;
   }): Promise<Transaction> {
     const ordinary = options.ordinaryAmount ?? -60;
     const investment = options.investmentAmount ?? -500;
@@ -270,12 +271,15 @@ describe("built-in reports and investment cash accounts (integration)", () => {
         accountId: brokerageId,
         transactionSplitId: investmentLine.id,
         securityId,
-        action: InvestmentAction.BUY,
+        action: options.action ?? InvestmentAction.BUY,
         transactionDate: options.date ?? "2026-03-10",
         quantity: 10,
         price: Math.abs(investment) / 10,
         commission: 0,
-        totalAmount: investment,
+        // A MAGNITUDE, as `calculateTotalAmount` stores it; the split line's own
+        // amount carries the cash direction (negative for a BUY, positive for a
+        // SELL).
+        totalAmount: Math.abs(investment),
         exchangeRate: 1,
         status: TransactionStatus.UNRECONCILED,
       } as Partial<InvestmentTransaction>),
@@ -495,6 +499,7 @@ describe("built-in reports and investment cash accounts (integration)", () => {
       metric?: MetricType;
       direction?: DirectionFilter;
       includeTransfers?: boolean;
+      filters?: CustomReport["filters"];
     }) {
       const report = await dataSource.manager.save(
         dataSource.manager.create(CustomReport, {
@@ -503,7 +508,7 @@ describe("built-in reports and investment cash accounts (integration)", () => {
           viewType: ReportViewType.TABLE,
           timeframeType: TimeframeType.CUSTOM,
           groupBy: overrides.groupBy ?? GroupByType.CATEGORY,
-          filters: {},
+          filters: overrides.filters ?? {},
           config: {
             metric: overrides.metric ?? MetricType.TOTAL_AMOUNT,
             includeTransfers: overrides.includeTransfers ?? false,
@@ -617,6 +622,113 @@ describe("built-in reports and investment cash accounts (integration)", () => {
       });
 
       expect(result.data).toEqual([expect.objectContaining({ value: 60 })]);
+    });
+
+    it("honours a brokerage account named inside a mixed OR group", async () => {
+      // Conditions in a group are OR'd, so this filter explicitly asks for
+      // brokerage rows. A whole-report boolean read it as "not an account
+      // scope" and excluded the sleeve globally, making the arm unmatchable
+      // (audit F-CUSTOM-OR-001).
+      await insertTransaction({
+        accountId: brokerageId,
+        amount: -75,
+        categoryId: groceriesCategoryId,
+        payeeName: "Brokerage fee",
+      });
+
+      const result = await runCustomReport({
+        groupBy: GroupByType.CATEGORY,
+        filters: {
+          filterGroups: [
+            {
+              conditions: [
+                { field: "account", value: [brokerageId] },
+                { field: "category", value: [salaryCategoryId] },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(result.summary.total).toBe(75);
+    });
+
+    it("does not admit the sleeve through an unrelated OR arm", async () => {
+      // The negative control for the case above: Groceries matches, but the
+      // brokerage account was never named, so its row stays out.
+      await insertTransaction({
+        accountId: brokerageId,
+        amount: -75,
+        categoryId: groceriesCategoryId,
+        payeeName: "Brokerage fee",
+      });
+      await insertTransaction({
+        accountId: chequingId,
+        amount: -40,
+        categoryId: groceriesCategoryId,
+        payeeName: "Bakery",
+      });
+
+      const result = await runCustomReport({
+        groupBy: GroupByType.CATEGORY,
+        filters: {
+          filterGroups: [
+            {
+              conditions: [
+                { field: "account", value: [chequingId] },
+                { field: "category", value: [groceriesCategoryId] },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(result.summary.total).toBe(40);
+    });
+
+    it("keeps an expense whose parent an embedded SELL turned positive", async () => {
+      // -60 groceries beside a +500 embedded SELL is a +440 parent. Direction
+      // was decided on that sum, so EXPENSES_ONLY threw the row away before
+      // provenance could remove the SELL (audit F-CUSTOM-DIR-001).
+      await createTrade(InvestmentAction.BUY, {
+        date: "2026-03-05",
+        quantity: 10,
+        price: 50,
+      });
+      const parent = await createEmbeddedInvestmentParent({
+        ordinaryAmount: -60,
+        investmentAmount: 500,
+        action: InvestmentAction.SELL,
+      });
+      expect(Number(parent.amount)).toBe(440);
+
+      const custom = await runCustomReport({
+        groupBy: GroupByType.CATEGORY,
+        direction: DirectionFilter.EXPENSES_ONLY,
+      });
+      const builtIn = await withUserContext(userId, () =>
+        spending.getSpendingByCategory(userId, START, END),
+      );
+
+      expect(custom.summary.total).toBe(60);
+      // The same ledger through the other engine: same answer.
+      expect(custom.summary.total).toBe(builtIn.totalSpending);
+    });
+
+    it("keeps income whose parent an embedded BUY turned negative", async () => {
+      const parent = await createEmbeddedInvestmentParent({
+        ordinaryAmount: 60,
+        investmentAmount: -500,
+        payeeName: "Brokerage statement",
+      });
+      expect(Number(parent.amount)).toBe(-440);
+
+      const result = await runCustomReport({
+        groupBy: GroupByType.CATEGORY,
+        direction: DirectionFilter.INCOME_ONLY,
+      });
+
+      expect(result.summary.total).toBe(60);
     });
 
     it("still counts ordinary cash in the sleeve, and agrees with the built-in report", async () => {
@@ -951,9 +1063,12 @@ describe("built-in reports and investment cash accounts (integration)", () => {
     });
 
     it("counts ordinary cash on a standalone investment account", async () => {
-      // A .mny import produces these: account_type INVESTMENT with no sub-type,
-      // holding both securities and its own cash. It IS the cash side, so the
-      // brokerage-sleeve exclusion must not reach it.
+      // account_type INVESTMENT with no sub-type: the shape the ordinary
+      // account-create path produces, and which net-worth and the monthly
+      // comparison already branch on. It holds both securities and its own
+      // cash, so it IS the cash side and the sleeve exclusion must not reach
+      // it. (A .mny import is NOT such a case -- `map-reference.ts` always
+      // emits the linked CASH/BROKERAGE pair.)
       const standalone = await createTestAccount(dataSource, userId, {
         name: "Legacy Brokerage",
         openingBalance: 0,

--- a/backend/test/integration/report-investment-cash.integration.spec.ts
+++ b/backend/test/integration/report-investment-cash.integration.spec.ts
@@ -1,0 +1,521 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+// Import order matters here and is load-bearing. `securities.module` sits in a
+// require cycle with the accounts and currencies graphs, and requiring the
+// module before the service it provides leaves `HoldingsService` undefined when
+// Nest reads InvestmentTransactionsService's parameter metadata -- the failure
+// reads as "the argument at index [3] is not available". The service comes
+// first, as in `investment-transactions.integration.spec.ts`, and the report
+// services (which reach `currencies/exchange-rate.service` through
+// `report-currency.service`) come after both.
+import { InvestmentTransactionsService } from "@/securities/investment-transactions.service";
+import { SecuritiesModule } from "@/securities/securities.module";
+import { SecuritiesService } from "@/securities/securities.service";
+import { AnomalyReportsService } from "@/built-in-reports/anomaly-reports.service";
+import { ComparisonReportsService } from "@/built-in-reports/comparison-reports.service";
+import { DataQualityReportsService } from "@/built-in-reports/data-quality-reports.service";
+import { IncomeReportsService } from "@/built-in-reports/income-reports.service";
+import { MonthlyCategoryBreakdownService } from "@/built-in-reports/monthly-category-breakdown.service";
+import { ReportCurrencyService } from "@/built-in-reports/report-currency.service";
+import { SpendingReportsService } from "@/built-in-reports/spending-reports.service";
+import { TaxRecurringReportsService } from "@/built-in-reports/tax-recurring-reports.service";
+import {
+  Account,
+  AccountSubType,
+  AccountType,
+} from "@/accounts/entities/account.entity";
+import {
+  Transaction,
+  TransactionStatus,
+} from "@/transactions/entities/transaction.entity";
+import { TransactionSplit } from "@/transactions/entities/transaction-split.entity";
+import { SplitKind } from "@/transactions/entities/split-kind.enum";
+import {
+  InvestmentAction,
+  InvestmentTransaction,
+} from "@/securities/entities/investment-transaction.entity";
+import { withUserContext } from "@/common/db/with-context";
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import {
+  createTestAccount,
+  createTestCategory,
+} from "../helpers/test-factories";
+
+/**
+ * INV-REPORT-001 against a real PostgreSQL database: a report's account scope is
+ * investment LINKAGE, never account type.
+ *
+ * An INVESTMENT account is a pair -- an `INVESTMENT_CASH` sleeve holding real
+ * money and an `INVESTMENT_BROKERAGE` sleeve holding securities -- so the old
+ * `AND a.account_type != 'INVESTMENT'` deleted the cash sleeve's whole ledger
+ * from fifteen report queries, salary deposits included (issue #1257). The
+ * rows that must go are the cash legs a trade generates, which the account-type
+ * filter never described in the first place.
+ *
+ * The unit specs mock `manager.query`, so they can only assert the text of the
+ * SQL. This suite runs it: it reproduces the issue's scenario with the real
+ * writer (`InvestmentTransactionsService.create` posts the cash leg) and checks
+ * both directions -- what must now appear, and what must still not.
+ */
+describe("built-in reports and investment cash accounts (integration)", () => {
+  let module: TestingModule;
+  let spending: SpendingReportsService;
+  let income: IncomeReportsService;
+  let comparison: ComparisonReportsService;
+  let anomalies: AnomalyReportsService;
+  let taxRecurring: TaxRecurringReportsService;
+  let dataQuality: DataQualityReportsService;
+  let breakdown: MonthlyCategoryBreakdownService;
+  let investments: InvestmentTransactionsService;
+  let dataSource: DataSource;
+
+  let userId: string;
+  let cashSleeveId: string;
+  let brokerageId: string;
+  let chequingId: string;
+  let salaryCategoryId: string;
+  let groceriesCategoryId: string;
+  let securityId: string;
+
+  const MONTH = "2026-03";
+  const START = "2026-03-01";
+  const END = "2026-03-31";
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([SecuritiesModule]);
+    investments = module.get(InvestmentTransactionsService);
+    dataSource = module.get(DataSource);
+
+    // The report services read the ledger with raw SQL and take only a
+    // DataSource and a currency resolver, so they are constructed directly.
+    // Reaching them through `BuiltInReportsModule` pulls the
+    // accounts/transactions/currencies module cycle in behind them, which the
+    // integration harness cannot build. Every fixture is USD, so no exchange
+    // rate is ever looked up and an empty rate list is the honest stub.
+    const currency = new ReportCurrencyService(dataSource, {
+      getLatestRates: async () => [],
+    } as never);
+    spending = new SpendingReportsService(dataSource, currency);
+    income = new IncomeReportsService(dataSource, currency);
+    comparison = new ComparisonReportsService(dataSource, currency);
+    anomalies = new AnomalyReportsService(dataSource, currency);
+    taxRecurring = new TaxRecurringReportsService(dataSource, currency);
+    dataQuality = new DataQualityReportsService(dataSource, currency);
+    breakdown = new MonthlyCategoryBreakdownService(dataSource, currency);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "holdings",
+      "security_prices",
+      "securities",
+      "transaction_splits",
+      "transactions",
+      "investment_transactions",
+      "monthly_account_balances",
+      "accounts",
+      "categories",
+      "payees",
+      "users",
+    ]);
+    await dataSource.query(
+      `INSERT INTO currencies (code, name, symbol, decimal_places) VALUES ('USD', 'US Dollar', '$', 2) ON CONFLICT DO NOTHING`,
+    );
+
+    const user = await createTestUserDirect(dataSource);
+    userId = user.id;
+
+    const cash = await createTestAccount(dataSource, userId, {
+      name: "TFSA - Cash",
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, cash.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_CASH,
+    });
+    cashSleeveId = cash.id;
+
+    const brokerage = await createTestAccount(dataSource, userId, {
+      name: "TFSA - Investments",
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, brokerage.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+      linkedAccountId: cashSleeveId,
+    });
+    brokerageId = brokerage.id;
+
+    const chequing = await createTestAccount(dataSource, userId, {
+      name: "Chequing",
+      openingBalance: 5000,
+      currentBalance: 5000,
+    });
+    chequingId = chequing.id;
+
+    salaryCategoryId = (
+      await createTestCategory(dataSource, userId, {
+        name: "Employment Income",
+        isIncome: true,
+      })
+    ).id;
+    groceriesCategoryId = (
+      await createTestCategory(dataSource, userId, { name: "Groceries" })
+    ).id;
+
+    const security = await withUserContext(userId, () =>
+      module.get(SecuritiesService).create(userId, {
+        symbol: "AAPL",
+        name: "Apple Inc.",
+        securityType: "STOCK" as any,
+        currencyCode: "USD",
+      } as any),
+    );
+    securityId = security.id;
+  });
+
+  async function insertTransaction(
+    overrides: Partial<Transaction>,
+  ): Promise<Transaction> {
+    const tx = dataSource.manager.create(Transaction, {
+      userId,
+      accountId: cashSleeveId,
+      transactionDate: "2026-03-10",
+      amount: -100,
+      currencyCode: "USD",
+      status: TransactionStatus.UNRECONCILED,
+      isTransfer: false,
+      isSplit: false,
+      ...overrides,
+    } as Partial<Transaction>);
+    return dataSource.manager.save(tx);
+  }
+
+  /**
+   * The scenario from issue #1257: $1,000 of employment income paid straight
+   * into the cash sleeve of an investment account.
+   */
+  async function insertSleeveSalary(): Promise<Transaction> {
+    return insertTransaction({
+      amount: 1000,
+      categoryId: salaryCategoryId,
+      payeeName: "Acme Payroll",
+      description: "March salary",
+    });
+  }
+
+  /** A BUY funded from the sleeve, so its cash leg lands in the sleeve. */
+  async function createBuy(
+    date = "2026-03-12",
+    quantity = 10,
+    price = 50,
+  ): Promise<InvestmentTransaction> {
+    return withUserContext(userId, () =>
+      investments.create(userId, {
+        accountId: brokerageId,
+        action: InvestmentAction.BUY,
+        transactionDate: date,
+        securityId,
+        quantity,
+        price,
+        commission: 0,
+      } as any),
+    );
+  }
+
+  describe("the reported bug", () => {
+    it("counts sleeve income in Cash Flow and excludes the trade's cash leg", async () => {
+      await insertSleeveSalary();
+      const buy = await createBuy();
+
+      // The writer really did post a cash leg into the sleeve -- otherwise the
+      // exclusion below would be proving nothing.
+      const leg = await dataSource.manager.findOneOrFail(Transaction, {
+        where: { id: buy.transactionId as string },
+      });
+      expect(leg.accountId).toBe(cashSleeveId);
+      expect(Number(leg.amount)).toBe(-500);
+      expect(leg.categoryId).toBeNull();
+
+      const cashFlow = await withUserContext(userId, () =>
+        income.getIncomeVsExpenses(userId, START, END),
+      );
+
+      expect(cashFlow.totals.income).toBe(1000);
+      expect(cashFlow.totals.expenses).toBe(0);
+      expect(cashFlow.totals.net).toBe(1000);
+      expect(cashFlow.data).toEqual([
+        { month: MONTH, income: 1000, expenses: 0, net: 1000 },
+      ]);
+    });
+
+    it("lists the sleeve's income category in Income by Source", async () => {
+      await insertSleeveSalary();
+      await createBuy();
+
+      const result = await withUserContext(userId, () =>
+        income.getIncomeBySource(userId, START, END),
+      );
+
+      expect(result.totalIncome).toBe(1000);
+      expect(result.data).toEqual([
+        expect.objectContaining({
+          categoryId: salaryCategoryId,
+          categoryName: "Employment Income",
+          total: 1000,
+        }),
+      ]);
+    });
+
+    it("counts sleeve spending by category without an Uncategorized bucket for the trade", async () => {
+      await insertTransaction({
+        amount: -60,
+        categoryId: groceriesCategoryId,
+        payeeName: "Corner Store",
+      });
+      await createBuy();
+
+      const result = await withUserContext(userId, () =>
+        spending.getSpendingByCategory(userId, START, END),
+      );
+
+      expect(result.data).toEqual([
+        expect.objectContaining({ categoryId: groceriesCategoryId, total: 60 }),
+      ]);
+      expect(result.totalSpending).toBe(60);
+    });
+
+    it("does not offer the generated trade payee as a merchant", async () => {
+      await insertTransaction({
+        amount: -60,
+        categoryId: groceriesCategoryId,
+        payeeName: "Corner Store",
+      });
+      const buy = await createBuy();
+
+      const leg = await dataSource.manager.findOneOrFail(Transaction, {
+        where: { id: buy.transactionId as string },
+      });
+      expect(leg.payeeName).toContain("AAPL");
+
+      const result = await withUserContext(userId, () =>
+        spending.getSpendingByPayee(userId, START, END),
+      );
+
+      const payees = result.data.map((row) => row.payeeName);
+      expect(payees).toEqual(["Corner Store"]);
+    });
+  });
+
+  /**
+   * The claim across the whole catalogue rather than report by report: adding a
+   * trade to a sleeve that already holds ordinary income and ordinary spending
+   * changes no report's answer. Every endpoint under `built-in-reports` that
+   * reads the transaction ledger is in the list; a new one belongs here too.
+   */
+  describe("every report", () => {
+    async function everyReport(): Promise<Record<string, unknown>> {
+      return withUserContext(userId, async () => ({
+        spendingByCategory: await spending.getSpendingByCategory(
+          userId,
+          START,
+          END,
+        ),
+        spendingByPayee: await spending.getSpendingByPayee(userId, START, END),
+        monthlySpendingTrend: await spending.getMonthlySpendingTrend(
+          userId,
+          START,
+          END,
+        ),
+        incomeBySource: await income.getIncomeBySource(userId, START, END),
+        incomeVsExpenses: await income.getIncomeVsExpenses(userId, START, END),
+        yearOverYear: await comparison.getYearOverYear(userId, 2),
+        weekendVsWeekday: await comparison.getWeekendVsWeekday(
+          userId,
+          START,
+          END,
+        ),
+        spendingAnomalies: await anomalies.getSpendingAnomalies(userId, 2),
+        taxSummary: await taxRecurring.getTaxSummary(userId, 2026),
+        recurringExpenses: await taxRecurring.getRecurringExpenses(userId, 1),
+        billPaymentHistory: await taxRecurring.getBillPaymentHistory(
+          userId,
+          START,
+          END,
+        ),
+        uncategorized: await dataQuality.getUncategorizedTransactions(
+          userId,
+          START,
+          END,
+        ),
+        duplicates: await dataQuality.getDuplicateTransactions(
+          userId,
+          START,
+          END,
+        ),
+        monthlyCategoryBreakdown: await breakdown.getMonthlyCategoryBreakdown(
+          userId,
+          START,
+          END,
+        ),
+      }));
+    }
+
+    it("answers the same with and without a trade in the sleeve", async () => {
+      await insertSleeveSalary();
+      await insertTransaction({
+        amount: -60,
+        categoryId: groceriesCategoryId,
+        payeeName: "Corner Store",
+      });
+
+      const before = await everyReport();
+      await createBuy();
+      const after = await everyReport();
+
+      expect(after).toEqual(before);
+    });
+
+    it("sees the sleeve's own rows in the first place", async () => {
+      // Guards the test above from passing because every report is empty --
+      // which is exactly what the defect produced.
+      await insertSleeveSalary();
+      await insertTransaction({
+        amount: -60,
+        categoryId: groceriesCategoryId,
+        payeeName: "Corner Store",
+      });
+      // An ordinary account alongside, so the test also says the fix left
+      // non-investment accounts alone.
+      await insertTransaction({
+        accountId: chequingId,
+        amount: -40,
+        categoryId: groceriesCategoryId,
+        payeeName: "Bakery",
+      });
+
+      const snapshot = JSON.stringify(await everyReport());
+
+      expect(snapshot).toContain("Corner Store");
+      expect(snapshot).toContain("Employment Income");
+      expect(snapshot).toContain("Bakery");
+    });
+  });
+
+  describe("what stays excluded", () => {
+    it("keeps a brokerage-sleeve row out of Cash Flow", async () => {
+      await insertSleeveSalary();
+      await insertTransaction({
+        accountId: brokerageId,
+        amount: 999,
+        categoryId: salaryCategoryId,
+        payeeName: "Stray brokerage row",
+      });
+
+      const cashFlow = await withUserContext(userId, () =>
+        income.getIncomeVsExpenses(userId, START, END),
+      );
+
+      expect(cashFlow.totals.income).toBe(1000);
+    });
+
+    it("keeps a trade's cash leg out of Uncategorized, and keeps a real one in", async () => {
+      await createBuy();
+      const manual = await insertTransaction({
+        amount: -25,
+        categoryId: null,
+        payeeName: "Unfiled sleeve fee",
+      });
+
+      const result = await withUserContext(userId, () =>
+        dataQuality.getUncategorizedTransactions(userId, START, END),
+      );
+
+      expect(result.transactions.map((t) => t.id)).toEqual([manual.id]);
+      // The list and the summary are two queries over one predicate; a
+      // difference between them is the defect this asserts against.
+      expect(result.summary.totalCount).toBe(1);
+      expect(result.summary.expenseCount).toBe(1);
+      expect(result.summary.expenseTotal).toBe(25);
+    });
+
+    it("does not report two identical trade legs as duplicate transactions", async () => {
+      // Two partial fills at the same price on the same day: identical cash
+      // legs, and neither is editable from the cash register.
+      await createBuy("2026-03-12", 10, 50);
+      await createBuy("2026-03-12", 10, 50);
+
+      const result = await withUserContext(userId, () =>
+        dataQuality.getDuplicateTransactions(userId, START, END),
+      );
+
+      expect(result.groups).toEqual([]);
+    });
+
+    it("does not count an investment line embedded in a split", async () => {
+      // Shaped as `createEmbeddedForSplit` writes it: the investment line
+      // carries no category and its InvestmentTransaction points at the split
+      // (`transaction_id` stays null, the parent's amount is the cash side).
+      const parent = await insertTransaction({
+        amount: -560,
+        isSplit: true,
+        categoryId: null,
+        payeeName: "Brokerage statement",
+      });
+      const groceries = dataSource.manager.create(TransactionSplit, {
+        transactionId: parent.id,
+        kind: SplitKind.CATEGORY,
+        categoryId: groceriesCategoryId,
+        amount: -60,
+      } as Partial<TransactionSplit>);
+      const investmentLine = dataSource.manager.create(TransactionSplit, {
+        transactionId: parent.id,
+        kind: SplitKind.INVESTMENT,
+        categoryId: null,
+        amount: -500,
+      } as Partial<TransactionSplit>);
+      await dataSource.manager.save([groceries, investmentLine]);
+      await dataSource.manager.save(
+        dataSource.manager.create(InvestmentTransaction, {
+          userId,
+          accountId: brokerageId,
+          transactionSplitId: investmentLine.id,
+          securityId,
+          action: InvestmentAction.BUY,
+          transactionDate: "2026-03-10",
+          quantity: 10,
+          price: 50,
+          commission: 0,
+          totalAmount: -500,
+          exchangeRate: 1,
+          status: TransactionStatus.UNRECONCILED,
+        } as Partial<InvestmentTransaction>),
+      );
+
+      const byCategory = await withUserContext(userId, () =>
+        spending.getSpendingByCategory(userId, START, END),
+      );
+
+      expect(byCategory.data).toEqual([
+        expect.objectContaining({ categoryId: groceriesCategoryId, total: 60 }),
+      ]);
+      expect(byCategory.totalSpending).toBe(60);
+
+      const cashFlow = await withUserContext(userId, () =>
+        income.getIncomeVsExpenses(userId, START, END),
+      );
+      expect(cashFlow.totals.expenses).toBe(60);
+    });
+  });
+});

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -441,7 +441,13 @@ Statement           A report over the transaction ledger includes an ordinary
                     transaction, or a row in a securities sleeve -- never by the
                     account's type. An INVESTMENT account is a pair, and its
                     INVESTMENT_CASH sleeve is ordinary money: salary, interest,
-                    fees, transfers in and out.
+                    fees, transfers in and out; a standalone INVESTMENT account
+                    (no sub-type, as .mny imports produce) IS its own cash side.
+                    The claim is symmetric, and the account type fails in both
+                    directions: an investment action with an explicit
+                    fundingAccountId posts its generated cash into an ORDINARY
+                    account, where an account-type predicate cannot see it at
+                    all.
 Source of truth     investment_transactions.transaction_id /
                     .transaction_split_id for the linkage; accounts.
                     account_sub_type for the sleeve. Not accounts.account_type,
@@ -450,7 +456,14 @@ Enforcement         One predicate, in backend/src/common/investment-filter.util.
                     investmentExclusionSql for raw-SQL report queries,
                     applyInvestmentTransactionFilters for QueryBuilder callers,
                     both built from the same fragments so the two dialects
-                    cannot drift. Applied by all fifteen ledger queries under
+                    cannot drift. An embedded investment split is excluded by
+                    both of its representations -- the split's declared kind and
+                    an investment_transactions row pointing at that split -- and
+                    at SPLIT-ROW granularity, so an ordinary sibling line on the
+                    same split parent survives (excluding the parent would lose
+                    it; keying only on transaction_id would miss the embedded
+                    line entirely, since its transaction_id is null). Applied by
+                    all fifteen ledger queries under
                     backend/src/built-in-reports/ and by the "Uncategorized"
                     filters on the register (transactions.service.ts), the
                     register summary (transaction-analytics.service.ts) and the
@@ -475,18 +488,27 @@ Required tests      Present: the two source scans above, and
                     and asserts both directions -- $1,000 of sleeve income
                     reaching Cash Flow and Income by Source, the generated leg
                     staying out of spending, payees, Uncategorized and
-                    duplicates, a brokerage-sleeve row staying out, an embedded
-                    investment split not becoming an Uncategorized bucket, and
-                    the catalogue-wide claim that adding a trade changes no
-                    report's answer. Unit specs mock manager.query and can only
+                    duplicates, a brokerage-sleeve row staying out, generated
+                    cash staying out of an ORDINARY funding account's report
+                    (BUY debit and DIVIDEND credit), a SELL credit staying out
+                    of income, ordinary cash on a standalone INVESTMENT account
+                    counting, the VOID and transfer-split exclusions still
+                    holding, an embedded investment split not becoming an
+                    Uncategorized bucket while its ordinary sibling still
+                    counts, the three Cash Flow queries reconciling with each
+                    other, and the catalogue-wide claim that adding a trade
+                    changes no report's answer. Unit specs mock manager.query and can only
                     assert the text of the SQL, which is why the behavioural
                     proof is the integration suite.
 Status              enforced
 ```
 
 The defect this records was not a subtle one: with `AND a.account_type !=
-'INVESTMENT'` in place, nine of the ten integration cases above fail, and the
-tenth passes only because every report was uniformly empty for that account.
+'INVESTMENT'` in place, sixteen of the seventeen integration cases above fail,
+and the seventeenth passes only because every report was uniformly empty for
+that account. The focused audit of issue #1257 recorded the same root as
+`F-1257-001` (MEDIUM, derived reporting only -- no stored balance is wrong) and
+the naive-repair trap as `DR-1257-001`.
 
 ## Scheduled occurrences
 

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -66,7 +66,7 @@ implied.
 | INV-REDEEM-001 | A redemption's accrued interest moves cash once and is income once | enforced |
 | INV-RECONCILE-001 | While the strict lock is on, a reconciled transaction is not altered | enforced |
 | INV-FX-001 | An unavailable rate never becomes 1:1 | enforced |
-| INV-REPORT-001 | A report's account scope is investment linkage, not account type | enforced |
+| INV-REPORT-001 | A report's account scope is investment linkage, not account type | partial |
 | INV-OCCURRENCE-001 | One scheduled occurrence has at most one financial effect | enforced |
 | INV-OCCURRENCE-002 | A stored override price survives reopening | enforced |
 | INV-CLAIM-001 | An emergency-access claim token is consumed exactly once | enforced |
@@ -526,7 +526,28 @@ Required tests      Present: the two source scans above, and
                     changes no report's answer. Unit specs mock manager.query and can only
                     assert the text of the SQL, which is why the behavioural
                     proof is the integration suite.
-Status              enforced
+Unenforced paths    backend/src/reports/ -- the USER-DEFINED custom report
+                    engine. It reads the same ledger through hydrated TypeORM
+                    entities (getFilteredTransactions -> aggregateData) and
+                    applies no investment provenance at all, so a free-standing
+                    BUY's generated cash leg is reported as `Uncategorized`
+                    spending and an embedded investment split child is counted
+                    beside its ordinary sibling: the canonical -560 parent
+                    reports 560 there, not 60 (re-audit F-CUSTOM-001). The
+                    behaviour predates the #1257 work and is byte-identical at
+                    the merge base, so it is existing debt rather than a
+                    regression -- but the statement above is written as a product
+                    rule and that engine breaks it, which is why the status below
+                    is `partial`. The gap is pinned by a known-gap block in
+                    backend/src/common/investment-filter.guard.spec.ts that fails
+                    when the engine STARTS applying provenance, so closing it
+                    forces this entry to be updated rather than left stale.
+                    Migrating it means sharing these rules, not copying another
+                    account-type predicate: exclude generated cash by
+                    transaction_id, exclude embedded investment children at
+                    split-row granularity, keep the ordinary siblings, and leave
+                    the report's own transfer configuration alone.
+Status              partial
 ```
 
 The defect this records was not a subtle one: with `AND a.account_type !=

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -555,9 +555,26 @@ Also covered        backend/src/reports/ -- the USER-DEFINED custom report
                     engine is byte-identical at the merge base. The two dialects
                     differ by exactly one clause, deliberately: the SQL form
                     drops transfer children because no built-in report using it
-                    includes transfers, while a custom report carries its own
-                    includeTransfers configuration and that decision stays where
-                    the user made it.
+                    includes transfers, while this one says nothing about
+                    transfers at all. Direction (Income/Expenses only) is
+                    applied to the split LINES in that engine, never to the
+                    parent's own amount: a -60 expense beside a +500 embedded
+                    SELL is a +440 parent, and rejecting that row on its sum
+                    discarded the expense before provenance could run (audit
+                    F-CUSTOM-DIR-001). The securities-sleeve exception is per
+                    ROW, keyed on the accounts the report explicitly names,
+                    because conditions inside a filter group are OR'd and a
+                    whole-report boolean cannot tell `account = Brokerage OR
+                    category = Salary` from `account = Chequing OR payee = Acme`
+                    (F-CUSTOM-OR-001).
+Outside this rule   Transfer SPLIT LINES in the custom report engine.
+                    `includeTransfers` is applied there to the PARENT only, so a
+                    transfer line inside a non-transfer parent is counted today
+                    (a -260 parent of -60 groceries and a -200 transfer reports
+                    260). Unchanged from before this work, a transfer-policy
+                    question rather than an investment-provenance one, and
+                    tracked separately -- named here so the `enforced` status
+                    below is not read as covering it.
                     The category-keyed aggregates (ai/insights,
                     budgets/budget-generator, the payee totals) are structurally
                     unable to admit either row and are deliberately not listed as

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -567,14 +567,18 @@ Also covered        backend/src/reports/ -- the USER-DEFINED custom report
                     whole-report boolean cannot tell `account = Brokerage OR
                     category = Salary` from `account = Chequing OR payee = Acme`
                     (F-CUSTOM-OR-001).
-Outside this rule   Transfer SPLIT LINES in the custom report engine.
-                    `includeTransfers` is applied there to the PARENT only, so a
-                    transfer line inside a non-transfer parent is counted today
-                    (a -260 parent of -60 groceries and a -200 transfer reports
-                    260). Unchanged from before this work, a transfer-policy
-                    question rather than an investment-provenance one, and
-                    tracked separately -- named here so the `enforced` status
-                    below is not read as covering it.
+                    Transfer SPLIT LINES are the report's own decision, not this
+                    invariant's: `includeTransfers` is applied per LINE in that
+                    engine (`narrowSplitLines`), because a split parent carrying
+                    a transfer line is not itself a transfer -- so a -260 parent
+                    of -60 groceries and a -200 transfer reported 260 until it
+                    was. Investment provenance is a property of the data; which
+                    transfers to count is a property of the report.
+                    The AI forecast baseline
+                    (ai/forecast/forecast-aggregator.service.ts) reads one row
+                    per payment with no split join, so it derives the reportable
+                    amount too: it had been training on a -560 parent as 560 of
+                    household spending.
                     The category-keyed aggregates (ai/insights,
                     budgets/budget-generator, the payee totals) are structurally
                     unable to admit either row and are deliberately not listed as

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -442,7 +442,10 @@ Statement           A report over the transaction ledger includes an ordinary
                     account's type. An INVESTMENT account is a pair, and its
                     INVESTMENT_CASH sleeve is ordinary money: salary, interest,
                     fees, transfers in and out; a standalone INVESTMENT account
-                    (no sub-type, as .mny imports produce) IS its own cash side.
+                    (account_type INVESTMENT with a NULL sub-type, which the
+                    ordinary account-create path produces and which net_worth and
+                    the monthly comparison already branch on) IS its own cash
+                    side.
                     The claim is symmetric, and the account type fails in both
                     directions: an investment action with an explicit
                     fundingAccountId posts its generated cash into an ORDINARY
@@ -535,9 +538,15 @@ Also covered        backend/src/reports/ -- the USER-DEFINED custom report
                     reaches it; it gets the same rule in the other dialect
                     (isEmbeddedInvestmentSplit / ordinarySplitLines /
                     reportableTransactionAmount, beside the SQL in
-                    investment-filter.util.ts). Its selector applies
-                    applyInvestmentTransactionFilters and hydrates
-                    splits.investmentTransaction; its six aggregators iterate
+                    investment-filter.util.ts). Its selector always excludes the
+                    generated cash leg (investmentLinkedTransactionExclusion) and
+                    excludes the securities sleeve
+                    (brokerageExclusionForEntity) only from a report that did not
+                    NAME an account -- built-in reports have no account picker,
+                    this one does, and answering an explicitly scoped report with
+                    nothing is worse than showing the rows that were asked for.
+                    It hydrates splits.investmentTransaction; its six aggregators
+                    iterate
                     ordinary lines and ask for the reportable amount rather than
                     reading a parent's own. Until this was done a generated BUY
                     leg was reported as `Uncategorized` spending and the

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -66,7 +66,7 @@ implied.
 | INV-REDEEM-001 | A redemption's accrued interest moves cash once and is income once | enforced |
 | INV-RECONCILE-001 | While the strict lock is on, a reconciled transaction is not altered | enforced |
 | INV-FX-001 | An unavailable rate never becomes 1:1 | enforced |
-| INV-REPORT-001 | A report's account scope is investment linkage, not account type | partial |
+| INV-REPORT-001 | A report's account scope is investment linkage, not account type | enforced |
 | INV-OCCURRENCE-001 | One scheduled occurrence has at most one financial effect | enforced |
 | INV-OCCURRENCE-002 | A stored override price survives reopening | enforced |
 | INV-CLAIM-001 | An emergency-access claim token is consumed exactly once | enforced |
@@ -513,7 +513,10 @@ Required tests      Present: the two source scans above, and
                     nothing at all (by payee, as recurring spending, and in the
                     Uncategorized list and summary), a pure embedded-investment
                     passthrough being absent from Uncategorized and never
-                    learned as a recurring expense, a brokerage-sleeve row
+                    learned as a recurring expense, the custom report engine
+                    answering the same 60 through five groupings and agreeing
+                    with the built-in report over one fixture, a brokerage-sleeve
+                    row
                     staying out, generated
                     cash staying out of an ORDINARY funding account's report
                     (BUY debit and DIVIDEND credit), a SELL credit staying out
@@ -526,28 +529,34 @@ Required tests      Present: the two source scans above, and
                     changes no report's answer. Unit specs mock manager.query and can only
                     assert the text of the SQL, which is why the behavioural
                     proof is the integration suite.
-Unenforced paths    backend/src/reports/ -- the USER-DEFINED custom report
+Also covered        backend/src/reports/ -- the USER-DEFINED custom report
                     engine. It reads the same ledger through hydrated TypeORM
-                    entities (getFilteredTransactions -> aggregateData) and
-                    applies no investment provenance at all, so a free-standing
-                    BUY's generated cash leg is reported as `Uncategorized`
-                    spending and an embedded investment split child is counted
-                    beside its ordinary sibling: the canonical -560 parent
-                    reports 560 there, not 60 (re-audit F-CUSTOM-001). The
-                    behaviour predates the #1257 work and is byte-identical at
-                    the merge base, so it is existing debt rather than a
-                    regression -- but the statement above is written as a product
-                    rule and that engine breaks it, which is why the status below
-                    is `partial`. The gap is pinned by a known-gap block in
-                    backend/src/common/investment-filter.guard.spec.ts that fails
-                    when the engine STARTS applying provenance, so closing it
-                    forces this entry to be updated rather than left stale.
-                    Migrating it means sharing these rules, not copying another
-                    account-type predicate: exclude generated cash by
-                    transaction_id, exclude embedded investment children at
-                    split-row granularity, keep the ordinary siblings, and leave
-                    the report's own transfer configuration alone.
-Status              partial
+                    entities and aggregates in TypeScript, so no SQL fragment
+                    reaches it; it gets the same rule in the other dialect
+                    (isEmbeddedInvestmentSplit / ordinarySplitLines /
+                    reportableTransactionAmount, beside the SQL in
+                    investment-filter.util.ts). Its selector applies
+                    applyInvestmentTransactionFilters and hydrates
+                    splits.investmentTransaction; its six aggregators iterate
+                    ordinary lines and ask for the reportable amount rather than
+                    reading a parent's own. Until this was done a generated BUY
+                    leg was reported as `Uncategorized` spending and the
+                    canonical -560 parent reported 560 rather than 60 (re-audit
+                    F-CUSTOM-001) -- existing debt rather than a regression: that
+                    engine is byte-identical at the merge base. The two dialects
+                    differ by exactly one clause, deliberately: the SQL form
+                    drops transfer children because no built-in report using it
+                    includes transfers, while a custom report carries its own
+                    includeTransfers configuration and that decision stays where
+                    the user made it.
+                    The category-keyed aggregates (ai/insights,
+                    budgets/budget-generator, the payee totals) are structurally
+                    unable to admit either row and are deliberately not listed as
+                    mechanism: each INNER JOINs a category, and a generated cash
+                    leg has none while a split parent's own category_id is NULL.
+                    If one of those joins is ever loosened to a LEFT JOIN it
+                    needs this predicate in the same change.
+Status              enforced
 ```
 
 The defect this records was not a subtle one: with `AND a.account_type !=

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -462,8 +462,20 @@ Enforcement         One predicate, in backend/src/common/investment-filter.util.
                     at SPLIT-ROW granularity, so an ordinary sibling line on the
                     same split parent survives (excluding the parent would lose
                     it; keying only on transaction_id would miss the embedded
-                    line entirely, since its transaction_id is null). Applied by
-                    all fifteen ledger queries under
+                    line entirely, since its transaction_id is null).
+                    A report that reads only the parent row cannot classify a
+                    line at all -- t.amount there is the sum of every child --
+                    so it derives its figure through
+                    reportableTransactionAmountSql: the sum of the children that
+                    are neither transfer nor investment, NULL when the row
+                    represents no ordinary cash. Spending by Payee, Recurring
+                    Expenses, Bill Payment History and the Uncategorized list
+                    and summary read that instead of t.amount. Duplicate
+                    Transactions is the one declared exception, marked in its SQL
+                    as a PARENT-IDENTITY REPORT: its subject is the stored row,
+                    so a split parent entered twice is a duplicate at its stored
+                    amount and the remedy is deleting one whole transaction.
+                    Applied by all fifteen ledger queries under
                     backend/src/built-in-reports/ and by the "Uncategorized"
                     filters on the register (transactions.service.ts), the
                     register summary (transaction-analytics.service.ts) and the
@@ -474,8 +486,16 @@ Enforcement         One predicate, in backend/src/common/investment-filter.util.
                     backend/src/common/investment-filter.guard.spec.ts: no
                     account-type exclusion anywhere in src/, and every
                     built-in-report query that is not transfer-only carries the
-                    exclusion (the transfer-only exemption is derived from the
-                    query, since an investment cash leg is never a transfer).
+                    exclusion IN THE REPRESENTATION ITS SHAPE NEEDS -- a query
+                    joining transaction_splits must use the split-aware
+                    conjunction, and a parent-only query must derive its amount,
+                    since accepting the bare substring passed exactly the defect
+                    the branch audit found (F-RPT-001). Both exemptions are
+                    derived from the query rather than kept as a list of file
+                    names: transfer-only (an investment cash leg is never a
+                    transfer) and the declared PARENT-IDENTITY marker. The
+                    classifier carries its own negative controls, so the scan is
+                    known to fire rather than merely known to pass.
 Concurrency scope   -- (read path)
 Retry semantics     -- (read path)
 Crash semantics     -- (read path)
@@ -488,7 +508,13 @@ Required tests      Present: the two source scans above, and
                     and asserts both directions -- $1,000 of sleeve income
                     reaching Cash Flow and Income by Source, the generated leg
                     staying out of spending, payees, Uncategorized and
-                    duplicates, a brokerage-sleeve row staying out, generated
+                    duplicates, the parent-only consumers reporting a mixed
+                    split at its ordinary 60 rather than the parent's 560 or
+                    nothing at all (by payee, as recurring spending, and in the
+                    Uncategorized list and summary), a pure embedded-investment
+                    passthrough being absent from Uncategorized and never
+                    learned as a recurring expense, a brokerage-sleeve row
+                    staying out, generated
                     cash staying out of an ORDINARY funding account's report
                     (BUY debit and DIVIDEND credit), a SELL credit staying out
                     of income, ordinary cash on a standalone INVESTMENT account
@@ -504,11 +530,17 @@ Status              enforced
 ```
 
 The defect this records was not a subtle one: with `AND a.account_type !=
-'INVESTMENT'` in place, sixteen of the seventeen integration cases above fail,
-and the seventeenth passes only because every report was uniformly empty for
-that account. The focused audit of issue #1257 recorded the same root as
+'INVESTMENT'` in place, sixteen of the twenty-three integration cases above
+fail, and the rest pass only because every report was uniformly empty for that
+account. The focused audit of issue #1257 recorded the same root as
 `F-1257-001` (MEDIUM, derived reporting only -- no stored balance is wrong) and
 the naive-repair trap as `DR-1257-001`.
+
+The parent-only half was found by a second audit, of the fix itself
+(`F-RPT-001`), and is worth recording as its own lesson: removing a filter that
+was hiding too much exposes every row it was also hiding *correctly*. The
+account-type predicate had been doing two jobs, and only one of them was wrong.
+Five of the cases above fail on the first fix and pass on the second.
 
 ## Scheduled occurrences
 

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -66,6 +66,7 @@ implied.
 | INV-REDEEM-001 | A redemption's accrued interest moves cash once and is income once | enforced |
 | INV-RECONCILE-001 | While the strict lock is on, a reconciled transaction is not altered | enforced |
 | INV-FX-001 | An unavailable rate never becomes 1:1 | enforced |
+| INV-REPORT-001 | A report's account scope is investment linkage, not account type | enforced |
 | INV-OCCURRENCE-001 | One scheduled occurrence has at most one financial effect | enforced |
 | INV-OCCURRENCE-002 | A stored override price survives reopening | enforced |
 | INV-CLAIM-001 | An emergency-access claim token is consumed exactly once | enforced |
@@ -429,6 +430,63 @@ Status              enforced
 At a real rate of 1.3500, a false 100.00 CAD would understate a 135.00 CAD
 position by 35.00 and report it as measured -- which is what the null return and
 the scan now prevent.
+
+### INV-REPORT-001 -- a report's account scope is investment linkage, not account type
+
+```text
+Statement           A report over the transaction ledger includes an ordinary
+                    categorized cash row whatever account it sits in, and
+                    excludes a row that is an investment movement. Membership is
+                    decided by what the row IS -- the cash leg of an investment
+                    transaction, or a row in a securities sleeve -- never by the
+                    account's type. An INVESTMENT account is a pair, and its
+                    INVESTMENT_CASH sleeve is ordinary money: salary, interest,
+                    fees, transfers in and out.
+Source of truth     investment_transactions.transaction_id /
+                    .transaction_split_id for the linkage; accounts.
+                    account_sub_type for the sleeve. Not accounts.account_type,
+                    which is the same value for both halves of the pair.
+Enforcement         One predicate, in backend/src/common/investment-filter.util.ts:
+                    investmentExclusionSql for raw-SQL report queries,
+                    applyInvestmentTransactionFilters for QueryBuilder callers,
+                    both built from the same fragments so the two dialects
+                    cannot drift. Applied by all fifteen ledger queries under
+                    backend/src/built-in-reports/ and by the "Uncategorized"
+                    filters on the register (transactions.service.ts), the
+                    register summary (transaction-analytics.service.ts) and the
+                    bulk-update filter (transaction-bulk-update.service.ts) --
+                    the last one a write path, where the old predicate let a
+                    "select all uncategorized" sweep reach the cash legs a trade
+                    owns. Two scans in
+                    backend/src/common/investment-filter.guard.spec.ts: no
+                    account-type exclusion anywhere in src/, and every
+                    built-in-report query that is not transfer-only carries the
+                    exclusion (the transfer-only exemption is derived from the
+                    query, since an investment cash leg is never a transfer).
+Concurrency scope   -- (read path)
+Retry semantics     -- (read path)
+Crash semantics     -- (read path)
+Failure response    -- a report answers; it does not refuse.
+Required tests      Present: the two source scans above, and
+                    backend/test/integration/report-investment-cash.integration
+                    .spec.ts, which reproduces issue #1257 against a real
+                    database using the real writer
+                    (InvestmentTransactionsService.create posts the cash leg)
+                    and asserts both directions -- $1,000 of sleeve income
+                    reaching Cash Flow and Income by Source, the generated leg
+                    staying out of spending, payees, Uncategorized and
+                    duplicates, a brokerage-sleeve row staying out, an embedded
+                    investment split not becoming an Uncategorized bucket, and
+                    the catalogue-wide claim that adding a trade changes no
+                    report's answer. Unit specs mock manager.query and can only
+                    assert the text of the SQL, which is why the behavioural
+                    proof is the integration suite.
+Status              enforced
+```
+
+The defect this records was not a subtle one: with `AND a.account_type !=
+'INVESTMENT'` in place, nine of the ten integration cases above fail, and the
+tenth passes only because every report was uniformly empty for that account.
 
 ## Scheduled occurrences
 

--- a/docs/verification-contract.md
+++ b/docs/verification-contract.md
@@ -77,6 +77,7 @@ adds value but proves nothing on its own. `--` means not applicable.
 | INV-REDEEM-001 accrued interest | required | **required** | required | -- | -- | -- | -- | optional |
 | INV-RECONCILE-001 reconciled lock | supporting | **required** | required | required | -- | -- | -- | optional |
 | INV-FX-001 no 1:1 fallback | **required** | **required** | required | -- | -- | required | optional | required |
+| INV-REPORT-001 report account scope | supporting | **required** | **required** | -- | -- | -- | -- | optional |
 | INV-OCCURRENCE-001 one effect | supporting | -- | required | required | **required** | required | -- | required |
 | INV-OCCURRENCE-002 override price | required | -- | -- | -- | -- | -- | -- | required |
 | INV-CLAIM-001 single-use claim | supporting | -- | required | **required** | optional | optional | -- | required |


### PR DESCRIPTION
## Linked discussion / issue

Closes #1257
Approved in: #1256 (reporting quality), and the focused `/audit` comment on #1257, which prescribes the provenance-based correction this PR implements

## Summary

A report decides whether a ledger row counts by **investment provenance**, never by the account's type.

`INVESTMENT` is the `account_type` of *both* halves of a linked pair — the `INVESTMENT_CASH` sleeve holding ordinary money and the `INVESTMENT_BROKERAGE` sleeve holding securities — so `AND a.account_type != 'INVESTMENT'` deleted a real ledger from fifteen report queries. Salary paid into a brokerage's cash side vanished from Cash Flow, Income by Source, spending, tax and the Uncategorized list (#1257). It never described the rows it was meant to remove either: the cash leg a BUY/SELL/DIVIDEND posts lives in that same cash account, carries no category and no transfer flag — and when the action names an explicit `fundingAccountId`, that leg lands in an *ordinary* account, where no account-type predicate could ever see it. The same month could report 1000 of expenses nobody spent.

What a row *is* decides it, and the predicate is written once per dialect in `backend/src/common/investment-filter.util.ts`:

| | |
|---|---|
| Raw SQL | `investmentExclusionSql` — brokerage sleeve, generated cash leg, embedded investment split line |
| QueryBuilder | `applyInvestmentTransactionFilters` — built from the same fragments, so the two cannot drift |
| Parent-only readers | `reportableTransactionAmountSql` — `t.amount` on a split parent is the sum of *every* line, so a report that never joins splits derives the ordinary part instead, `NULL` when the row represents no ordinary cash |
| Hydrated entities | `isEmbeddedInvestmentSplit` / `ordinarySplitLines` / `reportableTransactionAmount` — the custom report engine aggregates in TypeScript and cannot use SQL fragments |

An embedded investment line is excluded by **both** of its representations (the split's `kind` and an `investment_transactions` row pointing at it) and at **split-row granularity**, so an ordinary sibling on a mixed parent survives: a `-560` parent of `-60` groceries and a `-500` embedded BUY reports `60`, not `560` and not `0`.

Surfaces brought onto the rule — every reader of the transaction ledger, because a partial fix leaves two engines answering the same question differently:

- all fifteen built-in report queries (Cash Flow, Income by Source, Spending by Category/Payee/Trend, Tax Summary, Recurring Expenses, Bill Payment History, Year-over-Year, Weekend vs Weekday, Anomalies, Monthly Category Breakdown, Uncategorized list and summary, Duplicate Transactions);
- the "Uncategorized" filters on the register, the register summary and **bulk update** — a write path, where "select all uncategorized" could reach the cash legs a trade owns;
- register grouped totals and the recurring-charge detector the AI assistant and MCP read;
- the user-defined custom report engine;
- the AI forecast baseline.

Two deliberate decisions are recorded in the code rather than left implicit: **Duplicate Transactions** is a `PARENT-IDENTITY REPORT` — its subject is the stored row, so a split parent entered twice is a duplicate at its stored amount, because the remedy is deleting one whole transaction. And the **custom report's own line-level choices** (direction, `includeTransfers`) are applied to the split lines rather than to the parent's sum, since a `-60` expense beside a `+500` embedded SELL is a `+440` parent and rejecting it on that sign threw the expense away.

`INV-REPORT-001` in `docs/system-invariants.md` states the rule, its mechanism and its scope. Two source scans hold it: no account-type exclusion may reappear anywhere in `src/`, and every ledger query must carry the exclusion *in the representation its shape needs* — a split-joining query the conjunction, a parent-only query the derived amount. The exemptions (transfer-only queries, the declared parent-identity marker) are read off the query, not kept as a list of file names a new query could quietly join.

Backend only: no schema change, no migration, no frontend change, no user-facing strings.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
      One concern — report membership by investment provenance — deliberately applied to every ledger reader. Fixing one engine and not the next leaves Cash Flow and a custom report disagreeing about the same rows, which is the defect restated.
- [x] New behavior has tests, and the existing suite passes.
      40 real-PostgreSQL cases in `backend/test/integration/report-investment-cash.integration.spec.ts`, driven through the real writer (`InvestmentTransactionsService.create` posts the cash leg). Sixteen fail on `main`; each later correction is pinned by cases that fail on the commit before it. Unit specs mock `manager.query`, so they can only assert the text of the SQL — the behavioural proof is the integration suite. Local: `TZ=UTC npm run test:unit` 13 496 passed / 498 suites; `npm run test:integration` 457 passed / 36 suites; typecheck, lint, prettier clean.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
      No user-facing strings changed. The Cash Flow subtitle ("across all accounts") becomes true rather than needing a rewrite.
- [x] No shared/core areas were refactored without prior agreement.
      `common/investment-filter.util.ts` is extended rather than duplicated, which is what the audit on #1257 asked for ("share the same canonical fragments/rules rather than re-encode the classification independently").
- [x] The branch is rebased on the latest `main`.
      11 ahead, 0 behind `origin/main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## What a reviewer should look at first

- `backend/src/common/investment-filter.util.ts` — the whole rule, both dialects, and why each clause exists.
- `backend/src/common/investment-filter.guard.spec.ts` — what stops it being undone, including its own negative controls.
- `backend/test/integration/report-investment-cash.integration.spec.ts` — the behaviour, against a real database.

Known and deliberately **not** in this PR:

- PDF export and browser E2E were not executed (no stack available in the working environment). The backend API values are the changed state and the three Cash Flow queries are asserted to reconcile with each other; the frontend consumes them unchanged.
- `holdings.service.ts` lets a first SELL create a negative holding (the insufficient-shares check sits only in the existing-holding branch). Pre-existing, outside this change, and worth its own issue — the SELL fixture here buys before selling so it does not rely on it.

## AI assistance disclosure

Written with Claude Code. The implementation, tests and documentation were produced with AI assistance and then put through four rounds of the repository's `/audit` protocol plus three `/code-review` passes; every finding from those rounds is either fixed in this branch or recorded above as out of scope. Each new invariant was broken on purpose once to confirm its test fails, and each guard was verified by mutation. The result has been reviewed and is owned by the author.
