### PR TITLE
fix(transactions): a background load must not clear the user's selection

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -338,6 +338,10 @@ The request key is every selector that changes the *meaning* of the response, no
 
 **A dirty keyed form is data.** Changing the request key while a form has unsaved edits calls for a confirmation, a preserved draft, or an explicit save/discard flow; silently unmounting it is data loss. A form rendered for scenario A must also stop being editable once scenario B is the current selection -- two obligations, and meeting the second by discarding the first is not meeting both.
 
+**A background load finishing is not the user acting.** State a page throws away when the user changes a filter -- a selection, a draft, a scroll position -- keys off the criteria the *user* chose, never off a derived object the page recomputes as data lands. The transactions page's `bulkUpdateFilters` falls back to every visible account when no account filter is set, so it changes the moment the accounts request answers; `useTransactionSelection` compared that object and silently cleared a selection the user had already made (CI run #2873 saw it as a bulk-update banner that never appeared). Pass the user's own criteria as the reset key and keep the resolved scope for the server payload -- derived from the one object, so the two lists cannot drift. The row set carries the same distinction: the first page of rows arriving is a load finishing, not a page change.
+
+**A `useMemo` that sorts copies first.** `Array.prototype.sort` reorders in place, so a display memo sorting a shared memoized array reorders what every other consumer reads, and the value then depends on which memo happened to run first -- `accountFilterOptions` sorting `filteredAccounts` decided the bulk-update account scope's order as a side effect of rendering a dropdown. Write `[...xs].sort(...)`, always.
+
 Regression tests for this class need deferred promises, and must assert on what the user *can do*, not only on what is rendered (`docs/testing-contract.md` carries the wider adversarial list):
 
 | Case | Assertion |
@@ -350,6 +354,37 @@ Regression tests for this class need deferred promises, and must assert on what 
 | Save on the default selection, nothing else happens | the response is adopted |
 
 **Both sides of that comparison must come from the same place.** The origin key a mutation captures and the key the loader is holding have to be produced by one expression -- take the origin from what the loader actually stamped (`dataKey` on `useReportData`), never rebuild it from the rendered payload's fields. The GEM report built its page key from a `strategyId` *state* unset until the user picks from a switcher, and the save's origin from `data.strategy.id`, always a real id: they could never match on the ordinary path, so every save was discarded with no refetch behind it. A key comparison that silently drops the common case looks exactly like one that works.
+
+### An act() warning is a failure, not a log line
+
+A test asserting on a tree React has not finished updating reads whatever
+happened to be committed when the assertion ran -- it passes or fails on
+timing, not on behaviour. React says so, on stderr, and nobody is watching
+stderr in a 14,000-test run: CI run #2873 carried fifteen act warnings under a
+green tick, in the same job whose one real failure was a race. So `src/test/setup.ts`
+routes them into `src/test/act-guard.ts`, which **fails** the test that earned
+them. `act-guard.test.ts` checks the behaviour and scans `setup.ts` for the
+wiring, because a guard nothing calls is not a guard.
+
+Fix the update, never the message. In order of preference: await the thing that
+lands late (`await screen.findBy...`, `await waitFor(...)`); or wrap the trigger
+in `await act(async () => { ... })`. Adding the text to a console filter is the
+one response that is always wrong.
+
+Three sources produce nearly all of them here:
+
+- **A synchronous test with a request still in flight.** The response commits
+  after the test returns, into whichever tree is mounted by then. Settle it
+  before returning, even when the assertion is about the state *before* it
+  arrives (`useStaleReconciliation.test.ts`).
+- **`vi.waitFor` and `element.dispatchEvent`, which are not act-aware.** Prefer
+  RTL's `waitFor` and `fireEvent`; `fireEvent(element, event)` takes an event
+  object when a test needs to spy on that exact one. Where Vitest's fake timers
+  rule out RTL's `waitFor` -- it cannot drive them -- drain the clock inside
+  act: `await act(async () => { await vi.advanceTimersByTimeAsync(n); })`.
+- **A store write with the tree mounted.** Zustand notifies subscribers
+  synchronously, so `useDensityStore.setState(...)` re-renders outside act
+  unless wrapped. Writing *before* the render does not need it.
 
 ### A busy flag shared by nesting operations is a counter, not a boolean
 

--- a/frontend/src/app/transactions/page.test.tsx
+++ b/frontend/src/app/transactions/page.test.tsx
@@ -1721,6 +1721,43 @@ describe('TransactionsPage', () => {
     });
   });
 
+  // Regression: CI run #2873, where this file's first Bulk Update test failed
+  // with "Unable to find [data-testid=bulk-update-btn]" while the register
+  // showed all three rows -- the selection had been cleared, not never made.
+  // The page's bulk-update scope falls back to every visible account, so it
+  // changes the moment the accounts request lands; on a loaded runner that
+  // landed after the click and wiped the selection with it. A background load
+  // finishing is not the user changing a filter.
+  describe('Selection survives a background load', () => {
+    it('keeps the row selected when the accounts request lands after the click', async () => {
+      mockGetAll.mockResolvedValue({
+        data: mockTransactions,
+        pagination: { page: 1, totalPages: 1, total: 3 },
+      });
+      mockGetSummary.mockResolvedValue({ totalIncome: 0, totalExpenses: 0, netCashFlow: 0, transactionCount: 0 });
+      // The accounts request is the slow one, as it was on the CI runner.
+      let landAccounts: () => void = () => {};
+      mockGetAllAccounts.mockImplementation(
+        () => new Promise((resolve) => { landAccounts = () => resolve(mockAccounts); }),
+      );
+
+      render(<TransactionsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('select-tx-1')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId('select-tx-1'));
+      expect(screen.getByTestId('bulk-update-btn')).toBeInTheDocument();
+
+      await act(async () => {
+        landAccounts();
+        await Promise.resolve();
+      });
+
+      expect(screen.getByTestId('bulk-update-btn')).toBeInTheDocument();
+    });
+  });
+
   describe('Bulk Update', () => {
     beforeEach(() => {
       mockGetAll.mockResolvedValue({

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -770,10 +770,27 @@ function TransactionsContent() {
     return institutions.find((i) => i.id === widgetAccount.institutionId);
   }, [widgetAccount, institutions]);
 
+  // The selection resets on the criteria the *user* chose, not on
+  // `bulkUpdateFilters`: that object falls back to every visible account when
+  // no account filter is set, so it changes the moment the accounts request
+  // lands, and clearing there dropped a selection the user had already made.
+  // Derived from `bulkUpdateFilters` -- with only the derived account scope
+  // swapped for the user's own choice -- so the two lists cannot drift apart.
+  const selectionUserFilterKey = useMemo(
+    () =>
+      JSON.stringify({
+        ...bulkUpdateFilters,
+        accountIds: filters.filterAccountIds,
+        accountStatus: filters.filterAccountStatus,
+      }),
+    [bulkUpdateFilters, filters.filterAccountIds, filters.filterAccountStatus],
+  );
+
   const selection = useTransactionSelection(
     transactions,
     pagination?.total ?? 0,
     bulkUpdateFilters,
+    selectionUserFilterKey,
   );
 
   const handleBulkUpdate = useCallback(async (updateFields: Partial<Pick<BulkUpdateData, 'payeeId' | 'payeeName' | 'categoryId' | 'description' | 'status' | 'tagIds'>>) => {

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -549,9 +549,15 @@ describe('InvestmentValueChart', () => {
       vi.setSystemTime(new Date(2026, 7, 12));
       try {
         render(<InvestmentValueChart />);
-        await vi.waitFor(() =>
-          expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled(),
-        );
+        // Not `vi.waitFor`: it polls outside act, so the state the response
+        // sets commits outside it and the assertions below read a tree React
+        // has not finished with. Draining the fake clock inside `act` settles
+        // the request and its render together. RTL's own `waitFor` is not the
+        // way out either -- it cannot drive Vitest's fake timers.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1000);
+        });
+        expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
       }

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
@@ -601,48 +601,66 @@ describe('OverrideEditorDialog', () => {
       mockGetSecurityPrices.mockResolvedValue([]);
     });
 
-    it('hides Amount / Category / Split toggle for investment occurrences', () => {
+    /**
+     * The dialog looks the security's price up on mount. A test that asserts
+     * synchronously returns before that answer lands, so the state it sets
+     * commits outside act() -- against whatever tree happens to be mounted by
+     * then. The tests below that wait for "Use latest close" already settle the
+     * lookup; the ones mocking an empty price list have nothing to wait for and
+     * settle it here instead.
+     */
+    async function settlePriceLookup() {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    it('hides Amount / Category / Split toggle for investment occurrences', async () => {
       render(
         <OverrideEditorDialog
           {...defaultProps}
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       expect(screen.queryByText('Amount')).not.toBeInTheDocument();
       expect(screen.queryByText('Category')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('Split this occurrence')).not.toBeInTheDocument();
     });
 
-    it('shows Quantity, Price, and Total Price inputs', () => {
+    it('shows Quantity, Price, and Total Price inputs', async () => {
       render(
         <OverrideEditorDialog
           {...defaultProps}
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       expect(screen.getByLabelText('Quantity (shares)')).toBeInTheDocument();
       expect(screen.getByLabelText('Price per share')).toBeInTheDocument();
       expect(screen.getByLabelText('Total Price')).toBeInTheDocument();
     });
 
-    it('seeds Total Price from saved quantity * price', () => {
+    it('seeds Total Price from saved quantity * price', async () => {
       render(
         <OverrideEditorDialog
           {...defaultProps}
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
       expect(totalInput.value).toBe('1,000');
     });
 
-    it('updates Quantity when Total Price is changed', () => {
+    it('updates Quantity when Total Price is changed', async () => {
       render(
         <OverrideEditorDialog
           {...defaultProps}
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
       fireEvent.change(totalInput, { target: { value: '250' } });
       fireEvent.blur(totalInput);
@@ -815,6 +833,7 @@ describe('OverrideEditorDialog', () => {
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       fireEvent.change(screen.getByLabelText('Price per share'), {
         target: { value: '123.45' },
       });
@@ -858,6 +877,7 @@ describe('OverrideEditorDialog', () => {
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       // A brand-new override inherits the price from the schedule -> "from the
       // schedule", never "saved on this occurrence".
       expect(screen.getByText('Using the price from the schedule.')).toBeInTheDocument();
@@ -889,6 +909,7 @@ describe('OverrideEditorDialog', () => {
           existingOverride={existingOverride}
         />,
       );
+      await settlePriceLookup();
       expect(
         screen.getByText('Using the price saved on this occurrence.'),
       ).toBeInTheDocument();
@@ -908,6 +929,7 @@ describe('OverrideEditorDialog', () => {
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       expect(screen.getByText('Using the price from the schedule.')).toBeInTheDocument();
       const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
       fireEvent.change(priceInput, { target: { value: '150' } });
@@ -1102,7 +1124,7 @@ describe('OverrideEditorDialog', () => {
       expect(payload.isSplit).toBeUndefined();
     });
 
-    it('prefills existing override values when editing', () => {
+    it('prefills existing override values when editing', async () => {
       const existingOverride = {
         id: 'ov1',
         scheduledTransactionId: 'inv1',
@@ -1126,6 +1148,7 @@ describe('OverrideEditorDialog', () => {
           existingOverride={existingOverride}
         />,
       );
+      await settlePriceLookup();
       const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
       const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
       expect(Number(qtyInput.value)).toBe(3);

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
@@ -1223,19 +1223,33 @@ describe('PostTransactionDialog', () => {
       mockGetSecurityPrices.mockResolvedValue([]);
     });
 
-    it('seeds Total Price from saved quantity * price', () => {
+    /**
+     * The dialog looks the security's price up on mount. A test that asserts
+     * synchronously returns before that answer lands, so the state it sets
+     * commits outside act() -- against whatever tree happens to be mounted by
+     * then. The tests that wait for "Use latest close" settle the lookup
+     * themselves; the ones mocking an empty price list settle it here.
+     */
+    async function settlePriceLookup() {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    it('seeds Total Price from saved quantity * price', async () => {
       render(
         <PostTransactionDialog
           {...defaultProps}
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
       // 10 * 100 + 0 commission = 1000
       expect(totalInput.value).toBe('1,000');
     });
 
-    it('seeds Total Price from the scheduled total amount when set', () => {
+    it('seeds Total Price from the scheduled total amount when set', async () => {
       render(
         <PostTransactionDialog
           {...defaultProps}
@@ -1247,17 +1261,19 @@ describe('PostTransactionDialog', () => {
           } as any}
         />,
       );
+      await settlePriceLookup();
       const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
       expect(totalInput.value).toBe('750');
     });
 
-    it('updates Total Price when Quantity is changed', () => {
+    it('updates Total Price when Quantity is changed', async () => {
       render(
         <PostTransactionDialog
           {...defaultProps}
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
       fireEvent.change(qtyInput, { target: { value: '5' } });
       const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
@@ -1265,13 +1281,14 @@ describe('PostTransactionDialog', () => {
       expect(totalInput.value).toBe('500');
     });
 
-    it('updates Quantity when Total Price is changed', () => {
+    it('updates Quantity when Total Price is changed', async () => {
       render(
         <PostTransactionDialog
           {...defaultProps}
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
       fireEvent.change(totalInput, { target: { value: '250' } });
       // Trigger blur to commit the value
@@ -1496,7 +1513,7 @@ describe('PostTransactionDialog', () => {
       expect('investmentTotalValue' in payload).toBe(false);
     });
 
-    it('accounts for commission in total computation (BUY)', () => {
+    it('accounts for commission in total computation (BUY)', async () => {
       const buyWithCommission = {
         ...investmentTransaction,
         investmentCommission: 9.99,
@@ -1507,12 +1524,13 @@ describe('PostTransactionDialog', () => {
           scheduledTransaction={buyWithCommission}
         />,
       );
+      await settlePriceLookup();
       const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
       // BUY: 10 * 100 + 9.99 = 1009.99
       expect(totalInput.value).toBe('1,009.99');
     });
 
-    it('accounts for commission in total computation (SELL subtracts)', () => {
+    it('accounts for commission in total computation (SELL subtracts)', async () => {
       const sellWithCommission = {
         ...investmentTransaction,
         investmentAction: 'SELL',
@@ -1524,12 +1542,13 @@ describe('PostTransactionDialog', () => {
           scheduledTransaction={sellWithCommission}
         />,
       );
+      await settlePriceLookup();
       const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
       // SELL: 10 * 100 - 9.99 = 990.01
       expect(totalInput.value).toBe('990.01');
     });
 
-    it('prefills Quantity / Price / Total Price from nextOverride when one exists', () => {
+    it('prefills Quantity / Price / Total Price from nextOverride when one exists', async () => {
       const txWithOverride = {
         ...investmentTransaction,
         nextOverride: {
@@ -1555,6 +1574,7 @@ describe('PostTransactionDialog', () => {
           scheduledTransaction={txWithOverride}
         />,
       );
+      await settlePriceLookup();
       const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
       const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
       const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
@@ -1632,7 +1652,7 @@ describe('PostTransactionDialog', () => {
       expect(totalInput.value).toBe('125');
     });
 
-    it('falls back to base values when override has null investment fields', () => {
+    it('falls back to base values when override has null investment fields', async () => {
       const txWithSparseOverride = {
         ...investmentTransaction,
         nextOverride: {
@@ -1658,13 +1678,14 @@ describe('PostTransactionDialog', () => {
           scheduledTransaction={txWithSparseOverride}
         />,
       );
+      await settlePriceLookup();
       const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
       const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
       expect(Number(qtyInput.value)).toBe(10); // base
       expect(Number(priceInput.value)).toBe(100); // base
     });
 
-    it('updates projected balance header from the current quantity / price (BUY)', () => {
+    it('updates projected balance header from the current quantity / price (BUY)', async () => {
       // Brokerage currentBalance 5000; BUY 10 * 100 = -1000 → 4000.
       render(
         <PostTransactionDialog
@@ -1672,6 +1693,7 @@ describe('PostTransactionDialog', () => {
           scheduledTransaction={investmentTransaction}
         />,
       );
+      await settlePriceLookup();
       expect(screen.getByText('$4000.00')).toBeInTheDocument();
 
       // User edits quantity to 5 → cash impact -500 → 4500.
@@ -1705,7 +1727,7 @@ describe('PostTransactionDialog', () => {
       expect(screen.getByText('$5125.00')).toBeInTheDocument();
     });
 
-    it('reflects override values in the projected balance on open', () => {
+    it('reflects override values in the projected balance on open', async () => {
       const txWithOverride = {
         ...investmentTransaction,
         nextOverride: {
@@ -1731,6 +1753,7 @@ describe('PostTransactionDialog', () => {
           scheduledTransaction={txWithOverride}
         />,
       );
+      await settlePriceLookup();
       // Override qty 3 * price 100 = -300 → 5000 - 300 = 4700
       expect(screen.getByText('$4700.00')).toBeInTheDocument();
     });

--- a/frontend/src/components/securities/SecurityList.test.tsx
+++ b/frontend/src/components/securities/SecurityList.test.tsx
@@ -73,7 +73,13 @@ describe('SecurityList', () => {
     expect(screen.getByText('Bonds')).toBeInTheDocument();
     expect(screen.queryByText('Global aggregate bond ETF.')).not.toBeInTheDocument();
 
-    useDensityStore.setState({ densities: { securities: 'dense' } });
+    // The density store is subscribed to by the mounted tree, so this write
+    // re-renders it -- act-wrapped, unlike the `compact` write above, which
+    // runs before anything is mounted. (Same rule as the reset in
+    // `src/test/setup.ts`.)
+    act(() => {
+      useDensityStore.setState({ densities: { securities: 'dense' } });
+    });
     rerender(
       <SecurityList securities={securities} onEdit={onEdit} onToggleActive={onToggleActive} onOpen={onOpen} />,
     );

--- a/frontend/src/components/ui/DateInput.test.tsx
+++ b/frontend/src/components/ui/DateInput.test.tsx
@@ -182,7 +182,10 @@ describe('DateInput', () => {
       const { getByLabelText } = renderDateInput('2025-06-15');
       const event = new KeyboardEvent('keydown', { key: 't', bubbles: true });
       const preventSpy = vi.spyOn(event, 'preventDefault');
-      getByLabelText('Date').dispatchEvent(event);
+      // `fireEvent(element, event)`, not `element.dispatchEvent(event)`: the
+      // spy needs this exact event object, and a bare dispatch skips the act()
+      // wrapper, so the date the 't' shortcut sets commits outside it.
+      fireEvent(getByLabelText('Date'), event);
       expect(preventSpy).toHaveBeenCalled();
     });
 

--- a/frontend/src/hooks/useStaleReconciliation.test.ts
+++ b/frontend/src/hooks/useStaleReconciliation.test.ts
@@ -33,9 +33,12 @@ describe('useStaleReconciliation', () => {
     mockGetStale.mockResolvedValue(summary);
   });
 
-  it('is undefined before the answer arrives', () => {
+  it('is undefined before the answer arrives', async () => {
     const { result } = renderHook(() => useStaleReconciliation());
     expect(result.current).toBeUndefined();
+    // The request is still in flight. Let it land here rather than committing
+    // into whatever tree is mounted when the microtask finally runs.
+    await waitFor(() => expect(result.current).toBeDefined());
   });
 
   it('indexes the last reconciled date by account', async () => {

--- a/frontend/src/hooks/useTransactionFilters.test.ts
+++ b/frontend/src/hooks/useTransactionFilters.test.ts
@@ -459,6 +459,27 @@ describe('useTransactionFilters - derived data and options', () => {
     expect(result.current.filteredAccounts.every(a => a.isClosed)).toBe(true);
   });
 
+  // `accountFilterOptions` sorts for display, and `filteredAccounts` is what the
+  // transactions page derives the bulk-update account scope from. Sorting in
+  // place reordered that scope as a side effect of rendering the dropdown, so
+  // the scope's value depended on which memo ran first.
+  it('sorts the account dropdown without reordering filteredAccounts', () => {
+    const unsorted = [
+      { id: 'a3', name: 'Zebra Credit Union', isClosed: false } as any,
+      { id: 'a1', name: 'Alpha Bank', isClosed: false } as any,
+    ];
+    const { result } = renderHook(() =>
+      useTransactionFilters({ ...defaultOptions, accounts: unsorted } as any),
+    );
+
+    expect(result.current.accountFilterOptions.map(o => o.label)).toEqual([
+      'Alpha Bank',
+      'Zebra Credit Union',
+    ]);
+    expect(result.current.filteredAccounts.map(a => a.id)).toEqual(['a3', 'a1']);
+    expect(unsorted.map(a => a.id)).toEqual(['a3', 'a1']);
+  });
+
   it('sorts payees alphabetically and excludes inactive', () => {
     const { result } = renderHook(() => useTransactionFilters({ ...defaultOptions, payees } as any));
     const labels = result.current.payeeFilterOptions.map(o => o.label);

--- a/frontend/src/hooks/useTransactionFilters.ts
+++ b/frontend/src/hooks/useTransactionFilters.ts
@@ -302,7 +302,10 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
   const categoryLabelMap = useMemo(() => buildCategoryLabelMap(categories), [categories]);
 
   const accountFilterOptions = useMemo(() => {
-    return filteredAccounts
+    // Copy before sorting: `filteredAccounts` is a memoized array other
+    // consumers read (it is what the bulk-update account scope is derived
+    // from), and Array.prototype.sort reorders in place.
+    return [...filteredAccounts]
       .sort((a, b) => a.name.localeCompare(b.name))
       .map(account => ({ value: account.id, label: account.name }));
   }, [filteredAccounts]);

--- a/frontend/src/hooks/useTransactionSelection.test.ts
+++ b/frontend/src/hooks/useTransactionSelection.test.ts
@@ -37,6 +37,7 @@ function createTransaction(id: string): Transaction {
 }
 
 const emptyFilters: BulkUpdateFilters = {};
+const EMPTY_KEY = JSON.stringify(emptyFilters);
 
 describe('useTransactionSelection', () => {
   const transactions = [
@@ -47,7 +48,7 @@ describe('useTransactionSelection', () => {
 
   it('starts with no selection', () => {
     const { result } = renderHook(() =>
-      useTransactionSelection(transactions, 100, emptyFilters)
+      useTransactionSelection(transactions, 100, emptyFilters, EMPTY_KEY)
     );
 
     expect(result.current.selectedIds.size).toBe(0);
@@ -59,7 +60,7 @@ describe('useTransactionSelection', () => {
 
   it('toggleTransaction selects and deselects individual transactions', () => {
     const { result } = renderHook(() =>
-      useTransactionSelection(transactions, 100, emptyFilters)
+      useTransactionSelection(transactions, 100, emptyFilters, EMPTY_KEY)
     );
 
     act(() => result.current.toggleTransaction('tx-1'));
@@ -74,7 +75,7 @@ describe('useTransactionSelection', () => {
 
   it('toggleAllOnPage selects all transactions on the current page', () => {
     const { result } = renderHook(() =>
-      useTransactionSelection(transactions, 100, emptyFilters)
+      useTransactionSelection(transactions, 100, emptyFilters, EMPTY_KEY)
     );
 
     act(() => result.current.toggleAllOnPage());
@@ -84,7 +85,7 @@ describe('useTransactionSelection', () => {
 
   it('toggleAllOnPage deselects all when all are selected', () => {
     const { result } = renderHook(() =>
-      useTransactionSelection(transactions, 100, emptyFilters)
+      useTransactionSelection(transactions, 100, emptyFilters, EMPTY_KEY)
     );
 
     act(() => result.current.toggleAllOnPage());
@@ -97,7 +98,7 @@ describe('useTransactionSelection', () => {
 
   it('selectAllMatchingTransactions enables filter-based selection', () => {
     const { result } = renderHook(() =>
-      useTransactionSelection(transactions, 100, emptyFilters)
+      useTransactionSelection(transactions, 100, emptyFilters, EMPTY_KEY)
     );
 
     act(() => result.current.selectAllMatchingTransactions());
@@ -109,7 +110,7 @@ describe('useTransactionSelection', () => {
 
   it('clearSelection resets everything', () => {
     const { result } = renderHook(() =>
-      useTransactionSelection(transactions, 100, emptyFilters)
+      useTransactionSelection(transactions, 100, emptyFilters, EMPTY_KEY)
     );
 
     act(() => result.current.selectAllMatchingTransactions());
@@ -123,7 +124,7 @@ describe('useTransactionSelection', () => {
 
   it('toggleTransaction excludes a single id while keeping selectAllMatching active', () => {
     const { result } = renderHook(() =>
-      useTransactionSelection(transactions, 100, emptyFilters)
+      useTransactionSelection(transactions, 100, emptyFilters, EMPTY_KEY)
     );
 
     act(() => result.current.selectAllMatchingTransactions());
@@ -149,7 +150,7 @@ describe('useTransactionSelection', () => {
     const page2 = [createTransaction('tx-3'), createTransaction('tx-4')];
 
     const { result, rerender } = renderHook(
-      ({ txs }) => useTransactionSelection(txs, 100, emptyFilters),
+      ({ txs }) => useTransactionSelection(txs, 100, emptyFilters, EMPTY_KEY),
       { initialProps: { txs: page1 } }
     );
 
@@ -168,7 +169,7 @@ describe('useTransactionSelection', () => {
     const page2 = [createTransaction('tx-3'), createTransaction('tx-4')];
 
     const { result, rerender } = renderHook(
-      ({ txs }) => useTransactionSelection(txs, 100, emptyFilters),
+      ({ txs }) => useTransactionSelection(txs, 100, emptyFilters, EMPTY_KEY),
       { initialProps: { txs: page1 } }
     );
 
@@ -190,7 +191,7 @@ describe('useTransactionSelection', () => {
 
   it('toggleAllOnPage excludes all current page ids in selectAllMatching mode', () => {
     const { result } = renderHook(() =>
-      useTransactionSelection(transactions, 100, emptyFilters)
+      useTransactionSelection(transactions, 100, emptyFilters, EMPTY_KEY)
     );
 
     act(() => result.current.selectAllMatchingTransactions());
@@ -211,7 +212,7 @@ describe('useTransactionSelection', () => {
 
   it('clearSelection clears excludedIds too', () => {
     const { result } = renderHook(() =>
-      useTransactionSelection(transactions, 100, emptyFilters)
+      useTransactionSelection(transactions, 100, emptyFilters, EMPTY_KEY)
     );
 
     act(() => result.current.selectAllMatchingTransactions());
@@ -228,7 +229,7 @@ describe('useTransactionSelection', () => {
     const filters2: BulkUpdateFilters = { search: 'bar' };
 
     const { result, rerender } = renderHook(
-      ({ filters }) => useTransactionSelection(transactions, 100, filters),
+      ({ filters }) => useTransactionSelection(transactions, 100, filters, JSON.stringify(filters)),
       { initialProps: { filters: filters1 } }
     );
 
@@ -240,10 +241,69 @@ describe('useTransactionSelection', () => {
     expect(result.current.selectAllMatching).toBe(false);
   });
 
+  // Regression: CI run #2873. Both of these cleared the selection because the
+  // page finished loading something, not because the user did anything: the
+  // click landed while a request was still in flight and the response wiped it
+  // on arrival. `page.test.tsx` holds the same race end to end.
+  describe('a background load does not drop the selection', () => {
+    it('keeps a selection made before the first page of rows arrives', () => {
+      const { result, rerender } = renderHook(
+        ({ txs }) => useTransactionSelection(txs, 100, emptyFilters, EMPTY_KEY),
+        { initialProps: { txs: [] as Transaction[] } }
+      );
+
+      act(() => result.current.toggleTransaction('tx-1'));
+      expect(result.current.selectionCount).toBe(1);
+
+      // The initial transactions request resolves after the click.
+      rerender({ txs: transactions });
+
+      expect(result.current.selectionCount).toBe(1);
+      expect(result.current.isTransactionSelected('tx-1')).toBe(true);
+    });
+
+    it('keeps a selection when the resolved account scope arrives', () => {
+      // `currentFilters` gains the visible-account fallback once the accounts
+      // request lands; the user's own criteria (the key) never changed.
+      const { result, rerender } = renderHook(
+        ({ filters }) => useTransactionSelection(transactions, 100, filters, EMPTY_KEY),
+        { initialProps: { filters: emptyFilters } }
+      );
+
+      act(() => result.current.toggleTransaction('tx-1'));
+      expect(result.current.selectionCount).toBe(1);
+
+      rerender({ filters: { accountIds: ['acc-1', 'acc-2'] } });
+
+      expect(result.current.selectionCount).toBe(1);
+      expect(result.current.isTransactionSelected('tx-1')).toBe(true);
+      // The payload still carries the resolved scope it must send.
+      act(() => result.current.selectAllMatchingTransactions());
+      expect(result.current.buildSelectionPayload().filters).toEqual({
+        accountIds: ['acc-1', 'acc-2'],
+      });
+    });
+
+    it('still clears when a real page change follows the first load', () => {
+      const page2 = [createTransaction('tx-4'), createTransaction('tx-5')];
+      const { result, rerender } = renderHook(
+        ({ txs }) => useTransactionSelection(txs, 100, emptyFilters, EMPTY_KEY),
+        { initialProps: { txs: [] as Transaction[] } }
+      );
+
+      rerender({ txs: transactions });
+      act(() => result.current.toggleTransaction('tx-1'));
+      expect(result.current.selectionCount).toBe(1);
+
+      rerender({ txs: page2 });
+      expect(result.current.selectionCount).toBe(0);
+    });
+  });
+
   describe('buildSelectionPayload', () => {
     it('returns ids mode when using individual selection', () => {
       const { result } = renderHook(() =>
-        useTransactionSelection(transactions, 100, emptyFilters)
+        useTransactionSelection(transactions, 100, emptyFilters, EMPTY_KEY)
       );
 
       act(() => result.current.toggleTransaction('tx-1'));
@@ -259,7 +319,7 @@ describe('useTransactionSelection', () => {
     it('returns filter mode when selectAllMatching is active', () => {
       const filters: BulkUpdateFilters = { accountIds: ['acc-1'], search: 'test' };
       const { result } = renderHook(() =>
-        useTransactionSelection(transactions, 100, filters)
+        useTransactionSelection(transactions, 100, filters, EMPTY_KEY)
       );
 
       act(() => result.current.selectAllMatchingTransactions());
@@ -274,7 +334,7 @@ describe('useTransactionSelection', () => {
     it('includes excludedIds in filter-mode payload', () => {
       const filters: BulkUpdateFilters = { accountIds: ['acc-1'] };
       const { result } = renderHook(() =>
-        useTransactionSelection(transactions, 100, filters)
+        useTransactionSelection(transactions, 100, filters, EMPTY_KEY)
       );
 
       act(() => result.current.selectAllMatchingTransactions());

--- a/frontend/src/hooks/useTransactionSelection.ts
+++ b/frontend/src/hooks/useTransactionSelection.ts
@@ -22,25 +22,34 @@ export function useTransactionSelection(
   transactions: Transaction[],
   totalMatching: number,
   currentFilters: BulkUpdateFilters,
+  // The criteria the *user* chose, as a stable string. The selection resets on
+  // this and never on `currentFilters`, because `currentFilters` carries a
+  // scope the page derives from data that is still loading -- see the effect
+  // below. Required (not defaulted to `currentFilters`) so a call site has to
+  // decide which of the two it means.
+  userFilterKey: string,
 ): UseTransactionSelectionReturn {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [excludedIds, setExcludedIds] = useState<Set<string>>(new Set());
   const [selectAllMatching, setSelectAllMatching] = useState(false);
 
-  // Track filter changes to clear selection
-  const filtersRef = useRef(currentFilters);
+  // Clear the selection when the user changes what they are filtering by.
+  //
+  // This keys off `userFilterKey`, never off `currentFilters`. `currentFilters`
+  // is the resolved scope the server payload needs, and its account list falls
+  // back to every visible account -- so it changes the moment the accounts
+  // request lands. That is data arriving, not the user changing a filter, and
+  // clearing on it silently dropped a selection made while the page was still
+  // loading.
+  const filterKeyRef = useRef(userFilterKey);
   /* eslint-disable react-hooks/set-state-in-effect -- clearing selection when filters change */
   useEffect(() => {
-    const prev = filtersRef.current;
-    const changed =
-      JSON.stringify(prev) !== JSON.stringify(currentFilters);
-    if (changed) {
-      setSelectedIds(new Set());
-      setExcludedIds(new Set());
-      setSelectAllMatching(false);
-      filtersRef.current = currentFilters;
-    }
-  }, [currentFilters]);
+    if (filterKeyRef.current === userFilterKey) return;
+    filterKeyRef.current = userFilterKey;
+    setSelectedIds(new Set());
+    setExcludedIds(new Set());
+    setSelectAllMatching(false);
+  }, [userFilterKey]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   // Clear individual selections on page change (but not selectAllMatching/excludedIds,
@@ -49,10 +58,16 @@ export function useTransactionSelection(
   const prevTransactionIdsKey = useRef(transactionIdsKey);
   /* eslint-disable react-hooks/set-state-in-effect -- clearing selection on page change */
   useEffect(() => {
-    if (prevTransactionIdsKey.current !== transactionIdsKey && !selectAllMatching) {
+    const prev = prevTransactionIdsKey.current;
+    prevTransactionIdsKey.current = transactionIdsKey;
+    // An empty row set is not a page the user could have navigated away from,
+    // so rows arriving into one is a load finishing, not a page change.
+    // Clearing there drops a selection that outlived an empty or failed load,
+    // and there is no page it could be stale against.
+    if (prev === '') return;
+    if (prev !== transactionIdsKey && !selectAllMatching) {
       setSelectedIds(new Set());
     }
-    prevTransactionIdsKey.current = transactionIdsKey;
   }, [transactionIdsKey, selectAllMatching]);
   /* eslint-enable react-hooks/set-state-in-effect */
 

--- a/frontend/src/test/act-guard.test.ts
+++ b/frontend/src/test/act-guard.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { failOnActWarnings, isActWarning, pendingActWarnings, recordActWarning } from './act-guard';
+
+// React's real message, verbatim, including the printf placeholder that carries
+// the component name as a separate argument.
+const REACT_ACT_WARNING =
+  'An update to %s inside a test was not wrapped in act(...).\n\n' +
+  'When testing, code that causes React state updates should be wrapped into act(...):';
+
+describe('act-guard', () => {
+  it('recognizes React act warnings and nothing else', () => {
+    expect(isActWarning([REACT_ACT_WARNING, 'TransactionsPage'])).toBe(true);
+    expect(
+      isActWarning(['Warning: The current testing environment is not configured to support act(...)']),
+    ).toBe(true);
+    expect(isActWarning(['<path> attribute d: Expected number'])).toBe(false);
+    expect(isActWarning(['[useTransactionSelection]', 'Save failed'])).toBe(false);
+    expect(isActWarning([new Error('boom')])).toBe(false);
+  });
+
+  it('fails the test, naming the component React named', () => {
+    recordActWarning([REACT_ACT_WARNING, 'TransactionsPage']);
+    expect(pendingActWarnings()).toHaveLength(1);
+
+    expect(() => failOnActWarnings()).toThrow(/An update to TransactionsPage inside a test/);
+  });
+
+  it('reports once per distinct warning, and resets so it fails only the test that earned it', () => {
+    recordActWarning([REACT_ACT_WARNING, 'DateInput']);
+    recordActWarning([REACT_ACT_WARNING, 'DateInput']);
+    recordActWarning([REACT_ACT_WARNING, 'SecurityList']);
+
+    expect(() => failOnActWarnings()).toThrow(/2 act\(\) warnings/);
+    // Reported once: a warning left in the buffer would fail every later test
+    // in the file and hide which one actually produced it.
+    expect(pendingActWarnings()).toHaveLength(0);
+    expect(() => failOnActWarnings()).not.toThrow();
+  });
+
+  it('says nothing when nothing was recorded', () => {
+    expect(() => failOnActWarnings()).not.toThrow();
+  });
+
+  // A guard nothing calls is not a guard. `setup.ts` is the only wiring, and it
+  // is a side-effecting file that cannot be imported twice to assert on -- so
+  // the wiring is checked by reading it.
+  describe('setup.ts wiring', () => {
+    const setup = readFileSync(join(__dirname, 'setup.ts'), 'utf8');
+
+    it('routes console.error through the guard', () => {
+      expect(setup).toMatch(/isActWarning\(args\)/);
+      expect(setup).toMatch(/recordActWarning\(args\)/);
+    });
+
+    it('fails after every test and after the last one', () => {
+      // In `afterEach`, after `cleanup()`: an update React commits while
+      // unmounting belongs to the test that mounted the tree.
+      expect(setup).toMatch(/cleanup\(\);[\s\S]*?failOnActWarnings\(\);[\s\S]*?\}\);/);
+      expect(setup).toMatch(/afterAll\(failOnActWarnings\)/);
+    });
+
+    it('does not suppress act warnings anywhere else', () => {
+      // Any second mention of act() in a console filter would be a silencer.
+      const filtered = setup.match(/msg\.includes\('([^']*)'\)/g) ?? [];
+      expect(filtered.some((m) => /act/i.test(m))).toBe(false);
+    });
+  });
+});

--- a/frontend/src/test/act-guard.ts
+++ b/frontend/src/test/act-guard.ts
@@ -1,0 +1,55 @@
+/**
+ * Fail a test run on React's act() warnings instead of printing them.
+ *
+ * An act warning is a test reading a tree React has not finished updating: the
+ * assertion sees whatever happened to be committed when it ran, so the test
+ * passes or fails on timing rather than on behaviour. They are invisible on a
+ * fast machine -- the late update lands inside the act scope and nothing is
+ * printed -- and surface on a loaded CI runner, which is the one place nobody
+ * is watching stderr. CI run #2873 carried fifteen of them under a green tick.
+ *
+ * Fix the update, never the symptom: await the thing that lands late
+ * (`await screen.findBy...`, `await waitFor(...)`), or wrap the trigger in
+ * `await act(async () => { ... })`. Filtering the message back out would only
+ * restore the silence this exists to remove.
+ *
+ * Wired in `setup.ts`; `act-guard.test.ts` checks both this behaviour and that
+ * the wiring is still there.
+ */
+const ACT_WARNING = /not wrapped in act|not configured to support act/;
+
+const warnings: string[] = [];
+
+/** True when `console.error`'s arguments are one of React's act warnings. */
+export function isActWarning(args: readonly unknown[]): boolean {
+  return typeof args[0] === 'string' && ACT_WARNING.test(args[0]);
+}
+
+/**
+ * Record one warning. React formats these printf-style ("An update to %s ..."),
+ * so the component name arrives as a separate argument -- interpolate it, or
+ * the report names no component at all.
+ */
+export function recordActWarning(args: readonly unknown[]): void {
+  const template = typeof args[0] === 'string' ? args[0] : '';
+  let i = 1;
+  const formatted = template.replace(/%[sdifoOc]/g, () => String(args[i++] ?? ''));
+  warnings.push(formatted.split('\n')[0].trim());
+}
+
+/** Test-only: what has been recorded and not yet reported. */
+export function pendingActWarnings(): readonly string[] {
+  return [...warnings];
+}
+
+/** Throw if anything was recorded since the last call, and reset. */
+export function failOnActWarnings(): void {
+  if (warnings.length === 0) return;
+  const seen = [...new Set(warnings)];
+  warnings.length = 0;
+  throw new Error(
+    `React logged ${seen.length === 1 ? 'an act() warning' : `${seen.length} act() warnings`} ` +
+      'during this test. An update landed outside act(), so the assertions ran against a tree ' +
+      `React had not finished updating.\n\n${seen.join('\n\n')}`,
+  );
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,8 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
-import { afterEach, vi } from 'vitest';
+import { afterAll, afterEach, vi } from 'vitest';
+
+import { failOnActWarnings, isActWarning, recordActWarning } from './act-guard';
 
 afterEach(async () => {
   cleanup();
@@ -21,7 +23,14 @@ afterEach(async () => {
   // assertion read the mock. The two would never see each other's writes.
   const { useDensityStore } = await import('@/store/densityStore');
   useDensityStore.setState({ densities: {} });
+  // Last, so an update React commits during `cleanup()` is counted against the
+  // test that mounted the tree rather than the next one.
+  failOnActWarnings();
 });
+
+// `cleanup()` for the file's final test runs inside that test's own afterEach
+// above, but a warning React logs after the last hook has nowhere else to go.
+afterAll(failOnActWarnings);
 
 // Suppress known-harmless jsdom warnings for SVG elements used by Recharts.
 // Also suppress tagged output from the project's `createLogger` (e.g.
@@ -32,6 +41,13 @@ const LOGGER_TAG_RE = /^\[[A-Za-z][\w-]*\]$/;
 const originalConsoleError = console.error;
 console.error = (...args: unknown[]) => {
   const msg = typeof args[0] === 'string' ? args[0] : '';
+  // Recorded rather than printed: the failure raised in `afterEach` names the
+  // test, which one line on stderr in a 14,000-test run does not. See
+  // `act-guard.ts` for why these are failures and not noise.
+  if (isActWarning(args)) {
+    recordActWarning(args);
+    return;
+  }
   if (
     msg.includes('is unrecognized in this browser') ||
     msg.includes('is using incorrect casing') ||


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: _none — see below._

There is no approved discussion for this one. It is not proposed work: CI Pipeline run
[#2873](https://github.com/kenlasko/monize/actions/runs/32981262822) on `main` failed, and the
maintainer asked for the failure to be diagnosed and fixed. Everything here is scoped to what that
run got wrong. Happy to go back through propose-first if you would rather this were split or
reshaped.

## Summary

Run #2873's `Frontend Unit Tests` job failed on one assertion out of 14,089 — the bulk-update
banner missing after a row was selected in `transactions/page.test.tsx`. The DOM it dumped showed
all three rows rendered and no banner, so the selection had been **cleared**, not never made.

Two paths clear it, and both mistook a request finishing for the user acting:

- **`bulkUpdateFilters` falls back to every visible account** when no account filter is set, so it
  changes the moment the accounts request answers. `useTransactionSelection` compared that object
  and cleared. It now resets on `userFilterKey` — the criteria the user actually chose — while
  `currentFilters` stays what the `mode: "filter"` payload needs. The key is derived from
  `bulkUpdateFilters` with only the derived account scope swapped for the user's own, so the two
  lists cannot drift; the parameter is required rather than defaulted, so a call site has to decide
  which of the two it means.
- **An empty row set is not a page the user could have navigated away from**, so rows arriving into
  one is a load finishing, not a page change.

This is a user-facing bug, not only a flaky test: a click on a checkbox while the accounts request
is still in flight loses the selection silently.

Also fixed alongside it: `accountFilterOptions` sorted `filteredAccounts` **in place** — the array
the bulk-update account scope is derived from — so that scope's order depended on which `useMemo`
ran first.

### Act warnings are now failures

The same job carried **fifteen act() warnings under a green tick**. A test asserting on a tree React
has not finished updating passes or fails on timing rather than on behaviour, and nobody reads
stderr in a 14,000-test run. `src/test/act-guard.ts` now collects them and fails the test that
earned them; `act-guard.test.ts` covers the behaviour *and* scans `setup.ts` for the wiring, since a
guard nothing calls is not a guard.

Turning them into failures reproduced all fifteen locally and surfaced **ten more** in
`PostTransactionDialog.test.tsx` that CI had not reported. All twenty-five are fixed at the source —
settling a request still in flight, replacing the non-act-aware `vi.waitFor` and
`element.dispatchEvent`, and wrapping a Zustand write made with the tree mounted — never by
filtering the message back out.

### Verification

| Check | Result |
| --- | --- |
| `tsc --noEmit` | clean |
| `eslint .` | clean |
| `TZ=UTC vitest run` | 727 files / 14,101 tests passing, zero act warnings |
| Backend `doc-paths` + `source-comment-paths` guards | 35 passing (they check the new `frontend/CLAUDE.md` rules) |
| Baseline `main`, full suite | green — confirming nothing here was pre-existing |

Each of the four regression tests was run against the **original** code and fails there: two in
`useTransactionSelection.test.ts`, one end-to-end in `page.test.tsx` reproducing the CI error
message verbatim, and one pinning the in-place sort.

Two things worth flagging honestly:

- I could not reproduce the precise CI ordering locally despite ~30 attempts (timing jitter,
  coverage, CPU contention, twelve repeat runs). What is proven is that the selection *was* cleared,
  that exactly two paths clear it, and that the accounts race reproduces the identical error. Both
  paths are now guarded.
- `InvestmentValueChart.test.tsx` flaked once in an intermediate full-suite run — pre-existing and
  timing-dependent (baseline `main` was green and it passed on re-run). Its act warning was one of
  the fifteen and fixing that plausibly addresses it, but I have not proven that.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **No.** This is a red-CI fix on
      `main` requested directly by the maintainer, not proposed work.
- [x] This PR addresses a **single concern** (large work is split into a series). — One concern:
      what run #2873 got wrong. It has two strands (the selection race; the act warnings), both
      found in that job's log. Say the word if you would rather they were two PRs.
- [x] New behavior has tests, and the existing suite passes. — Four regression tests, each verified
      to fail on the original code; full suite green.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — No user-facing
      strings are added or changed, so the catalogs are untouched and parity is unaffected.
- [x] No shared/core areas were refactored without prior agreement. — `useTransactionSelection`'s
      signature gains one required parameter, and its only production call site is the transactions
      page. `src/test/setup.ts` is shared and does change behaviour: it now fails a test on an act
      warning. That is the point of the change, but it is the line to look at first.
- [x] The branch is rebased on the latest `main`. — 0 behind, 1 ahead of `origin/main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written by Claude Code (Claude Opus 5), driven by the maintainer. The diagnosis, the fix, the
regression tests and the two `frontend/CLAUDE.md` rules are all AI-authored. Every claim in this
description was checked by running the thing it describes rather than by inspection — including
running each new regression test against the unfixed code to confirm it actually fails there. The
limits of what was reproduced are stated above rather than smoothed over.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YATGDV3Vcg6MjtrZyDmzUU)_