### PR TITLE
fix(test): fail only on the act warning that names a component

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -371,6 +371,22 @@ lands late (`await screen.findBy...`, `await waitFor(...)`); or wrap the trigger
 in `await act(async () => { ... })`. Adding the text to a console filter is the
 one response that is always wrong.
 
+**Exactly one message is that failure**: `An update to <Component> inside a test
+was not wrapped in act(...)`. React's other act-related line -- `The current
+testing environment is not configured to support act(...)` -- is a different
+condition and is deliberately *not* failed on. It fires when an update is
+checked while `IS_REACT_ACT_ENVIRONMENT` is unset, which happens during teardown
+after RTL has restored the flag; it names no component, so it points at nothing,
+and it depends on timing the suite does not control. Matching it turned `main`
+red on CI run #2875, on a test nothing had changed and that neither the PR run
+nor three full local runs of the same commit had flagged. **A guard against
+flakiness that is itself timing-dependent is worse than none.**
+
+And a guard classifies in one place: `recordIfActWarning` both recognises and
+records, because the two were separate functions that disagreed -- the
+classifier rejected a message the recorder stored anyway, so a warning nothing
+recognised could still fail a test.
+
 Three sources produce nearly all of them here:
 
 - **A synchronous test with a request still in flight.** The response commits

--- a/frontend/src/test/act-guard.test.ts
+++ b/frontend/src/test/act-guard.test.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 
 import { describe, expect, it } from 'vitest';
 
-import { failOnActWarnings, isActWarning, pendingActWarnings, recordActWarning } from './act-guard';
+import { failOnActWarnings, pendingActWarnings, recordIfActWarning } from './act-guard';
 
 // React's real message, verbatim, including the printf placeholder that carries
 // the component name as a separate argument.
@@ -13,26 +13,46 @@ const REACT_ACT_WARNING =
 
 describe('act-guard', () => {
   it('recognizes React act warnings and nothing else', () => {
-    expect(isActWarning([REACT_ACT_WARNING, 'TransactionsPage'])).toBe(true);
-    expect(
-      isActWarning(['Warning: The current testing environment is not configured to support act(...)']),
-    ).toBe(true);
-    expect(isActWarning(['<path> attribute d: Expected number'])).toBe(false);
-    expect(isActWarning(['[useTransactionSelection]', 'Save failed'])).toBe(false);
-    expect(isActWarning([new Error('boom')])).toBe(false);
+    expect(recordIfActWarning([REACT_ACT_WARNING, 'TransactionsPage'])).toBe(true);
+    expect(recordIfActWarning(['<path> attribute d: Expected number'])).toBe(false);
+    expect(recordIfActWarning(['[useTransactionSelection]', 'Save failed'])).toBe(false);
+    expect(recordIfActWarning([new Error('boom')])).toBe(false);
+    // Only the first was recognised, so only it is pending. Draining here keeps
+    // it from failing the next test in this file.
+    expect(pendingActWarnings()).toHaveLength(1);
+    expect(() => failOnActWarnings()).toThrow();
+  });
+
+  // Regression: CI run #2875 turned `main` red on `DividendIncomeReport`, a test
+  // nothing had changed. React's environment message is a different condition,
+  // it names no component, and it fires from teardown timing the suite does not
+  // control -- so it is not a test failure. See the note in `act-guard.ts`.
+  it('does not fail a test on the "environment is not configured" message', () => {
+    const envMessage =
+      'Warning: The current testing environment is not configured to support act(...)';
+    expect(recordIfActWarning([envMessage])).toBe(false);
+    expect(pendingActWarnings()).toHaveLength(0);
+    expect(() => failOnActWarnings()).not.toThrow();
+  });
+
+  // Classifying and recording are one call, so a message the guard does not
+  // recognise cannot be recorded by a second door and fail a test anyway.
+  it('records only what it recognises', () => {
+    recordIfActWarning(['some unrelated console.error']);
+    expect(pendingActWarnings()).toHaveLength(0);
   });
 
   it('fails the test, naming the component React named', () => {
-    recordActWarning([REACT_ACT_WARNING, 'TransactionsPage']);
+    recordIfActWarning([REACT_ACT_WARNING, 'TransactionsPage']);
     expect(pendingActWarnings()).toHaveLength(1);
 
     expect(() => failOnActWarnings()).toThrow(/An update to TransactionsPage inside a test/);
   });
 
   it('reports once per distinct warning, and resets so it fails only the test that earned it', () => {
-    recordActWarning([REACT_ACT_WARNING, 'DateInput']);
-    recordActWarning([REACT_ACT_WARNING, 'DateInput']);
-    recordActWarning([REACT_ACT_WARNING, 'SecurityList']);
+    recordIfActWarning([REACT_ACT_WARNING, 'DateInput']);
+    recordIfActWarning([REACT_ACT_WARNING, 'DateInput']);
+    recordIfActWarning([REACT_ACT_WARNING, 'SecurityList']);
 
     expect(() => failOnActWarnings()).toThrow(/2 act\(\) warnings/);
     // Reported once: a warning left in the buffer would fail every later test
@@ -52,8 +72,7 @@ describe('act-guard', () => {
     const setup = readFileSync(join(__dirname, 'setup.ts'), 'utf8');
 
     it('routes console.error through the guard', () => {
-      expect(setup).toMatch(/isActWarning\(args\)/);
-      expect(setup).toMatch(/recordActWarning\(args\)/);
+      expect(setup).toMatch(/recordIfActWarning\(args\)/);
     });
 
     it('fails after every test and after the last one', () => {

--- a/frontend/src/test/act-guard.ts
+++ b/frontend/src/test/act-guard.ts
@@ -16,25 +16,44 @@
  * Wired in `setup.ts`; `act-guard.test.ts` checks both this behaviour and that
  * the wiring is still there.
  */
-const ACT_WARNING = /not wrapped in act|not configured to support act/;
+
+/**
+ * Only the actionable warning, and deliberately not React's other act-related
+ * message -- "The current testing environment is not configured to support
+ * act(...)". Matching that one turned `main` red on CI run #2875, on a test
+ * nothing had changed.
+ *
+ * It is a different condition, and not one a test author can act on: React logs
+ * it when an update is checked while `IS_REACT_ACT_ENVIRONMENT` is unset, which
+ * happens during teardown after RTL has already restored the flag. It names no
+ * component, so it points at nothing, and it depends on timing the suite does
+ * not control -- it appeared on neither the PR run nor three full local runs of
+ * the same commit. Failing on it makes the suite flaky, which is the very thing
+ * this guard exists to prevent.
+ */
+const ACT_WARNING = /not wrapped in act/;
 
 const warnings: string[] = [];
 
-/** True when `console.error`'s arguments are one of React's act warnings. */
-export function isActWarning(args: readonly unknown[]): boolean {
-  return typeof args[0] === 'string' && ACT_WARNING.test(args[0]);
-}
-
 /**
- * Record one warning. React formats these printf-style ("An update to %s ..."),
- * so the component name arrives as a separate argument -- interpolate it, or
- * the report names no component at all.
+ * Record one `console.error` call if it is React's act warning, and report
+ * whether it was recorded so the caller can swallow it.
+ *
+ * Classifying and recording are one function on purpose. They were two, and the
+ * pair disagreed: the classifier rejected a message the recorder stored anyway,
+ * so a warning nothing recognised could still fail a test.
+ *
+ * React formats these printf-style ("An update to %s ..."), so the component
+ * name arrives as a separate argument -- interpolate it, or the report names no
+ * component at all.
  */
-export function recordActWarning(args: readonly unknown[]): void {
+export function recordIfActWarning(args: readonly unknown[]): boolean {
   const template = typeof args[0] === 'string' ? args[0] : '';
+  if (!ACT_WARNING.test(template)) return false;
   let i = 1;
   const formatted = template.replace(/%[sdifoOc]/g, () => String(args[i++] ?? ''));
   warnings.push(formatted.split('\n')[0].trim());
+  return true;
 }
 
 /** Test-only: what has been recorded and not yet reported. */

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
 import { afterAll, afterEach, vi } from 'vitest';
 
-import { failOnActWarnings, isActWarning, recordActWarning } from './act-guard';
+import { failOnActWarnings, recordIfActWarning } from './act-guard';
 
 afterEach(async () => {
   cleanup();
@@ -44,8 +44,7 @@ console.error = (...args: unknown[]) => {
   // Recorded rather than printed: the failure raised in `afterEach` names the
   // test, which one line on stderr in a 14,000-test run does not. See
   // `act-guard.ts` for why these are failures and not noise.
-  if (isActWarning(args)) {
-    recordActWarning(args);
+  if (recordIfActWarning(args)) {
     return;
   }
   if (


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: _none — this fixes red `main`._

CI Pipeline run [#2875](https://github.com/kenlasko/monize/actions/runs/33030096632) on `main`
failed immediately after #1267 merged. The cause is the act guard that PR added, so this is my
regression to fix, not proposed work.

## Summary

Run #2875's `Frontend Unit Tests` failed on
`DividendIncomeReport.test.tsx > strips the account name suffix in the CSV filename` — a test
nothing in #1267 had touched. The failure was the guard itself, not the test.

React emits **two** act-related messages and the guard matched both. Only one is a defect a test
author can act on:

| Message | Condition | Actionable |
| --- | --- | --- |
| `An update to <Component> inside a test was not wrapped in act(...)` | a real late update; names the component | yes |
| `The current testing environment is not configured to support act(...)` | an update checked while `IS_REACT_ACT_ENVIRONMENT` is unset — during teardown, after RTL restores the flag | **no** |

The second names no component, so it points at nothing, and it depends on timing the suite does not
control: it fired on neither PR run #2874 nor three full local runs of the same commit. **A guard
against flakiness that is itself timing-dependent is worse than none**, so it is no longer a
failure.

Underneath it was a second defect. Classification lived in `isActWarning` and recording in
`recordActWarning`, and the two disagreed — the classifier rejected a message the recorder stored
regardless, so a warning nothing recognised could still fail a test. Even a narrowed regex would
have leaked through that. They are now one call, `recordIfActWarning`, which both recognises and
records.

**The guard still bites.** A planted late update still fails, naming the component. The twenty-five
act-warning fixes from #1267 are untouched — this changes only which messages the guard fails on.

### Verification

The reproduction was written and run against the **unfixed** guard first, and fails there.

| Check | Result |
| --- | --- |
| Repro of the false positive, before the fix | fails (as it should) |
| Planted late update, after the fix | still fails, naming the component |
| `DividendIncomeReport.test.tsx` | 52 passed |
| `act-guard.test.ts` | 9 passed, incl. regressions for both defects |
| `tsc --noEmit`, `eslint` | clean |
| Backend `doc-paths` + `source-comment-paths` | 35 passed |
| `TZ=UTC vitest run` | **727 / 727 files, 14,103 / 14,103 tests** |

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **No.** This repairs red `main`
      caused by my own change in #1267.
- [x] This PR addresses a **single concern** (large work is split into a series). — One: the act
      guard's false-positive mode.
- [x] New behavior has tests, and the existing suite passes. — Two regression tests (the environment
      message; record-only-what-you-recognise), the repro verified to fail on the unfixed guard, and
      a full green suite.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — Test
      infrastructure only; no user-facing strings exist in this diff.
- [x] No shared/core areas were refactored without prior agreement. — `src/test/setup.ts` and
      `act-guard.ts` are shared test infrastructure and are the whole subject of this PR. The change
      makes the guard strictly *less* likely to fail a test; it cannot mask a real act warning,
      which the retained "still bites" test proves.
- [x] The branch is rebased on the latest `main`. — Branched from `8a7c07b`, the #1267 merge commit.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written by Claude Code (Claude Opus 5). This one is a self-inflicted regression: I included the
environment message in the guard's pattern in #1267 having explicitly noted in my own reasoning that
it was "a different problem", and did not weigh that a timing-dependent guard would produce
timing-dependent failures. The PR run and three local full runs were all green on that commit, so
nothing short of merging surfaced it. The fix was reproduced before being made, and the guard's
remaining teeth were re-verified rather than assumed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YATGDV3Vcg6MjtrZyDmzUU)_