### PR TITLE
test(investments): wait for the call being asserted, and stop sessionStorage leaking between tests

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -402,6 +402,36 @@ Three sources produce nearly all of them here:
   synchronously, so `useDensityStore.setState(...)` re-renders outside act
   unless wrapped. Writing *before* the render does not need it.
 
+### Awaiting static chrome synchronises nothing
+
+`await screen.findByText('Portfolio Value Over Time')` resolves on the page's
+title -- markup that renders before any request does. Every assertion keyed off
+it is asserting on an async call it never waited for. Wait for the thing being
+asserted (`await waitFor(() => expect(api.x).toHaveBeenCalledTimes(1))`), which
+cannot mask a real failure: a call that never happens still times out.
+
+The trap is worst where a call is **second-stage** -- issued only after an
+earlier response commits. The Portfolio Value chart's prior-close baseline is
+gated on `chartPoints[0]`, so it cannot fire until the intraday response lands;
+tests asserting it right after the title passed on a fast machine and failed on
+CI run #2877. Before asserting that a request was made, ask what has to resolve
+first.
+
+Two exceptions, both real: an assertion already inside a `waitFor` callback, and
+one inside a pinned clock -- RTL's `waitFor` cannot drive Vitest's fake timers
+and will hang until the test times out, so there the act-wrapped drain is the
+barrier. A blanket sweep over a file with mixed timer regimes walks into that.
+
+### Test isolation is every storage, not just `localStorage`
+
+`src/test/setup.ts` clears `localStorage` between tests, and for a long time
+cleared nothing else. The Portfolio Value chart caches its intraday response in
+`sessionStorage`, and a leaked entry hydrates the next test's chart
+*synchronously on mount* -- which moves a second-stage request to immediate and
+silently changes what that test is exercising. Anything a component persists is
+shared state between tests: clear it, or the suite's behaviour depends on
+ordering.
+
 ### A busy flag shared by nesting operations is a counter, not a boolean
 
 One mutation can start another ("save and carry on" runs the deferred scenario create from inside the settings save's own `onSaved`). With a single boolean the inner sets it, the outer's `finally` clears it, and the page goes live over a request still on the wire. Count the operations in flight and derive the flag (`pending > 0`); every begin needs exactly one end, on both success and failure paths.

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -245,20 +245,24 @@ describe('InvestmentValueChart', () => {
   it('passes accountIds to API when provided', async () => {
     render(<InvestmentValueChart accountIds={['acc-1', 'acc-2']} />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accountIds: 'acc-1,acc-2',
-      })
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountIds: 'acc-1,acc-2',
+        })
+      )
     );
   });
 
   it('does not pass accountIds when empty array', async () => {
     render(<InvestmentValueChart accountIds={[]} />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accountIds: undefined,
-      })
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountIds: undefined,
+        })
+      )
     );
   });
 
@@ -287,15 +291,21 @@ describe('InvestmentValueChart', () => {
     });
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(investmentsApi.getIntradayValue).toHaveBeenCalledWith(
-      expect.objectContaining({ range: '1m' }),
+    await waitFor(() =>
+      expect(investmentsApi.getIntradayValue).toHaveBeenCalledWith(
+        expect.objectContaining({ range: '1m' }),
+      )
     );
     // The daily endpoint is still reached, but only for the prior-close
     // baseline -- its window ends the day before the chart's first point, so
     // none of the plotted series comes from it.
-    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledTimes(1);
-    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
-      expect.objectContaining({ endDate: '2023-12-31' }),
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledTimes(1)
+    );
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
+        expect.objectContaining({ endDate: '2023-12-31' }),
+      )
     );
   });
 
@@ -338,7 +348,9 @@ describe('InvestmentValueChart', () => {
   it('uses daily API for 1y range (DAILY_RANGES)', async () => {
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled()
+    );
     expect(netWorthApi.getInvestmentsMonthly).not.toHaveBeenCalled();
   });
 
@@ -347,7 +359,9 @@ describe('InvestmentValueChart', () => {
     dateRangeState.resolvedRange = { start: '2022-01-01', end: '2024-01-01' };
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled()
+    );
     expect(netWorthApi.getInvestmentsMonthly).not.toHaveBeenCalled();
   });
 
@@ -368,14 +382,20 @@ describe('InvestmentValueChart', () => {
     });
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(investmentsApi.getIntradayValue).toHaveBeenCalledWith(
-      expect.objectContaining({ range: '1d' }),
+    await waitFor(() =>
+      expect(investmentsApi.getIntradayValue).toHaveBeenCalledWith(
+        expect.objectContaining({ range: '1d' }),
+      )
     );
     // As above: the only daily call is the prior-close baseline, whose window
     // ends the day before the session on screen.
-    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledTimes(1);
-    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
-      expect.objectContaining({ endDate: '2024-01-01' }),
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledTimes(1)
+    );
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
+        expect.objectContaining({ endDate: '2024-01-01' }),
+      )
     );
   });
 
@@ -520,7 +540,9 @@ describe('InvestmentValueChart', () => {
 
       // From 9000, not from the 10000 first point.
       await waitFor(() => expect(card('Change')).toContain('+$2000.00'));
-      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
+      await waitFor(() =>
+        expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled()
+      );
     });
 
     it('still measures a long range from the first point plotted', async () => {
@@ -532,9 +554,13 @@ describe('InvestmentValueChart', () => {
       await screen.findByText('Portfolio Value Over Time');
       await waitFor(() => expect(card('Change')).toContain('+$5000.00'));
       // One call, for the chart itself -- no baseline lookup.
-      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledTimes(1);
-      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
-        expect.objectContaining({ endDate: '2024-01-01' }),
+      await waitFor(() =>
+        expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledTimes(1)
+      );
+      await waitFor(() =>
+        expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
+          expect.objectContaining({ endDate: '2024-01-01' }),
+        )
       );
     });
 
@@ -557,12 +583,17 @@ describe('InvestmentValueChart', () => {
         await act(async () => {
           await vi.advanceTimersByTimeAsync(1000);
         });
+        // Bare, not `waitFor`: the fake clock is still installed here and RTL's
+        // `waitFor` cannot drive it, so it would hang until the test times out.
+        // The act-wrapped drain above is this assertion's barrier.
         expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
       }
-      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
-        expect.objectContaining({ startDate: '2025-08-11' }),
+      await waitFor(() =>
+        expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
+          expect.objectContaining({ startDate: '2025-08-11' }),
+        )
       );
     });
   });
@@ -825,7 +856,9 @@ describe('InvestmentValueChart', () => {
     ]);
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(netWorthApi.getInvestmentsMonthly).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsMonthly).toHaveBeenCalled()
+    );
     expect(netWorthApi.getInvestmentsDaily).not.toHaveBeenCalled();
   });
 
@@ -844,16 +877,20 @@ describe('InvestmentValueChart', () => {
   it('passes displayCurrency to API when it differs from defaultCurrency', async () => {
     render(<InvestmentValueChart displayCurrency="USD" />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
-      expect.objectContaining({ displayCurrency: 'USD' }),
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
+        expect.objectContaining({ displayCurrency: 'USD' }),
+      )
     );
   });
 
   it('does not pass displayCurrency to API when it matches defaultCurrency', async () => {
     render(<InvestmentValueChart displayCurrency="CAD" />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
-      expect.objectContaining({ displayCurrency: undefined }),
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalledWith(
+        expect.objectContaining({ displayCurrency: undefined }),
+      )
     );
   });
 
@@ -1006,7 +1043,9 @@ describe('InvestmentValueChart', () => {
     ]);
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(netWorthApi.getInvestmentsMonthly).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(netWorthApi.getInvestmentsMonthly).toHaveBeenCalled()
+    );
     expect(netWorthApi.getInvestmentsDaily).not.toHaveBeenCalled();
   });
 
@@ -1024,8 +1063,10 @@ describe('InvestmentValueChart', () => {
     });
     render(<InvestmentValueChart displayCurrency="USD" />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(investmentsApi.getIntradayValue).toHaveBeenCalledWith(
-      expect.objectContaining({ displayCurrency: 'USD' }),
+    await waitFor(() =>
+      expect(investmentsApi.getIntradayValue).toHaveBeenCalledWith(
+        expect.objectContaining({ displayCurrency: 'USD' }),
+      )
     );
   });
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -10,6 +10,14 @@ afterEach(async () => {
   // filter a test selects is written to localStorage, and without this the
   // next test in the file would start with that filter still applied.
   window.localStorage?.clear();
+  // sessionStorage is the same hazard and was missed. The Portfolio Value
+  // chart caches its intraday response there, and a leaked entry hydrates the
+  // next test's chart *synchronously on mount* -- which moves the prior-close
+  // baseline request from second-stage to immediate. Tests asserting on that
+  // request then passed or failed on whether an earlier test happened to leave
+  // a usable entry behind, which is how `InvestmentValueChart` went green in
+  // isolation and red in a full suite (CI run #2877).
+  window.sessionStorage?.clear();
   // Row density is one store for every view, so clearing its localStorage
   // entry is not enough -- the module-level state outlives it. Reset after `cleanup()`,
   // never before: writing to a store while the tree is still mounted


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: _none — see below._

No approved discussion. This is not proposed work: CI Pipeline run
[#2877](https://github.com/kenlasko/monize/actions/runs/33033160827) left `main` red on
`InvestmentValueChart.test.tsx`, and the maintainer asked for the cause to be chased. Happy to go
back through propose-first if you would rather this were split or reshaped.

## Summary

`main` is red on `InvestmentValueChart.test.tsx > uses intraday API for 1d range` —
`expected getInvestmentsDaily to be called 1 times, but got 0`. Zero act warnings, so the guard
from #1267/#1268 is not involved. The same file failed the same way in an earlier local full-suite
run, in a *different* test.

**This PR fixes two real defects. It does not prove either of them caused run #2877.** That
distinction is the most important thing in this description, so it is stated first.

### 1. The assertion has no barrier

`await screen.findByText('Portfolio Value Over Time')` resolves on the chart's *title* — markup
rendered before any request does. Eleven assertions in this file used it as their synchronisation
point.

It matters most for the failing one, because that call is **second-stage**. For a `1d` range with
`fallbackToDaily: false`, `loadDailyOrMonthly` is never reached, so the single expected
`getInvestmentsDaily` call is the prior-close baseline — and `usePortfolioChangeBaseline` gates its
fetch on `firstPointDate: isoDatePart(chartPoints[0]?.iso)`, null until data arrives. It therefore
cannot fire until the intraday response commits. The test asserts it without waiting for it.

Positive API-call assertions now wait for the call. `waitFor` cannot mask a real failure: a call
that never happens still times out.

### 2. `sessionStorage` leaks between tests

`src/test/setup.ts` clears `localStorage` and cleared nothing else. The chart caches its intraday
response in `sessionStorage`, so a leaked entry hydrates the next test's chart **synchronously on
mount** — moving the baseline request from second-stage to immediate and silently changing what
that test exercises.

The two changes are coupled in a way worth noticing: with the cache cleared the baseline is
*always* second-stage, so fixing isolation alone would make the unguarded assertion race **every
time** rather than occasionally. Both halves are needed.

### What I could not do: reproduce it

Ten runs of the file under CPU contention, a full local suite, and three targeted mechanism tests —
none failed. All three mechanism tests reported the baseline already called at title-time,
contradicting the source reading, which means the scratch harness was not faithfully reproducing
the real test's conditions rather than that the theory is settled. I drew a conclusion from those
scratch tests twice and was wrong both times; I am not doing it a third time.

So: two correct fixes and a plausible mechanism, not a proof. If it recurs, the next step is
instrumenting a full-suite run to capture the actual call ordering at the moment of failure, rather
than trying to synthesise it.

For context, this file has been intermittently red on `main` since before any of my changes — it is
not a regression from #1267 or #1268, whose diffs touched only one unrelated test in it.

### Two sites deliberately left bare

Three assertions already sat inside `waitFor` blocks. One sits inside the pinned-clock test, where
RTL's `waitFor` **cannot drive Vitest's fake timers** and wrapping it hung the file for 300s until
the test timeout — there the act-wrapped drain above it is the barrier. A blanket sweep over a file
with mixed timer regimes walks straight into that; mine did, and the hang is how I found out.

### Verification

| Check | Result |
| --- | --- |
| `tsc --noEmit` | clean |
| `eslint` | clean |
| `TZ=UTC vitest run` (full suite, both fixes) | 727 files / 14,103 tests passing |
| Affected files together | 129 passing |
| Backend `doc-paths` + `source-comment-paths` guards | 35 passing (they check the new `frontend/CLAUDE.md` rules) |
| `InvestmentValueChart.test.tsx` × 10 under CPU contention | passing (also passed *before* the fix — hence "not a proof") |

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **No.** Red-CI investigation on
      `main`, requested directly by the maintainer.
- [x] This PR addresses a **single concern** (large work is split into a series). — One concern:
      why `InvestmentValueChart` fails in a full suite. Both changes came out of that one
      investigation and are coupled as described above.
- [x] New behavior has tests, and the existing suite passes. — No new behaviour; this changes test
      synchronisation and test isolation. Full suite green.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — No user-facing
      strings are added or changed; catalogs untouched.
- [x] No shared/core areas were refactored without prior agreement. — `src/test/setup.ts` is shared
      and does change behaviour for every test file: `sessionStorage` is now cleared between tests.
      That is the line to review first. Any test that was silently relying on a leaked cache entry
      would change behaviour — none did, but the full suite is the only evidence for that.
- [x] The branch is rebased on the latest `main`. — 0 behind, 2 ahead of `origin/main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written by Claude Code (Claude Opus 5), driven by the maintainer. The investigation, both fixes and
the two `frontend/CLAUDE.md` rules are AI-authored. The limits are stated rather than smoothed over:
the failure was never reproduced, three mechanism tests contradicted the source reading, and this
description says "not a proof" because that is the honest state of it — not as hedging, but because
a previous change in this same series was merged on a confident claim and turned `main` red.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YATGDV3Vcg6MjtrZyDmzUU)_