### PR TITLE
Fix Account Balances pie treating liabilities as assets

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -197,6 +197,10 @@ Whether a picker *offers* to create is a property of the surface, not the field:
 
 `balanceColor` (`lib/format.ts`) is the one rule: negative is red, everything else neutral. Do not add `|| isLiability` (or any `accountType` test) -- a credit card at a credit balance is not in the red, and the sign already carries the meaning. `gainLossColor` is the sibling for a *change* in value (green when up), not for a balance.
 
+### A chart over values of both signs keeps the sign beside the magnitude
+
+A pie can only size a slice from `Math.abs`, but the abs is presentation, never the value: carry the signed figure with the datum, print it in the legend and tooltip, colour the two sides from the semantic pair (`CHART_COLOURS_ASSETS` / `CHART_COLOURS_LIABILITIES` in `lib/chart-colours.ts`), and net a mixed group the way the table beside it does. The footer of a mixed chart is the signed net figure under its honest name (Net Worth) -- a sum of absolute values labelled "Total" reports assets plus debt as if both increased financial value (issue #1243). `AccountBalancesReport`'s chart is the worked example.
+
 ### A scheduled occurrence's amount is `nextOccurrenceEffectiveAmount`, never `nextOverride?.amount ?? amount`
 
 `ScheduledTransaction.amount` was computed at whatever FX rate was current when it was written, so for a top-level investment schedule (whose `amount` is the *security-currency* cash impact) or a split parent carrying an investment line it is a stale snapshot -- and it is labelled with the brokerage account's `currencyCode`, not the settlement currency the cash lands in. Read `effectiveAmount` / `effectiveAmountComplete` / `effectiveCurrencyCode` through `lib/scheduled-effective-amount.ts` (`scheduleEffectiveAmount`, `overrideEffectiveAmount`, `nextOccurrenceEffectiveAmount`, `sumEffectiveOccurrences`).

--- a/frontend/src/components/reports/AccountBalancesReport.test.tsx
+++ b/frontend/src/components/reports/AccountBalancesReport.test.tsx
@@ -77,6 +77,10 @@ vi.mock("@/hooks/useDateFormat", () => ({
 
 vi.mock("@/lib/chart-colours", () => ({
   CHART_COLOURS: ["#3b82f6", "#ef4444", "#22c55e"],
+  // Pinned so the tests can tell an asset slice's colour from a liability's
+  // without depending on the real palettes.
+  CHART_COLOURS_ASSETS: ["#111111", "#222222"],
+  CHART_COLOURS_LIABILITIES: ["#999999", "#888888"],
 }));
 
 vi.mock("recharts", () => ({
@@ -766,6 +770,182 @@ describe("AccountBalancesReport", () => {
     await act(async () => { fireEvent.click(tableViewButton()); });
     await waitFor(() => {
       expect(screen.queryByTestId("pie-chart")).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * The pie used to Math.abs() every balance, so a $30,000 mortgage became a
+   * $30,000 asset-looking slice and the footer summed assets plus debt under
+   * "Total" (issue #1243). The chart now keeps the sign beside the magnitude:
+   * liability slices are identified by palette and by a signed amount, mixed
+   * groups net the way the table does, and the footer of a mixed chart is the
+   * signed net worth.
+   */
+  describe("pie chart with assets and liabilities", () => {
+    function legendItems(): string[] {
+      return screen
+        .getAllByTestId("chart-legend-item")
+        .map((item) => item.textContent ?? "");
+    }
+
+    it("shows liabilities signed and labels the footer Net Worth, not Total", async () => {
+      mockGetAll.mockResolvedValue([
+        acc({ currentBalance: 100000 }),
+        acc({ id: "acc-2", name: "Home Loan", accountType: "MORTGAGE" }),
+      ]);
+      mockGetBalancesAsOf.mockResolvedValue(
+        balancesFor([balance("acc-1", 100000), balance("acc-2", -30000)]),
+      );
+      render(<AccountBalancesReport />);
+      await waitFor(() => {
+        expect(screen.getByText("Total Assets")).toBeInTheDocument();
+      });
+      await act(async () => { fireEvent.click(chartViewButton()); });
+      await waitFor(() => {
+        expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
+      });
+
+      // The liability slice keeps its sign; percentages are shares of the pie.
+      const legend = legendItems();
+      expect(legend.find((item) => item.includes("Chequing"))).toContain(
+        "$100000.00 (76.9%)",
+      );
+      expect(legend.find((item) => item.includes("Mortgage"))).toContain(
+        "$-30000.00 (23.1%)",
+      );
+
+      // The footer is the signed net worth, matching the summary card -- never
+      // assets plus debt presented as "Total".
+      expect(screen.getByTestId("chart-net-worth")).toHaveTextContent("$70000.00");
+      expect(screen.queryByTestId("chart-total")).not.toBeInTheDocument();
+      expect(screen.queryByText("$130000.00")).not.toBeInTheDocument();
+    });
+
+    it("colours liability slices from the liability palette", async () => {
+      mockGetAll.mockResolvedValue([
+        acc(),
+        acc({ id: "acc-2", name: "Visa", accountType: "CREDIT_CARD" }),
+      ]);
+      mockGetBalancesAsOf.mockResolvedValue(
+        balancesFor([balance("acc-1", 5000), balance("acc-2", -1200)]),
+      );
+      render(<AccountBalancesReport />);
+      await waitFor(() => {
+        expect(screen.getByText("Total Assets")).toBeInTheDocument();
+      });
+      await act(async () => { fireEvent.click(chartViewButton()); });
+      await waitFor(() => {
+        expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
+      });
+
+      const items = screen.getAllByTestId("chart-legend-item");
+      const dotColour = (name: string) =>
+        items
+          .find((item) => item.textContent?.includes(name))!
+          .querySelector("div")!.style.backgroundColor;
+      // The mocked palettes: assets #111111..., liabilities #999999...
+      expect(dotColour("Chequing")).toBe("rgb(17, 17, 17)");
+      expect(dotColour("Credit Card")).toBe("rgb(153, 153, 153)");
+    });
+
+    it("nets assets against liabilities within an institution group, as the table does", async () => {
+      mockGetInstitutions.mockResolvedValue([{ id: "inst-1", name: "Big Bank" }]);
+      mockGetAll.mockResolvedValue([
+        acc({ institutionId: "inst-1" }),
+        acc({
+          id: "acc-2",
+          name: "Home Loan",
+          accountType: "MORTGAGE",
+          institutionId: "inst-1",
+        }),
+        acc({ id: "acc-3", name: "Car Loan", accountType: "LOAN" }),
+      ]);
+      mockGetBalancesAsOf.mockResolvedValue(
+        balancesFor([
+          balance("acc-1", 100000),
+          balance("acc-2", -30000),
+          balance("acc-3", -50000),
+        ]),
+      );
+      render(<AccountBalancesReport />);
+      await waitFor(() => {
+        expect(screen.getByText("Total Assets")).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText("Group by"), {
+          target: { value: "institution" },
+        });
+      });
+      await act(async () => { fireEvent.click(chartViewButton()); });
+      await waitFor(() => {
+        expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
+      });
+
+      // Big Bank's slice is its net, never |100000| + |-30000| = 130000; the
+      // no-institution group is a pure liability and stays signed. The pie's
+      // denominator is 70000 + 50000.
+      const legend = legendItems();
+      expect(legend.find((item) => item.includes("Big Bank"))).toContain(
+        "$70000.00 (58.3%)",
+      );
+      expect(legend.find((item) => item.includes("No institution"))).toContain(
+        "$-50000.00 (41.7%)",
+      );
+      expect(screen.queryByText(/130000\.00/)).not.toBeInTheDocument();
+
+      // Footer: 100000 - 30000 - 50000, not a sum of magnitudes.
+      expect(screen.getByTestId("chart-net-worth")).toHaveTextContent("$20000.00");
+    });
+
+    it("keeps the Total footer for a chart holding only assets", async () => {
+      mockGetAll.mockResolvedValue([
+        acc({ currentBalance: 3000 }),
+        acc({ id: "acc-2", name: "Rainy Day", accountType: "SAVINGS" }),
+      ]);
+      mockGetBalancesAsOf.mockResolvedValue(
+        balancesFor([balance("acc-1", 3000), balance("acc-2", 7000)]),
+      );
+      render(<AccountBalancesReport />);
+      await waitFor(() => {
+        expect(screen.getByText("Total Assets")).toBeInTheDocument();
+      });
+      await act(async () => { fireEvent.click(chartViewButton()); });
+      await waitFor(() => {
+        expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("chart-total")).toHaveTextContent("$10000.00");
+      expect(screen.queryByTestId("chart-net-worth")).not.toBeInTheDocument();
+    });
+
+    it("draws each ungrouped account signed, liabilities on their own palette", async () => {
+      mockGetAll.mockResolvedValue([
+        acc(),
+        acc({ id: "acc-2", name: "Visa", accountType: "CREDIT_CARD" }),
+      ]);
+      mockGetBalancesAsOf.mockResolvedValue(
+        balancesFor([balance("acc-1", 5000), balance("acc-2", -1200)]),
+      );
+      render(<AccountBalancesReport />);
+      await waitFor(() => {
+        expect(screen.getByText("Total Assets")).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText("Group by"), {
+          target: { value: "none" },
+        });
+      });
+      await act(async () => { fireEvent.click(chartViewButton()); });
+      await waitFor(() => {
+        expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
+      });
+
+      const items = screen.getAllByTestId("chart-legend-item");
+      const visa = items.find((item) => item.textContent?.includes("Visa"))!;
+      expect(visa).toHaveTextContent("$-1200.00");
+      expect(visa.querySelector("div")!.style.backgroundColor).toBe(
+        "rgb(153, 153, 153)",
+      );
+      expect(screen.getByTestId("chart-net-worth")).toHaveTextContent("$3800.00");
     });
   });
 

--- a/frontend/src/components/reports/AccountBalancesReport.tsx
+++ b/frontend/src/components/reports/AccountBalancesReport.tsx
@@ -18,7 +18,10 @@ import { sumConverted, combineTotals } from '@/lib/currency-total';
 import { PartialTotal } from '@/components/ui/PartialTotal';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { useReportData } from '@/hooks/useReportData';
-import { CHART_COLOURS } from '@/lib/chart-colours';
+import {
+  CHART_COLOURS_ASSETS,
+  CHART_COLOURS_LIABILITIES,
+} from '@/lib/chart-colours';
 import { ReportError } from '@/components/reports/ReportError';
 import {
   AccountBalancesControls,
@@ -267,17 +270,25 @@ export function AccountBalancesReport() {
     }));
   }, [accounts, accountTypeLabels]);
 
+  /** The signed value in the display currency; null when unknown. */
+  const signedDisplayValue = useCallback(
+    (entry: LogicalAccount): number | null => {
+      if (entry.combinedValue === null) return null;
+      return convertToDisplay(entry.combinedValue, entry.primary.currencyCode);
+    },
+    [convertToDisplay],
+  );
+
   /** The figure a row prints, in the display currency; null when unknown. */
   const displayValue = useCallback(
     (entry: LogicalAccount): number | null => {
-      if (entry.combinedValue === null) return null;
-      const converted = convertToDisplay(entry.combinedValue, entry.primary.currencyCode);
+      const converted = signedDisplayValue(entry);
       if (converted === null) return null;
       return isLiabilityAccountType(entry.primary.accountType)
         ? Math.abs(converted)
         : converted;
     },
-    [convertToDisplay],
+    [signedDisplayValue],
   );
 
   const groups = useMemo(
@@ -416,40 +427,81 @@ export function AccountBalancesReport() {
     [convertToDisplay],
   );
 
+  /**
+   * A pie can only size a slice from a magnitude, so the sign travels beside
+   * it: `signedValue` is what the slice *is* (a liability slice is money owed,
+   * not money held), and the two sides draw from separate palettes so their
+   * accounting role survives the colour cycling (issue #1243).
+   */
   const chartData = useMemo(() => {
-    const data: Array<{ name: string; value: number; color: string }> = [];
+    const data: Array<{
+      name: string;
+      value: number;
+      signedValue: number;
+      color: string;
+    }> = [];
+    let assetIdx = 0;
+    let liabilityIdx = 0;
+    const push = (name: string, rawSignedValue: number) => {
+      // At the storage precision: a group netting to a floating-point epsilon
+      // is a zero, not a sliver of a slice with a $0.00 legend row.
+      const signedValue = Math.round(rawSignedValue * 10000) / 10000;
+      // A zero-size slice reads as a measured zero, so it is not drawn.
+      if (signedValue === 0) return;
+      const color =
+        signedValue < 0
+          ? CHART_COLOURS_LIABILITIES[liabilityIdx++ % CHART_COLOURS_LIABILITIES.length]
+          : CHART_COLOURS_ASSETS[assetIdx++ % CHART_COLOURS_ASSETS.length];
+      data.push({ name, value: Math.abs(signedValue), signedValue, color });
+    };
     if (groupBy === 'none') {
-      visibleAccounts.forEach((entry, idx) => {
-        const converted = displayValue(entry);
+      for (const entry of visibleAccounts) {
+        const converted = signedDisplayValue(entry);
         // No value, no slice: a slice sized from an unconvertible amount is in
-        // the wrong currency, and a zero-size one reads as a measured zero.
-        if (converted === null || Math.abs(converted) === 0) return;
-        data.push({
-          name: entry.displayName,
-          value: Math.abs(converted),
-          color: CHART_COLOURS[idx % CHART_COLOURS.length],
-        });
-      });
+        // the wrong currency.
+        if (converted === null) continue;
+        push(entry.displayName, converted);
+      }
     } else {
-      groups.forEach((group, idx) => {
-        const total = group.entries.reduce((sum, entry) => {
-          const converted = displayValue(entry);
-          return converted === null ? sum : sum + Math.abs(converted);
+      for (const group of groups) {
+        // A group can hold both signs (an institution with a chequing account
+        // and a mortgage), so its slice is the signed net -- the same figure
+        // the table prints for that group -- never the sum of magnitudes.
+        const signedTotal = group.entries.reduce((sum, entry) => {
+          const converted = signedDisplayValue(entry);
+          return converted === null ? sum : sum + converted;
         }, 0);
-        if (total <= 0) return;
-        data.push({
-          name: groupLabel(group.key),
-          value: total,
-          color: CHART_COLOURS[idx % CHART_COLOURS.length],
-        });
-      });
+        push(groupLabel(group.key), signedTotal);
+      }
     }
     return data.sort((a, b) => b.value - a.value);
-  }, [groupBy, groups, visibleAccounts, displayValue, groupLabel]);
+  }, [groupBy, groups, visibleAccounts, signedDisplayValue, groupLabel]);
 
+  /**
+   * The pie's denominator: the sum of slice magnitudes, which is what each
+   * percentage is a share of. With liabilities on screen this is gross
+   * exposure, not a total of anything -- the footer prints the signed net
+   * worth instead, and this figure stays internal.
+   */
   const chartTotal = useMemo(
     () => chartData.reduce((sum, d) => sum + d.value, 0),
     [chartData],
+  );
+
+  /**
+   * Whether anything on the chart is on the debt side of zero. Decided from
+   * the signed components rather than the slices, because a mixed group can
+   * net positive while still containing a liability -- its slice is then a net
+   * figure, and labelling the footer "Total" over a sum of nets would present
+   * net worth under a name that hides the netting.
+   */
+  const chartHasLiabilities = useMemo(
+    () =>
+      visibleAccounts.some((entry) => {
+        const converted = signedDisplayValue(entry);
+        return converted !== null && converted < 0;
+      }),
+    [visibleAccounts, signedDisplayValue],
   );
 
   const CustomTooltip = ({
@@ -457,7 +509,7 @@ export function AccountBalancesReport() {
     payload,
   }: {
     active?: boolean;
-    payload?: Array<{ payload: { name: string; value: number } }>;
+    payload?: Array<{ payload: { name: string; value: number; signedValue?: number } }>;
   }) => {
     if (active && payload?.length) {
       const data = payload[0].payload;
@@ -466,7 +518,9 @@ export function AccountBalancesReport() {
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
           <p className="font-medium text-gray-900 dark:text-gray-100">{data.name}</p>
           <p className="text-gray-600 dark:text-gray-400">
-            {formatCurrency(data.value, displayCurrency)} ({pct}%)
+            {/* The signed amount: a liability slice is money owed, and the
+                minus sign is what says so in text. */}
+            {formatCurrency(data.signedValue ?? data.value, displayCurrency)} ({pct}%)
           </p>
         </div>
       );
@@ -692,23 +746,58 @@ export function AccountBalancesReport() {
                 {chartData.map((item, index) => {
                   const pct = chartTotal > 0 ? ((item.value / chartTotal) * 100).toFixed(1) : '0.0';
                   return (
-                    <div key={index} className="flex items-center gap-2 text-sm">
+                    <div
+                      key={index}
+                      className="flex items-center gap-2 text-sm"
+                      data-testid="chart-legend-item"
+                    >
                       <div
                         className="w-3 h-3 rounded-full flex-shrink-0"
                         style={{ backgroundColor: item.color }}
                       />
                       <span className="text-gray-600 dark:text-gray-400 truncate">{item.name}</span>
-                      <span className="text-gray-900 dark:text-gray-100 ml-auto whitespace-nowrap">{pct}%</span>
+                      {/* Signed, so a liability's role is stated in text, not
+                          only in the palette. */}
+                      <span className="text-gray-900 dark:text-gray-100 ml-auto whitespace-nowrap">
+                        {formatCurrency(item.signedValue, displayCurrency)} ({pct}%)
+                      </span>
                     </div>
                   );
                 })}
               </div>
 
+              {/* With liabilities in the mix the sum of slice magnitudes is
+                  gross exposure, not a total -- the honest footer figure is
+                  the signed net worth, matching the summary card above,
+                  partial marker included. */}
               <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 text-center">
-                <div className="text-sm text-gray-500 dark:text-gray-400">{t('accountBalances.total')}</div>
-                <div className="font-semibold text-gray-900 dark:text-gray-100">
-                  {formatCurrency(chartTotal, displayCurrency)}
-                </div>
+                {chartHasLiabilities ? (
+                  <>
+                    <div className="text-sm text-gray-500 dark:text-gray-400">
+                      {t('accountBalances.netWorth')}
+                    </div>
+                    <div
+                      className="font-semibold text-gray-900 dark:text-gray-100"
+                      data-testid="chart-net-worth"
+                    >
+                      <PartialTotal total={totals.netWorth} displayCurrency={displayCurrency}>
+                        {formatCurrency(totals.netWorth.value, displayCurrency)}
+                      </PartialTotal>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="text-sm text-gray-500 dark:text-gray-400">
+                      {t('accountBalances.total')}
+                    </div>
+                    <div
+                      className="font-semibold text-gray-900 dark:text-gray-100"
+                      data-testid="chart-total"
+                    >
+                      {formatCurrency(chartTotal, displayCurrency)}
+                    </div>
+                  </>
+                )}
               </div>
             </>
           )}

--- a/frontend/src/lib/chart-colours.ts
+++ b/frontend/src/lib/chart-colours.ts
@@ -3,6 +3,10 @@
  *
  * CHART_COLOURS (20) — general-purpose, used by most reports.
  * CHART_COLOURS_INCOME (10) — green-to-purple gradient for income charts.
+ * CHART_COLOURS_ASSETS / CHART_COLOURS_LIABILITIES — semantic pair for a chart
+ * mixing values of both signs (issue #1243): positive values cycle cool hues,
+ * negative ones warm reds, so the two sides never share a colour however far
+ * either cycle runs.
  */
 
 export const CHART_COLOURS = [
@@ -15,4 +19,14 @@ export const CHART_COLOURS = [
 export const CHART_COLOURS_INCOME = [
   '#22c55e', '#10b981', '#14b8a6', '#06b6d4', '#0ea5e9',
   '#3b82f6', '#6366f1', '#8b5cf6', '#a855f7', '#d946ef',
+] as const;
+
+export const CHART_COLOURS_ASSETS = [
+  '#3b82f6', '#22c55e', '#8b5cf6', '#14b8a6', '#6366f1',
+  '#06b6d4', '#10b981', '#a855f7', '#0ea5e9', '#84cc16',
+] as const;
+
+export const CHART_COLOURS_LIABILITIES = [
+  '#ef4444', '#f97316', '#e11d48', '#dc2626', '#ea580c',
+  '#be123c', '#b91c1c', '#c2410c',
 ] as const;


### PR DESCRIPTION
## Linked discussion / issue

Closes #1243
Approved in: https://github.com/kenlasko/monize/issues/1243 (labelled `approved-to-build`)

## Summary

The Account Balances report's Pie Chart view applied `Math.abs()` to every account or group before building the chart, so a $30,000 mortgage became an asset-looking slice, mixed institution groups summed magnitudes instead of netting, and the footer labelled assets-plus-debt as "Total" ($130,000 for $100,000 of assets and $30,000 of debt).

The chart now preserves the sign beside the magnitude:

- Each slice carries its **signed value**; the magnitude only sizes the slice. Grouped views net signed values within the group — the same figure the table prints for that group — so an institution holding a chequing account and a mortgage shows its net, and a group netting to zero (at 4dp) draws no slice.
- Liability (negative) slices draw from a new warm `CHART_COLOURS_LIABILITIES` palette and assets from a cool `CHART_COLOURS_ASSETS` palette (both in `lib/chart-colours.ts`), so the accounting role survives colour cycling; the legend and tooltip also print the **signed amount**, so the role is stated in text, not colour alone.
- When anything on the chart is on the debt side of zero, the footer is labelled **Net Worth** and shows the signed net through the same `PartialTotal`-aware figure as the summary card (decided from the signed components, so an institution group that nets positive while containing a mortgage still gets the honest label). An asset-only chart keeps its "Total" footer.
- Percentages remain shares of the pie (sum of slice magnitudes), which is what a slice's size shows.

No new user-facing strings: the footer reuses the already-translated `accountBalances.netWorth` key, so every locale is covered without catalog changes. The rule is recorded in `frontend/CLAUDE.md` ("A chart over values of both signs keeps the sign beside the magnitude").

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes (frontend suite: 738 files / 14,429 tests green; lint, type-check and the UI-conventions guard pass).
- [x] All user-facing strings are translated for **every** locale (i18n parity) — no new strings; the footer reuses the existing `accountBalances.netWorth` key.
- [x] No shared/core areas were refactored without prior agreement (`chart-colours.ts` only gains two additive palettes; `CHART_COLOURS` is untouched).
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

This change was authored with Claude Code from the issue's description; the approach follows the existing `AssetsVsLiabilities` dashboard widget precedent (semantic liability colour, "Net Worth" footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vj13XHtwpzoFuKmpjZWR1X

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vj13XHtwpzoFuKmpjZWR1X)_