### PR TITLE
fix(reports): keep actual and projected apart before the Debt Payoff chart reduction

### DIFF
--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -647,9 +647,9 @@ Five of the cases above fail on the first fix and pass on the second.
 ```text
 Statement           Reducing a series so it fits a chart axis is a RENDERING
                     decision and reaches nothing else. No count, total, average,
-                    percentage, summary card or export may be derived from an
-                    aggregated or down-sampled series; each is derived from the
-                    full data the reduction was made from. Two reductions,
+                    percentage, summary card or export may be derived from a
+                    down-sampled or lossily bucketed series; each is derived from
+                    the full data the reduction was made from. Two reductions,
                     because a series is one of two kinds: a STOCK (a balance, a
                     running total) has a value at a point in time, so showing
                     every Nth point drops resolution while every point still
@@ -658,29 +658,76 @@ Statement           Reducing a series so it fits a chart axis is a RENDERING
                     the interval it stood for and the chart shows a subset
                     presented as the whole. A flow is reduced by SUMMING
                     contiguous groups.
-                    Monthly aggregation is the same rule one step earlier: a
-                    month is not a payment. Weekly and biweekly schedules, extra
-                    principal payments and two payments in one month all collapse
-                    into one bucket, so a count taken after aggregation is wrong
-                    before any sampling happens.
+                    What the ban names is a reduction that CHANGES a figure's
+                    meaning or provenance, not the word "aggregate": a rollup
+                    that preserves both is not one. The Debt Payoff Timeline's
+                    summary reads the full monthly series precisely because a
+                    month's end-of-month balance and cumulative totals are the
+                    same facts the events carry, exactly. A count is the case
+                    that is never preserved -- a month is not a payment. Weekly
+                    and biweekly schedules, extra principal payments and two
+                    payments in one month all collapse into one bucket, so a
+                    count taken after aggregation is wrong before any sampling
+                    happens.
+                    Provenance is the other thing an aggregation must preserve,
+                    and it survives only by being part of the group's IDENTITY.
+                    Which side of the history/projection line a row is on is
+                    grouped ON, never computed from the group's members
+                    afterwards: a weekly, biweekly or semi-monthly loan routinely
+                    has a real payment and a projected one in the same calendar
+                    month, so a month keyed on its label alone is a bucket that
+                    is neither measured nor predicted. One bar cannot honestly be
+                    half measured and half predicted, and neither can the row a
+                    bar is built from.
+                    A label is therefore not an identity. Two chart rows share
+                    one -- the month either side of the line, and a bucketed flow
+                    row labelled as the span it covers -- while recharts keys its
+                    category axis, its tooltip lookup and every ReferenceLine on
+                    the datum's own value, so two rows under one label collapse
+                    onto one category and a marker drawn there lands on whichever
+                    came first.
 Source of truth     The unreduced series -- for a loan, the payment events
                     frontend/src/lib/loan-history.ts derives from the ledger.
 Enforcement         One module: frontend/src/lib/chart-sampling.ts
                     (sampleStockSeries for a stock, bucketFlowSeries for a flow,
-                    CHART_MAX_POINTS the shared budget). The reduced series is
-                    bound to its OWN name and handed to a chart; the full series
-                    keeps the name every figure reads. The payment count is
-                    historicalPaymentCount (loan-history.ts), read by both the
-                    Debt Payoff Timeline and the Loan Amortization report so one
-                    loan cannot have two answers.
-                    frontend/src/lib/chart-reduction.guard.test.ts holds three
+                    CHART_MAX_POINTS the shared budget, axisKeyFor/axisTickLabel
+                    the row identity a category axis is keyed on). The reduced
+                    series is bound to its OWN name and handed to a chart; the
+                    full series keeps the name every figure reads. The payment
+                    count is historicalPaymentCount (loan-history.ts), read by
+                    both the Debt Payoff Timeline and the Loan Amortization
+                    report so one loan cannot have two answers.
+                    Monthly aggregation in DebtPayoffTimelineReport groups
+                    contiguous runs over a DATE-ORDERED series keyed on the month
+                    AND the row's side of the line, so the group's provenance is
+                    its key rather than a property derived from its members, and
+                    a future-dated posted payment landing among the projected rows
+                    opens its own run instead of being folded back into a month
+                    it no longer sits beside. Each resulting row carries an
+                    axisKey (its position, then its label) and the charts pass
+                    axisTickLabel as their tickFormatter, so the two rows of a
+                    shared month are two categories and the tick still reads the
+                    month. Whether a projection EXISTS is read from the
+                    projection's own rows, never from whether aggregation left an
+                    all-projected row: a loan paying off inside the month of its
+                    last real payment has a projection whose every row shares that
+                    month, and asking the aggregate erased the "Today" divider and
+                    the Est. Payoff card together with the forecast principal.
+                    frontend/src/lib/chart-reduction.guard.test.ts holds four
                     scans: no count taken by filtering a schedule on isProjected
-                    anywhere in src/, both loan reports reading the shared count,
-                    and no reduced series measured (.length, .reduce, .filter,
-                    .some, .every, .forEach, .flatMap) -- a lookup such as .find,
-                    which a tooltip needs, is allowed because it cannot
-                    aggregate. The measurement scan reads one file at a time, so
-                    it can only see what a reduced series is CALLED: any name a
+                    anywhere in src/, no group's provenance derived from its
+                    members (`.every(... isProjected ...)`, the exact shape that
+                    called a mixed month historical -- `.some` and `.filter` are
+                    left alone, being ordinary questions about rows nothing has
+                    merged), both loan reports reading the shared count, and no
+                    reduced series measured (.length, .reduce, .filter, .some,
+                    .every, .forEach, .flatMap) -- a lookup such as .find, which a
+                    tooltip needs, is allowed because it cannot aggregate. A fifth
+                    pins the Debt Payoff Timeline's three category axes to
+                    dataKey="axisKey" and axisTickLabel, since keying one back on
+                    the month is how two rows collapse into one. The
+                    measurement scan reads one file at a time, so it can only
+                    see what a reduced series is CALLED: any name a
                     reduced binding is ALIASED to in the same file
                     (`return { points: chartPoints }`) is banned under the same
                     rule, and a reduced series crossing a module boundary keeps
@@ -693,8 +740,9 @@ Enforcement         One module: frontend/src/lib/chart-sampling.ts
                     not to the full one: a recharts ReferenceLine whose value
                     matches no axis category is silently not drawn, so the
                     Payment Distribution chart's "Today" divider comes from the
-                    first projected BUCKET's label -- the balance chart's bare
-                    month matches no bucketed range.
+                    first projected BUCKET's own axis key -- the balance chart's
+                    key addresses a row of a different series, and a bare month
+                    matches no bucketed range.
 Concurrency scope   -- (render path)
 Retry semantics     -- (render path)
 Crash semantics     -- (render path)
@@ -702,18 +750,38 @@ Failure response    -- a chart draws; it does not refuse.
 Required tests      Present: the source scans above; the unit matrix in
                     frontend/src/lib/chart-sampling.test.ts (a stock sample keeps
                     the endpoints and every kept row and emits each index once; a
-                    flow bucket conserves the total, stays within the budget and
-                    never merges across a boundary); and the behavioural cases in
+                    flow bucket conserves the total, stays within the budget,
+                    hands each bucket its own position and never merges across a
+                    boundary -- split 101/99 rather than 100/100, so the
+                    transition falls INSIDE a group and the flush is what saves
+                    it, since an even split passes with the boundary mechanism
+                    deleted; and an axis key is unique per row, prints its label
+                    back including a label holding the separator, and passes a
+                    non-key value through); and the behavioural cases in
                     frontend/src/components/reports/DebtPayoffTimelineReport
                     .test.tsx, which assert Payments Made against a 300-payment
                     history while the chart is sampled, two payments in one month
                     counted as two, 26 biweekly payments counted as 26 rather
                     than 12, the distribution chart conserving every month's
                     principal, the distribution chart's "Today" marker naming a
-                    label its own axis has, and the history/projection transition
+                    key its own axis has, and the history/projection transition
                     surviving the stride. Each fails on the pre-fix component
                     with the figures issue #1244 reports (61, 1, 12, half the
                     money, a marker on a month no bucket is called).
+                    Four more hold the provenance rule, on a 0% weekly loan whose
+                    one real payment (100 on 3 Aug) and two projected payments
+                    (100 each, 17 and 24 Aug) all fall in August, with the clock
+                    pinned to 2026-08-10: August's historical principal is 100 and
+                    its projected principal 200 rather than 300 of history; the
+                    historical balance is the measured 200 rather than the
+                    projection's end-of-month 0; the report still knows it has a
+                    projection when the loan pays off inside that month, so the
+                    Est. Payoff card and the "Today" divider are both drawn and
+                    the two August rows are two axis keys under one label; and a
+                    future-dated posted payment interleaved with the projected
+                    rows stays in its own run, leaving the chart date-ordered with
+                    October carrying both a historical and a projected row. All
+                    four fail on the merged #1280 component.
                     Each case waits on the COUNT rather than on the chart
                     mounting: a loan carrying terms projects from its current
                     balance alone, so the chart appears on a projection-only
@@ -731,6 +799,15 @@ inherited by the count, the totals and the Payment Distribution chart because
 all four read one array. That is the shape to look for: a variable that is
 assigned its own reduced form (`points = points.filter(...)`) leaves nothing
 downstream able to tell which of the two it holds.
+
+The first fix stopped the reduction reaching a figure and left the step BEFORE
+it -- monthly aggregation -- grouping on the label alone, so the boundary-aware
+reducer that #1244 added was handed rows whose provenance had already been
+merged away (PR #1280 audit, F-1280-01). That is the second shape to look for:
+a property recomputed from a group's members (`group.every(...)`) is a property
+that was not part of what made the group, and the answer is only as good as the
+grouping. Make it part of the key, and a mixed bucket becomes unrepresentable
+rather than mislabelled.
 
 ### INV-LOAN-001 -- a recurring overpayment's cadence is a calendar
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -567,11 +567,34 @@ own events, and two payments in one month are two. The count is
 `historicalPaymentCount(history)` (`lib/loan-history.ts`), read by both loan
 reports so one loan cannot have two answers.
 
+**Provenance is part of an aggregation's identity, never computed from its
+members.** A weekly, biweekly or semi-monthly loan routinely has a real payment
+and a projected one in the same calendar month. Grouped on the month alone and
+then asked `group.every((item) => item.isProjected)`, August came out
+*historical* while holding two thirds forecast principal and the projection's
+end-of-month balance -- and when the loan paid off inside that month, no
+projected row survived at all, so the "Today" divider and the Est. Payoff card
+went with it. `bucketFlowSeries`'s `boundary` cannot repair that: by the time it
+runs the two sides are one row. Group on the month *and* the side of the line,
+over a date-ordered series and as contiguous runs, so a future-dated posted
+payment landing among the projected rows opens its own run. And ask the
+projection whether a projection exists -- not the buckets.
+
+**A label is not an identity.** Two chart rows share one -- the month either
+side of the line, and a bucketed flow row labelled as the span it covers --
+while recharts keys its category axis, its tooltip lookup and every
+`ReferenceLine` on the datum's own value. Give each row an `axisKey`
+(`axisKeyFor` in `lib/chart-sampling.ts`: its position, then its label), key the
+axis on that, and pass `axisTickLabel` as the `tickFormatter` so the tick still
+reads "Aug 2026". Keyed on the label, the two rows collapse onto one category
+and the divider lands on whichever came first.
+
 **A marker drawn on a reduced series is keyed to that series.** A recharts
 `ReferenceLine` whose value matches no axis category is silently not drawn, so
 the Payment Distribution chart's "Today" divider comes from the first projected
-*bucket's* label -- the balance chart's bare month matches no bucketed range,
-and the divider disappears on exactly the long loans bucketing exists for.
+*bucket's own axis key* -- the balance chart's key addresses a row of a
+different series, and the divider disappears on exactly the long loans bucketing
+exists for.
 
 Assigning a reduced series back over its source (`points = points.filter(...)`)
 is how this happens -- once the two are one variable, nothing downstream can
@@ -582,7 +605,9 @@ taken by filtering a schedule on `isProjected`, for both reports reading the
 shared count, and for any reduced series -- or any name one is aliased to in the
 same file -- being *measured* (`.length`, `.reduce`, `.filter`, `.some`,
 `.every`, `.forEach`); a `.find` for the row a tooltip hovers is allowed,
-because a lookup cannot aggregate. INV-REPORT-002.
+because a lookup cannot aggregate. It also scans for a group's provenance
+derived from its members (`.every(... isProjected ...)`) and pins the Debt
+Payoff Timeline's three axes to `dataKey="axisKey"`. INV-REPORT-002.
 
 ### An unknown value must not render as a measured zero
 

--- a/frontend/src/components/reports/DebtPayoffTimelineReport.test.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@/test/render';
 import { DebtPayoffTimelineReport } from './DebtPayoffTimelineReport';
+import { axisTickLabel } from '@/lib/chart-sampling';
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
@@ -1234,11 +1235,12 @@ describe('DebtPayoffTimelineReport', () => {
       ]);
     });
 
-    it('marks today on the distribution chart with a label that axis has', async () => {
-      // A bucketed bar is labelled as a RANGE, so the balance chart's bare
-      // "Sep 2026" matches no category here and recharts draws nothing --
-      // silently, on exactly the long loans bucketing exists for, under a
-      // caption that still says the dashed line marks today.
+    it('marks today on the distribution chart with a key that axis has', async () => {
+      // A bucketed bar is labelled as a RANGE and addressed by its own position
+      // among the buckets, so the balance chart's key for "Sep 2026" matches no
+      // category here and recharts draws nothing -- silently, on exactly the
+      // long loans bucketing exists for, under a caption that still says the
+      // dashed line marks today.
       mockGetAllAccounts.mockResolvedValue([{
         id: 'loan-1',
         name: 'Long Mortgage',
@@ -1260,7 +1262,8 @@ describe('DebtPayoffTimelineReport', () => {
       await renderAwaitingHistory('120');
       fireEvent.click(screen.getByText('Principal vs Interest'));
 
-      const bars: Array<{ label: string; isProjected: boolean }> = chartRows('bar-chart');
+      const bars: Array<{ label: string; axisKey: string; isProjected: boolean }> =
+        chartRows('bar-chart');
       // Long enough to bucket, and carrying both sides of the transition.
       expect(bars.some((bar) => bar.label.includes('\u2013'))).toBe(true);
       expect(bars.some((bar) => bar.isProjected)).toBe(true);
@@ -1269,9 +1272,13 @@ describe('DebtPayoffTimelineReport', () => {
       expect(markers).toHaveLength(1);
       const markerX = markers[0].getAttribute('data-x');
       // The value has to BE an axis category, or the marker is not drawn.
-      expect(bars.map((bar) => bar.label)).toContain(markerX);
+      expect(bars.map((bar) => bar.axisKey)).toContain(markerX);
       // And it is the transition: the first bucket on the projected side.
-      expect(bars.find((bar) => bar.isProjected)?.label).toBe(markerX);
+      const transition = bars.find((bar) => bar.isProjected);
+      expect(transition?.axisKey).toBe(markerX);
+      // The identity is unique, and the tick still prints the bucket's span.
+      expect(new Set(bars.map((bar) => bar.axisKey)).size).toBe(bars.length);
+      expect(axisTickLabel(markerX ?? '')).toBe(transition?.label);
     });
 
     it('draws the projection marker on the real transition month', async () => {
@@ -1303,6 +1310,164 @@ describe('DebtPayoffTimelineReport', () => {
       // The two rows either side of the transition are adjacent in the drawn
       // series, so the "Today" line and the area join sit on the real boundary.
       expect(drawn[firstProjected - 1].isProjected).toBe(false);
+    });
+  });
+
+  // --- Issue #1280 audit F-1280-01: provenance survives monthly aggregation --
+  //
+  // A weekly, biweekly or semi-monthly loan routinely has a real payment and a
+  // projected one in the SAME calendar month. Grouping by month alone merges
+  // them, and the merged row was labelled historical whenever it held any
+  // historical entry -- so forecast principal was drawn as measured history,
+  // a projected end-of-month balance was published as the historical balance,
+  // and a loan that pays off inside that month lost its projection entirely.
+  describe('a month holding both a real and a projected payment (F-1280-01)', () => {
+    // The overlap is decided against TODAY, so the clock is pinned. Only `Date`
+    // is faked: RTL's `waitFor` cannot drive Vitest's fake timers.
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(new Date('2026-08-10T12:00:00Z'));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /** The number under the "Payments Made" heading in Account Details. */
+    const paymentsMade = () =>
+      screen.getByText('Payments Made').parentElement?.querySelector('p')?.textContent;
+
+    const chartRows = (testId: 'area-chart' | 'bar-chart') =>
+      JSON.parse(screen.getByTestId(testId).getAttribute('data-rows') ?? '[]');
+
+    const renderAwaitingHistory = async (expected: string) => {
+      render(<DebtPayoffTimelineReport />);
+      await waitFor(() => expect(paymentsMade()).toBe(expected));
+    };
+
+    /**
+     * A 0% weekly loan so every figure below is exact and independent of
+     * rounding: 300 opened, 100 paid on 3 Aug, 200 owing, and two projected
+     * 100s on 17 and 24 Aug. All four rows format to "Aug 2026".
+     */
+    const weeklyLoanPayingOffThisMonth = () => {
+      mockGetAllAccounts.mockResolvedValue([{
+        id: 'loan-1',
+        name: 'Short Weekly Loan',
+        accountType: 'LOAN',
+        currentBalance: -200,
+        openingBalance: -300,
+        interestRate: 0,
+        paymentAmount: 100,
+        paymentFrequency: 'WEEKLY',
+        isCanadianMortgage: false,
+        isVariableRate: false,
+        isClosed: false,
+      }]);
+      mockGetAllTransactions.mockResolvedValue({
+        data: [
+          { id: 'actual-aug-03', transactionDate: '2026-08-03', amount: 100, linkedTransaction: null },
+        ],
+        pagination: { hasMore: false },
+      });
+    };
+
+    it('keeps the projected principal out of the historical bar', async () => {
+      weeklyLoanPayingOffThisMonth();
+      await renderAwaitingHistory('1');
+      fireEvent.click(screen.getByText('Principal vs Interest'));
+
+      const bars: Array<{ principalPaid: number; isProjected: boolean }> =
+        chartRows('bar-chart');
+      const sum = (projected: boolean) =>
+        bars
+          .filter((bar) => bar.isProjected === projected)
+          .reduce((total, bar) => total + bar.principalPaid, 0);
+
+      // 100 was paid; 200 is forecast. Merged, August read 300 of history.
+      expect(sum(false)).toBe(100);
+      expect(sum(true)).toBe(200);
+    });
+
+    it('never publishes a projected balance as the historical one', async () => {
+      weeklyLoanPayingOffThisMonth();
+      await renderAwaitingHistory('1');
+
+      const rows: Array<{
+        historicalBalance?: number;
+        projectedBalance?: number;
+        balance: number;
+        isProjected: boolean;
+      }> = chartRows('area-chart');
+
+      // The measured debt is 200. The merged row carried the projection's
+      // end-of-month 0 under `historicalBalance`.
+      const historical = rows.filter((row) => row.historicalBalance !== undefined);
+      expect(historical).not.toHaveLength(0);
+      expect(historical[historical.length - 1].historicalBalance).toBe(200);
+      expect(rows.some((row) => row.isProjected)).toBe(true);
+      expect(rows[rows.length - 1].balance).toBe(0);
+    });
+
+    it('keeps a future-dated posted payment in its own run among the projected rows', async () => {
+      // A repayment posted ahead of its date is a HISTORICAL event dated after
+      // the projection starts, so the two interleave. Grouping by a month key
+      // would fold it back into a month it no longer sits beside; grouping
+      // contiguous runs over a date-ordered series gives it its own row.
+      mockGetAllAccounts.mockResolvedValue([{
+        id: 'loan-1',
+        name: 'Prepaid Loan',
+        accountType: 'LOAN',
+        currentBalance: -300,
+        openingBalance: -600,
+        interestRate: 0,
+        paymentAmount: 100,
+        paymentFrequency: 'MONTHLY',
+        isCanadianMortgage: false,
+        isVariableRate: false,
+        isClosed: false,
+      }]);
+      mockGetAllTransactions.mockResolvedValue({
+        data: [
+          { id: 'past', transactionDate: '2026-07-15', amount: 100, linkedTransaction: null },
+          { id: 'ahead', transactionDate: '2026-10-15', amount: 100, linkedTransaction: null },
+        ],
+        pagination: { hasMore: false },
+      });
+
+      await renderAwaitingHistory('2');
+
+      const rows: Array<{ date: string; label: string; axisKey: string; isProjected: boolean }> =
+        chartRows('area-chart');
+      // Date order, and one identity per row.
+      expect(rows.map((row) => row.date.slice(0, 10))).toEqual(
+        [...rows].map((row) => row.date.slice(0, 10)).sort(),
+      );
+      expect(new Set(rows.map((row) => row.axisKey)).size).toBe(rows.length);
+      // October holds a posted payment and projected ones, and they are not one
+      // row: the historical run sits between two projected runs.
+      const october = rows.filter((row) => row.label === 'Oct 2026');
+      expect(october.length).toBeGreaterThan(1);
+      expect(october.some((row) => !row.isProjected)).toBe(true);
+      expect(october.some((row) => row.isProjected)).toBe(true);
+    });
+
+    it('still knows it has a projection when the loan pays off in the transition month', async () => {
+      weeklyLoanPayingOffThisMonth();
+      await renderAwaitingHistory('1');
+
+      // The Today divider and the Est. Payoff card both come from the
+      // projection; merged into a single historical August row, neither drew.
+      expect(screen.getByText('Est. Payoff')).toBeInTheDocument();
+      const markers = screen.getAllByTestId('reference-line');
+      expect(markers).toHaveLength(1);
+      const drawn: Array<{ label: string; axisKey: string; isProjected: boolean }> =
+        chartRows('area-chart');
+      const transition = drawn.find((row) => row.isProjected);
+      expect(transition?.axisKey).toBe(markers[0].getAttribute('data-x'));
+      // Both August rows are on the axis, under one label and two identities.
+      expect(drawn.map((row) => row.label)).toEqual(['Aug 2026', 'Aug 2026']);
+      expect(new Set(drawn.map((row) => row.axisKey)).size).toBe(2);
+      expect(axisTickLabel(transition?.axisKey ?? '')).toBe('Aug 2026');
     });
   });
 });

--- a/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
@@ -28,7 +28,12 @@ import {
   historicalPaymentCount,
   resolveCurrentLoanTerms,
 } from '@/lib/loan-history';
-import { bucketFlowSeries, sampleStockSeries } from '@/lib/chart-sampling';
+import {
+  axisKeyFor,
+  axisTickLabel,
+  bucketFlowSeries,
+  sampleStockSeries,
+} from '@/lib/chart-sampling';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useReportData } from '@/hooks/useReportData';
 import { usePersistedAccountId } from '@/hooks/usePersistedAccountFilter';
@@ -41,6 +46,19 @@ import { useTranslations } from 'next-intl';
 interface PayoffScheduleItem {
   date: string;
   label: string;
+  /**
+   * What the category axis, the tooltip lookup and every ReferenceLine key on.
+   *
+   * Not the label: a month is no longer unique. A weekly, biweekly or
+   * semi-monthly loan routinely has a real payment and a projected one in the
+   * same calendar month, and that month is one row on each side of the
+   * history/projection line -- two rows, one label. Recharts keys a category
+   * axis on the datum's own value, so two rows sharing a label collapse onto
+   * one category and the "Today" divider lands on whichever came first.
+   * `axisKeyFor` prefixes the row's position; `axisTickLabel` prints the label
+   * back, so the tick still reads "Aug 2026".
+   */
+  axisKey: string;
   balance: number;
   historicalBalance?: number;
   projectedBalance?: number;
@@ -50,6 +68,12 @@ interface PayoffScheduleItem {
   cumulativeInterest: number;
   isProjected: boolean;
 }
+
+/**
+ * A payment before month aggregation: no axis identity yet, because a chart row
+ * is what gets one and these are the events a chart row is built FROM.
+ */
+type SchedulePoint = Omit<PayoffScheduleItem, 'axisKey'>;
 
 const ACCOUNT_STORAGE_KEY = 'monize-reports-debt-payoff-timeline-account';
 
@@ -213,16 +237,23 @@ export function DebtPayoffTimelineReport() {
   // loan has and is what any figure is read from, while `chartSchedule` is that
   // series reduced to fit the axis and is read by nothing but a chart. They were
   // one array, so every total and count downstream described the reduction.
-  const { payoffSchedule, chartSchedule, projectionStartLabel, projectionPaidOff } = useMemo((): {
+  const { payoffSchedule, chartSchedule, projectionStartAxisKey, hasProjection, projectionPaidOff } = useMemo((): {
     /** Every month, historical and projected. The series figures come from. */
     payoffSchedule: PayoffScheduleItem[];
     /** `payoffSchedule` reduced to fit the axis. Rendering only. */
     chartSchedule: PayoffScheduleItem[];
+    /** Whether a forward projection was produced at all. Read from the
+     *  projection itself, never from whether monthly aggregation happened to
+     *  leave an all-projected row: a loan paying off inside the month of its
+     *  last real payment has a projection whose every row shares that month. */
+    hasProjection: boolean;
     /** Whether the forward projection reached payoff, or stopped at the
      *  projection horizon. False also when there is no projection at all --
      *  the flag only ever gates a figure derived from one. */
     projectionPaidOff: boolean;
-    projectionStartLabel: string | null;
+    /** The axis key of the first projected row -- what the "Today" divider is
+     *  drawn at. An axis key, not a month: see `PayoffScheduleItem.axisKey`. */
+    projectionStartAxisKey: string | null;
   } => {
     // Both guards: upstream's `projectionPaidOff` must be in every return, and
     // `history` is now a hoisted memo that is null until an account is selected.
@@ -230,12 +261,13 @@ export function DebtPayoffTimelineReport() {
       return {
         payoffSchedule: [],
         chartSchedule: [],
-        projectionStartLabel: null,
+        projectionStartAxisKey: null,
+        hasProjection: false,
         projectionPaidOff: false,
       };
 
     // --- Historical payments from actual transactions ---
-    const schedule: PayoffScheduleItem[] = history.events.map((event) => ({
+    const schedule: SchedulePoint[] = history.events.map((event) => ({
       date: event.date,
       label: formatChartDate(event.date, 'MMM yyyy'),
       balance: event.balance,
@@ -248,6 +280,7 @@ export function DebtPayoffTimelineReport() {
 
     // --- Project future payments ---
     let projectionPaidOff = false;
+    let hasProjection = false;
     // `rateChanges` is this branch's addition and is not optional decoration:
     // without it the projection runs at whatever stale scalar the account still
     // holds, so this report and the loan detail page gave the same loan two
@@ -263,6 +296,10 @@ export function DebtPayoffTimelineReport() {
       // interest is a subtotal, so the summary below cannot report either as a
       // lifetime figure (INV-LOAN-002).
       projectionPaidOff = projection.paidOff;
+      // Asked of the projection, not of the aggregated series it feeds: the
+      // rows are the fact, and whether any of them survives into a month of its
+      // own is a question about buckets.
+      hasProjection = projection.rows.length > 0;
 
       for (const row of projection.rows) {
         schedule.push({
@@ -278,28 +315,50 @@ export function DebtPayoffTimelineReport() {
       }
     }
 
-    // --- Aggregate by month (a chart granularity, never a count) ---
+    // --- Aggregate by month AND provenance (a chart granularity, never a count) ---
     // Every event in a month folds into one row: the flows sum, the stocks take
     // the month's last value. Nothing counts these rows -- two payments in one
     // month are one row here and two payments in `paymentsMade`.
-    const monthGroups = new Map<string, PayoffScheduleItem[]>();
-    for (const item of schedule) {
-      const group = monthGroups.get(item.label);
-      if (group) group.push(item);
-      else monthGroups.set(item.label, [item]);
+    //
+    // Which side of the history/projection line a row is on is part of the
+    // GROUP'S IDENTITY, not a property computed from its members. A weekly,
+    // biweekly or semi-monthly loan routinely has a real payment and a projected
+    // one in the same calendar month -- an ordinary state, not malformed input.
+    // Keyed on the month alone the two merged, and the merged row was called
+    // historical whenever it held any historical entry: August's forecast
+    // principal was drawn as measured history, the projection's end-of-month
+    // balance was published as the historical one, and a loan that pays off
+    // inside that month left no projected row at all, so the "Today" divider and
+    // the Est. Payoff card both vanished. `bucketFlowSeries`'s boundary cannot
+    // recover any of that -- by the time it runs the provenance is already gone.
+    //
+    // Groups are contiguous RUNS over a date-ordered series rather than a lookup
+    // by key, so a future-dated posted payment landing among the projected rows
+    // opens its own run instead of being folded back into a month it no longer
+    // sits beside.
+    const chronological = [...schedule].sort((a, b) =>
+      a.date.slice(0, 10).localeCompare(b.date.slice(0, 10)),
+    );
+    const monthGroups: SchedulePoint[][] = [];
+    let currentGroupKey: string | null = null;
+    for (const item of chronological) {
+      const key = `${item.isProjected ? 'projected' : 'historical'}\u0000${item.label}`;
+      if (key !== currentGroupKey) {
+        monthGroups.push([]);
+        currentGroupKey = key;
+      }
+      monthGroups[monthGroups.length - 1].push(item);
     }
-    const monthlySchedule: PayoffScheduleItem[] = [...monthGroups.values()].map((group) => {
+    const monthlySchedule: SchedulePoint[] = monthGroups.map((group) => {
       // Spread the month's LAST entry: `balance` and the cumulative totals are
       // end-of-month values, and `date` travels with them so every field on the
-      // row describes the same moment. (Nothing reads `date` today; the label is
-      // what the charts key on.)
+      // row describes the same moment. `isProjected` comes with it and is the
+      // whole group's, since the group is keyed on it.
       const last = group[group.length - 1];
       return {
         ...last,
         principalPaid: group.reduce((sum, item) => sum + item.principalPaid, 0),
         interestPaid: group.reduce((sum, item) => sum + item.interestPaid, 0),
-        // A month is projected only if all its entries are projected.
-        isProjected: group.every((item) => item.isProjected),
       };
     });
 
@@ -309,6 +368,10 @@ export function DebtPayoffTimelineReport() {
       firstProjectedIdx === -1 ? monthlySchedule.length - 1 : firstProjectedIdx - 1;
     const decorated: PayoffScheduleItem[] = monthlySchedule.map((item, index) => ({
       ...item,
+      // The month is no longer an identity now that it can appear on both sides
+      // of the line, so the position supplies one. The tick still prints the
+      // month (`axisTickLabel`).
+      axisKey: axisKeyFor(index, item.label),
       historicalBalance: item.isProjected ? undefined : item.balance,
       // The last historical point also carries a projected value, so the two
       // areas meet instead of leaving a gap at the transition.
@@ -317,11 +380,11 @@ export function DebtPayoffTimelineReport() {
           ? item.balance
           : undefined,
     }));
-    const startLabel = firstProjectedIdx === -1 ? null : decorated[firstProjectedIdx].label;
+    const startKey = firstProjectedIdx === -1 ? null : decorated[firstProjectedIdx].axisKey;
 
     // --- Reduce for rendering only ---
     // The two transition rows are kept whatever the stride: the "Today" line is
-    // drawn at `projectionStartLabel` and the areas join on the row before it,
+    // drawn at `projectionStartAxisKey` and the areas join on the row before it,
     // so sampling either away moves a semantic marker onto whichever month the
     // stride happened to retain -- on a 30-year mortgage, years off.
     const chartSchedule = sampleStockSeries(decorated, {
@@ -331,7 +394,8 @@ export function DebtPayoffTimelineReport() {
     return {
       payoffSchedule: decorated,
       chartSchedule,
-      projectionStartLabel: startLabel,
+      projectionStartAxisKey: startKey,
+      hasProjection,
       projectionPaidOff,
     };
     // `history` replaces the raw `transactions`/`interestTransactions` deps: the
@@ -357,7 +421,6 @@ export function DebtPayoffTimelineReport() {
     const totalPrincipalPaid = lastItem.cumulativePrincipal;
     // Use openingBalance if set, otherwise derive from principal paid + remaining balance
     const originalBalance = Math.abs(selectedAccount.openingBalance) || (totalPrincipalPaid + currentBalance);
-    const hasProjection = payoffSchedule.some((item) => item.isProjected);
     // A projected figure is only a payoff, or a lifetime interest total, when the
     // projection actually reached payoff. Truncated at the horizon, the last
     // row's date is 50 years out with a balance still owing and its cumulative
@@ -377,7 +440,7 @@ export function DebtPayoffTimelineReport() {
       hasProjection,
       projectedPayoffDate,
     };
-  }, [payoffSchedule, selectedAccount, projectionPaidOff]);
+  }, [payoffSchedule, selectedAccount, hasProjection, projectionPaidOff]);
 
   // The interest figure's caption has to match what the figure is: history alone,
   // a lifetime estimate, or -- when the projection stopped at the horizon -- the
@@ -406,17 +469,22 @@ export function DebtPayoffTimelineReport() {
     () =>
       bucketFlowSeries(
         distributionMonths,
-        (group) => {
+        (group, index) => {
           const principalPaid = group.reduce((sum, item) => sum + item.principalPaid, 0);
           const interestPaid = group.reduce((sum, item) => sum + item.interestPaid, 0);
           const total = principalPaid + interestPaid;
           const first = group[0];
           const last = group[group.length - 1];
+          const label =
+            group.length === 1
+              ? first.label
+              : t('debtPayoff.periodRange', { start: first.label, end: last.label });
           return {
-            label:
-              group.length === 1
-                ? first.label
-                : t('debtPayoff.periodRange', { start: first.label, end: last.label }),
+            label,
+            // Two buckets can share a label: the month a real payment and a
+            // projected one both fall in is one bucket on each side of the
+            // boundary. The bucket's position is what makes it addressable.
+            axisKey: axisKeyFor(index, label),
             principalPercent: (principalPaid / total) * 100,
             interestPercent: (interestPaid / total) * 100,
             principalPaid,
@@ -433,20 +501,22 @@ export function DebtPayoffTimelineReport() {
   );
 
   // The distribution chart's "Today" divider. It cannot reuse
-  // `projectionStartLabel`: that is a bare month, while a bucket spanning more
-  // than one month is labelled as a RANGE, so a recharts ReferenceLine keyed on
-  // the month matches no category on this axis and is silently not drawn --
-  // exactly on the long loans bucketing exists for. A bucket never straddles the
-  // boundary, so the first projected bucket's own label is the transition.
-  const distributionProjectionStartLabel = useMemo(
-    () => distributionData.find((bucket) => bucket.isProjected)?.label ?? null,
+  // `projectionStartAxisKey`: that addresses a row of the BALANCE series, and
+  // these are different rows -- a bucket spans a range of months and carries a
+  // position among the buckets. A ReferenceLine whose value matches no category
+  // on its own axis is silently not drawn, exactly on the long loans bucketing
+  // exists for. A bucket never straddles the boundary, so the first projected
+  // bucket is the transition.
+  const distributionProjectionStartAxisKey = useMemo(
+    () => distributionData.find((bucket) => bucket.isProjected)?.axisKey ?? null,
     [distributionData],
   );
 
   const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string; dataKey: string }>; label?: string }) => {
     if (active && payload && payload.length) {
-      // Check if this point is projected
-      const chartData = payoffSchedule.find((item) => item.label === label);
+      // Check if this point is projected. `label` is the axis KEY recharts was
+      // given, so the lookup is on that; the heading prints the month back.
+      const chartData = payoffSchedule.find((item) => item.axisKey === label);
       const isProjected = chartData?.isProjected ?? false;
       // Deduplicate entries that overlap at the transition point
       const seen = new Set<string>();
@@ -460,7 +530,8 @@ export function DebtPayoffTimelineReport() {
       return (
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
           <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">
-            {label} {isProjected && <span className="text-xs text-blue-500 dark:text-blue-400">{t('debtPayoff.projected')}</span>}
+            {label === undefined ? '' : axisTickLabel(label)}{' '}
+            {isProjected && <span className="text-xs text-blue-500 dark:text-blue-400">{t('debtPayoff.projected')}</span>}
           </p>
           {deduped.map((entry, index) => (
             <p key={index} className="text-sm" style={{ color: entry.color }}>
@@ -658,7 +729,8 @@ export function DebtPayoffTimelineReport() {
                   <AreaChart data={chartSchedule}>
                     <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis
-                      dataKey="label"
+                      dataKey="axisKey"
+                      tickFormatter={axisTickLabel}
                       tick={{ fontSize: 11 }}
                       interval="preserveStartEnd"
                     />
@@ -677,7 +749,7 @@ export function DebtPayoffTimelineReport() {
                       strokeWidth={2}
                       connectNulls={false}
                     />
-                    {projectionStartLabel && (
+                    {projectionStartAxisKey && (
                       <Area
                         type="monotone"
                         dataKey="projectedBalance"
@@ -690,9 +762,9 @@ export function DebtPayoffTimelineReport() {
                         connectNulls={false}
                       />
                     )}
-                    {projectionStartLabel && (
+                    {projectionStartAxisKey && (
                       <ReferenceLine
-                        x={projectionStartLabel}
+                        x={projectionStartAxisKey}
                         stroke={chartColors.axis}
                         strokeDasharray="4 4"
                         strokeWidth={2}
@@ -715,7 +787,8 @@ export function DebtPayoffTimelineReport() {
                   <BarChart data={chartSchedule}>
                     <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis
-                      dataKey="label"
+                      dataKey="axisKey"
+                      tickFormatter={axisTickLabel}
                       tick={{ fontSize: 11 }}
                       interval="preserveStartEnd"
                     />
@@ -737,9 +810,9 @@ export function DebtPayoffTimelineReport() {
                       fill={chartColors.warning}
                       name={t('debtPayoff.seriesInterestPaid')}
                     />
-                    {projectionStartLabel && (
+                    {projectionStartAxisKey && (
                       <ReferenceLine
-                        x={projectionStartLabel}
+                        x={projectionStartAxisKey}
                         stroke={chartColors.axis}
                         strokeDasharray="4 4"
                         strokeWidth={2}
@@ -762,7 +835,8 @@ export function DebtPayoffTimelineReport() {
                   <BarChart data={distributionData}>
                     <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis
-                      dataKey="label"
+                      dataKey="axisKey"
+                      tickFormatter={axisTickLabel}
                       tick={{ fontSize: 11 }}
                       interval="preserveStartEnd"
                     />
@@ -774,11 +848,11 @@ export function DebtPayoffTimelineReport() {
                     <Tooltip
                       content={({ active, payload, label: tooltipLabel }) => {
                         if (active && payload && payload.length) {
-                          const data = distributionData.find((d) => d.label === tooltipLabel);
+                          const data = distributionData.find((d) => d.axisKey === tooltipLabel);
                           return (
                             <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
                               <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">
-                                {tooltipLabel}{' '}
+                                {data?.label ?? tooltipLabel}{' '}
                                 {data?.isProjected && (
                                   <span className="text-xs text-blue-500 dark:text-blue-400">{t('debtPayoff.projected')}</span>
                                 )}
@@ -808,9 +882,9 @@ export function DebtPayoffTimelineReport() {
                       fill={chartColors.warning}
                       name={t('debtPayoff.seriesInterest')}
                     />
-                    {distributionProjectionStartLabel && (
+                    {distributionProjectionStartAxisKey && (
                       <ReferenceLine
-                        x={distributionProjectionStartLabel}
+                        x={distributionProjectionStartAxisKey}
                         stroke={chartColors.axis}
                         strokeDasharray="4 4"
                         strokeWidth={2}
@@ -827,7 +901,7 @@ export function DebtPayoffTimelineReport() {
                 </ResponsiveContainer>
               </div>
             )}
-            {projectionStartLabel && (
+            {projectionStartAxisKey && (
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">
                 {t('debtPayoff.projectionNote')}
               </p>

--- a/frontend/src/lib/chart-reduction.guard.test.ts
+++ b/frontend/src/lib/chart-reduction.guard.test.ts
@@ -6,8 +6,8 @@ import { describe, it, expect } from 'vitest';
  *
  * The Debt Payoff Timeline built one array -- payment events, aggregated by
  * month, then sampled down to fit the axis -- and read "Payments Made" off it,
- * so a loan with 300 payments reported 61. Two rules keep that shut, and both
- * are scans because both mistakes are mechanical:
+ * so a loan with 300 payments reported 61. Four rules keep that shut, all of
+ * them scans because every one of these mistakes is mechanical:
  *
  *  1. A payment count comes from `historicalPaymentCount`, never from filtering
  *     a schedule on `isProjected`. That filter is indistinguishable, at the
@@ -17,6 +17,13 @@ import { describe, it, expect } from 'vitest';
  *     looked up in (a tooltip finding the row it hovers), but never MEASURED:
  *     a `.length`, `.reduce`, `.filter`, `.some`, `.every` or `.forEach` over a
  *     reduced series answers a question about pixels.
+ *  3. Which side of the history/projection line an aggregate is on is part of
+ *     the group's IDENTITY, never computed from its members afterwards -- the
+ *     defect the PR #1280 audit found, one step upstream of the reduction the
+ *     first two rules govern.
+ *  4. A chart keys its category axis on the row's own identity, because a label
+ *     is not one: a month holding a real payment and a projected payment is two
+ *     rows under one name.
  *
  * The second scan reads one file at a time, so it can only see what a reduced
  * series is CALLED. An alias is therefore part of the rule rather than a hole
@@ -56,6 +63,24 @@ const productionSources = Object.entries(allSources).filter(
 
 /** A count of historical rows taken by filtering a schedule. */
 const COUNT_BY_FILTER = /\.filter\([^\n]*isProjected[^\n]*\)\s*\.length/;
+
+/**
+ * A group's side of the history/projection line, computed from its members.
+ *
+ * The Debt Payoff Timeline collapsed its rows into calendar months and then
+ * asked `group.every((item) => item.isProjected)` which side the month was on.
+ * A weekly, biweekly or semi-monthly loan routinely has a real payment and a
+ * projected one in the same month, so the month was called historical while
+ * holding forecast principal and a forecast end-of-month balance -- and a loan
+ * paying off inside that month left no projected row at all, taking the "Today"
+ * divider and the Est. Payoff card with it (PR #1280 audit, F-1280-01).
+ *
+ * Provenance is part of an aggregation's IDENTITY: group on it, and the group's
+ * answer comes with every member. `.some` and `.filter` are left alone -- asking
+ * whether a series contains a projection, or reading the historical rows out of
+ * one, are ordinary questions about rows nothing has merged.
+ */
+const PROVENANCE_BY_EVERY = /\.every\([^\n]*isProjected[^\n]*\)/;
 
 /** Aggregating over a series -- as opposed to drawing it or looking a row up. */
 const MEASURED = ['length', 'reduce', 'filter', 'some', 'every', 'forEach', 'flatMap'];
@@ -110,6 +135,47 @@ describe('a chart reduction never reaches a figure (issue #1244)', () => {
         .map(({ number, line }) => `${path}:${number}: ${line.trim()}`),
     );
     expect(offenders).toEqual([]);
+  });
+
+  it('never asks a group which side of the line it is on', () => {
+    const offenders = productionSources.flatMap(([path, content]) =>
+      withoutComments(content)
+        .split('\n')
+        .map((line, index) => ({ line, number: index + 1 }))
+        .filter(({ line }) => PROVENANCE_BY_EVERY.test(line))
+        .map(({ number, line }) => `${path}:${number}: ${line.trim()}`),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('detects a planted group-provenance derivation', () => {
+    // Negative control: without it, deleting the regex leaves the scan above
+    // passing over anything.
+    const planted = withoutComments(
+      [
+        '// isProjected: group.every((item) => item.isProjected),',
+        'isProjected: group.every((item) => item.isProjected),',
+        'const any = rows.some((row) => row.isProjected);',
+      ].join('\n'),
+    ).split('\n');
+    expect(PROVENANCE_BY_EVERY.test(planted[0])).toBe(false);
+    expect(PROVENANCE_BY_EVERY.test(planted[1])).toBe(true);
+    // A question about rows nothing merged is not the banned shape.
+    expect(PROVENANCE_BY_EVERY.test(planted[2])).toBe(false);
+  });
+
+  it('keys the Debt Payoff Timeline axes on the row identity, not the month', () => {
+    // Two rows share a month -- the one a real payment and a projected payment
+    // both fall in. Recharts keys its category axis, its tooltip lookup and
+    // every ReferenceLine on the datum's own value, so keyed on the month the
+    // two collapse onto one category and the "Today" divider lands on whichever
+    // came first. `axisKey` is the identity; `axisTickLabel` prints the month.
+    const report = withoutComments(
+      allSources['/src/components/reports/DebtPayoffTimelineReport.tsx'],
+    );
+    expect(report).not.toContain('dataKey="label"');
+    expect(report.match(/dataKey="axisKey"/g) ?? []).toHaveLength(3);
+    expect(report.match(/tickFormatter=\{axisTickLabel\}/g) ?? []).toHaveLength(3);
   });
 
   it('has both loan reports reading the shared count', () => {

--- a/frontend/src/lib/chart-sampling.test.ts
+++ b/frontend/src/lib/chart-sampling.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { CHART_MAX_POINTS, bucketFlowSeries, sampleStockSeries } from './chart-sampling';
+import {
+  CHART_MAX_POINTS,
+  axisKeyFor,
+  axisTickLabel,
+  bucketFlowSeries,
+  sampleStockSeries,
+} from './chart-sampling';
 
 describe('sampleStockSeries', () => {
   it('leaves a series that already fits alone', () => {
@@ -67,11 +73,14 @@ describe('bucketFlowSeries', () => {
   });
 
   it('never merges across a boundary', () => {
-    // 100 historical rows then 100 projected: at a stride of 4 the 25th bucket
-    // would straddle the two without the boundary.
+    // 101 historical rows then 99 projected. The group size is ceil(200/60) = 4
+    // and the groups start at 0, 4, 8 ... 100, so the transition falls INSIDE
+    // the group starting at 100 -- the boundary has to flush it early. Splitting
+    // 100/100 instead puts the transition exactly on a group start, where the
+    // case passes with the boundary mechanism deleted.
     const rows = [
-      ...Array.from({ length: 100 }, () => ({ value: 1, projected: false })),
-      ...Array.from({ length: 100 }, () => ({ value: 1, projected: true })),
+      ...Array.from({ length: 101 }, () => ({ value: 1, projected: false })),
+      ...Array.from({ length: 99 }, () => ({ value: 1, projected: true })),
     ];
     const bucketed = bucketFlowSeries(
       rows,
@@ -83,6 +92,20 @@ describe('bucketFlowSeries', () => {
     );
     expect(bucketed.every((bucket) => bucket.kinds === 1)).toBe(true);
     expect(bucketed.reduce((total, bucket) => total + bucket.value, 0)).toBe(200);
+    // The flush is visible: one bucket is shorter than the group size because
+    // the run ended inside it.
+    expect(bucketed.some((bucket) => bucket.value === 1)).toBe(true);
+  });
+
+  it('hands each bucket its own position', () => {
+    // A bucket's label is not an identity -- two buckets can share one -- so the
+    // position is what a caller builds an axis key from.
+    const rows = Array.from({ length: 200 }, () => 1);
+    const positions = bucketFlowSeries(rows, (_group, index) => index);
+    expect(positions).toEqual(positions.map((_value, index) => index));
+
+    // And on the pass-through path, where the series already fits.
+    expect(bucketFlowSeries([1, 2, 3], (_group, index) => index)).toEqual([0, 1, 2]);
   });
 
   it('keeps one bucket per run when the runs outnumber the budget', () => {
@@ -98,5 +121,37 @@ describe('bucketFlowSeries', () => {
 
   it('handles an empty series', () => {
     expect(bucketFlowSeries([], sum)).toEqual([]);
+  });
+});
+
+describe('axis keys', () => {
+  it('gives two rows under one label two identities', () => {
+    // The month a real payment and a projected one share is one chart row on
+    // each side of the line. Recharts keys its axis, its tooltip lookup and
+    // every ReferenceLine on the datum's own value, so under one label the two
+    // collapse onto one category.
+    const historical = axisKeyFor(0, 'Aug 2026');
+    const projected = axisKeyFor(1, 'Aug 2026');
+    expect(historical).not.toBe(projected);
+    expect(axisTickLabel(historical)).toBe('Aug 2026');
+    expect(axisTickLabel(projected)).toBe('Aug 2026');
+  });
+
+  it('prints back a label holding the separator', () => {
+    // The position comes first precisely so the cut is unambiguous.
+    expect(axisTickLabel(axisKeyFor(7, 'a|b'))).toBe('a|b');
+  });
+
+  it('prints back a bucket span', () => {
+    expect(axisTickLabel(axisKeyFor(12, 'Sep 2026 \u2013 Nov 2026'))).toBe(
+      'Sep 2026 \u2013 Nov 2026',
+    );
+  });
+
+  it('passes through a value that is not an axis key', () => {
+    // Recharts hands a tick formatter whatever the axis holds, and a formatter
+    // that throws takes the chart with it.
+    expect(axisTickLabel('Aug 2026')).toBe('Aug 2026');
+    expect(axisTickLabel(100)).toBe('100');
   });
 });

--- a/frontend/src/lib/chart-sampling.ts
+++ b/frontend/src/lib/chart-sampling.ts
@@ -71,9 +71,14 @@ export function sampleStockSeries<T>(
 /**
  * A flow series reduced by SUMMING contiguous groups, so no period is dropped.
  *
- * `combine` receives each group in order and returns the row to draw -- it owns
- * the aggregation (summing the amounts, labelling the span) because only the
- * caller knows what its fields mean.
+ * `combine` receives each group in order, with the group's position among the
+ * groups, and returns the row to draw -- it owns the aggregation (summing the
+ * amounts, labelling the span) because only the caller knows what its fields
+ * mean. The position is there so a bucket can carry an identity its label
+ * cannot supply: two buckets legitimately share a label (the month a real
+ * payment and a projected one both fall in appears once on each side of the
+ * boundary), and a recharts category axis, tooltip lookup and ReferenceLine all
+ * key on the datum's own value.
  *
  * `boundary`, when supplied, forces a group break between two rows it answers
  * differently for. The payoff charts use it so a bucket never straddles the
@@ -90,7 +95,7 @@ export function sampleStockSeries<T>(
  */
 export function bucketFlowSeries<T, R>(
   rows: readonly T[],
-  combine: (group: T[]) => R,
+  combine: (group: T[], index: number) => R,
   options: {
     maxPoints?: number;
     boundary?: (row: T) => unknown;
@@ -99,7 +104,7 @@ export function bucketFlowSeries<T, R>(
   const maxPoints = options.maxPoints ?? CHART_MAX_POINTS;
   if (rows.length === 0) return [];
   if (rows.length <= maxPoints || maxPoints <= 0) {
-    return rows.map((row) => combine([row]));
+    return rows.map((row, index) => combine([row], index));
   }
 
   const groupSize = Math.ceil(rows.length / maxPoints);
@@ -117,5 +122,43 @@ export function bucketFlowSeries<T, R>(
     current.push(row);
   }
   if (current.length > 0) groups.push(current);
-  return groups.map(combine);
+  return groups.map((group, index) => combine(group, index));
+}
+
+/**
+ * Separates a chart row's position from its label inside an axis key.
+ *
+ * The position comes FIRST so the separator is unambiguous whatever the label
+ * holds: `axisTickLabel` cuts at the first occurrence, and no label -- a
+ * localized month, a range spanning two of them -- begins with one.
+ */
+const AXIS_KEY_SEPARATOR = '|';
+
+/**
+ * A chart row's identity on a category axis: its position, then its label.
+ *
+ * A label is not an identity. Two rows legitimately share one -- the month a
+ * real payment and a projected payment both fall in is one row on each side of
+ * the history/projection line, and a bucketed flow row is labelled as the span
+ * it covers -- while recharts keys its category axis, its tooltip lookup and
+ * every ReferenceLine on the datum's own value. Two rows under one label
+ * collapse onto one category, and a marker drawn there lands on whichever came
+ * first. Give the chart `axisKey` as its `dataKey` and `axisTickLabel` as its
+ * `tickFormatter`: the identity is unique, the tick still reads "Aug 2026".
+ */
+export function axisKeyFor(position: number, label: string): string {
+  return `${position}${AXIS_KEY_SEPARATOR}${label}`;
+}
+
+/**
+ * The label an axis key prints.
+ *
+ * A value that is not an axis key comes back unchanged: recharts hands a tick
+ * formatter whatever the axis holds, and a formatter that throws takes the
+ * chart with it.
+ */
+export function axisTickLabel(value: string | number): string {
+  const key = String(value);
+  const separator = key.indexOf(AXIS_KEY_SEPARATOR);
+  return separator === -1 ? key : key.slice(separator + 1);
 }


### PR DESCRIPTION
## Linked discussion / issue

Closes #<!-- issue number for F-1280-01, once one exists -->
Approved in: <!-- discussion/issue link -->

Follow-up to PR #1280 (`fix(reports): count payments, not chart samples, on the
Debt Payoff Timeline`, issue #1244). The scope comes from the retrospective
audit of that PR, finding **F-1280-01 (MEDIUM)**: "mixed actual/projected months
are collapsed into historical financial data". The audit found no existing issue
describing this scenario — under propose-first, one needs to be opened and
linked above.

## Summary

`DebtPayoffTimelineReport` collapsed its rows into calendar months **before** the
history/projection boundary was preserved, then asked
`group.every((item) => item.isProjected)` which side of the line the month was
on. A weekly, biweekly or semi-monthly loan routinely has a real payment and a
projected one in the same calendar month — an ordinary state, not malformed
input — so the month came out *historical* while carrying forecast principal and
the projection's end-of-month balance. `bucketFlowSeries`'s `boundary`, added by
#1280 for exactly this reason, could not repair it: by the time it ran, the two
sides were one row.

Numerical reproduction (0% weekly loan, clock pinned to 2026-08-10; 100 paid on
3 Aug, 100 projected on each of 17 and 24 Aug):

| View | Before | After |
| --- | --- | --- |
| Principal vs Interest, August | 300 as history | 100 history + 200 projected |
| Balance, August historical balance | 0 (end of projection) | 200 (measured debt) |
| `hasProjection` when the loan pays off that month | false — the "Today" divider and the Est. Payoff card both vanish | true, both drawn |

### Changes

- **Provenance is part of the group's identity**, not a property computed from
  its members. Monthly aggregation groups contiguous runs over a date-ordered
  series, keyed on the month **and** the side of the line. Ordering by date also
  gives a future-dated posted payment its own run instead of folding it back
  into a month it no longer sits beside.
- **Whether a projection exists is read from the projection itself**
  (`projection.rows`), never from whether aggregation happened to leave an
  all-projected row.
- **A label is no longer an identity.** Two rows share a month, and recharts keys
  its category axis, its tooltip lookup and every `ReferenceLine` on the datum's
  own value — under one label the two collapse onto one category and the marker
  lands on whichever came first. `axisKeyFor` / `axisTickLabel`
  (`lib/chart-sampling.ts`) give each row its position as an identity while the
  tick still prints "Aug 2026". `bucketFlowSeries` hands `combine` the bucket's
  position for the same reason — two buckets can share a label too.

### Tests

Four component cases on the mixed month — historical vs projected principal, the
historical balance, a payoff inside the transition month, and an interleaved
future-dated payment — **all four fail on the merged #1280 component** (verified
by `git checkout HEAD --` on the file and re-running). Plus unit cases for the
bucket position and the axis key, and two new scans in
`chart-reduction.guard.test.ts`, each with a planted-violation control: no
group's provenance derived from its members (`.every(... isProjected ...)`), and
the Debt Payoff Timeline's three axes pinned to `dataKey="axisKey"` with
`axisTickLabel`.

Also fixes the edge case the audit flagged: the 100/100 split in the "never
merges across a boundary" unit test put the transition exactly on a group start,
so it passed with the boundary mechanism deleted. It is 101/99 now, where the
transition falls **inside** a group and the flush is what saves the case.

### Contracts

`INV-REPORT-002` gains the provenance rule and the identity rule. Its ban is also
reworded to name a reduction that changes a figure's **meaning or provenance**
rather than the word "aggregate" — a semantics-preserving stock rollup, which
`summary` reads, was never the target. That was the audit's second documentation
point. `frontend/CLAUDE.md` gains the same two rules in short form.

### Deliberately out of scope

The report still calls `buildLoanProjectionInput` without a server projection
anchor, and the guard is still name-based rather than type-level. The audit left
both as open hypotheses rather than findings; neither substitutes for preserving
provenance.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **to be
      filled in**: the scope comes from the PR #1280 audit, not from a
      previously approved discussion.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes. — frontend: 740
      files, 14,469 tests; `tsc --noEmit`, `eslint` and `i18n:check` clean; the
      backend documentation-path guards (35 tests) pass.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
      — no new strings; the catalogs are untouched.
- [ ] No shared/core areas were refactored without prior agreement. — **needs
      confirmation**: `lib/chart-sampling.ts` is shared by four call sites. The
      change is additive and backward compatible (`combine` gains a second
      argument, two new functions are exported) and the other three call sites
      are untouched — but it is still a shared module.
- [x] The branch is rebased on the latest `main`. — the branch is `origin/main`
      (`9e2c551`) plus one commit.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Diagnosis, implementation, tests and documentation changes written by Claude Code
from the retrospective audit of PR #1280. The defect was first reproduced with a
test failing on merged `main`, and the fix verified by re-running those tests
against the pre-fix component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdeYEfavj8KRUMgKcpaJ8v