### PR TITLE
docs: add the v1.15.1 release notes

### DIFF
--- a/docs/release-notes/1.15.1.md
+++ b/docs/release-notes/1.15.1.md
@@ -1,0 +1,192 @@
+# v1.15.1
+
+The **follow-through** release.
+
+v1.15.0 was the audit release, and a fair bit of what it found was left pointing at things rather than fixed. This is the fixing. **A scheduled payment now costs the same figure on every screen that draws it** -- the dashboard, the forecast, the budget, the bills page, the reminder email, the assistant -- because all of them ask the server for the same occurrence instead of each doing their own arithmetic on a stored snapshot. **Loan and mortgage schedules stop over-billing**: an off-by-one end date, a semi-monthly frequency the recurrence engine never understood, an interest figure the reports estimated instead of reading. And **reports stop losing an entire ledger**: money paid into a brokerage's cash side was being filtered out of fifteen report queries because of the account type it happened to carry.
+
+Two things every deployment should read before upgrading: **automatic backups were going out unencrypted** in a case nobody had noticed, and `AI_ENCRYPTION_KEY` is now `ENCRYPTION_KEY` (the old name still works). See [Backup and restore](#backup-and-restore).
+
+There is also a visual pass -- **payee brand icons and category glyphs** throughout, colour themes that finally look like different themes, and a reconcile screen that fits on a phone.
+
+## Scheduled transactions and bills
+
+### One occurrence, one answer
+
+A scheduled transaction stores the amount it was worth when it was written. For anything FX-sensitive -- an investment schedule, or a split carrying an investment line -- that number stops describing the next occurrence the moment a currency moves underneath it. v1.15.0 taught the cash-flow forecast to re-resolve and left nine other surfaces reading the stored column, so one schedule showed **1,500 CAD on five screens and 1,350 CAD on the forecast that predicts its posting** (#1247).
+
+Every one of those surfaces now asks the server for the same thing: the **occurrence** -- its amount, its currency, whether the amount is fully known, the date it actually falls on, and the account whose balance it moves. Three consequences worth knowing about:
+
+- **The account matters as much as the amount.** A scheduled investment's account is the brokerage, but the cash settles in the funding or linked cash account. An account-level projection keyed on the stored column charged the brokerage for cash it never moved *and* left the funding account's chart missing the outflow it pays.
+- **An override moves the occurrence, and the lookup follows it.** An occurrence is identified by its recurrence slot, not by the date it was moved to, so a surface that keyed on the moved date was quietly reading the template for every occurrence you had changed.
+- **A re-priced split can change direction.** A mixed-sign split parent stored at -200 can post +150 once its investment line re-prices. Where the direction cannot be proved without the missing rate, it is reported as unknown -- a neutral badge on the reminder email, no bucket total in the assistant -- rather than guessed into a red bill or a green deposit.
+
+### Totals that name their currency, or withhold themselves
+
+Upcoming-bill rollups are converted into one currency before being summed, and that currency is stated alongside the figure. Where a pair has no rate the total is withheld and the pair is named; where an occurrence's own amount is unknown it is excluded by count, because that is a different problem with a different fix and folding the two together sent you to repair a rate that was already there.
+
+A filter on the list no longer narrows the totals about the window: asking the assistant for deposits used to publish "total upcoming bills: 0" over a window holding a 1,200 bill.
+
+### The dashboard widget stops summing across currencies
+
+**Upcoming Bills and Deposits** lists the occurrences and nothing that stands for more than one of them -- both the "Total due" and "Total incoming" rows are gone. Per-row amounts still come from the server's effective-amount contract, still carry their own settlement currency, and an unpriceable occurrence still renders as unavailable rather than as a stale snapshot.
+
+### A scheduled investment's rate remembers which pair it was for
+
+A stored FX rate on a scheduled investment was a bare number with no record of the currency pair it belonged to, so changing the currency of the referenced security or account left the rate applying to a pair that no longer existed -- and the posting converted the cash at it anyway (#1167, migration `162`). Rates are now self-describing: the posting path re-derives the current pair and reuses the stored rate only when it still matches. Override splits also gained stable ids (migration `163`), fixing a pre-existing split override that became uneditable after upgrade.
+
+## Loans and mortgages
+
+### Stop billing a payment that was already made
+
+Three separate defects each added an installment nobody owed:
+
+- **An end date one payment too long.** A schedule of N payments advances N-1 intervals from the first payment, but the loan and mortgage end-date formulas advanced N -- so the schedule reached occurrence N+1, one extra installment against a loan the amortization already reported as repaid. The code is fixed and migration `166` heals the bounds already written, only where the correction is provable.
+- **A semi-monthly mortgage that never advanced.** Mortgage setup wrote `SEMI_MONTHLY` where the recurrence engine spells it `SEMIMONTHLY`, and the engine's switch passed through unchanged: the next due date came back the same date, so the occurrence stayed due forever and the schedule froze. Migration `165` heals both the spelling and the frozen due date.
+- **The final payment, over-billed.** The loan compounding convention is now named and applied consistently, the overpayment cadence is dated rather than assumed, and the projection horizon is derived instead of guessed.
+
+### An installment priced from the balance on its own due date
+
+A scheduled loan payment's interest drifted from the amortization report because the two were anchored differently -- the report on today, the bill on its due date (#1253). Interest for an installment due on date `d` is now computed from the ledger balance **as of `d`** and the rate in effect on `d`, through one predicate shared by the report and the bill. And an installment is judged overdue against **your** calendar day, not the server's, so a payment due today stopped being flagged late in the evening in western time zones.
+
+### Loan history reports the ledger, never an estimate
+
+The loan detail page and the amortization report used to fill a gap in booked interest with an *estimated* figure, which then propagated into cumulative interest and everything derived from it (#1255). Interest now comes from provenance: what the ledger actually recorded, with a measured zero rendered as zero and a failed lookup rendered as a failure with a retry -- not as history. One set of current terms is shown on every surface that quotes them.
+
+### Debt Payoff Timeline
+
+- **Payments are counted, not chart samples** (#1244). The "payments remaining" figure was reading the number of points the chart had been reduced to.
+- **Actual and projected stay apart** through that reduction, so a downsampled chart no longer blends a payment you made into the line predicting the ones you have not.
+
+## Reports
+
+### An investment account is a pair, so account type was never the right filter
+
+`INVESTMENT` is the account type of *both* halves of a linked pair -- the cash sleeve holding ordinary money and the brokerage sleeve holding securities. An `account_type != 'INVESTMENT'` clause in fifteen report queries therefore deleted a real ledger: **salary paid into a brokerage's cash side vanished** from Cash Flow, Income by Source, spending, tax and the Uncategorized list (#1257).
+
+It never described the rows it was meant to remove, either. The cash leg a BUY or SELL posts lives in that same cash account -- and when the trade names an explicit funding account, that leg lands in an ordinary account where no account-type predicate could ever have seen it, reporting an investment purchase as spending nobody did.
+
+What a row *is* now decides it, written once and used by both the SQL reports and the custom report engine. Two related fixes came with it: a report reading only a split's parent row was counting an embedded trade as spending (a -560 parent made of -60 groceries and a -500 BUY reported as 560 spent), and "Uncategorized" no longer lists auto-generated trade legs as rows you forgot to file.
+
+### Elsewhere in Reports
+
+- **Account Balances no longer treats liabilities as assets in its pie chart** -- a credit card balance was being drawn as a slice of what you own.
+- **Favourite reports sort to the top of the report switcher** (#1224), and toggling a favourite is reflected there immediately.
+- **Historical portfolio valuation honours manual and imported prices** (#1242). Monthly net-worth snapshots valued securities flagged "skip price updates" from raw transaction prices instead of their accepted close, so a 401(k) holding 120 shares reported $7,320 against an accepted close worth $14,400. That flag now governs external price *fetching* only, and migration `164` recomputes the snapshots persisted under the old rule.
+
+## Investments and Microsoft Money import
+
+- **Redeem CD/Bond records its accrued interest.** The activity gains an **Accrued Interest** field, and the gross payout is principal plus interest on the redemption itself rather than a sell transaction with a separate cash leg beside it. On import, Money Plus stores some redemptions as a SELL with positive interest instead of a redeem code, and those are now normalized to a real REDEEM. (Thanks **@bcorob**.)
+- **The import verification report reads cash-like investments correctly.** For CDs, U.S. savings bonds and money-market funds, Money keeps trades but creates no tax-lot rows -- so the reconciliation, which used open lots as the authoritative "shares in Money" reading, reported 0 shares and flagged a difference on an import that was in fact correct. The import itself was never wrong. (Thanks **@bcorob**.)
+- **Money watch accounts are excluded from net worth on `.mny` import**, and badged as such in the import wizard so you can see it before you commit.
+
+## Look and feel
+
+### Payee icons and category glyphs
+
+Payees get a **brand icon**, resolved from the payee's website through the same server-side favicon fetcher the institutions already used and cached in the database -- your browser never contacts a third party to draw one (migration `160`). Categories get an **icon** that subcategories inherit, drawn as a glyph rather than printed as text. Both appear in the register (at normal and compact density), the transactions sidebar, and the Payees page's Default Category column. On phones the brand badges are hidden in the register, where the width is better spent on the payee name.
+
+### Themes that look like different themes
+
+The colour themes shared one grey ramp, so light mode was one card in fifteen skins. Each theme now has generated greys and its own intensity, its light-mode paper is tinted, and the theme picker shows the palettes instead of naming them. The colour-blind theme is tinted, and high contrast is back as a job of its own rather than a hue.
+
+Underneath, the primitives that kept getting in the way were settled: one card surface for every dashboard widget, a **Badge** primitive replacing about fifty hand-rolled status pills, a **Modal** with a title, footer and entrance, one **EmptyState** for every list, shared table chrome, skeletons that no longer shift the layout, focus rings shown to the keyboard only, and buttons that answer a press.
+
+### PWA boot
+
+The install splash and the offline fallback **follow your theme and palette** instead of flashing the stock green, the theme is encoded in the manifest URL so a cookieless update check stays dark, and a hung launch always gets an exit -- the splash is hidden rather than detached, which used to crash every subsequent navigation. Both surfaces are translated for every locale.
+
+## Backup and restore
+
+### Automatic backups were going out in plaintext
+
+Automatic backups are encrypted with the copy of your password the server captures when you sign in. Where no usable copy was held, they were written **unencrypted** (#1269). They no longer are. Settings -> Backup and Restore now shows the state plainly and can capture the password from a session that predates the feature; OIDC accounts, which have no password of ours, set a dedicated backup password there or choose to leave backups unencrypted deliberately.
+
+### `AI_ENCRYPTION_KEY` is now `ENCRYPTION_KEY`
+
+The variable encrypts more than AI keys -- provider API keys, emergency-access credentials and the stored backup password -- so it is renamed and moved to the required settings at the top of `.env.example`. **`AI_ENCRYPTION_KEY` is still read, and still wins where both are set**, so an existing deployment upgrades without re-keying anything.
+
+The backend still starts without it and warns on every boot; a future release will require it. Keep the value safe and keep it the same: changing or losing it re-encrypts nothing, and every secret already stored becomes unreadable.
+
+### A restore is refused before it costs anything
+
+The restore path had three design risks and now has measurements instead of assumptions (#1073). The upload is **authorized before space is reserved for it**, the wait is bounded and a caller who left is dropped, and the size ceilings are derived from a **measured** peak RSS -- a restore costs about 6.1 times its expanded payload plus a fixed 78 MiB, not the 3x the old model assumed. The compressed ceiling now follows the expanded one down, closing a case where a 66 MiB upload was accepted against a 100 MiB expanded ceiling it would then blow past on decompression. Refusals say what happened, in your language.
+
+## Market data
+
+### An unreachable provider is called once, logged once, and reported once
+
+Yahoo Finance became unreachable from a deployment's container and every code path that wanted a price kept calling it, several times a second, logging `TypeError: fetch failed` with a stack containing nothing actionable. The operator restarted the container because of the log; the restart produced the log (#1265).
+
+- **A breaker per provider.** Five transport failures in a five-minute window open it for a minute, each failed probe doubling the window to a 15-minute cap; one probe is admitted per window and its success closes it. A refused call costs no socket and no wait.
+- **One log line, with the cause.** The undici chain and socket fields become a single bounded line naming the actual DNS or TLS failure, rate-limited to one per provider per minute, with a count of what it suppressed.
+- **An email to administrators, at most one pair per episode.** A 15-minute minimum outage, one notice per episode, and a six-hour floor between notices; the all-clear is derived from state rather than scheduled, so it survives a restart. Each admin gets it in their own locale, and a deployment with no SMTP does nothing at all. (New table via migration `169`.)
+- **A restart is not new information.** Start-up warm-up honours the per-index cooldown.
+
+## Everyday fixes
+
+- **A background refresh no longer clears the transactions you had selected.**
+- **Quick-filling from Recent keeps the account, currency and date you had entered** instead of overwriting them with the source transaction's.
+- **The reconcile page fits a phone.** Full device width, row actions in the long-press sheet, Select All and Select None on one row, the desktop actions column restored, the shared date toggle, and no more `-0.00` placeholder in the statement balance field. Its edit modal renders on screen again.
+- **The register can hide the year in the Date column on mobile**, giving the room to the payee -- a per-user option, translated everywhere.
+- **Transfers with a blank payee resolve their label at display time** (#1214). The old writers stamped "Transfer to <account>" into the row, which went stale when the counterpart was renamed and could not follow the reader's language; migration `161` blanks exactly the rows that were stamped.
+- **Recurring charges filter by account server-side.** The panel used to enumerate an account's payees and send the list, which produced a 400 once the list outgrew the endpoint's cap. (Thanks **@bcorob** for the report and the first fix.)
+- **The investment detail page's YTD income loads again** -- it was asking a paged endpoint for more than it accepts, and a scan now fails any new call site that does.
+- **Automatic backups claim their due work correctly** under the query that dispatches them.
+
+## Under the hood
+
+- Migrations `160`-`169`: payee logos, blank transfer payees, scheduled-investment FX currency pairs and override split ids, the #1242 snapshot recompute, the semi-monthly and end-date heals, a reminder-days clamp, override occurrence identity, and the provider health table. Two pairs of migrations each claimed the same prefix on merge and were renumbered; the one that cannot be re-run safely kept its number and is registered as non-rerunnable.
+- **Raw SQL column names are checked against `schema.sql`** by a guard test.
+- **The parallel unit run is separated from the PostgreSQL integration suites**, which share one database and cannot run beside each other. `npm test` runs both in order; `npm run test:unit` is the offline path.
+- Test hygiene: the `act` guard fails only on warnings that name a component, `sessionStorage` no longer leaks between tests, and the known-violation register is empty again.
+- Documentation: [provider outage alerts](../specs/provider-outage-alerts.md), [scheduled loan installment pricing](../specs/scheduled-loan-installment-pricing.md), [redemption accrued interest](../specs/redemption-accrued-interest.md) and [scheduled investment FX currency pair](../specs/scheduled-investment-fx-currency-pair.md) were each written before the implementation they guide. The [audit protocol](../audits/) gained its Universal Adversarial layer, and the `CLAUDE.md` files were compacted.
+
+## Credit
+
+**@WMP** carried the occurrence contract (#1247), the report-provenance fix (#1257), the loan and mortgage corrections (#1253, #1255), the restore admission work (#1073), the provider outage breaker (#1265) and the invariant catalog -- most of this release, and most of it found by reviewing rather than by being told. **@bcorob** continues to make the Microsoft Money import trustworthy for people migrating real files, this time for CDs and bonds. Issues #1214, #1224, #1242, #1244, #1247, #1253, #1255, #1257, #1265 and #1269 are all fixed here.
+
+## All Changes
+* Guard raw SQL column names against schema.sql by @kenlasko in https://github.com/kenlasko/monize/pull/1222
+* Add payee logos, category icons, and shared Card primitive by @kenlasko in https://github.com/kenlasko/monize/pull/1223
+* Add "Accrued Interest" field to "Redeem CD/Bond" investment activity by @bcorob in https://github.com/kenlasko/monize/pull/1225
+* Document and enforce critical system invariants by @WMP in https://github.com/kenlasko/monize/pull/1226
+* Resolve blank transfer payees at display time instead of stamping them by @kenlasko in https://github.com/kenlasko/monize/pull/1228
+* Money import: show correct quantity for cash-like investments on import report (affects report only) by @bcorob in https://github.com/kenlasko/monize/pull/1231
+* Make the colour themes actually look different, and settle the primitives that got in the way by @kenlasko in https://github.com/kenlasko/monize/pull/1234
+* Fixed the 400 error in RecurringChargesPanel.tsx:115. by @bcorob in https://github.com/kenlasko/monize/pull/1230
+* Fix the remaining over-cap `limit` call site, and scan for the next one by @kenlasko in https://github.com/kenlasko/monize/pull/1233
+* Fix red main: empty the known-violation register now that #1230 has landed by @kenlasko in https://github.com/kenlasko/monize/pull/1237
+* Recurring charges: filter by account server-side instead of enumerating payee ids by @kenlasko in https://github.com/kenlasko/monize/pull/1235
+* Exclude Money watch accounts from net worth on .mny import by @kenlasko in https://github.com/kenlasko/monize/pull/1236
+* Money Import: create REDEEM transaction with accrued interest when importing SELL with paired interest by @bcorob in https://github.com/kenlasko/monize/pull/1239
+* PWA boot surfaces follow the theme and palette, and a hung launch always gets an exit by @kenlasko in https://github.com/kenlasko/monize/pull/1240
+* Compact all CLAUDE.md files for efficient reading by @kenlasko in https://github.com/kenlasko/monize/pull/1245
+* Hide payee brand badges on mobile in the transactions register by @kenlasko in https://github.com/kenlasko/monize/pull/1246
+* Issue #1167 - Scheduled Investment FX Provenance Review Summary by @WMP in https://github.com/kenlasko/monize/pull/1232
+* docs: add comprehensive audit review prompt (V3) by @WMP in https://github.com/kenlasko/monize/pull/1248
+* Fix historical portfolio valuation to honor manual and imported prices (#1242) by @WMP in https://github.com/kenlasko/monize/pull/1249
+* docs: commit the Universal Adversarial protocol source document by @WMP in https://github.com/kenlasko/monize/pull/1250
+* Mobile register: option to hide the year in the Date column, giving the room to the payee by @kenlasko in https://github.com/kenlasko/monize/pull/1252
+* Show favourite reports at the top of the report switcher (#1224) by @WMP in https://github.com/kenlasko/monize/pull/1251
+* Fix the reconcile page's mobile rendering and modernize its table interactions by @kenlasko in https://github.com/kenlasko/monize/pull/1262
+* [Tests] Separate the parallel unit run from the PostgreSQL integration suites by @WMP in https://github.com/kenlasko/monize/pull/1259
+* Report membership follows investment provenance, not account type (#1257) by @WMP in https://github.com/kenlasko/monize/pull/1260
+* Preserve the account, currency and date when quick-filling from Recent by @kenlasko in https://github.com/kenlasko/monize/pull/1263
+* Bound the restore queue, authorize its upload, and measure what a restore costs (#1073) by @WMP in https://github.com/kenlasko/monize/pull/1261
+* Remove the Total due row from the Upcoming Bills widget by @kenlasko in https://github.com/kenlasko/monize/pull/1264
+* fix(transactions): a background load must not clear the user's selection by @kenlasko in https://github.com/kenlasko/monize/pull/1267
+* fix(test): fail only on the act warning that names a component by @kenlasko in https://github.com/kenlasko/monize/pull/1268
+* test(investments): wait for the call being asserted, and stop sessionStorage leaking between tests by @kenlasko in https://github.com/kenlasko/monize/pull/1270
+* Serve one effective scheduled occurrence to every surface (#1247) by @WMP in https://github.com/kenlasko/monize/pull/1271
+* Fixes for over-committing mortgage schedules by @WMP in https://github.com/kenlasko/monize/pull/1272
+* fix(backup): stop automatic backups going out in plaintext, and rename AI_ENCRYPTION_KEY to ENCRYPTION_KEY by @kenlasko in https://github.com/kenlasko/monize/pull/1275
+* Loan history reports the ledger, never an estimated interest (#1255) by @WMP in https://github.com/kenlasko/monize/pull/1273
+* Stop calling an unreachable market-data provider, and say so once (#1265) by @WMP in https://github.com/kenlasko/monize/pull/1274
+* fix: price scheduled loan installments from the dated ledger balance (#1253) by @kenlasko in https://github.com/kenlasko/monize/pull/1278
+* Fix Account Balances pie treating liabilities as assets by @kenlasko in https://github.com/kenlasko/monize/pull/1279
+* fix(reports): count payments, not chart samples, on the Debt Payoff Timeline (#1244) by @kenlasko in https://github.com/kenlasko/monize/pull/1280
+* fix(loans): judge an overdue installment on the user's calendar day (#1253) by @WMP in https://github.com/kenlasko/monize/pull/1281
+* fix(reports): keep actual and projected apart before the Debt Payoff chart reduction by @WMP in https://github.com/kenlasko/monize/pull/1282
+* Remove the summary total from Upcoming Bills & Deposits by @kenlasko in https://github.com/kenlasko/monize/pull/1283
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.15.0...v1.15.1

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -81,6 +81,7 @@ Notes for past releases live alongside this file, one Markdown file per version
 matching [GitHub Release](https://github.com/kenlasko/monize/releases), newest
 first:
 
+- [v1.15.1](1.15.1.md)
 - [v1.15.0](1.15.0.md)
 - [v1.14.0](1.14.0.md)
 - [v1.13.0](1.13.0.md)


### PR DESCRIPTION
Covers the 42 pull requests merged since the v1.15.0 version bump
(7625c5e..HEAD), grouped the way the archived notes are: scheduled
transactions and bills, loans and mortgages, reports, investments and
Microsoft Money import, look and feel, backup and restore, market data,
everyday fixes, and under the hood.

Two operator-facing items are called out in the opening paragraph
because an upgrade needs them read first: automatic backups were being
written unencrypted where the server held no usable copy of the user's
password (#1269), and AI_ENCRYPTION_KEY is renamed to ENCRYPTION_KEY
(the old name is still read and still wins where both are set).

The All Changes list follows merge order into main rather than pull
request number, matching how the previous notes were generated. Four
entries are retitled from their branch-shaped pull request titles
("Fix for #1247", "Claude/log size email notifications 7i70fd") to say
what shipped; the links are unchanged.

Also adds v1.15.1 to the archive index in docs/release-notes/README.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DRf3cJek5PBxEtTKNpyJys