### PR TITLE
Give hooks the shared intl provider, and fail a test on a missing message

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -730,7 +730,21 @@ Never use synchronous `act(() => {...})` for calls that trigger async side-effec
 
 ## Testing Conventions
 
-**Custom render** (`test/render.tsx`): Wraps components with `ThemeProvider`. Import `render` from `@/test/render` instead of `@testing-library/react`.
+**Custom render** (`test/render.tsx`): Wraps components with `ThemeProvider` and a `NextIntlClientProvider` carrying every English namespace. Import `render` **and `renderHook`** from `@/test/render`, never from `@testing-library/react`.
+
+### A missing message is a failure, and the harness is what supplies them
+
+`useTranslations` does not throw on a missing message -- it reports the error and returns the KEY, so a toast renders `common.importComplete` instead of "Import complete" while the test passes. Vitest's default reporter buffers that stderr line away for passing tests, so it is visible only in a CI log.
+
+The harness looked correct throughout: `render.tsx` has always loaded every English namespace from an `import.meta.glob`. But it wrapped only `render`, and its `export * from '@testing-library/react'` re-exported `renderHook` **untouched** -- so a hook test had no way to get a provider except to build one, and fourteen files did, each with a hand-picked namespace list, every one of them partial. `useImportWizard` reads `import` and `common`; its test supplied `import` alone. A hand-picked list is a snapshot of what its subject used the day it was written, and nothing fails when it rots.
+
+So: **`renderHook` is exported from `@/test/render` too**, wrapped in the same providers, and both compose a caller's own `wrapper` *inside* them rather than replacing them (a test needing StrictMode no longer has to give up intl to get it). A nested provider is worse than it looks -- it SHADOWS the full message set for everything below it, so adding one narrows the catalogue rather than widening it.
+
+`src/test/intl-guard.ts` turns any `MISSING_MESSAGE` / `INVALID_MESSAGE` / `INVALID_KEY` / `INSUFFICIENT_PATH` / `FORMATTING_ERROR` into a test failure, wired both as the shared provider's `onError` and as a `console.error` filter in `setup.ts` -- two doors, so a tree rendered outside the harness is still caught. `ENVIRONMENT_FALLBACK` is deliberately excluded: it is a property of the harness, fires identically for every test, and names nothing an author can act on (the same reasoning as the act guard's second React message).
+
+`intl-harness.guard.test.ts` scans for the two ways round it: `render`/`renderHook` imported from `@testing-library/react`, and a `NextIntlClientProvider` built in a test. Its `ALLOWED_*` sets are deliberate exceptions -- tests that genuinely vary the locale, and the boot-path components defined by having no providers -- while `RTL_IMPORT_BASELINE` is shrink-only: 45 older tests that work today only because their subjects happen not to translate anything. Converting one means deleting its line.
+
+Fix the lookup, never the symptom. Adding a code to the ignore list only restores the silence the guard exists to remove.
 
 **Global mocks** (`test/setup.ts`): `next/navigation` (useRouter, usePathname, useSearchParams), `react-hot-toast`, `localStorage`, `window.scrollTo`, `window.matchMedia`.
 

--- a/frontend/src/components/auth/AuthShell.test.tsx
+++ b/frontend/src/components/auth/AuthShell.test.tsx
@@ -1,15 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { NextIntlClientProvider } from 'next-intl';
 import { render } from '@/test/render';
 import { AuthShell } from './AuthShell';
 import { CARD_CLASS } from '@/components/ui/Card';
 
 function renderShell(ui: React.ReactElement) {
-  return render(
-    <NextIntlClientProvider locale="en" messages={{}}>
-      {ui}
-    </NextIntlClientProvider>,
-  );
+  return render(ui);
 }
 
 describe('AuthShell', () => {
@@ -59,11 +54,9 @@ describe('AuthShell', () => {
     expect(document.querySelector('.max-w-lg')).toBeTruthy();
     expect(document.querySelector('.max-w-md')).toBeFalsy();
     rerender(
-      <NextIntlClientProvider locale="en" messages={{}}>
-        <AuthShell>
-          <div>x</div>
-        </AuthShell>
-      </NextIntlClientProvider>,
+      <AuthShell>
+        <div>x</div>
+      </AuthShell>,
     );
     expect(getByText('x')).toBeInTheDocument();
     expect(document.querySelector('.max-w-md')).toBeTruthy();

--- a/frontend/src/components/import/SelectAccountStep.test.tsx
+++ b/frontend/src/components/import/SelectAccountStep.test.tsx
@@ -11,7 +11,11 @@ describe('SelectAccountStep', () => {
       transactions: [{ date: '2024-01-01', amount: -50, payee: 'Test', memo: '', category: '', number: '' }],
       investmentTransactions: [],
       qifType: 'Bank' as const,
-      accountType: 'Bank',
+      // `qifType` really is 'Bank' (a QIF file-type marker); `accountType` is
+      // the AccountType union and has no such member, so the copied value made
+      // `formatAccountType` look up `common.accountTypes.Bank` and render the
+      // key. Nothing failed, because the assertion below only checks the label.
+      accountType: 'CHEQUING',
       accountName: '',
       transactionCount: 1,
       dateRange: { start: '2024-01-01', end: '2024-01-31' },
@@ -163,8 +167,13 @@ describe('SelectAccountStep', () => {
       { id: 'acc-2', name: 'Brokerage', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE' },
     ] as any[];
     render(<SelectAccountStep {...defaultProps} accounts={accounts} />);
-    // Only non-brokerage accounts should appear in the select
-    expect(screen.getByText(/Chequing/)).toBeInTheDocument();
+    // Only non-brokerage accounts should appear in the select. Match the whole
+    // option label rather than /Chequing/: the fixture's own account type now
+    // resolves to "Chequing" in the Detected Type line too, and a loose pattern
+    // matched that instead of the option. Assert the brokerage's ABSENCE as
+    // well -- that is the claim this test makes, and nothing checked it.
+    expect(screen.getByText('Chequing (Chequing)')).toBeInTheDocument();
+    expect(screen.queryByText(/Brokerage/)).not.toBeInTheDocument();
   });
 
   it('clicking create new account button calls setShowCreateAccount', () => {

--- a/frontend/src/components/investments/CashRegisterFilters.test.tsx
+++ b/frontend/src/components/investments/CashRegisterFilters.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StrictMode } from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@/test/render';
 import { renderHook } from '@testing-library/react';
-import { NextIntlClientProvider } from 'next-intl';
 import {
   CashFilterBar,
   CashFilterToggleButton,
@@ -11,8 +10,6 @@ import {
   useCashFilterOptions,
 } from './CashRegisterFilters';
 import { transactionsApi } from '@/lib/transactions';
-import investmentsNs from '@/i18n/messages/en/investments.json';
-import commonNs from '@/i18n/messages/en/common.json';
 
 vi.mock('@/lib/transactions', () => ({
   transactionsApi: { getRegisterFilterOptions: vi.fn() },
@@ -33,14 +30,7 @@ const OPTIONS = {
 };
 
 function renderWithMessages(ui: React.ReactElement) {
-  return render(
-    <NextIntlClientProvider
-      locale="en"
-      messages={{ investments: investmentsNs, common: commonNs }}
-    >
-      {ui}
-    </NextIntlClientProvider>,
-  );
+  return render(ui);
 }
 
 describe('countActiveCashFilters', () => {

--- a/frontend/src/components/investments/InvestmentRegisterPanel.test.tsx
+++ b/frontend/src/components/investments/InvestmentRegisterPanel.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act, waitFor, cleanup } from '@/test/render';
-import { NextIntlClientProvider } from 'next-intl';
 import toast from 'react-hot-toast';
 import { InvestmentRegisterPanel } from './InvestmentRegisterPanel';
 import { accountsApi } from '@/lib/accounts';
@@ -9,10 +8,6 @@ import { transactionsApi } from '@/lib/transactions';
 import { invalidateBalanceCaches } from '@/lib/apiCache';
 import type { Account } from '@/types/account';
 import { TransactionStatus, type Transaction } from '@/types/transaction';
-import investmentMessages from '@/i18n/messages/en/accountDetail-investment.json';
-import investmentsNs from '@/i18n/messages/en/investments.json';
-import transactionsNs from '@/i18n/messages/en/transactions.json';
-import commonNs from '@/i18n/messages/en/common.json';
 
 vi.mock('@/lib/investments', () => ({
   investmentsApi: {
@@ -161,21 +156,11 @@ async function renderPanel(
 ) {
   await act(async () => {
     render(
-      <NextIntlClientProvider
-        locale="en"
-        messages={{
-          'accountDetail-investment': investmentMessages,
-          investments: investmentsNs,
-          transactions: transactionsNs,
-          common: commonNs,
-        }}
-      >
-        <InvestmentRegisterPanel
-          holdingsAccount={holdingsAccount}
-          cashAccount={cashAccount}
-          onDataChanged={onDataChanged}
-        />
-      </NextIntlClientProvider>,
+      <InvestmentRegisterPanel
+        holdingsAccount={holdingsAccount}
+        cashAccount={cashAccount}
+        onDataChanged={onDataChanged}
+      />,
     );
   });
 }

--- a/frontend/src/components/investments/InvestmentViewToggle.test.tsx
+++ b/frontend/src/components/investments/InvestmentViewToggle.test.tsx
@@ -1,17 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@/test/render';
-import { NextIntlClientProvider } from 'next-intl';
 import { InvestmentViewToggle } from './InvestmentViewToggle';
-import messages from '@/i18n/messages/en/investments.json';
 
 function renderToggle(
   value: 'brokerage' | 'cash',
   onChange = vi.fn(),
 ) {
   render(
-    <NextIntlClientProvider locale="en" messages={{ investments: messages }}>
-      <InvestmentViewToggle value={value} onChange={onChange} />
-    </NextIntlClientProvider>,
+    <InvestmentViewToggle value={value} onChange={onChange} />,
   );
   return { onChange };
 }

--- a/frontend/src/components/ui/DensityToggle.test.tsx
+++ b/frontend/src/components/ui/DensityToggle.test.tsx
@@ -1,16 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@/test/render';
-import { NextIntlClientProvider } from 'next-intl';
 import { DensityToggle, DensityToggleBar } from './DensityToggle';
 import { useDensityStore } from '@/store/densityStore';
 import commonNs from '@/i18n/messages/en/common.json';
 
 function renderToggle(ui: React.ReactElement) {
-  return render(
-    <NextIntlClientProvider locale="en" messages={{ common: commonNs }}>
-      {ui}
-    </NextIntlClientProvider>,
-  );
+  return render(ui);
 }
 
 describe('DensityToggle', () => {

--- a/frontend/src/components/ui/ListTopToolbar.test.tsx
+++ b/frontend/src/components/ui/ListTopToolbar.test.tsx
@@ -1,16 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/render';
-import { NextIntlClientProvider } from 'next-intl';
 import { ListTopToolbar } from './ListTopToolbar';
 import { useDensityStore } from '@/store/densityStore';
-import commonNs from '@/i18n/messages/en/common.json';
 
 function renderToolbar(ui: React.ReactElement) {
-  return render(
-    <NextIntlClientProvider locale="en" messages={{ common: commonNs }}>
-      {ui}
-    </NextIntlClientProvider>,
-  );
+  return render(ui);
 }
 
 const PAGING = {

--- a/frontend/src/hooks/useImportWizard.test.tsx
+++ b/frontend/src/hooks/useImportWizard.test.tsx
@@ -1,16 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
-import { ReactNode } from 'react';
-import { NextIntlClientProvider } from 'next-intl';
-import importEn from '@/i18n/messages/en/import.json';
+import { renderHook, act, waitFor } from '@/test/render';
 
-// Hook emits toasts via next-intl; resolve them against the real English
-// catalog so renderHook has an intl context.
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <NextIntlClientProvider locale="en" messages={{ import: importEn }}>
-    {children}
-  </NextIntlClientProvider>
-);
 import { useImportWizard } from './useImportWizard';
 
 // --- Mocks ---
@@ -228,7 +218,7 @@ describe('useImportWizard - initial load', () => {
     mockGetCategories.mockResolvedValue([baseCategory()]);
     mockGetSecurities.mockResolvedValue([baseSecurity()]);
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
 
     await waitFor(() => {
       expect(result.current.accounts).toHaveLength(1);
@@ -242,7 +232,7 @@ describe('useImportWizard - initial load', () => {
 
   it('handles initial load failure by showing toast error', async () => {
     mockGetAllAccounts.mockRejectedValue(new Error('boom'));
-    renderHook(() => useImportWizard(), { wrapper });
+    renderHook(() => useImportWizard());
     await waitFor(() => {
       expect(mockGetAllAccounts).toHaveBeenCalled();
     });
@@ -250,7 +240,7 @@ describe('useImportWizard - initial load', () => {
 
   it('handles getColumnMappings rejection without breaking load', async () => {
     mockGetColumnMappings.mockRejectedValueOnce(new Error('nope'));
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => {
       expect(result.current.savedColumnMappings).toEqual([]);
     });
@@ -261,7 +251,7 @@ describe('useImportWizard - initial load', () => {
     const account = baseAccount({ id: 'acc-1' });
     mockGetAllAccounts.mockResolvedValue([account]);
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
 
     await waitFor(() => {
       expect(result.current.preselectedAccount?.id).toBe('acc-1');
@@ -272,7 +262,7 @@ describe('useImportWizard - initial load', () => {
     mockSearchParamsGet = (key) => (key === 'accountId' ? 'unknown' : null);
     mockGetAllAccounts.mockResolvedValue([baseAccount()]);
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => {
       expect(result.current.accounts).toHaveLength(1);
     });
@@ -285,7 +275,7 @@ describe('useImportWizard - QIF file upload', () => {
     mockGetAllAccounts.mockResolvedValue([baseAccount()]);
     mockParseQif.mockResolvedValue(baseParsedQif());
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -303,7 +293,7 @@ describe('useImportWizard - QIF file upload', () => {
     mockGetAllAccounts.mockResolvedValue([baseAccount({ id: 'acc-1' })]);
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: ['Food'] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -316,7 +306,7 @@ describe('useImportWizard - QIF file upload', () => {
 
   it('parses OFX file (.ofx detected by extension)', async () => {
     mockParseOfx.mockResolvedValue(baseParsedQif());
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -328,7 +318,7 @@ describe('useImportWizard - QIF file upload', () => {
   });
 
   it('rejects when files of mixed types are uploaded', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -342,7 +332,7 @@ describe('useImportWizard - QIF file upload', () => {
   });
 
   it('handles empty file selection (no-op)', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -353,7 +343,7 @@ describe('useImportWizard - QIF file upload', () => {
 
   it('parses bulk QIF files', async () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: [] }));
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -368,7 +358,7 @@ describe('useImportWizard - QIF file upload', () => {
 
   it('handles QIF parse error', async () => {
     mockParseQif.mockRejectedValue(new Error('bad'));
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -390,7 +380,7 @@ describe('useImportWizard - QIF file upload', () => {
     });
     mockGetSecurities.mockResolvedValue([]);
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     const content = '!Account\nNAcct1\n^\n!Account\nNAcct2\n^\n!Type:Cat\nNFood\n^';
@@ -407,7 +397,7 @@ describe('useImportWizard - QIF file upload', () => {
     mockParseQifMulti.mockResolvedValue({ isMultiAccount: false, categoryDefs: [], tagDefs: [], accounts: [], totalTransactionCount: 0, securities: [], detectedDateFormat: 'MM/DD/YYYY', sampleDates: [] });
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: [] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     const content = '!Account\nNAcct1\n^\n!Account\nNAcct2\n^';
@@ -422,7 +412,7 @@ describe('useImportWizard - QIF file upload', () => {
 describe('useImportWizard - CSV upload', () => {
   it('parses CSV headers and goes to csvColumnMapping step', async () => {
     mockParseCsvHeaders.mockResolvedValue({ headers: ['Date', 'Amount', 'Memo'], sampleRows: [['1/1/24', '10', 'x']], rowCount: 1 });
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -436,7 +426,7 @@ describe('useImportWizard - CSV upload', () => {
 
   it('handles bulk CSV upload', async () => {
     mockParseCsvHeaders.mockResolvedValue({ headers: ['Date', 'Amount'], sampleRows: [], rowCount: 0 });
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -451,7 +441,7 @@ describe('useImportWizard - CSV upload', () => {
   });
 
   it('CSV column mapping change updates state', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     act(() => {
@@ -461,7 +451,7 @@ describe('useImportWizard - CSV upload', () => {
   });
 
   it('CSV transfer rules change updates state', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     act(() => {
@@ -472,7 +462,7 @@ describe('useImportWizard - CSV upload', () => {
 
   it('CSV delimiter change re-parses headers', async () => {
     mockParseCsvHeaders.mockResolvedValue({ headers: ['A', 'B'], sampleRows: [], rowCount: 0 });
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -488,7 +478,7 @@ describe('useImportWizard - CSV upload', () => {
   });
 
   it('CSV delimiter change with no files is a no-op', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -499,7 +489,7 @@ describe('useImportWizard - CSV upload', () => {
 
   it('CSV delimiter change handles parse error', async () => {
     mockParseCsvHeaders.mockResolvedValue({ headers: ['A'], sampleRows: [], rowCount: 0 });
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -515,7 +505,7 @@ describe('useImportWizard - CSV upload', () => {
 
   it('CSV hasHeader change re-parses headers', async () => {
     mockParseCsvHeaders.mockResolvedValue({ headers: ['A'], sampleRows: [], rowCount: 0 });
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -529,7 +519,7 @@ describe('useImportWizard - CSV upload', () => {
   });
 
   it('CSV hasHeader change with no files is a no-op', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -542,7 +532,7 @@ describe('useImportWizard - CSV upload', () => {
     mockParseCsvHeaders.mockResolvedValue({ headers: ['Date', 'Amount'], sampleRows: [], rowCount: 0 });
     mockParseCsv.mockResolvedValue(baseParsedQif({ categories: [], transferAccounts: [] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -564,7 +554,7 @@ describe('useImportWizard - CSV upload', () => {
       .mockResolvedValueOnce({ headers: ['Different'], sampleRows: [], rowCount: 0 });
     mockParseCsv.mockResolvedValue(baseParsedQif({ categories: [] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -582,7 +572,7 @@ describe('useImportWizard - CSV upload', () => {
   });
 
   it('CSV mapping complete with no files is a no-op', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -594,7 +584,7 @@ describe('useImportWizard - CSV upload', () => {
   it('CSV mapping complete handles parse error', async () => {
     mockParseCsvHeaders.mockResolvedValue({ headers: ['A'], sampleRows: [], rowCount: 0 });
     mockParseCsv.mockRejectedValue(new Error('bad'));
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -611,7 +601,7 @@ describe('useImportWizard - CSV upload', () => {
     mockCreateColumnMapping.mockResolvedValue({
       id: 'm1', name: 'Test', columnMappings: {}, transferRules: [], createdAt: '', updatedAt: '',
     });
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -624,7 +614,7 @@ describe('useImportWizard - CSV upload', () => {
     mockCreateColumnMapping
       .mockResolvedValueOnce({ id: 'm1', name: 'A', columnMappings: {}, transferRules: [], createdAt: '', updatedAt: '' })
       .mockResolvedValueOnce({ id: 'm1', name: 'A', columnMappings: {}, transferRules: [], createdAt: '', updatedAt: '' });
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => { await result.current.handleSaveColumnMapping('A'); });
@@ -635,7 +625,7 @@ describe('useImportWizard - CSV upload', () => {
 
   it('CSV save column mapping handles error', async () => {
     mockCreateColumnMapping.mockRejectedValue(new Error('boom'));
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -645,7 +635,7 @@ describe('useImportWizard - CSV upload', () => {
   });
 
   it('CSV load column mapping restores config and rules', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     act(() => {
@@ -662,7 +652,7 @@ describe('useImportWizard - CSV upload', () => {
   });
 
   it('CSV load column mapping with no transfer rules defaults to empty', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     act(() => {
@@ -681,7 +671,7 @@ describe('useImportWizard - CSV upload', () => {
       id: 'm1', name: 'X', columnMappings: {}, transferRules: [], createdAt: '', updatedAt: '',
     });
     mockDeleteColumnMapping.mockResolvedValue(undefined);
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => { await result.current.handleSaveColumnMapping('X'); });
@@ -693,7 +683,7 @@ describe('useImportWizard - CSV upload', () => {
 
   it('CSV delete column mapping handles error', async () => {
     mockDeleteColumnMapping.mockRejectedValue(new Error('boom'));
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => { await result.current.handleDeleteColumnMapping('m1'); });
@@ -721,7 +711,7 @@ describe('useImportWizard - CSV investment mode', () => {
     mockLooksLikeInvestmentCsv.mockReturnValue(true);
     mockAutoMatchInvestmentColumns.mockReturnValue({ actionColumn: 1, securityColumn: 2, quantityColumn: 3 });
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await uploadCsv(result);
@@ -738,7 +728,7 @@ describe('useImportWizard - CSV investment mode', () => {
     mockParseCsvHeaders.mockResolvedValue({ headers: ['Date', 'Amount'], sampleRows: [], rowCount: 0 });
     mockLooksLikeInvestmentCsv.mockReturnValue(false);
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await uploadCsv(result, 'bank.csv');
@@ -751,7 +741,7 @@ describe('useImportWizard - CSV investment mode', () => {
     mockParseCsvHeaders.mockResolvedValue({ headers: investmentHeaders, sampleRows: [], rowCount: 0 });
     mockAutoMatchInvestmentColumns.mockReturnValue({ actionColumn: 1, securityColumn: 2 });
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await uploadCsv(result);
@@ -794,7 +784,7 @@ describe('useImportWizard - CSV investment mode', () => {
       actionColumn: 1, securityColumn: 2, quantityColumn: 3, priceColumn: 4, commissionColumn: 5,
     });
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await uploadCsv(result);
@@ -834,7 +824,7 @@ describe('useImportWizard - CSV investment mode', () => {
     }));
     mockImportCsv.mockResolvedValue(importResult({ imported: 4 }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await uploadCsv(result);
@@ -874,7 +864,7 @@ describe('useImportWizard - CSV investment mode', () => {
     }));
     mockImportCsv.mockResolvedValue(importResult({ imported: 2 }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await uploadCsv(result, 'bank.csv');
@@ -903,7 +893,7 @@ describe('useImportWizard - CSV investment mode', () => {
       securities: ['AAPL'],
     }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await uploadCsv(result, 'bank.csv');
@@ -928,7 +918,7 @@ describe('useImportWizard - CSV investment mode', () => {
       investmentSummary,
     }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await uploadCsv(result);
@@ -955,7 +945,7 @@ describe('useImportWizard - CSV investment mode', () => {
       securities: [],
     }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(2));
 
     await uploadCsv(result);
@@ -975,7 +965,7 @@ describe('useImportWizard - account creation', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: [] }));
     mockCreateAccount.mockResolvedValue(baseAccount({ id: 'new-1', name: 'New' }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     // upload a file so importFiles is populated
@@ -999,7 +989,7 @@ describe('useImportWizard - account creation', () => {
       brokerageAccount: baseAccount({ id: 'brk-1', name: 'Brokerage', accountSubType: 'INVESTMENT_BROKERAGE' }),
     });
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1020,7 +1010,7 @@ describe('useImportWizard - account creation', () => {
   });
 
   it('rejects account creation when name is empty', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1033,7 +1023,7 @@ describe('useImportWizard - account creation', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: [] }));
     mockCreateAccount.mockRejectedValue(new Error('fail'));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1050,7 +1040,7 @@ describe('useImportWizard - account creation', () => {
 describe('useImportWizard - mapping handlers', () => {
   it('handleAccountMappingChange updates accountId', async () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ transferAccounts: ['Other'], categories: [] }));
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1076,7 +1066,7 @@ describe('useImportWizard - mapping handlers', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ securities: ['XYZ'], categories: [] }));
     mockGetSecurities.mockResolvedValue([baseSecurity({ id: 'sec-aapl', symbol: 'AAPL', name: 'Apple' })]);
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.securities).toHaveLength(1));
 
     await act(async () => {
@@ -1117,7 +1107,7 @@ describe('useImportWizard - mapping handlers', () => {
 
 describe('useImportWizard - security lookup', () => {
   it('rejects too-short query', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1129,7 +1119,7 @@ describe('useImportWizard - security lookup', () => {
   it('shows toast when no candidates returned', async () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ securities: ['XYZ'], categories: [] }));
     mockLookupCandidates.mockResolvedValue([]);
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1148,7 +1138,7 @@ describe('useImportWizard - security lookup', () => {
       { symbol: 'XYZ', name: 'XYZ Co', securityType: 'STOCK', exchange: 'NYSE', currencyCode: 'USD' },
     ]);
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1168,7 +1158,7 @@ describe('useImportWizard - security lookup', () => {
       { symbol: 'XYZ', name: 'B', securityType: 'STOCK', exchange: 'TSX' },
     ]);
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1194,7 +1184,7 @@ describe('useImportWizard - security lookup', () => {
       { symbol: 'B', name: 'B', securityType: 'STOCK' },
     ]);
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1213,7 +1203,7 @@ describe('useImportWizard - security lookup', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ securities: ['XYZ'], categories: [] }));
     mockLookupCandidates.mockResolvedValue([{ symbol: 'XYZ', name: 'X', securityType: 'STOCK' }]);
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1230,7 +1220,7 @@ describe('useImportWizard - security lookup', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ securities: ['XYZ'], categories: [] }));
     mockLookupCandidates.mockRejectedValue(new Error('boom'));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1249,7 +1239,7 @@ describe('useImportWizard - import handlers', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: [] }));
     mockImportQif.mockResolvedValue(importResult({ imported: 5 }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1268,7 +1258,7 @@ describe('useImportWizard - import handlers', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: [] }));
     mockImportQif.mockResolvedValue(importResult({ imported: 3, errors: 2 }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1288,7 +1278,7 @@ describe('useImportWizard - import handlers', () => {
     mockParseCsv.mockResolvedValue(baseParsedQif({ categories: [] }));
     mockImportCsv.mockResolvedValue(importResult({ imported: 3 }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1310,7 +1300,7 @@ describe('useImportWizard - import handlers', () => {
     mockParseOfx.mockResolvedValue(baseParsedQif({ categories: [] }));
     mockImportOfx.mockResolvedValue(importResult({ imported: 2 }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1325,7 +1315,7 @@ describe('useImportWizard - import handlers', () => {
   });
 
   it('rejects import with no files', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
     await act(async () => {
       await result.current.handleImport();
@@ -1337,7 +1327,7 @@ describe('useImportWizard - import handlers', () => {
     mockGetAllAccounts.mockResolvedValue([]);
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: [] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1355,7 +1345,7 @@ describe('useImportWizard - import handlers', () => {
     mockImportQif.mockResolvedValueOnce(importResult({ imported: 1 }))
                   .mockResolvedValueOnce(importResult({ imported: 0, errors: 1, errorMessages: ['x'] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1380,7 +1370,7 @@ describe('useImportWizard - import handlers', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: [] }));
     mockImportQif.mockRejectedValue(new Error('boom'));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1414,7 +1404,7 @@ describe('useImportWizard - import handlers', () => {
       }))
       .mockResolvedValueOnce(importResult({ imported: 1 }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1452,7 +1442,7 @@ describe('useImportWizard - import handlers', () => {
       loanAccountsNeedingSetup: [{ accountId: 'l1', accountName: 'Loan1', accountType: 'LOAN' }],
     }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1476,7 +1466,7 @@ describe('useImportWizard - import handlers', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: [] }));
     mockImportQif.mockRejectedValue(new Error('catastrophic'));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1501,7 +1491,7 @@ describe('useImportWizard - multi-account import', () => {
     });
     mockImportQifMulti.mockResolvedValue(importResult({ imported: 5 }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     const content = '!Account\nNA\n^\n!Account\nNB\n^';
@@ -1518,7 +1508,7 @@ describe('useImportWizard - multi-account import', () => {
   });
 
   it('multi-account import is no-op without content', async () => {
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1535,7 +1525,7 @@ describe('useImportWizard - multi-account import', () => {
     });
     mockImportQifMulti.mockRejectedValue(new Error('boom'));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1555,7 +1545,7 @@ describe('useImportWizard - multi-account import', () => {
     });
     mockImportQifMulti.mockResolvedValue(importResult({ imported: 5, errors: 2 }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(mockGetCurrencies).toHaveBeenCalled());
 
     await act(async () => {
@@ -1574,7 +1564,7 @@ describe('useImportWizard - import more / reset', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ categories: [] }));
     mockImportQif.mockResolvedValue(importResult());
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1599,7 +1589,7 @@ describe('useImportWizard - derived options', () => {
       baseCategory({ id: 'c1', name: 'Food' }),
       baseCategory({ id: 'c2', name: 'Sub', parentId: 'c1' }),
     ]);
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.categories).toHaveLength(2));
     expect(result.current.categoryOptions.length).toBeGreaterThan(0);
   });
@@ -1609,7 +1599,7 @@ describe('useImportWizard - derived options', () => {
       baseCategory({ id: 'c1', name: 'A' }),
       baseCategory({ id: 'c2', name: 'B', parentId: 'c1' }),
     ]);
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.categories).toHaveLength(2));
     expect(result.current.parentCategoryOptions.find(o => o.value === 'c1')).toBeTruthy();
     expect(result.current.parentCategoryOptions.find(o => o.value === 'c2')).toBeFalsy();
@@ -1622,7 +1612,7 @@ describe('useImportWizard - derived options', () => {
       baseAccount({ id: 'a3', name: 'Mortgage', accountType: 'MORTGAGE' }),
       baseAccount({ id: 'a4', name: 'Brk', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE' }),
     ]);
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(4));
 
     const opts = result.current.getAccountOptions();
@@ -1635,7 +1625,7 @@ describe('useImportWizard - derived options', () => {
 
   it('getSecurityOptions includes a skip option and all securities', async () => {
     mockGetSecurities.mockResolvedValue([baseSecurity({ id: 's1', symbol: 'A', name: 'Apple' })]);
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.securities).toHaveLength(1));
     const opts = result.current.getSecurityOptions();
     expect(opts[0].value).toBe('');
@@ -1644,7 +1634,7 @@ describe('useImportWizard - derived options', () => {
 
   it('currencyOptions sorts default currency first', async () => {
     mockPrefDefaultCurrency = 'CAD';
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.currencyOptions.length).toBeGreaterThan(0));
     expect(result.current.currencyOptions[0].value).toBe('CAD');
   });
@@ -1658,7 +1648,7 @@ describe('useImportWizard - derived options', () => {
       { code: 'CAD', name: 'CA Dollar', symbol: 'CA$', decimalPlaces: 2, isActive: true },
       { code: 'AUD', name: 'AU Dollar', symbol: 'A$', decimalPlaces: 2, isActive: true },
     ]);
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.currencyOptions.length).toBe(3));
     expect(result.current.currencyOptions[0].value).toBe('CAD');
     expect(result.current.currencyOptions.slice(1).map((o) => o.value)).toEqual(['AUD', 'USD']);
@@ -1673,7 +1663,7 @@ describe('useImportWizard - selectAccount auto-select effect', () => {
     ]);
     mockParseQif.mockResolvedValue(baseParsedQif({ accountType: 'CHEQUING', categories: [] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(2));
 
     await act(async () => {
@@ -1691,7 +1681,7 @@ describe('useImportWizard - selectAccount auto-select effect', () => {
     ]);
     mockParseQif.mockResolvedValue(baseParsedQif({ accountType: 'CHEQUING', categories: [] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1709,7 +1699,7 @@ describe('useImportWizard - selectAccount auto-select effect', () => {
     ]);
     mockParseQif.mockResolvedValue(baseParsedQif({ accountType: 'INVESTMENT', categories: [] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(2));
 
     await act(async () => {
@@ -1728,7 +1718,7 @@ describe('useImportWizard - mapAccounts effect', () => {
     ]);
     mockParseQif.mockResolvedValue(baseParsedQif({ transferAccounts: ['Savings Acct'], categories: [] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1751,7 +1741,7 @@ describe('useImportWizard - mapSecurities bulk lookup effect', () => {
       symbol: 'UNKN', name: 'Unknown Co', securityType: 'STOCK', exchange: 'NYSE', currencyCode: 'USD',
     });
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1773,7 +1763,7 @@ describe('useImportWizard - mapSecurities bulk lookup effect', () => {
     mockParseQif.mockResolvedValue(baseParsedQif({ securities: ['UNKN'], categories: [] }));
     mockLookupSecurity.mockRejectedValue(new Error('boom'));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1794,7 +1784,7 @@ describe('useImportWizard - mapSecurities bulk lookup effect', () => {
     mockGetSecurities.mockResolvedValue([]);
     mockParseQif.mockResolvedValue(baseParsedQif({ securities: [], categories: [] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1811,7 +1801,7 @@ describe('useImportWizard - shouldShowMapAccounts', () => {
     mockGetAllAccounts.mockResolvedValue([baseAccount()]);
     mockParseQif.mockResolvedValue(baseParsedQif({ accountType: 'INVESTMENT', transferAccounts: ['X'], categories: [] }));
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {
@@ -1865,7 +1855,7 @@ describe('useImportWizard - .mny wipe confirmation', () => {
       completedAt: null,
     });
 
-    const { result } = renderHook(() => useImportWizard(), { wrapper });
+    const { result } = renderHook(() => useImportWizard());
     await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
     await act(async () => {

--- a/frontend/src/hooks/useInvestmentData.test.tsx
+++ b/frontend/src/hooks/useInvestmentData.test.tsx
@@ -1,17 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { type ReactNode } from 'react';
-import { NextIntlClientProvider } from 'next-intl';
-import investmentsEn from '@/i18n/messages/en/investments.json';
+import { renderHook, act } from '@/test/render';
 import { useInvestmentData } from './useInvestmentData';
-
-// useInvestmentData emits its delete-failure toast through next-intl; resolve
-// it against the real English catalog so assertions on visible text stay accurate.
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <NextIntlClientProvider locale="en" messages={{ investments: investmentsEn }}>
-    {children}
-  </NextIntlClientProvider>
-);
 
 // --- API mocks ---
 const mockDeleteTransaction = vi.fn();
@@ -143,7 +132,7 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
     let resolveDelete!: () => void;
     mockDeleteTransaction.mockReturnValue(new Promise<void>(res => { resolveDelete = res; }));
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
 
     // Seed state with two transactions
     await act(async () => {
@@ -178,7 +167,7 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
       pagination: { page: 1, limit: 25, total: 2, totalPages: 1, hasMore: false },
     });
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     holdReloadOpen();
@@ -199,7 +188,7 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
       pagination: { page: 1, limit: 25, total: 10, totalPages: 1, hasMore: false },
     });
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     holdReloadOpen();
@@ -222,7 +211,7 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
       pagination: { page: 1, limit: 25, total: 10, totalPages: 1, hasMore: false },
     });
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     // Filter to a single account.
@@ -243,7 +232,7 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
   it('calls deleteTransaction API with the correct id', async () => {
     mockDeleteTransaction.mockResolvedValue(undefined);
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     await act(async () => {
@@ -258,7 +247,7 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
     const freshSummary = { totalValue: 4000, totalCost: 3500, totalGain: 500 };
     mockGetPortfolioSummary.mockResolvedValue(freshSummary);
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     await act(async () => {
@@ -280,7 +269,7 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
     mockGetPortfolioSummary.mockResolvedValue(mockSummary);
     mockGetTransactions.mockResolvedValue({ data: [], pagination: null });
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     expect(result.current.isLoading).toBe(false);
@@ -298,7 +287,7 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
   it('does not call setIsLoading on successful delete (no full reload)', async () => {
     mockDeleteTransaction.mockResolvedValue(undefined);
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     // isLoading should be false after initial load
@@ -318,7 +307,7 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
     mockGetPortfolioSummary.mockResolvedValue(mockSummary);
     mockGetTransactions.mockResolvedValue({ data: [makeTx('t1'), makeTx('t2')], pagination: null });
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     await act(async () => {
@@ -335,7 +324,7 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
     mockGetPortfolioSummary.mockResolvedValue(mockSummary);
     mockGetTransactions.mockResolvedValue({ data: [], pagination: null });
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     const summaryCallsBefore = mockGetPortfolioSummary.mock.calls.length;
@@ -383,7 +372,7 @@ describe('useInvestmentData – accountId URL filter', () => {
     mockSearchParamsGet = (key: string) => key === 'accountId' ? 'broker-1' : null;
     mockGetInvestmentAccounts.mockResolvedValue([brokerageAccount, cashAccount]);
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     expect(result.current.selectedAccountIds).toEqual(['broker-1']);
@@ -393,7 +382,7 @@ describe('useInvestmentData – accountId URL filter', () => {
     mockSearchParamsGet = (key: string) => key === 'accountId' ? 'broker-1' : null;
     mockGetInvestmentAccounts.mockResolvedValue([brokerageAccount, cashAccount]);
 
-    renderHook(() => useInvestmentData(), { wrapper });
+    renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     expect(mockRouterReplace).toHaveBeenCalledWith('/investments', { scroll: false });
@@ -403,7 +392,7 @@ describe('useInvestmentData – accountId URL filter', () => {
     mockSearchParamsGet = (key: string) => key === 'accountId' ? 'nonexistent-id' : null;
     mockGetInvestmentAccounts.mockResolvedValue([brokerageAccount, cashAccount]);
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     // Should remain empty (default) since the account was not found
@@ -416,7 +405,7 @@ describe('useInvestmentData – accountId URL filter', () => {
     mockSearchParamsGet = (key: string) => key === 'accountId' ? 'cash-1' : null;
     mockGetInvestmentAccounts.mockResolvedValue([brokerageAccount, cashAccount]);
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     expect(result.current.selectedAccountIds).toEqual([]);
@@ -426,7 +415,7 @@ describe('useInvestmentData – accountId URL filter', () => {
     mockSearchParamsGet = () => null;
     mockGetInvestmentAccounts.mockResolvedValue([brokerageAccount, cashAccount]);
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     expect(result.current.selectedAccountIds).toEqual([]);
@@ -454,7 +443,7 @@ describe('useInvestmentData – pagination, filters, handlers', () => {
   });
 
   it('handleAccountChange updates selection and resets pages', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => {
       result.current.handleAccountChange(['b1']);
@@ -464,7 +453,7 @@ describe('useInvestmentData – pagination, filters, handlers', () => {
   });
 
   it('handleSecurityClick opens the security detail page', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => {
       result.current.handleSecurityClick('sec-1');
@@ -475,7 +464,7 @@ describe('useInvestmentData – pagination, filters, handlers', () => {
   });
 
   it('handleFiltersChange updates filter and resets page', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => {
       result.current.handleFiltersChange({ action: 'BUY' });
@@ -485,7 +474,7 @@ describe('useInvestmentData – pagination, filters, handlers', () => {
 
   it('goToPage updates page when within bounds', async () => {
     mockGetTransactions.mockResolvedValue({ data: [], pagination: { page: 1, limit: 25, total: 50, totalPages: 2, hasMore: false } });
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => { result.current.goToPage(2); });
     expect(result.current.currentPage).toBe(2);
@@ -493,7 +482,7 @@ describe('useInvestmentData – pagination, filters, handlers', () => {
 
   it('goToPage rejects out-of-bounds pages', async () => {
     mockGetTransactions.mockResolvedValue({ data: [], pagination: { page: 1, limit: 25, total: 1, totalPages: 1, hasMore: false } });
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => { result.current.goToPage(99); });
     expect(result.current.currentPage).toBe(1);
@@ -502,7 +491,7 @@ describe('useInvestmentData – pagination, filters, handlers', () => {
   });
 
   it('clearCashFilters resets all cash filter state', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => {
       result.current.setCashFilters({
@@ -520,21 +509,21 @@ describe('useInvestmentData – pagination, filters, handlers', () => {
   });
 
   it('handleCashClick navigates to transactions page', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => { result.current.handleCashClick('cash-x'); });
     expect(mockRouterPush).toHaveBeenCalledWith('/transactions?accountId=cash-x');
   });
 
   it('goToCashPage updates page when within bounds', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => { result.current.goToCashPage(2); });
     expect(result.current.cashCurrentPage).toBe(2);
   });
 
   it('handleCashTransactionUpdate replaces matching transaction', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => {
       result.current.handleCashTransactionUpdate({ id: 'x', amount: 5 } as any);
@@ -542,20 +531,20 @@ describe('useInvestmentData – pagination, filters, handlers', () => {
   });
 
   it('getSelectedBrokerageAccountId returns first selected', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => { result.current.handleAccountChange(['b1']); });
     expect(result.current.getSelectedBrokerageAccountId()).toBe('b1');
   });
 
   it('getSelectedBrokerageAccountId returns undefined when none selected', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     expect(result.current.getSelectedBrokerageAccountId()).toBeUndefined();
   });
 
   it('cashAccountIds derives from selected brokerages with linkedAccountId', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     expect(result.current.cashAccountIds).toEqual(['c1']);
 
@@ -564,7 +553,7 @@ describe('useInvestmentData – pagination, filters, handlers', () => {
   });
 
   it('hasActiveCashFilters returns false when none set', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     expect(result.current.hasActiveCashFilters).toBe(false);
     expect(result.current.activeCashFilterCount).toBe(0);
@@ -591,7 +580,7 @@ describe('useInvestmentData – cash transaction loading', () => {
   });
 
   it('loadCashTransactionsIfNeeded loads when view is "cash"', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => {
       result.current.loadCashTransactionsIfNeeded('cash');
@@ -600,7 +589,7 @@ describe('useInvestmentData – cash transaction loading', () => {
   });
 
   it('loadCashTransactionsIfNeeded skips when view is not "cash"', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     act(() => {
       result.current.loadCashTransactionsIfNeeded('brokerage');
@@ -608,7 +597,7 @@ describe('useInvestmentData – cash transaction loading', () => {
   });
 
   it('refreshAfterWrite reloads both registers and bumps the chart key', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     const summaryCallsBefore = mockGetPortfolioSummary.mock.calls.length;
@@ -625,7 +614,7 @@ describe('useInvestmentData – cash transaction loading', () => {
   });
 
   it('loadCashFilterData loads categories and payees', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => {
       await result.current.loadCashFilterData();
@@ -633,7 +622,7 @@ describe('useInvestmentData – cash transaction loading', () => {
   });
 
   it('handleCashFormSuccess closes form and reloads data', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     // openCashCreate then handleCashFormSuccess
     act(() => result.current.openCashCreate());
@@ -641,19 +630,19 @@ describe('useInvestmentData – cash transaction loading', () => {
   });
 
   it('handleNewTransaction opens create modal', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     act(() => result.current.handleNewTransaction());
   });
 
   it('handleEditTransaction opens edit modal', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     act(() => result.current.handleEditTransaction(makeTx('t1') as any));
   });
 
   it('handleFormSuccess reloads portfolio data', async () => {
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     await act(async () => result.current.handleFormSuccess());
   });
@@ -686,7 +675,7 @@ describe('useInvestmentData – selectableAccounts ordering', () => {
       makeAccount('2', 'Mango Brokerage'),
     ]);
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     expect(result.current.selectableAccounts.map(a => a.name)).toEqual([
@@ -703,7 +692,7 @@ describe('useInvestmentData – selectableAccounts ordering', () => {
       makeAccount('s1', 'Standalone Fund', undefined as unknown as string),
     ]);
 
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
 
     // Cash sub-accounts are filtered out; the remaining two stay alphabetical.
@@ -729,7 +718,7 @@ describe('useInvestmentData – pruning stale account IDs', () => {
     mockGetInvestmentAccounts.mockResolvedValue([
       { id: 'broker-1', name: 'B', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE', linkedAccountId: null, currencyCode: 'USD', currentBalance: 0 },
     ]);
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     expect(result.current.selectedAccountIds).toEqual([]);
   });
@@ -757,7 +746,7 @@ describe('useInvestmentData – edit URL parameter flow', () => {
     const originalGetTx = (investmentsApiMod.investmentsApi as any).getTransaction;
     (investmentsApiMod.investmentsApi as any).getTransaction = mockGetTx;
     try {
-      renderHook(() => useInvestmentData(), { wrapper });
+      renderHook(() => useInvestmentData());
       await act(async () => { await new Promise(res => setTimeout(res, 0)); });
       expect(mockGetTx).toHaveBeenCalledWith('tx-edit-1');
     } finally {
@@ -771,7 +760,7 @@ describe('useInvestmentData – edit URL parameter flow', () => {
     const originalGetTx = (investmentsApiMod.investmentsApi as any).getTransaction;
     (investmentsApiMod.investmentsApi as any).getTransaction = vi.fn().mockRejectedValue(new Error('boom'));
     try {
-      renderHook(() => useInvestmentData(), { wrapper });
+      renderHook(() => useInvestmentData());
       await act(async () => { await new Promise(res => setTimeout(res, 0)); });
       expect(mockRouterReplace).toHaveBeenCalled();
     } finally {
@@ -792,7 +781,7 @@ describe('useInvestmentData – delete error toast', () => {
 
   it('updates pagination optimistically when transaction is deleted', async () => {
     mockDeleteTransaction.mockResolvedValue(undefined);
-    const { result } = renderHook(() => useInvestmentData(), { wrapper });
+    const { result } = renderHook(() => useInvestmentData());
     await act(async () => { await new Promise(res => setTimeout(res, 0)); });
     expect(result.current.pagination?.total).toBe(1);
     holdReloadOpen();

--- a/frontend/src/hooks/useLogicalAccounts.test.tsx
+++ b/frontend/src/hooks/useLogicalAccounts.test.tsx
@@ -1,18 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { renderHook } from '@testing-library/react';
-import { NextIntlClientProvider } from 'next-intl';
+import { renderHook } from '@/test/render';
 import { useLogicalAccounts } from './useLogicalAccounts';
 import { Account } from '@/types/account';
 import { PortfolioSummary } from '@/types/investment';
-import messages from '@/i18n/messages/en/accounts.json';
-
-function wrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <NextIntlClientProvider locale="en" messages={{ accounts: messages }}>
-      {children}
-    </NextIntlClientProvider>
-  );
-}
 
 const brokerage = {
   id: 'brok',
@@ -46,8 +36,7 @@ describe('useLogicalAccounts', () => {
   it('folds a pair and strips the localized suffix', () => {
     const { result } = renderHook(
       () => useLogicalAccounts([brokerage, cash], summary),
-      { wrapper },
-    );
+          );
 
     expect(result.current).toHaveLength(1);
     expect(result.current[0].displayName).toBe('TFSA');
@@ -59,8 +48,7 @@ describe('useLogicalAccounts', () => {
   it('leaves the combined value unknown while there is no portfolio summary', () => {
     const { result } = renderHook(
       () => useLogicalAccounts([brokerage, cash], null),
-      { wrapper },
-    );
+          );
 
     expect(result.current[0].combinedValue).toBeNull();
   });
@@ -69,8 +57,7 @@ describe('useLogicalAccounts', () => {
     const accounts = [brokerage, cash];
     const { result, rerender } = renderHook(
       () => useLogicalAccounts(accounts, summary),
-      { wrapper },
-    );
+          );
     const first = result.current;
 
     rerender();

--- a/frontend/src/hooks/useMainAccountName.test.tsx
+++ b/frontend/src/hooks/useMainAccountName.test.tsx
@@ -1,17 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { renderHook } from '@testing-library/react';
-import { NextIntlClientProvider } from 'next-intl';
+import { renderHook } from '@/test/render';
 import { useMainAccountName, useAccountOptionLabel } from './useMainAccountName';
 import { Account } from '@/types/account';
-import messages from '@/i18n/messages/en/accounts.json';
-
-function wrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <NextIntlClientProvider locale="en" messages={{ accounts: messages }}>
-      {children}
-    </NextIntlClientProvider>
-  );
-}
 
 const cashHalf = {
   id: 'cash',
@@ -22,7 +12,7 @@ const cashHalf = {
 
 describe('useMainAccountName', () => {
   it('strips the pair suffixes', () => {
-    const { result } = renderHook(() => useMainAccountName(), { wrapper });
+    const { result } = renderHook(() => useMainAccountName());
 
     expect(result.current('TFSA - Brokerage')).toBe('TFSA');
     expect(result.current('TFSA - Cash')).toBe('TFSA');
@@ -33,9 +23,7 @@ describe('useMainAccountName', () => {
   // the account surfaces. Keyed on `t` it changed identity every render, so
   // every memo built on it recomputed and every effect depending on one re-ran.
   it('keeps a stable identity across renders', () => {
-    const { result, rerender } = renderHook(() => useMainAccountName(), {
-      wrapper,
-    });
+    const { result, rerender } = renderHook(() => useMainAccountName());
     const first = result.current;
 
     rerender();
@@ -46,13 +34,13 @@ describe('useMainAccountName', () => {
 
 describe('useAccountOptionLabel', () => {
   it('labels an option with the entity name and currency, suffix stripped', () => {
-    const { result } = renderHook(() => useAccountOptionLabel(), { wrapper });
+    const { result } = renderHook(() => useAccountOptionLabel());
 
     expect(result.current(cashHalf)).toBe('TFSA (CAD)');
   });
 
   it('marks a closed account with the translated status word', () => {
-    const { result } = renderHook(() => useAccountOptionLabel(), { wrapper });
+    const { result } = renderHook(() => useAccountOptionLabel());
 
     expect(result.current({ ...cashHalf, isClosed: true })).toBe(
       'TFSA (CAD) (Closed)',
@@ -60,9 +48,7 @@ describe('useAccountOptionLabel', () => {
   });
 
   it('keeps a stable identity across renders', () => {
-    const { result, rerender } = renderHook(() => useAccountOptionLabel(), {
-      wrapper,
-    });
+    const { result, rerender } = renderHook(() => useAccountOptionLabel());
     const first = result.current;
 
     rerender();
@@ -73,7 +59,7 @@ describe('useAccountOptionLabel', () => {
   // lands -- so without stripping they offer "TFSA - Cash" while every other
   // surface calls the same account "TFSA".
   it('reads a linked cash half as the account the user knows', () => {
-    const { result } = renderHook(() => useAccountOptionLabel(), { wrapper });
+    const { result } = renderHook(() => useAccountOptionLabel());
 
     expect(result.current(cashHalf)).not.toContain(' - Cash');
     expect(result.current(cashHalf)).toContain('TFSA');
@@ -82,8 +68,7 @@ describe('useAccountOptionLabel', () => {
   it('drops the currency for narrow rows that ask for it', () => {
     const { result } = renderHook(
       () => useAccountOptionLabel({ withCurrency: false }),
-      { wrapper },
-    );
+          );
 
     expect(result.current(cashHalf)).toBe('TFSA');
   });

--- a/frontend/src/hooks/usePriceRefresh.test.tsx
+++ b/frontend/src/hooks/usePriceRefresh.test.tsx
@@ -1,22 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { ReactNode } from 'react';
-import { NextIntlClientProvider } from 'next-intl';
-import securitiesEn from '@/i18n/messages/en/securities.json';
+import { renderHook, act } from '@/test/render';
 import {
   isMarketHours,
   getRefreshInProgress,
   setRefreshInProgress,
   usePriceRefresh,
 } from './usePriceRefresh';
-
-// usePriceRefresh emits its toasts through next-intl; resolve them against the
-// real English catalog so assertions on visible text stay accurate.
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <NextIntlClientProvider locale="en" messages={{ securities: securitiesEn }}>
-    {children}
-  </NextIntlClientProvider>
-);
 
 vi.mock('@/lib/investments', () => ({
   investmentsApi: {
@@ -90,7 +79,7 @@ describe('usePriceRefresh', () => {
   });
 
   it('returns isRefreshing and trigger functions', () => {
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     expect(result.current.isRefreshing).toBe(false);
     expect(typeof result.current.triggerManualRefresh).toBe('function');
     expect(typeof result.current.triggerAutoRefresh).toBe('function');
@@ -102,7 +91,7 @@ describe('usePriceRefresh', () => {
       updated: 1, failed: 0, totalSecurities: 1, skipped: 0, results: [], lastUpdated: '',
     });
 
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
@@ -121,7 +110,7 @@ describe('usePriceRefresh', () => {
       updated: 2, failed: 0, totalSecurities: 2, skipped: 0, results: [], lastUpdated: '',
     });
 
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh(['s-1', 's-3']);
     });
@@ -131,7 +120,7 @@ describe('usePriceRefresh', () => {
   it('shows the no-securities toast when scope filters out everything', async () => {
     vi.mocked(investmentsApi.getSecurities).mockResolvedValue([sec('s-1')] as any);
 
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh(['s-99']);
     });
@@ -149,7 +138,7 @@ describe('usePriceRefresh', () => {
       updated: 1, failed: 0, totalSecurities: 1, skipped: 0, results: [], lastUpdated: '',
     });
 
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
@@ -166,7 +155,7 @@ describe('usePriceRefresh', () => {
       updated: 1, failed: 0, totalSecurities: 1, skipped: 0, results: [], lastUpdated: '',
     });
 
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
@@ -192,7 +181,7 @@ describe('usePriceRefresh', () => {
       updated: 2, failed: 0, totalSecurities: 2, skipped: 0, results: [], lastUpdated: '',
     });
 
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
@@ -205,7 +194,7 @@ describe('usePriceRefresh', () => {
   it('shows error toast on failure', async () => {
     vi.mocked(investmentsApi.getSecurities).mockRejectedValue(new Error('fail'));
 
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
@@ -215,7 +204,7 @@ describe('usePriceRefresh', () => {
   it('shows toast when no securities', async () => {
     vi.mocked(investmentsApi.getSecurities).mockResolvedValue([] as any);
 
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
@@ -228,7 +217,7 @@ describe('usePriceRefresh', () => {
       updated: 1, failed: 1, totalSecurities: 2, skipped: 0, results: [], lastUpdated: '',
     });
 
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
@@ -254,7 +243,7 @@ describe('usePriceRefresh', () => {
       lastUpdated: '',
     });
 
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
@@ -276,7 +265,7 @@ describe('usePriceRefresh', () => {
       lastUpdated: '2026-04-15T14:06:00Z',
     });
 
-    const { result } = renderHook(() => usePriceRefresh({ onRefreshComplete }), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh({ onRefreshComplete }));
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
@@ -285,7 +274,7 @@ describe('usePriceRefresh', () => {
 
   it('does nothing when refresh is already in progress', async () => {
     setRefreshInProgress(true);
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
@@ -295,7 +284,7 @@ describe('usePriceRefresh', () => {
   it('triggerAutoRefresh skips when outside market hours', async () => {
     // Real isMarketHours runs; check that when refreshInProgress is true it short-circuits
     setRefreshInProgress(true);
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     act(() => {
       result.current.triggerAutoRefresh();
     });
@@ -307,7 +296,7 @@ describe('usePriceRefresh', () => {
     vi.mocked(investmentsApi.refreshSelectedPrices).mockResolvedValue({
       updated: 1, failed: 0, totalSecurities: 1, skipped: 0, results: [], lastUpdated: '',
     });
-    const { result } = renderHook(() => usePriceRefresh(), { wrapper });
+    const { result } = renderHook(() => usePriceRefresh());
     await act(async () => {
       await result.current.triggerManualRefresh();
     });

--- a/frontend/src/hooks/useUndoRedo.test.tsx
+++ b/frontend/src/hooks/useUndoRedo.test.tsx
@@ -1,21 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { ReactNode } from 'react';
-import { NextIntlClientProvider } from 'next-intl';
-import commonEn from '@/i18n/messages/en/common.json';
-import layoutEn from '@/i18n/messages/en/layout.json';
+import { renderHook, act } from '@/test/render';
 
-// Hook emits toasts via next-intl; resolve them against the real English
-// catalogs so renderHook has an intl context. `layout` carries the action
-// descriptions and undo/redo prefixes; `common` carries the error messages.
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <NextIntlClientProvider
-    locale="en"
-    messages={{ common: commonEn, layout: layoutEn }}
-  >
-    {children}
-  </NextIntlClientProvider>
-);
 import toast from 'react-hot-toast';
 import { useUndoRedo } from './useUndoRedo';
 
@@ -50,7 +35,7 @@ describe('useUndoRedo', () => {
   });
 
   it('should return handleUndo and handleRedo functions', () => {
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
     expect(result.current.handleUndo).toBeInstanceOf(Function);
     expect(result.current.handleRedo).toBeInstanceOf(Function);
   });
@@ -65,7 +50,7 @@ describe('useUndoRedo', () => {
       description: 'ignored backend string',
     });
 
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
 
     await act(async () => {
       await result.current.handleUndo();
@@ -85,7 +70,7 @@ describe('useUndoRedo', () => {
       description: 'ignored backend string',
     });
 
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
 
     await act(async () => {
       await result.current.handleRedo();
@@ -100,7 +85,7 @@ describe('useUndoRedo', () => {
       response: { status: 404, data: { message: 'Nothing to undo' } },
     });
 
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
 
     await act(async () => {
       await result.current.handleUndo();
@@ -118,7 +103,7 @@ describe('useUndoRedo', () => {
       },
     });
 
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
 
     await act(async () => {
       await result.current.handleUndo();
@@ -139,7 +124,7 @@ describe('useUndoRedo', () => {
     const signalHandler = vi.fn();
     const unsubscribe = subscribeUndoRedo(signalHandler);
 
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
 
     await act(async () => {
       await result.current.handleUndo();
@@ -155,7 +140,7 @@ describe('useUndoRedo', () => {
       description: 'Undone: test',
     });
 
-    renderHook(() => useUndoRedo(), { wrapper });
+    renderHook(() => useUndoRedo());
 
     await act(async () => {
       document.dispatchEvent(
@@ -178,7 +163,7 @@ describe('useUndoRedo', () => {
       description: 'Redone: test',
     });
 
-    renderHook(() => useUndoRedo(), { wrapper });
+    renderHook(() => useUndoRedo());
 
     await act(async () => {
       document.dispatchEvent(
@@ -196,7 +181,7 @@ describe('useUndoRedo', () => {
   });
 
   it('should not trigger when focus is in an input', async () => {
-    renderHook(() => useUndoRedo(), { wrapper });
+    renderHook(() => useUndoRedo());
 
     const input = document.createElement('input');
     document.body.appendChild(input);
@@ -218,7 +203,7 @@ describe('useUndoRedo', () => {
   });
 
   it('should not trigger from textarea', async () => {
-    renderHook(() => useUndoRedo(), { wrapper });
+    renderHook(() => useUndoRedo());
     const ta = document.createElement('textarea');
     document.body.appendChild(ta);
     ta.focus();
@@ -231,7 +216,7 @@ describe('useUndoRedo', () => {
   });
 
   it('should not trigger when no modifier key', async () => {
-    renderHook(() => useUndoRedo(), { wrapper });
+    renderHook(() => useUndoRedo());
     await act(async () => {
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', bubbles: true }));
       await new Promise((r) => setTimeout(r, 10));
@@ -241,7 +226,7 @@ describe('useUndoRedo', () => {
 
   it('should respond to Ctrl+Y for redo', async () => {
     actionHistoryApi.redo.mockResolvedValue({ action: { id: 'a' }, description: 'Redo' });
-    renderHook(() => useUndoRedo(), { wrapper });
+    renderHook(() => useUndoRedo());
     await act(async () => {
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y', ctrlKey: true, bubbles: true }));
       await new Promise((r) => setTimeout(r, 10));
@@ -251,7 +236,7 @@ describe('useUndoRedo', () => {
 
   it('should show success toast (not error) when nothing to redo', async () => {
     actionHistoryApi.redo.mockRejectedValue({ response: { status: 404, data: { message: 'Nothing to redo' } } });
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
     await act(async () => {
       await result.current.handleRedo();
     });
@@ -260,7 +245,7 @@ describe('useUndoRedo', () => {
 
   it('should show error toast on redo conflict', async () => {
     actionHistoryApi.redo.mockRejectedValue({ response: { status: 409, data: { message: 'Conflict' } } });
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
     await act(async () => {
       await result.current.handleRedo();
     });
@@ -269,7 +254,7 @@ describe('useUndoRedo', () => {
 
   it('should show generic error toast when undo fails unexpectedly', async () => {
     actionHistoryApi.undo.mockRejectedValue({ response: { status: 500 } });
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
     await act(async () => {
       await result.current.handleUndo();
     });
@@ -278,7 +263,7 @@ describe('useUndoRedo', () => {
 
   it('should show generic error toast when redo fails unexpectedly', async () => {
     actionHistoryApi.redo.mockRejectedValue(new Error('boom'));
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
     await act(async () => {
       await result.current.handleRedo();
     });
@@ -287,7 +272,7 @@ describe('useUndoRedo', () => {
 
   it('uses default messages when 409 has no message', async () => {
     actionHistoryApi.undo.mockRejectedValue({ response: { status: 409, data: {} } });
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
     await act(async () => {
       await result.current.handleUndo();
     });
@@ -299,7 +284,7 @@ describe('useUndoRedo', () => {
     actionHistoryApi.undo.mockImplementation(
       () => new Promise((res) => { resolve = res; }),
     );
-    const { result } = renderHook(() => useUndoRedo(), { wrapper });
+    const { result } = renderHook(() => useUndoRedo());
 
     // Start first undo without awaiting so the second call races with it
     const firstPromise = result.current.handleUndo();

--- a/frontend/src/test/act-guard.test.ts
+++ b/frontend/src/test/act-guard.test.ts
@@ -79,7 +79,10 @@ describe('act-guard', () => {
       // In `afterEach`, after `cleanup()`: an update React commits while
       // unmounting belongs to the test that mounted the tree.
       expect(setup).toMatch(/cleanup\(\);[\s\S]*?failOnActWarnings\(\);[\s\S]*?\}\);/);
-      expect(setup).toMatch(/afterAll\(failOnActWarnings\)/);
+      // `afterAll` gained a second guard (intl), so it is a block rather than a
+      // bare reference. Match the call inside it, not the old exact spelling --
+      // otherwise this asserts the formatting rather than the wiring.
+      expect(setup).toMatch(/afterAll\(\(\) => \{[\s\S]*?failOnActWarnings\(\);[\s\S]*?\}\)/);
     });
 
     it('does not suppress act warnings anywhere else', () => {

--- a/frontend/src/test/intl-guard.test.ts
+++ b/frontend/src/test/intl-guard.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { failOnIntlErrors, pendingIntlErrors, recordIfIntlError } from './intl-guard';
+
+/** next-intl's IntlError carries `code` and `message`; that is all we classify on. */
+function intlError(code: string, message = `${code}: something`) {
+  return Object.assign(new Error(message), { code });
+}
+
+describe('intl-guard', () => {
+  beforeEach(() => {
+    // Drain anything a previous case recorded, so each starts clean.
+    try {
+      failOnIntlErrors();
+    } catch {
+      /* expected when the previous case recorded something */
+    }
+  });
+
+  it('records an actionable message error and reports that it did', () => {
+    expect(recordIfIntlError(intlError('MISSING_MESSAGE'))).toBe(true);
+    expect(pendingIntlErrors()).toHaveLength(1);
+    expect(() => failOnIntlErrors()).toThrow(/MISSING_MESSAGE/);
+  });
+
+  it('is not vacuous -- it ignores things that are not intl errors', () => {
+    expect(recordIfIntlError('a plain string')).toBe(false);
+    expect(recordIfIntlError(new Error('no code'))).toBe(false);
+    expect(recordIfIntlError(undefined)).toBe(false);
+    expect(recordIfIntlError(null)).toBe(false);
+    expect(recordIfIntlError({ code: 42 })).toBe(false);
+    expect(pendingIntlErrors()).toHaveLength(0);
+    expect(() => failOnIntlErrors()).not.toThrow();
+  });
+
+  it('ignores ENVIRONMENT_FALLBACK', () => {
+    // A property of the harness, identical for every test in the run and
+    // actionable by none of them. See the comment in intl-guard.ts.
+    expect(recordIfIntlError(intlError('ENVIRONMENT_FALLBACK'))).toBe(false);
+    expect(() => failOnIntlErrors()).not.toThrow();
+  });
+
+  it('reports the failing message text, so the key is findable', () => {
+    recordIfIntlError(
+      intlError(
+        'MISSING_MESSAGE',
+        'MISSING_MESSAGE: Could not resolve `common` in messages for locale `en`.',
+      ),
+    );
+    expect(() => failOnIntlErrors()).toThrow(/Could not resolve `common`/);
+  });
+
+  it('collapses duplicates and counts distinct ones', () => {
+    recordIfIntlError(intlError('MISSING_MESSAGE', 'MISSING_MESSAGE: a'));
+    recordIfIntlError(intlError('MISSING_MESSAGE', 'MISSING_MESSAGE: a'));
+    recordIfIntlError(intlError('INVALID_KEY', 'INVALID_KEY: b'));
+    expect(() => failOnIntlErrors()).toThrow(/2 message errors/);
+  });
+
+  it('resets after reporting, so one test does not fail the next', () => {
+    recordIfIntlError(intlError('MISSING_MESSAGE'));
+    expect(() => failOnIntlErrors()).toThrow();
+    expect(pendingIntlErrors()).toHaveLength(0);
+    expect(() => failOnIntlErrors()).not.toThrow();
+  });
+
+  // A guard nothing calls is not a guard, and this one has two doors: the
+  // provider's onError (for trees rendered through `@/test/render`) and the
+  // console.error filter (for everything else). Both are checked by reading.
+  describe('wiring', () => {
+    const setup = readFileSync(join(__dirname, 'setup.ts'), 'utf8');
+    const render = readFileSync(join(__dirname, 'render.tsx'), 'utf8');
+
+    it('routes the shared provider onError through the guard', () => {
+      expect(render).toMatch(/onError=\{recordIfIntlError\}/);
+    });
+
+    it('routes console.error through the guard', () => {
+      expect(setup).toMatch(/recordIfIntlError/);
+    });
+
+    it('fails after every test and after the last one', () => {
+      expect(setup).toMatch(/cleanup\(\);[\s\S]*?failOnIntlErrors\(\);[\s\S]*?\}\);/);
+      expect(setup).toMatch(/afterAll\(\(\) => \{[\s\S]*?failOnIntlErrors\(\);[\s\S]*?\}\)/);
+    });
+
+    it('does not suppress intl errors anywhere else', () => {
+      // A second mention inside a console filter would be a silencer.
+      const filtered = setup.match(/msg\.includes\('([^']*)'\)/g) ?? [];
+      expect(filtered.some((m) => /intl|MISSING_MESSAGE/i.test(m))).toBe(false);
+    });
+  });
+});

--- a/frontend/src/test/intl-guard.ts
+++ b/frontend/src/test/intl-guard.ts
@@ -1,0 +1,97 @@
+/**
+ * Fail a test run on next-intl's message errors instead of printing them.
+ *
+ * `useTranslations` does not throw when a message is missing -- it reports the
+ * error and returns the KEY. So a toast that should read "Import complete"
+ * renders `common.importComplete`, the test still passes, and the only trace is
+ * a line on stderr that vitest's default reporter buffers away for passing
+ * tests. That is the same shape as the act warnings next door: invisible
+ * locally, visible only in a CI log nobody reads.
+ *
+ * It went unnoticed for as long as it did because the harness looked correct.
+ * `src/test/render.tsx` has always loaded EVERY English namespace from a glob,
+ * so a component rendered through it resolves everything. But `renderHook` was
+ * re-exported from `@testing-library/react` untouched, so hooks got no provider
+ * at all -- and fourteen test files answered that by hand-rolling a
+ * `NextIntlClientProvider` with a hand-picked namespace list. Every one of the
+ * fourteen was partial. `useImportWizard` calls `useTranslations('import')` and
+ * `useTranslations('common')`; its test supplied only `import`, so every
+ * `common` lookup in that hook reported MISSING_MESSAGE.
+ *
+ * A hand-picked list is a snapshot of what its subject used the day it was
+ * written, so it rots the moment a namespace is added -- silently, because
+ * nothing fails. This guard is what makes the rot loud: wired as the provider's
+ * `onError` in `render.tsx` and as a `console.error` filter in `setup.ts`, so
+ * an error is caught whether or not the tree went through our provider.
+ *
+ * Fix the lookup, never the symptom: render through `@/test/render`, which
+ * supplies every namespace and picks up new ones with no file to edit. Adding a
+ * code to the ignore list below only restores the silence this exists to
+ * remove.
+ */
+
+/**
+ * The codes that mean a test is reading a string the user would never see.
+ *
+ * Deliberately not `ENVIRONMENT_FALLBACK`: next-intl reports that when no
+ * explicit time zone is configured, which is a property of the harness rather
+ * than of the test, fires identically for every test in the run, and names
+ * nothing a test author can act on. Failing on it would make the whole suite
+ * red for a reason no individual test can fix -- the same trap the act guard
+ * documents for React's "testing environment is not configured" line.
+ */
+const FAILING_CODES = new Set([
+  'MISSING_MESSAGE',
+  'INSUFFICIENT_PATH',
+  'INVALID_MESSAGE',
+  'INVALID_KEY',
+  'FORMATTING_ERROR',
+]);
+
+const errors: string[] = [];
+
+/** next-intl's IntlError shape, as much of it as the classifier needs. */
+function intlErrorCode(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const code = (value as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+/**
+ * Record one candidate error if it is an actionable next-intl error, and report
+ * whether it was recorded so the caller can swallow it.
+ *
+ * Classifying and recording are one function on purpose -- `act-guard.ts` has
+ * the story of what happens when they are two and disagree.
+ *
+ * Takes `unknown` because it is fed from two places with different shapes: the
+ * provider's `onError` hands over an `IntlError` instance, while `console.error`
+ * hands over whatever next-intl's default handler printed.
+ */
+export function recordIfIntlError(value: unknown): boolean {
+  const code = intlErrorCode(value);
+  if (!code || !FAILING_CODES.has(code)) return false;
+  const message = (value as { message?: unknown }).message;
+  errors.push(typeof message === 'string' && message ? message : code);
+  return true;
+}
+
+/** Test-only: what has been recorded and not yet reported. */
+export function pendingIntlErrors(): readonly string[] {
+  return [...errors];
+}
+
+/** Throw if anything was recorded since the last call, and reset. */
+export function failOnIntlErrors(): void {
+  if (errors.length === 0) return;
+  const seen = [...new Set(errors)];
+  errors.length = 0;
+  throw new Error(
+    `next-intl reported ${
+      seen.length === 1 ? 'a message error' : `${seen.length} message errors`
+    } during this test. The lookup returned the KEY rather than the string a ` +
+      'user would see, so any assertion on that text was checking a broken ' +
+      'string.\n\nRender through `@/test/render` (its provider carries every ' +
+      `English namespace) rather than a hand-built message set.\n\n${seen.join('\n\n')}`,
+  );
+}

--- a/frontend/src/test/intl-harness.guard.test.ts
+++ b/frontend/src/test/intl-harness.guard.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * One test harness supplies intl and theme, and tests reach it through
+ * `@/test/render`.
+ *
+ * The defect this replaces was structural rather than careless. `render.tsx`
+ * has always loaded every English namespace from a glob, but it wrapped only
+ * `render`; its `export * from '@testing-library/react'` re-exported
+ * `renderHook` untouched. So a hook test had no way to get a provider except to
+ * build one, and fourteen files did -- each with a hand-picked namespace list,
+ * every one of them partial. `useImportWizard` reads `import` and `common`; its
+ * test supplied `import` alone, so every `common` lookup returned its key while
+ * the test passed.
+ *
+ * Two scans, because the harness has two ways to be bypassed:
+ *
+ *   1. Importing `render`/`renderHook` from `@testing-library/react` rather
+ *      than from `@/test/render`, which is how a test ends up with no provider.
+ *   2. Building a `NextIntlClientProvider` in a test, which is how it ends up
+ *      with a partial one. Nested inside the shared render it is worse than it
+ *      looks -- the inner provider SHADOWS the full message set for everything
+ *      below it, so adding one narrows the catalogue rather than widening it.
+ *
+ * Both lists shrink only. An entry is a deliberate exception with a reason, not
+ * a to-do: a test that genuinely varies the locale has to build its own
+ * provider, because the shared one pins `en`.
+ */
+/**
+ * TEST files only. Both patterns are correct and necessary in production --
+ * `app/layout.tsx` and `app/global-error.tsx` mount the real
+ * `NextIntlClientProvider`, which is the thing being mirrored here -- so a scan
+ * over all of `src/` would report the application itself.
+ */
+const sources = import.meta.glob('/src/**/*.test.{ts,tsx}', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+/**
+ * Blank out comments, keeping line numbering, so the scans read CODE.
+ *
+ * This file has to name both banned patterns in prose to explain them, and the
+ * docblock above quotes `NextIntlClientProvider` and the RTL import. Scanning
+ * raw text would fail this file on its own explanation, and the cheap way out
+ * is a weaker comment -- which is the opposite of the point.
+ */
+function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
+    .replace(/\/\/[^\n]*/g, (line) => ' '.repeat(line.length));
+}
+
+/** `render` or `renderHook` imported from RTL rather than the shared harness. */
+const RTL_RENDER_IMPORT =
+  /import\s*\{[^}]*\b(?:render|renderHook)\b[^}]*\}\s*from\s*'@testing-library\/react'/;
+
+const PROVIDER = /<NextIntlClientProvider\b/;
+
+/**
+ * Tests that legitimately render outside the shared harness. Each names why;
+ * none is a partial-namespace wrapper, which is the thing being banned.
+ */
+const ALLOWED_RTL_RENDER = new Set([
+  // Renders in Spanish and in a locale-varying wrapper: the shared provider
+  // pins `en`, so these cannot use it and stay meaningful.
+  '/src/app/error.test.tsx',
+  '/src/components/whats-new/WhatsNewModal.test.tsx',
+  // Subjects of the boot path, which is defined by having no providers around
+  // it -- wrapping them would test something else.
+  '/src/components/layout/BootSplash.test.tsx',
+  '/src/components/providers/BootSplashHider.test.tsx',
+  '/src/app/global-error.test.tsx',
+  // The theme provider's own test: it mounts the provider under test.
+  '/src/contexts/ThemeContext.test.tsx',
+]);
+
+const ALLOWED_PROVIDER = new Set([
+  // Locale-varying, as above. (`src/test/render.tsx` -- the one place the
+  // provider is legitimately built -- is not a test file, so the scan never
+  // reaches it and it needs no exemption.)
+  '/src/app/error.test.tsx',
+  '/src/components/whats-new/WhatsNewModal.test.tsx',
+]);
+
+/**
+ * Tests that still import from RTL and have not been converted yet. Unlike the
+ * allow-lists above these are not exceptions -- each is a hook or component
+ * test that predates the shared `renderHook` and works today only because its
+ * subject happens not to translate anything. Adding a `useTranslations` to any
+ * of their subjects would reintroduce the silent-key defect.
+ *
+ * The list SHRINKS ONLY: a new test cannot join it, and a converted one must
+ * leave it (both are asserted below). Converting a file means deleting its line
+ * and importing from `@/test/render`.
+ */
+const RTL_IMPORT_BASELINE = new Set([
+  '/src/components/investments/CashRegisterFilters.test.tsx',
+  '/src/components/ui/LoadingSkeleton.test.tsx',
+  '/src/components/ui/LoadingSpinner.test.tsx',
+  '/src/components/ui/NumericInput.test.tsx',
+  '/src/components/ui/Select.test.tsx',
+  '/src/components/ui/SortableHeader.test.tsx',
+  '/src/components/ui/SummaryCard.test.tsx',
+  '/src/hooks/useAnchorRect.test.ts',
+  '/src/hooks/useBillsFilters.test.ts',
+  '/src/hooks/useBrokerageFilterOptions.test.tsx',
+  '/src/hooks/useClickOutside.test.ts',
+  '/src/hooks/useDateFormat.test.ts',
+  '/src/hooks/useDateRange.test.ts',
+  '/src/hooks/useDebouncedValue.test.ts',
+  '/src/hooks/useDemoMode.test.ts',
+  '/src/hooks/useExchangeRates.test.ts',
+  '/src/hooks/useFormDirtyNotify.test.ts',
+  '/src/hooks/useFormModal.test.ts',
+  '/src/hooks/useFormSubmitRef.test.ts',
+  '/src/hooks/useHideOnScroll.test.ts',
+  '/src/hooks/useHighlightTarget.test.ts',
+  '/src/hooks/useIsMobile.test.ts',
+  '/src/hooks/useLoanProjection.test.tsx',
+  '/src/hooks/useLocalStorage.test.ts',
+  '/src/hooks/useLongPress.test.ts',
+  '/src/hooks/useMnyImport.test.ts',
+  '/src/hooks/useNumberFormat.test.ts',
+  '/src/hooks/useOnAiAction.test.ts',
+  '/src/hooks/useOnUndoRedo.test.ts',
+  '/src/hooks/usePersistedAccountFilter.test.ts',
+  '/src/hooks/usePortfolioChangeBaseline.test.ts',
+  '/src/hooks/useRelativeTime.test.ts',
+  '/src/hooks/useReportData.test.ts',
+  '/src/hooks/useScrollSpy.test.ts',
+  '/src/hooks/useScrollToTopOnNavigation.test.ts',
+  '/src/hooks/useSortableTable.test.ts',
+  '/src/hooks/useStaleReconciliation.test.ts',
+  '/src/hooks/useSwipeNavigation.test.ts',
+  '/src/hooks/useTableDensity.test.ts',
+  '/src/hooks/useTourAnchor.test.ts',
+  '/src/hooks/useTransactionFilters.test.ts',
+  '/src/hooks/useTransactionSelection.test.ts',
+  '/src/hooks/useTransactionSubmitMode.test.ts',
+  '/src/hooks/useWidgetConfig.test.tsx',
+]);
+
+/**
+ * This file, which cannot scan itself: the fixtures in the stripper test quote
+ * both banned patterns as STRING literals, and `withoutComments` blanks
+ * comments rather than strings -- so the scanner would report itself for the
+ * examples that prove it works.
+ */
+const SELF = '/src/test/intl-harness.guard.test.ts';
+
+function offenders(pattern: RegExp, allowed: Set<string>): string[] {
+  return Object.entries(sources)
+    .filter(([path]) => path !== SELF)
+    .filter(([path]) => !allowed.has(path))
+    .filter(([, content]) => pattern.test(withoutComments(content)))
+    .map(([path]) => path)
+    .sort();
+}
+
+describe('the intl test harness is reached through @/test/render', () => {
+  it('strips comments but still sees code', () => {
+    // Load-bearing in both directions, so tested in both.
+    const stripped = withoutComments(
+      [
+        "// import { render } from '@testing-library/react';",
+        '/* <NextIntlClientProvider> */',
+        "import { renderHook } from '@testing-library/react';",
+        '<NextIntlClientProvider locale="en">',
+      ].join('\n'),
+    ).split('\n');
+
+    expect(RTL_RENDER_IMPORT.test(stripped[0])).toBe(false);
+    expect(PROVIDER.test(stripped[1])).toBe(false);
+    expect(RTL_RENDER_IMPORT.test(stripped[2])).toBe(true);
+    expect(PROVIDER.test(stripped[3])).toBe(true);
+    expect(stripped).toHaveLength(4);
+  });
+
+  it('found the tree to scan', () => {
+    // An empty glob would make every assertion below vacuously true.
+    expect(Object.keys(sources).length).toBeGreaterThan(300);
+  });
+
+  it('no NEW test imports render or renderHook from @testing-library/react', () => {
+    const current = offenders(RTL_RENDER_IMPORT, ALLOWED_RTL_RENDER);
+    expect(
+      current.filter((path) => !RTL_IMPORT_BASELINE.has(path)),
+      "Import { render, renderHook } from '@/test/render' instead: RTL's own are " +
+        'unwrapped, so the tree gets no intl provider and every translated string ' +
+        'resolves to its key.',
+    ).toEqual([]);
+  });
+
+  it('the baseline only shrinks', () => {
+    // A file that has been converted must leave the list, or the list stops
+    // being a record of remaining work and becomes permission.
+    const current = new Set(offenders(RTL_RENDER_IMPORT, ALLOWED_RTL_RENDER));
+    expect(
+      [...RTL_IMPORT_BASELINE].filter((path) => !current.has(path)),
+      'These no longer import render/renderHook from @testing-library/react. ' +
+        'Delete them from RTL_IMPORT_BASELINE.',
+    ).toEqual([]);
+  });
+
+  it('no test builds its own NextIntlClientProvider', () => {
+    expect(
+      offenders(PROVIDER, ALLOWED_PROVIDER),
+      'Render through `@/test/render`, whose provider carries every English ' +
+        'namespace from a glob. A hand-built message set is a snapshot of what ' +
+        'its subject used the day it was written, and nested inside the shared ' +
+        'render it shadows the full set rather than adding to it.',
+    ).toEqual([]);
+  });
+
+  it('every allowed entry still exists and still needs the exemption', () => {
+    // A stale exemption is how a list stops shrinking. Both sets are checked:
+    // the file must exist, and it must actually still match the pattern it is
+    // exempt from -- otherwise the entry is dead and should be deleted.
+    for (const path of ALLOWED_RTL_RENDER) {
+      expect(sources[path], `${path} is exempt but no longer exists`).toBeDefined();
+      expect(
+        RTL_RENDER_IMPORT.test(withoutComments(sources[path])),
+        `${path} no longer imports render from RTL -- drop its exemption`,
+      ).toBe(true);
+    }
+    for (const path of ALLOWED_PROVIDER) {
+      expect(sources[path], `${path} is exempt but no longer exists`).toBeDefined();
+      expect(
+        PROVIDER.test(withoutComments(sources[path])),
+        `${path} no longer builds a provider -- drop its exemption`,
+      ).toBe(true);
+    }
+  });
+});

--- a/frontend/src/test/render.tsx
+++ b/frontend/src/test/render.tsx
@@ -1,7 +1,13 @@
-import { render, RenderOptions } from '@testing-library/react';
-import { ReactElement } from 'react';
+import {
+  render,
+  renderHook,
+  RenderHookOptions,
+  RenderOptions,
+} from '@testing-library/react';
+import { ComponentType, ReactElement, ReactNode } from 'react';
 import { NextIntlClientProvider } from 'next-intl';
 import { ThemeProvider } from '@/contexts/ThemeContext';
+import { recordIfIntlError } from './intl-guard';
 
 // Eagerly load every English namespace so component tests resolve translated
 // strings without mocking next-intl. New namespaces are picked up automatically
@@ -22,20 +28,70 @@ const testMessages = Object.fromEntries(
   }),
 );
 
-function AllProviders({ children }: { children: React.ReactNode }) {
+type Wrapper = ComponentType<{ children: ReactNode }>;
+
+/**
+ * `onError` turns a missing or malformed message into a test failure instead of
+ * a buffered stderr line -- see `intl-guard.ts`. Returning without rethrowing
+ * keeps the render going, so the failure is reported once, by name, in the
+ * `afterEach` rather than as a render crash pointing at next-intl's internals.
+ */
+function AllProviders({ children }: { children: ReactNode }) {
   return (
-    <NextIntlClientProvider locale="en" messages={testMessages}>
+    <NextIntlClientProvider
+      locale="en"
+      messages={testMessages}
+      onError={recordIfIntlError}
+    >
       <ThemeProvider>{children}</ThemeProvider>
     </NextIntlClientProvider>
   );
 }
 
-function customRender(
-  ui: ReactElement,
-  options?: Omit<RenderOptions, 'wrapper'>,
+/**
+ * Compose the caller's wrapper INSIDE the shared providers rather than
+ * replacing them.
+ *
+ * RTL takes a single `wrapper`, so a test needing one more layer (StrictMode,
+ * a store provider) used to have to give up intl and theme to get it -- which
+ * is how several of these tests ended up hand-building a provider in the first
+ * place. Nesting means the extra layer costs nothing.
+ */
+function composeWrapper(inner?: Wrapper): Wrapper {
+  if (!inner) return AllProviders;
+  const Inner = inner;
+  return function ComposedWrapper({ children }: { children: ReactNode }) {
+    return (
+      <AllProviders>
+        <Inner>{children}</Inner>
+      </AllProviders>
+    );
+  };
+}
+
+function customRender(ui: ReactElement, options?: RenderOptions) {
+  return render(ui, { ...options, wrapper: composeWrapper(options?.wrapper) });
+}
+
+/**
+ * `renderHook` with the same providers `render` gives a component.
+ *
+ * This exists because its absence was a trap rather than a gap: `export * from
+ * '@testing-library/react'` below re-exports RTL's own `renderHook`, so a test
+ * importing it from this module still got no intl context and no theme, and the
+ * only symptom was a hook's translated strings silently resolving to their keys.
+ * The explicit export at the bottom shadows the star export -- the same
+ * mechanism that makes `customRender` win over RTL's `render`.
+ */
+function customRenderHook<Result, Props>(
+  callback: (initialProps: Props) => Result,
+  options?: RenderHookOptions<Props>,
 ) {
-  return render(ui, { wrapper: AllProviders, ...options });
+  return renderHook(callback, {
+    ...options,
+    wrapper: composeWrapper(options?.wrapper),
+  });
 }
 
 export * from '@testing-library/react';
-export { customRender as render };
+export { customRender as render, customRenderHook as renderHook };

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -3,6 +3,7 @@ import { cleanup } from '@testing-library/react';
 import { afterAll, afterEach, vi } from 'vitest';
 
 import { failOnActWarnings, recordIfActWarning } from './act-guard';
+import { failOnIntlErrors, recordIfIntlError } from './intl-guard';
 
 afterEach(async () => {
   cleanup();
@@ -33,12 +34,16 @@ afterEach(async () => {
   useDensityStore.setState({ densities: {} });
   // Last, so an update React commits during `cleanup()` is counted against the
   // test that mounted the tree rather than the next one.
+  failOnIntlErrors();
   failOnActWarnings();
 });
 
 // `cleanup()` for the file's final test runs inside that test's own afterEach
 // above, but a warning React logs after the last hook has nowhere else to go.
-afterAll(failOnActWarnings);
+afterAll(() => {
+  failOnIntlErrors();
+  failOnActWarnings();
+});
 
 // Suppress known-harmless jsdom warnings for SVG elements used by Recharts.
 // Also suppress tagged output from the project's `createLogger` (e.g.
@@ -53,6 +58,15 @@ console.error = (...args: unknown[]) => {
   // test, which one line on stderr in a 14,000-test run does not. See
   // `act-guard.ts` for why these are failures and not noise.
   if (recordIfActWarning(args)) {
+    return;
+  }
+  // The same treatment for next-intl's message errors, and the reason this is
+  // here as well as on the provider's `onError`: a tree rendered outside
+  // `@/test/render` falls back to next-intl's default handler, which prints the
+  // IntlError object here. Catching it in both places means the guard does not
+  // depend on the test having used the right harness -- which is exactly the
+  // thing it exists to detect. See `intl-guard.ts`.
+  if (args.some(recordIfIntlError)) {
     return;
   }
   if (


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- no prior discussion: raised directly from the recurring CI stderr noise below -->

Not opened from a discussion — this started from the `MISSING_MESSAGE` errors recurring in the frontend unit-test logs. Happy to move it to a Discussion first if you'd prefer.

## Summary

Frontend unit tests keep logging `IntlError: MISSING_MESSAGE: Could not resolve 'common' in messages for locale 'en'`. Nothing is missing from the catalogs.

**Root cause.** `src/test/render.tsx` has always loaded every English namespace from an `import.meta.glob` — but it wrapped only `render`, and its `export * from '@testing-library/react'` re-exported `renderHook` **untouched**. A hook test therefore had no way to get a provider except to build one, and **14 files did, each with a hand-picked namespace list — all 14 partial**. `useImportWizard` calls `useTranslations('import')` *and* `useTranslations('common')`; its test supplied `import` alone. That is the reported error exactly.

It stayed invisible because `useTranslations` doesn't throw on a missing message — it returns the **key**, so a toast renders `common.importComplete` instead of "Import complete" and the test still passes. Vitest's default reporter buffers that stderr away for passing tests, so CI logs were the only place it showed. Same trap `frontend/CLAUDE.md` already documents for act warnings.

**Three parts:**

1. **`renderHook` is exported from `@/test/render`** with the same providers. Both it and `render` compose a caller's own `wrapper` *inside* them rather than replacing it, so a test needing StrictMode no longer gives up intl to get it. 12 of the 14 hand-rolled providers are deleted; the 2 that remain vary the **locale** deliberately (Spanish, and a multi-locale notice), which the shared provider can't. Worth noting a nested provider was worse than it looked — it *shadows* the full message set for everything below it, so adding one narrowed the catalogue.
2. **`src/test/intl-guard.ts`** turns `MISSING_MESSAGE` and siblings into a test failure, wired both as the provider's `onError` and as a `console.error` filter — two doors, so a tree rendered outside the harness is still caught. `ENVIRONMENT_FALLBACK` is excluded for the same reason the act guard excludes React's second message: it's a property of the harness and names nothing an author can act on.
3. **`src/test/intl-harness.guard.test.ts`** scans for both ways round it. The `ALLOWED_*` sets are deliberate exceptions (locale-varying tests; boot-path components defined by having no providers). `RTL_IMPORT_BASELINE` is **shrink-only** — 45 older tests that work today only because their subjects happen not to translate anything.

**The guard found a real defect on its first run.** `SelectAccountStep.test.tsx` set `accountType: 'Bank'`, copied from the sibling `qifType` field where `'Bank'` is a legitimate QIF marker. `AccountType` has no such member, so every render looked up `common.accountTypes.Bank` and drew the key. Fixing it then broke `filters compatible accounts`, whose `/Chequing/` had only been matching the option because the Detected Type line beside it was rendering a raw key — that assertion now names the whole option label and also asserts the brokerage's **absence**, which is what the test claims and nothing checked.

**Verification.** Reintroducing a partial hand-rolled provider fails 7 tests with `MISSING_MESSAGE: Could not resolve 'common'` and trips the import scan — both defenses fire on the original defect. Full suite **748 files / 14,592 tests green**; `type-check` and ESLint clean.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **not done**; see note above.
- [x] This PR addresses a **single concern** (the intl test harness).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — no catalog or user-facing string changed; test infrastructure only.
- [x] No shared/core areas were refactored without prior agreement. — `src/test/render.tsx` and `setup.ts` are shared test infrastructure and are the subject of the fix; production code is untouched.
- [x] The branch is rebased on the latest `main` (branched from `6cf9a4c`).
- [x] AI assistance is disclosed below.

## AI assistance disclosure

Written by Claude Code (Claude Opus 5) in a remote session, at @kenlasko's direction. The diagnosis, the fix and its guards were produced by the assistant; every claim above was checked by running the suite, and the two failure modes were confirmed by deliberately reintroducing them. Reviewer judgement still owns the call on the shrink-only baseline — 45 entries is a lot to accept, and converting those files instead is a legitimate alternative.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USpck1KD7CK6EHMZxBF3do)_