### PR TITLE
Fix elicitation capability check for SDK >= 1.23

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5919,9 +5919,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -8482,6 +8482,8 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9305,12 +9307,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -9688,12 +9691,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -9705,11 +9710,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9720,6 +9727,8 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9736,6 +9745,8 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",

--- a/backend/src/mcp/CLAUDE.md
+++ b/backend/src/mcp/CLAUDE.md
@@ -18,6 +18,7 @@ mcp/
   mcp-context.ts             # resolve, requireScope, toolResult/toolError, sanitization
   mcp-annotations.ts         # shared tool annotation presets (READ_ONLY/CREATE/UPDATE)
   mcp-write-limiter.ts       # per-user daily write cap for mutating tools
+  mcp-elicitation-support.ts # what each session's client does with elicitation
   tool-output-schemas.ts     # one Zod output schema (raw shape) per tool
   tools/<domain>.tool.ts     # tool definitions, grouped by domain
   resources/<name>.resource.ts
@@ -64,10 +65,20 @@ Checklist for a new tool:
 2. Add the tool to its domain `tools/*.tool.ts` with the five config fields above.
 3. Add its output schema to `tool-output-schemas.ts` (conventions below) and import it.
 4. Pick the right annotation preset (below).
-5. If it mutates data, derive scope `"write"`, enforce the daily write limit via `McpWriteLimiter` (see `transactions.tool.ts`), and sanitize user strings with `stripHtml(...)` before persisting. Gate the write behind a user confirmation with `confirmWrite(server, message, extra.requestId)` (pass `extra.requestId` so the elicitation is delivered on the tool call's own SSE stream, not the standalone GET stream); persist only on `"accepted"`/`"unsupported"`, return a `toolError` without writing on `"declined"`. `"unsupported"` means the client can't show a dialog -- it still gates every tool call with its own approval prompt, so proceeding is not a consent bypass.
+5. If it mutates data, derive scope `"write"`, enforce the daily write limit via `McpWriteLimiter` (see `transactions.tool.ts`), and sanitize user strings with `stripHtml(...)` before persisting. Gate the write behind a user confirmation with `confirmWrite(server, message, extra.requestId)` (pass `extra.requestId` so the elicitation is delivered on the tool call's own SSE stream, not the standalone GET stream); persist only on `"accepted"`/`"unsupported"`, return a `toolError` without writing on `"declined"`. `"unsupported"` means no dialog reached a human -- the client still gates every tool call with its own approval prompt, so proceeding is not a consent bypass.
    - **Relay first.** When the call is serving a prompt the user typed in the Monize web chat (reverse relay), confirm there instead: build the signed `PendingAiAction` with `AiActionBuilderService` (shared with the AI Assistant tool executor) and emit it. If the card is shown in the browser (committed via `/ai/actions/confirm` on approval), return `RELAY_PREVIEW_SHOWN` and do NOT write or `confirmWrite`; otherwise fall through to `confirmWrite`.
 6. Update `mcp-server.service.ts` count and `mcp.module.ts` if it's a new provider class.
 7. Add/extend tests (below). `mcp-annotations.spec.ts` enforces that every tool has title + input/output schema + annotations with the right read/write hints -- bump `EXPECTED_TOOL_COUNT` and `WRITE_TOOLS`/`IDEMPOTENT_WRITES`.
+
+## An advertised capability is not evidence; observed behaviour is
+
+`confirmWrite` used to read `getClientCapabilities().elicitation.form` as proof that a confirmation dialog could be shown, and therefore treated every failure of that dialog as the user saying no. `@modelcontextprotocol/sdk` >= 1.23 rewrites the legacy 2025-06-18 shape `{"elicitation":{}}` into `{"elicitation":{"form":{}}}` before `getClientCapabilities()` ever sees it, so the check stopped separating a client that shows dialogs from one that answers `-32601` or never answers at all -- and every write through such a client was refused, or hung until the client abandoned the tool call. **A capability the SDK synthesizes cannot carry a decision.**
+
+So the outcome decides, not the advertisement:
+
+- Only a returned `action` is a user's answer. A rejection whose code says the client answered for itself (`clientAnsweredForItself` in `mcp-elicitation-support.ts`: method not found, invalid request/params, parse error, connection closed, request timeout) is `"unsupported"`; an unaccounted-for failure shape stays `"declined"`, so a case nobody has reasoned about refuses the write.
+- Behaviour is remembered per session, in a `WeakMap` keyed on the session's `McpServer` so the record dies with the session. A client caught answering for itself is not asked again (the round trip costs `CONFIRM_TIMEOUT_MS` per row otherwise); a client that has answered once is never demoted, so a later unanswered dialog on it is `"declined"`.
+- **The wait must expire before the client abandons the tool call waiting on it.** Claude's MCP tool deadline is 60s; a five-minute server-side wait produced no result at all, only an opaque client-side timeout. `mcp-context.spec.ts` fails if `CONFIRM_TIMEOUT_MS` leaves that range, and pins the SDK normalization above so it cannot silently become load-bearing again.
 
 ## A relay turn belongs to one MCP session, for a bounded time
 

--- a/backend/src/mcp/mcp-context.spec.ts
+++ b/backend/src/mcp/mcp-context.spec.ts
@@ -1,4 +1,9 @@
 import {
+  ClientCapabilitiesSchema,
+  ErrorCode,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
   confirmWrite,
   hasScope,
   requireScope,
@@ -244,12 +249,126 @@ describe("mcp-context", () => {
       );
     });
 
-    it("returns 'declined' (never silently proceeds) when a supported dialog errors or times out", async () => {
-      const elicit = jest.fn().mockRejectedValue(new Error("timed out"));
+    it("returns 'declined' (never silently proceeds) when a supported dialog fails in an unaccounted-for way", async () => {
+      const elicit = jest.fn().mockRejectedValue(new Error("boom"));
       const server = fakeServer({ capabilities: caps, elicit });
       await expect(confirmWrite(server, "Confirm?", "req-1")).resolves.toBe(
         "declined",
       );
+    });
+
+    // The regression these guard: `@modelcontextprotocol/sdk` >= 1.23 rewrites a
+    // bare `{"elicitation":{}}` into `{"elicitation":{"form":{}}}`, so the
+    // capability pre-check stopped separating a client that shows dialogs from
+    // one that answers -32601 or never answers at all. Every such client then
+    // looked form-capable, its non-answer was read as the user saying no, and
+    // every write through Claude was refused (or hung past the client's own
+    // tool deadline). Only observed behaviour can tell them apart.
+    describe("a client that answers for itself", () => {
+      it("pins the SDK normalization the old capability check relied on", () => {
+        expect(ClientCapabilitiesSchema.parse({ elicitation: {} })).toEqual({
+          elicitation: { form: {} },
+        });
+      });
+
+      it.each([
+        ["method not found", ErrorCode.MethodNotFound],
+        ["request timeout", ErrorCode.RequestTimeout],
+        ["connection closed", ErrorCode.ConnectionClosed],
+        ["invalid request", ErrorCode.InvalidRequest],
+        ["invalid params", ErrorCode.InvalidParams],
+        ["parse error", ErrorCode.ParseError],
+      ])("returns 'unsupported' on %s", async (_label, code) => {
+        const elicit = jest
+          .fn()
+          .mockRejectedValue(new McpError(code, "client answered for itself"));
+        const server = fakeServer({ capabilities: caps, elicit });
+        await expect(confirmWrite(server, "Confirm?", "req-1")).resolves.toBe(
+          "unsupported",
+        );
+      });
+
+      it("stops asking it for the rest of the session", async () => {
+        const elicit = jest
+          .fn()
+          .mockRejectedValue(
+            new McpError(ErrorCode.MethodNotFound, "Method not found"),
+          );
+        const server = fakeServer({ capabilities: caps, elicit });
+        await confirmWrite(server, "Confirm?", "req-1");
+        await expect(confirmWrite(server, "Confirm?", "req-2")).resolves.toBe(
+          "unsupported",
+        );
+        expect(elicit).toHaveBeenCalledTimes(1);
+      });
+
+      it("keeps the session's memory to itself", async () => {
+        const silent = fakeServer({
+          capabilities: caps,
+          elicit: jest
+            .fn()
+            .mockRejectedValue(
+              new McpError(ErrorCode.MethodNotFound, "Method not found"),
+            ),
+        });
+        await confirmWrite(silent, "Confirm?", "req-1");
+
+        const capable = fakeServer({
+          capabilities: caps,
+          elicit: jest.fn().mockResolvedValue({ action: "decline" }),
+        });
+        await expect(confirmWrite(capable, "Confirm?", "req-1")).resolves.toBe(
+          "declined",
+        );
+      });
+    });
+
+    describe("a client that has already shown a dialog", () => {
+      it("refuses a later unanswered one rather than writing", async () => {
+        const elicit = jest
+          .fn()
+          .mockResolvedValueOnce({ action: "accept" })
+          .mockRejectedValueOnce(
+            McpError.fromError(ErrorCode.RequestTimeout, "Request timed out"),
+          );
+        const server = fakeServer({ capabilities: caps, elicit });
+        await expect(confirmWrite(server, "Confirm?", "req-1")).resolves.toBe(
+          "accepted",
+        );
+        await expect(confirmWrite(server, "Confirm?", "req-2")).resolves.toBe(
+          "declined",
+        );
+      });
+
+      it("is not demoted by that failure", async () => {
+        const elicit = jest
+          .fn()
+          .mockResolvedValueOnce({ action: "accept" })
+          .mockRejectedValueOnce(
+            McpError.fromError(ErrorCode.RequestTimeout, "Request timed out"),
+          )
+          .mockResolvedValueOnce({ action: "accept" });
+        const server = fakeServer({ capabilities: caps, elicit });
+        await confirmWrite(server, "Confirm?", "req-1");
+        await confirmWrite(server, "Confirm?", "req-2");
+        await expect(confirmWrite(server, "Confirm?", "req-3")).resolves.toBe(
+          "accepted",
+        );
+        expect(elicit).toHaveBeenCalledTimes(3);
+      });
+    });
+
+    // The wait has to end before the client abandons the tool call that is
+    // waiting on it, or an unanswerable dialog produces no result at all --
+    // which is how a five-minute wait surfaced as an opaque client-side
+    // "timed out after 60s" with no write and no explanation.
+    it("waits less than the shortest client tool deadline", async () => {
+      const elicit = jest.fn().mockResolvedValue({ action: "accept" });
+      const server = fakeServer({ capabilities: caps, elicit });
+      await confirmWrite(server, "Confirm?", "req-1");
+      const { timeout } = elicit.mock.calls[0][1];
+      expect(timeout).toBeGreaterThan(20_000);
+      expect(timeout).toBeLessThan(60_000);
     });
   });
 });

--- a/backend/src/mcp/mcp-context.ts
+++ b/backend/src/mcp/mcp-context.ts
@@ -1,6 +1,12 @@
 import { sanitizeToolResultStrings } from "../common/sanitization.util";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { RequestId } from "@modelcontextprotocol/sdk/types.js";
+import {
+  clientAnsweredForItself,
+  elicitationBehaviour,
+  recordElicitationAnswered,
+  recordElicitationSilent,
+} from "./mcp-elicitation-support";
 
 export interface McpUserContext {
   userId: string;
@@ -131,38 +137,57 @@ function normalizeNonFiniteNumbers(data: unknown): unknown {
 
 export type WriteConfirmation = "accepted" | "declined" | "unsupported";
 
-// A human needs time to read and decide, so override the SDK's short default
-// request timeout for the confirmation round-trip.
-const CONFIRM_TIMEOUT_MS = 5 * 60 * 1000;
+/**
+ * How long the confirmation dialog may stay unanswered.
+ *
+ * A human needs time to read and decide, so this overrides the SDK's short
+ * default request timeout -- but it must still expire BEFORE the client gives
+ * up on the `tools/call` that is waiting for it. Claude's MCP tool deadline is
+ * 60s, and the previous five-minute wait meant a client that never answers the
+ * elicitation produced no result at all: the tool call died at the client's own
+ * deadline with an opaque "timed out after 60s", no write and no explanation.
+ * Staying under the client deadline is what makes every branch below reportable.
+ */
+const CONFIRM_TIMEOUT_MS = 45 * 1000;
 
 /**
  * Ask the MCP client to confirm a write via elicitation -- the MCP-native
  * equivalent of the AI Assistant's approve/reject card. Returns:
  *  - "accepted": the user approved; proceed with the write.
- *  - "declined": the user rejected/cancelled, or a supported dialog
- *    failed/timed out; abort so a write never happens without an explicit
- *    accept.
- *  - "unsupported": the client advertises no form-elicitation capability, so no
- *    dialog can be shown and the caller falls back to its normal behavior. The
- *    client still gates every tool call with its own approval prompt, so this
- *    is not a consent bypass. Claude Desktop currently lands here: it does not
- *    advertise the elicitation capability (and returns -32601 for
- *    elicitation/create), so writes proceed under its own per-tool approval
- *    rather than an MCP-native confirm dialog.
+ *  - "declined": the user answered and the answer was no (reject/cancel), or
+ *    the dialog failed in a way we cannot account for; abort, so a write never
+ *    happens over a user's refusal.
+ *  - "unsupported": no dialog reached a human, so the caller falls back to its
+ *    normal behavior. The client still gates every tool call with its own
+ *    approval prompt, so this is not a consent bypass -- it is the only consent
+ *    step such a client has.
  *
- * We pre-check the capability (rather than relying solely on the thrown
- * "client does not support elicitation" error) so that only a genuine lack of
- * capability falls through to the write -- a dismissed or timed-out dialog on a
- * capable client must abort.
+ * **The advertised capability is not evidence that a dialog can be shown.**
+ * `@modelcontextprotocol/sdk` >= 1.23 normalizes the legacy 2025-06-18 shape
+ * `{"elicitation":{}}` into `{"elicitation":{"form":{}}}` before
+ * `getClientCapabilities()` ever sees it (`ElicitationCapabilitySchema`'s
+ * `z.preprocess`), so `elicitation.form` is now truthy for every client that
+ * advertises elicitation at all -- including the ones that answer -32601 to
+ * `elicitation/create`, and the ones that never answer it. That is the whole
+ * regression: on SDK <= 1.22 those clients fell through to "unsupported" and
+ * wrote under their own approval prompt; afterwards the same clients looked
+ * form-capable, so a failure to answer was read as the user saying no and every
+ * write through Claude was refused or hung until the client's own deadline.
+ * `mcp-context.spec.ts` pins the SDK's normalization so this cannot silently
+ * flip back into a load-bearing check.
+ *
+ * So the *outcome* carries the weight, not the capability: only a returned
+ * `action` is a user's answer. The pre-check is kept because a client
+ * advertising no elicitation at all still deserves to skip the round trip.
  *
  * `relatedRequestId` MUST be the in-flight tool call's request id (from the
  * handler's `extra.requestId`). Over the Streamable HTTP transport, a
  * server-to-client request with no related request id is routed to the
  * standalone GET SSE stream, which a tool-calling client (Claude Desktop, IDE
  * agents) does not keep open during a `tools/call` -- so the elicitation is
- * silently dropped and never shown, then times out as a decline. Threading the
- * tool call's id sends the elicitation back over that call's own POST SSE
- * stream, where the client is listening.
+ * silently dropped and never shown. Threading the tool call's id sends the
+ * elicitation back over that call's own POST SSE stream, where the client is
+ * listening.
  */
 export async function confirmWrite(
   server: McpServer,
@@ -171,6 +196,13 @@ export async function confirmWrite(
 ): Promise<WriteConfirmation> {
   const capabilities = server.server.getClientCapabilities();
   if (!capabilities?.elicitation?.form) {
+    return "unsupported";
+  }
+  // A client already caught answering for itself is not asked again: on a
+  // client that drops the request, the round trip costs CONFIRM_TIMEOUT_MS
+  // every time, which on a 25-row individual batch is the same paralysis in
+  // slow motion.
+  if (elicitationBehaviour(server) === "silent") {
     return "unsupported";
   }
   try {
@@ -182,9 +214,20 @@ export async function confirmWrite(
       },
       { timeout: CONFIRM_TIMEOUT_MS, relatedRequestId },
     );
+    recordElicitationAnswered(server);
     return result.action === "accept" ? "accepted" : "declined";
-  } catch {
-    return "declined";
+  } catch (err) {
+    if (!clientAnsweredForItself(err)) {
+      return "declined";
+    }
+    // A client that has already shown a dialog in this session can show
+    // another, so this failure is one unanswered dialog, not a client with no
+    // human behind it -- refuse rather than fall through to the write.
+    if (elicitationBehaviour(server) === "answers") {
+      return "declined";
+    }
+    recordElicitationSilent(server);
+    return "unsupported";
   }
 }
 

--- a/backend/src/mcp/mcp-elicitation-support.ts
+++ b/backend/src/mcp/mcp-elicitation-support.ts
@@ -1,0 +1,73 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * What this session's client has actually been observed to do with an
+ * `elicitation/create` request.
+ *
+ * The advertised capability cannot answer this. `@modelcontextprotocol/sdk`
+ * >= 1.23 rewrites the legacy 2025-06-18 shape `{"elicitation":{}}` into
+ * `{"elicitation":{"form":{}}}` before `getClientCapabilities()` sees it
+ * (`ElicitationCapabilitySchema`'s `z.preprocess`), so every client that
+ * advertises elicitation at all now looks form-capable -- the ones that answer
+ * -32601, and the ones that never answer, included. Only behaviour separates
+ * them, so behaviour is what we record.
+ *
+ *  - "unknown":  nothing observed yet.
+ *  - "answers":  the client returned an accept/decline/cancel at least once, so
+ *                it demonstrably shows dialogs to a human.
+ *  - "silent":   the client answered for itself (rejected the method, dropped
+ *                the connection, or never replied), so no human is behind it.
+ */
+export type ElicitationBehaviour = "unknown" | "answers" | "silent";
+
+/**
+ * Keyed on the `McpServer` because there is exactly one per MCP session
+ * (`mcp-http.controller.ts` builds a fresh server per `Mcp-Session-Id`), and a
+ * weak key means the record dies with the session -- no cleanup hook to forget,
+ * and no way for one client's observed behaviour to be read for another's.
+ */
+const observed = new WeakMap<McpServer, ElicitationBehaviour>();
+
+export function elicitationBehaviour(server: McpServer): ElicitationBehaviour {
+  return observed.get(server) ?? "unknown";
+}
+
+export function recordElicitationAnswered(server: McpServer): void {
+  observed.set(server, "answers");
+}
+
+/**
+ * Record that the client answered for itself. A client that has already proven
+ * it shows dialogs is NOT demoted: a single dropped connection or unanswered
+ * dialog on a capable client is a one-off, not evidence that the next
+ * confirmation would go unseen.
+ */
+export function recordElicitationSilent(server: McpServer): void {
+  if (observed.get(server) !== "answers") {
+    observed.set(server, "silent");
+  }
+}
+
+/**
+ * Whether an `elicitInput` rejection means the client answered for itself
+ * rather than for its user: it rejected the request as unknown or malformed,
+ * the connection went away, or it never replied at all. `MethodNotFound` is the
+ * one that matters in practice -- a client that advertises `elicitation` and
+ * then answers -32601 to `elicitation/create`.
+ *
+ * An unknown rejection shape is deliberately absent, so a failure nobody has
+ * reasoned about refuses the write instead of waving it through.
+ */
+export function clientAnsweredForItself(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null | undefined)?.code;
+  return (
+    typeof code === "number" &&
+    (code === ErrorCode.ConnectionClosed ||
+      code === ErrorCode.RequestTimeout ||
+      code === ErrorCode.ParseError ||
+      code === ErrorCode.InvalidRequest ||
+      code === ErrorCode.MethodNotFound ||
+      code === ErrorCode.InvalidParams)
+  );
+}


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

Fixes a regression where MCP clients that advertise `elicitation` capability but answer `-32601` (method not found) or never respond are incorrectly treated as capable of showing dialogs. This caused write confirmations to be refused or hang until the client's own tool deadline expired.

The root cause: `@modelcontextprotocol/sdk` >= 1.23 normalizes the legacy capability shape `{"elicitation":{}}` into `{"elicitation":{"form":{}}}` before the capability check sees it, so every client advertising elicitation now looks form-capable — including ones that reject the method or drop the connection. The advertised capability alone cannot distinguish them.

**Solution:** Track observed client behavior per session. Only a returned `action` (accept/decline/cancel) proves a human is behind the dialog. Clients that answer for themselves (reject the method, timeout, or never reply) are recorded as "silent" and skip future confirmation rounds, falling back to the client's own per-tool approval. Clients that have already shown a dialog are not demoted by a single failure.

The timeout is also reduced from 5 minutes to 45 seconds to stay under Claude's 60-second tool deadline, preventing opaque client-side timeouts when a dialog goes unanswered.

## Changes

- **`mcp-elicitation-support.ts`** (new): Tracks per-session elicitation behavior using a `WeakMap` keyed on `McpServer`. Exports helpers to record observed behavior and detect when a client answered for itself (specific error codes: `MethodNotFound`, `RequestTimeout`, `ConnectionClosed`, `ParseError`, `InvalidRequest`, `InvalidParams`).
- **`mcp-context.ts`**: Updated `confirmWrite()` to consult observed behavior before asking a "silent" client again, and to distinguish between a user's refusal and a client that never answered. Reduced `CONFIRM_TIMEOUT_MS` from 5 minutes to 45 seconds. Expanded docstring to explain the SDK normalization regression and why behavior, not capability, is the source of truth.
- **`mcp-context.spec.ts`**: Added comprehensive test suite covering:
  - Clients that answer for themselves (6 error codes tested)
  - Session memory (a silent client is not asked again; behavior is per-session)
  - Clients that have shown a dialog (one unanswered dialog refuses the write but does not demote the client)
  - Timeout validation (confirms it stays under 60s but above 20s)
  - Regression pin: verifies the SDK's normalization of `{"elicitation":{}}` to `{"elicitation":{"form":{}}}`
- **`CLAUDE.md`**: Updated tool checklist to clarify that `"unsupported"` means no dialog reached a human, not a lack of capability.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (elicitation capability regression).
- [x] New behavior has tests, and the existing suite passes.
- [x] No user-facing strings added (internal behavior only).
- [x] No shared/core areas refactored without prior agreement.
- [ ] The branch is rebased on the latest `main`.
- [ ] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_019eMq2jHZSWbbqD3KAJK4b2