### PR TITLE
fix(transactions): attachments on the phone card and a stacked form header

### DIFF
--- a/frontend/src/components/transactions/AttachmentsSection.test.tsx
+++ b/frontend/src/components/transactions/AttachmentsSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@/test/render';
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@/test/render';
 import toast from 'react-hot-toast';
 import { AttachmentsSection } from './AttachmentsSection';
 import { attachmentsApi } from '@/lib/attachments';
@@ -139,6 +139,37 @@ describe('AttachmentsSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockList.mockResolvedValue([]);
+  });
+
+  it('stacks the title over two half-width buttons on a phone, in both modes', async () => {
+    // Beside the title, Scan document and Add attachment overran a phone's
+    // width. The header is a column there and a row from `sm` up, and the
+    // buttons are grid cells that each take half the line.
+    const expectHeaderLayout = () => {
+      const header = screen.getByTestId('attachments-header');
+      expect(header.className).toContain('flex-col');
+      expect(header.className).toContain('sm:flex-row');
+      const actions = screen.getByTestId('attachments-actions');
+      expect(actions.className).toContain('grid-cols-2');
+      expect(actions.className).toContain('sm:flex');
+      const buttons = Array.from(actions.querySelectorAll('button'));
+      expect(buttons.map((b) => b.textContent)).toEqual([
+        'Scan document',
+        'Add attachment',
+      ]);
+      // The section title is not in the button row: it has a line of its own.
+      expect(actions.textContent).not.toContain('Attachments');
+      expect(header.textContent).toContain('Attachments');
+    };
+
+    await renderSection();
+    expectHeaderLayout();
+    cleanup();
+
+    await act(async () => {
+      render(<AttachmentsSection stagedFiles={[]} onStagedFilesChange={vi.fn()} />);
+    });
+    expectHeaderLayout();
   });
 
   it('shows the empty state when there are no attachments', async () => {

--- a/frontend/src/components/transactions/AttachmentsSection.tsx
+++ b/frontend/src/components/transactions/AttachmentsSection.tsx
@@ -60,6 +60,36 @@ function validateSelection(
   return null;
 }
 
+/**
+ * The section title with the Scan and Add controls, shared by both modes.
+ *
+ * On a phone the title takes a line of its own and the two buttons share the
+ * next one edge to edge: beside the title, two labelled buttons overran the
+ * dialog's width. The buttons are grid items there, so they stretch to their
+ * half without knowing about the layout -- each control's hidden file input
+ * is `display: none` and takes no cell. From `sm` up the title and the
+ * buttons sit on one line as before.
+ */
+function AttachmentsHeader({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('attachments');
+  return (
+    <div
+      data-testid="attachments-header"
+      className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+        {t('title')}
+      </span>
+      <div
+        data-testid="attachments-actions"
+        className="grid grid-cols-2 gap-2 sm:flex sm:items-center"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
 /** The Add-attachment button plus its hidden file input, shared by both modes. */
 function UploadControl({
   onFileSelected,
@@ -218,23 +248,18 @@ function SavedAttachments({ transactionId }: { transactionId: string }) {
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-          {t('title')}
-        </span>
-        <div className="flex items-center gap-2">
-          <ScanDocumentControl
-            onFileSelected={handleScanSelected}
-            onReady={rememberScanPicker}
-            disabled={uploading || atLimit}
-          />
-          <UploadControl
-            onFileSelected={handleFileSelected}
-            loading={uploading}
-            disabled={uploading || atLimit}
-          />
-        </div>
-      </div>
+      <AttachmentsHeader>
+        <ScanDocumentControl
+          onFileSelected={handleScanSelected}
+          onReady={rememberScanPicker}
+          disabled={uploading || atLimit}
+        />
+        <UploadControl
+          onFileSelected={handleFileSelected}
+          loading={uploading}
+          disabled={uploading || atLimit}
+        />
+      </AttachmentsHeader>
 
       {attachments.length === 0 ? (
         <p className="text-sm text-gray-500 dark:text-gray-400">{t('empty')}</p>
@@ -424,22 +449,17 @@ function StagedAttachments({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-          {t('title')}
-        </span>
-        <div className="flex items-center gap-2">
-          <ScanDocumentControl
-            onFileSelected={handleScanSelected}
-            onReady={rememberScanPicker}
-            disabled={atLimit}
-          />
-          <UploadControl
-            onFileSelected={handleFileSelected}
-            disabled={atLimit}
-          />
-        </div>
-      </div>
+      <AttachmentsHeader>
+        <ScanDocumentControl
+          onFileSelected={handleScanSelected}
+          onReady={rememberScanPicker}
+          disabled={atLimit}
+        />
+        <UploadControl
+          onFileSelected={handleFileSelected}
+          disabled={atLimit}
+        />
+      </AttachmentsHeader>
 
       {files.length === 0 ? (
         <p className="text-sm text-gray-500 dark:text-gray-400">{t('empty')}</p>

--- a/frontend/src/components/transactions/TransactionList.mobileWrapped.test.tsx
+++ b/frontend/src/components/transactions/TransactionList.mobileWrapped.test.tsx
@@ -197,6 +197,51 @@ describe('the register on a phone', () => {
     expect(plain.querySelectorAll('.col-span-3')).toHaveLength(1);
   });
 
+  it('shows the attachment count left of the category, and nothing at all for a row without one', async () => {
+    setPhoneViewport(true);
+    useDensityStore.setState({ densities: { transactions: 'normal' } });
+
+    const { container } = render(
+      <TransactionList
+        transactions={[
+          createTransaction({ id: 'tx-attached', attachmentCount: 2 }),
+          createTransaction({ id: 'tx-plain', attachmentCount: 0 }),
+        ]}
+        onEdit={vi.fn()}
+        onRefresh={vi.fn()}
+        isSingleAccountView
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Grocery Store')).toHaveLength(2);
+    });
+
+    const [attached, plain] = bodyRows(container);
+
+    // The same badge the tier table's Attachments column shows, in the
+    // category line and before the category pill.
+    const line2 = attached.querySelector('.col-span-3')!;
+    const badge = line2.querySelector('[data-testid="attachment-badge"]');
+    expect(badge).toBeTruthy();
+    expect(badge!.getAttribute('title')).toBe('2 attachments');
+    expect(badge!.textContent).toContain('2');
+    const category = screen.getAllByText('Groceries')[0];
+    expect(
+      badge!.compareDocumentPosition(category) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // A row with no attachments renders neither the badge nor the tier
+    // cell's dash: the category is the line's first element, flush left.
+    const plainLine2 = plain.querySelector('.col-span-3')!;
+    expect(plainLine2.querySelector('[data-testid="attachment-badge"]')).toBeNull();
+    const text = plainLine2.textContent ?? '';
+    // Nothing precedes the category -- the trailing dash further along the
+    // line is the running-balance placeholder, not an attachment cell.
+    expect(text.slice(0, text.indexOf('Groceries'))).toBe('');
+    expect(plainLine2.firstElementChild?.textContent).toContain('Groceries');
+  });
+
   it('keeps the tier table at Compact density', async () => {
     setPhoneViewport(true);
     useDensityStore.setState({ densities: { transactions: 'compact' } });

--- a/frontend/src/components/transactions/TransactionRow.tsx
+++ b/frontend/src/components/transactions/TransactionRow.tsx
@@ -50,6 +50,28 @@ function describeInvestmentSplit(split: TransactionSplit, uncategorizedLabel: st
   return symbol ? `${action}: ${symbol}` : action;
 }
 
+/**
+ * The paperclip and count a row with attachments shows. One rendering for
+ * the tier table's Attachments column and the phone card, so the two cannot
+ * drift; the caller decides whether a row has anything to show (the tier cell
+ * prints a dash for none, the card prints nothing at all).
+ */
+function AttachmentBadge({ count }: { count: number }) {
+  const t = useTranslations('transactions');
+  return (
+    <span
+      data-testid="attachment-badge"
+      className="inline-flex items-center gap-1 text-gray-600 dark:text-gray-300"
+      title={t('list.attachmentsCount', { count })}
+    >
+      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
+      </svg>
+      {count}
+    </span>
+  );
+}
+
 function CopyDropdown({ density, onDuplicate, onScheduleRecurring }: {
   density: DensityLevel;
   onDuplicate?: () => void;
@@ -302,9 +324,10 @@ export const TransactionRow = memo(function TransactionRow({
   // different set of facts -- every value below is the same value the tier
   // branch renders, from the same helper. Edit/Copy/Delete are deliberately
   // absent: on a phone those live in the long-press action sheet the same
-  // handlers below open. Description, Ref #, attachments and the three FX
-  // columns are left out to keep the card to two lines -- three when the row
-  // carries tags, which take a line of their own under the category.
+  // handlers below open. Description, Ref # and the three FX columns are left
+  // out to keep the card to two lines -- three when the row carries tags,
+  // which take a line of their own under the category. Attachments keep
+  // their place left of the category, but only on a row that has some.
   if (wrapped) {
     return (
       <tr
@@ -418,6 +441,13 @@ export const TransactionRow = memo(function TransactionRow({
                   {transaction.account?.name || '-'}
                 </span>
               )}
+              {/* Attachments sit left of the category, as the tier table's
+                  column does. A row with none renders nothing here -- not the
+                  tier cell's dash, and no empty element either -- so the
+                  category stays flush to the card's left edge. */}
+              {transaction.attachmentCount && transaction.attachmentCount > 0 ? (
+                <AttachmentBadge count={transaction.attachmentCount} />
+              ) : null}
               {transaction.linkedInvestmentTransactionId ? (
                 // No `title` here, unlike the tier cell: a hover tooltip is
                 // unreachable on a phone, and the pill's own label already
@@ -880,12 +910,7 @@ export const TransactionRow = memo(function TransactionRow({
       </td>
       <td className={`${cellPadding} whitespace-nowrap text-center text-sm ${registerColumnClass('attachments')}`}>
         {transaction.attachmentCount && transaction.attachmentCount > 0 ? (
-          <span className="inline-flex items-center gap-1 text-gray-600 dark:text-gray-300" title={t('list.attachmentsCount', { count: transaction.attachmentCount })}>
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
-            </svg>
-            {transaction.attachmentCount}
-          </span>
+          <AttachmentBadge count={transaction.attachmentCount} />
         ) : (
           <span className="text-gray-400 dark:text-gray-500">-</span>
         )}


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: requested directly by the repository owner (no linked issue or discussion; the scope and approach were given in the request itself).

## Summary

Two mobile layout fixes for attachments, both frontend-only.

**Register, phone Normal view.** The wrapped card left attachments out entirely. It now shows the same paperclip-and-count badge the desktop Attachments column shows, placed left of the category pill, and only on a row that has attachments. A row with none renders nothing in that slot (neither the badge nor the desktop dash), so the category stays flush to the card's left edge as before. The badge rendering is extracted into one `AttachmentBadge` component in `TransactionRow.tsx`, mounted by both the tier table and the phone card, so the two cannot drift.

**New/Edit transaction dialog.** The Attachments title and its two buttons shared one flex row in both the saved and the staged modes and overran a phone's width. Both now use a single `AttachmentsHeader` in `AttachmentsSection.tsx`: on a phone the title takes its own line and Scan document plus Add attachment sit beneath it as two half-width grid cells spanning the full width; from `sm` up the single-line layout is unchanged. This replaces two copies of the header.

**Tests.** The phone-card suite checks the badge precedes the category and that a row without attachments has nothing before it. The section suite checks the stacked header layout in both modes. Both new tests fail against the previous source. Typecheck, ESLint on the changed files, and the transactions and guard suites pass (50 files, 1427 tests).

## Checklist

- [ ] An approved discussion or issue exists and is linked above. (Requested directly by the repository owner; none linked.)
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). (No new strings; the badge reuses the existing `list.attachmentsCount` key.)
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Implemented with Claude Code from the repository owner's request, including the tests and the verification runs described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSndZcAdcaxgfMQhKNcaEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSndZcAdcaxgfMQhKNcaEA)_