### PR TITLE
Replace deepseek-v3.1 with gemma4 in Ollama Cloud sample models

### DIFF
--- a/frontend/src/types/ai.ts
+++ b/frontend/src/types/ai.ts
@@ -170,7 +170,7 @@ export const AI_PROVIDER_DEFAULT_MODELS: Record<AiProviderType, string[]> = {
   'ollama-cloud': [
     'gpt-oss:120b-cloud',
     'gpt-oss:20b-cloud',
-    'deepseek-v3.1:671b-cloud',
+    'gemma4:31b-cloud',
   ],
   'openai-compatible': [],
   mcp_relay: [],


### PR DESCRIPTION
## Linked discussion / issue

No discussion or issue link was provided for this change; it was requested directly by the repository owner.

Closes #
Approved in: requested directly by @kenlasko

## Summary

Swaps `deepseek-v3.1:671b-cloud` for `gemma4:31b-cloud` in the Ollama Cloud entry of `AI_PROVIDER_DEFAULT_MODELS` (`frontend/src/types/ai.ts`). These are the suggested model names offered when configuring an Ollama Cloud AI provider. That file was the only place in the repository naming the removed model.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [ ] New behavior has tests, and the existing suite passes. No behavior changed: the list is sample data with no test asserting its contents, so there is nothing to assert beyond the literal itself.
- [x] All user-facing strings are translated for **every** locale (i18n parity). No user-facing copy changed; model identifiers are not translated.
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wPzY6RpPXkptuwzZ5HYht

---
_Generated by [Claude Code](https://claude.ai/code/session_016wPzY6RpPXkptuwzZ5HYht)_