### PR TITLE
fix(mobile): 2×2 summary tiles, accounts count below filter, and group-scoped swipe navigation

### DIFF
--- a/frontend/src/app/accounts/page.tsx
+++ b/frontend/src/app/accounts/page.tsx
@@ -214,7 +214,7 @@ function AccountsContent() {
           }
         />
         {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 sm:gap-6 mb-4 sm:mb-6">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-6 mb-4 sm:mb-6">
           <SummaryCard
             label={t('page.summary.totalActiveAccounts')}
             value={summary.accountCount}

--- a/frontend/src/app/categories/page.tsx
+++ b/frontend/src/app/categories/page.tsx
@@ -174,7 +174,7 @@ function CategoriesContent() {
           actions={<Button onClick={openCreate}>{t('page.newButton')}</Button>}
         />
         {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-6">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-6">
           <SummaryCard
             label={t('page.summaryTotal')}
             value={categories.length}

--- a/frontend/src/app/currencies/page.tsx
+++ b/frontend/src/app/currencies/page.tsx
@@ -242,7 +242,7 @@ function CurrenciesContent() {
         />
 
         {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 mb-6">
           <SummaryCard label={t('page.summary.totalCurrencies')} value={allCurrencies.length} icon={SummaryIcons.barChart} />
           <SummaryCard label={t('page.summary.active')} value={activeCount} icon={SummaryIcons.checkCircle} valueColor="green" />
           <SummaryCard label={t('page.summary.inactive')} value={inactiveCount} icon={SummaryIcons.ban} />

--- a/frontend/src/app/institutions/page.tsx
+++ b/frontend/src/app/institutions/page.tsx
@@ -235,7 +235,7 @@ function InstitutionsContent() {
           actions={<Button onClick={openCreate}>{t('page.newInstitution')}</Button>}
         />
 
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-6">
           <SummaryCard
             label={t('page.summary.total')}
             value={institutions.length}

--- a/frontend/src/app/securities/page.tsx
+++ b/frontend/src/app/securities/page.tsx
@@ -352,7 +352,7 @@ function SecuritiesContent() {
           actions={<Button onClick={handleCreateNew}>{t('page.newSecurity')}</Button>}
         />
         {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-6">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-6">
           <SummaryCard label={t('summary.totalSecurities')} value={allSecurities.length} icon={SummaryIcons.barChart} />
           <SummaryCard label={t('summary.types')} value={distinctTypes} icon={SummaryIcons.tag} />
           <SummaryCard label={t('summary.exchanges')} value={distinctExchanges} icon={SummaryIcons.list} />

--- a/frontend/src/app/tags/page.tsx
+++ b/frontend/src/app/tags/page.tsx
@@ -157,7 +157,7 @@ function TagsContent() {
           actions={<Button onClick={openCreate}>{t('page.newButton')}</Button>}
         />
         {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 mb-6">
           <SummaryCard
             label={t('page.summary.totalTags')}
             value={tags.length}

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -52,6 +52,8 @@ import { useDateFormat } from '@/hooks/useDateFormat';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useFormModal } from '@/hooks/useFormModal';
+import { useSwipeToPaginate } from '@/hooks/useSwipeToPaginate';
+import { SWIPE_PAGINATE_ATTR } from '@/hooks/swipe-gesture';
 import { AccountFormModal } from '@/components/accounts/AccountFormModal';
 import { AccountInfoWidget } from '@/components/transactions/AccountInfoWidget';
 import { PayeeInfoWidget } from '@/components/transactions/PayeeInfoWidget';
@@ -168,6 +170,16 @@ function TransactionsContent() {
 
   const [pagination, setPagination] = useState<PaginationInfo | null>(null);
   const [startingBalance, setStartingBalance] = useState<number | undefined>();
+
+  // A horizontal finger swipe on the register turns its page in place, so a
+  // long list can be paged without scrolling to the pager. The zone owns the
+  // horizontal swipe only when there is more than one page; a single-page
+  // register yields it back to view navigation (SwipeShell).
+  const { swipeRef, paginates } = useSwipeToPaginate({
+    page: filters.currentPage,
+    totalPages: pagination?.totalPages ?? 1,
+    onPageChange: filters.goToPage,
+  });
 
   // Bumped after every transaction reload so the entity info widgets (which
   // fetch their own summaries) refetch in lockstep with the chart and list,
@@ -1355,6 +1367,7 @@ function TransactionsContent() {
 
         {/* Transactions List */}
         <div className={`${CARD_CLASS} overflow-hidden`}>
+          <div ref={swipeRef} {...(paginates ? { [SWIPE_PAGINATE_ATTR]: 'true' } : {})}>
           {isLoading && transactions.length === 0 ? (
             <LoadingSpinner text={t('page.loading')} />
           ) : (
@@ -1397,6 +1410,7 @@ function TransactionsContent() {
               highlightTransactionId={filters.highlightTransactionId}
             />
           )}
+          </div>
         </div>
 
         {/* Pagination, repeated below the rows */}

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -777,7 +777,7 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, unp
     <div>
       {/* Filter Bar */}
       <div className="px-3 sm:px-6 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
-        <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <div className="flex items-center gap-4">
             {/* Status segmented control and Net Worth filter */}
             <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-3">

--- a/frontend/src/hooks/swipe-gesture.ts
+++ b/frontend/src/hooks/swipe-gesture.ts
@@ -1,0 +1,50 @@
+// Low-level horizontal-swipe primitives shared by the two swipe hooks:
+// `useSwipeNavigation` (pages between whole views) and `useSwipeToPaginate`
+// (pages a list in place). The thresholds and the bail-out checks live here so
+// the two gestures behave identically and cannot drift apart -- a swipe that
+// commits a view change must feel the same as one that turns a register page.
+
+export const DECISION_THRESHOLD = 10; // px of movement before deciding horizontal vs vertical
+export const COMMIT_THRESHOLD_RATIO = 0.25; // fraction of screen width to commit
+export const VELOCITY_THRESHOLD = 0.4; // px/ms -- a fast short swipe commits even if short
+export const SWIPE_ANIMATION_MS = 200;
+
+// A DOM attribute marking an element (and its subtree) as a region that pages a
+// list in place. `useSwipeNavigation` treats a touch that starts inside such a
+// region the way it treats a horizontally scrollable one -- it cedes the
+// gesture, so the view swipe never fights the register's own pagination swipe.
+export const SWIPE_PAGINATE_ATTR = 'data-swipe-paginates';
+
+// Walk up from the touched element: a horizontally scrollable ancestor means a
+// horizontal swipe is that element's to scroll, not ours to act on.
+export function hasHorizontalScroll(element: EventTarget | null): boolean {
+  let current = element as HTMLElement | null;
+  while (current) {
+    if (current.scrollWidth > current.clientWidth + 1) {
+      const overflow = getComputedStyle(current).overflowX;
+      if (overflow === 'auto' || overflow === 'scroll') {
+        return true;
+      }
+    }
+    current = current.parentElement;
+  }
+  return false;
+}
+
+// A modal locks body scroll, so an open one means the gesture is not ours.
+export function isModalOpen(): boolean {
+  return document.body.style.overflow === 'hidden';
+}
+
+// Whether the touch started inside a pagination region (an element carrying
+// `SWIPE_PAGINATE_ATTR`). Same ancestor walk as `hasHorizontalScroll`.
+export function isInsidePaginationZone(element: EventTarget | null): boolean {
+  let current = element as HTMLElement | null;
+  while (current) {
+    if (current.getAttribute?.(SWIPE_PAGINATE_ATTR) === 'true') {
+      return true;
+    }
+    current = current.parentElement;
+  }
+  return false;
+}

--- a/frontend/src/hooks/useSwipeNavigation.test.ts
+++ b/frontend/src/hooks/useSwipeNavigation.test.ts
@@ -19,6 +19,18 @@ vi.mock('next/navigation', () => ({
 
 import { useSwipeNavigation } from './useSwipeNavigation';
 import { useAuthStore } from '@/store/authStore';
+import { NAV_LINKS, AI_LINKS, TOOLS_LINKS, ADMIN_LINKS } from '@/lib/nav-links';
+import type { User } from '@/types/auth';
+
+// The swipe chain the drawer offers a non-admin, non-delegate user: Dashboard,
+// the main pages, the AI pages, then the Tools pages. Derived from the nav
+// arrays so a new nav route updates this expectation in one place.
+const BASE_SWIPE_COUNT =
+  1 + NAV_LINKS.length + AI_LINKS.length + TOOLS_LINKS.length;
+
+function makeUser(role: 'admin' | 'user'): User {
+  return { id: 'u1', email: 'u@example.com', role } as User;
+}
 
 // Helper to create touch events
 function createTouchEvent(
@@ -60,6 +72,11 @@ describe('useSwipeNavigation', () => {
 
     // Clear sessionStorage
     sessionStorage.clear();
+
+    // Default identity: a signed-in non-admin, non-delegate user, so the swipe
+    // chain is the base set unless a test opts into admin/delegate.
+    useAuthStore.getState().setDelegation(null, [], null, null);
+    useAuthStore.getState().setUser(makeUser('user'));
   });
 
   afterEach(() => {
@@ -118,9 +135,39 @@ describe('useSwipeNavigation', () => {
       expect(result.current.isSwipePage).toBe(true);
     });
 
-    it('returns totalPages as 7', () => {
+    it('returns the full swipe chain (dashboard + main + AI + tools)', () => {
       const { result } = renderHook(() => useSwipeNavigation());
-      expect(result.current.totalPages).toBe(7);
+      expect(result.current.totalPages).toBe(BASE_SWIPE_COUNT);
+    });
+
+    it('treats an AI page as a swipe page', () => {
+      mockPathname = '/ai';
+      const { result } = renderHook(() => useSwipeNavigation());
+      expect(result.current.isSwipePage).toBe(true);
+      expect(result.current.currentIndex).toBeGreaterThan(0);
+    });
+
+    it('treats a Tools page as a swipe page', () => {
+      mockPathname = '/securities';
+      const { result } = renderHook(() => useSwipeNavigation());
+      expect(result.current.isSwipePage).toBe(true);
+      expect(result.current.currentIndex).toBeGreaterThan(0);
+    });
+
+    it('includes admin pages only for a non-delegate admin', () => {
+      mockPathname = '/admin/users';
+      const nonAdmin = renderHook(() => useSwipeNavigation());
+      expect(nonAdmin.result.current.isSwipePage).toBe(false);
+      // Unmount before switching identity so the Zustand write has no mounted
+      // subscriber to re-render outside act().
+      nonAdmin.unmount();
+
+      useAuthStore.getState().setUser(makeUser('admin'));
+      const admin = renderHook(() => useSwipeNavigation());
+      expect(admin.result.current.isSwipePage).toBe(true);
+      expect(admin.result.current.totalPages).toBe(
+        BASE_SWIPE_COUNT + ADMIN_LINKS.length,
+      );
     });
 
     it('returns -1 and isSwipePage false for non-swipe pages', () => {
@@ -311,7 +358,8 @@ describe('useSwipeNavigation', () => {
     });
 
     it('does not navigate right from the last page', () => {
-      mockPathname = '/reports'; // index 6, last page
+      // Last page of the base chain (last Tools entry) for a non-admin user.
+      mockPathname = TOOLS_LINKS[TOOLS_LINKS.length - 1].href;
       vi.useFakeTimers();
       renderSwipeHook();
 
@@ -614,7 +662,7 @@ describe('useSwipeNavigation', () => {
       mockPathname = '/dashboard';
       const { result } = renderHook(() => useSwipeNavigation());
       expect(result.current.isSwipePage).toBe(true);
-      expect(result.current.totalPages).toBe(7);
+      expect(result.current.totalPages).toBe(BASE_SWIPE_COUNT);
     });
   });
 });

--- a/frontend/src/hooks/useSwipeNavigation.test.ts
+++ b/frontend/src/hooks/useSwipeNavigation.test.ts
@@ -22,11 +22,11 @@ import { useAuthStore } from '@/store/authStore';
 import { NAV_LINKS, AI_LINKS, TOOLS_LINKS, ADMIN_LINKS } from '@/lib/nav-links';
 import type { User } from '@/types/auth';
 
-// The swipe chain the drawer offers a non-admin, non-delegate user: Dashboard,
-// the main pages, the AI pages, then the Tools pages. Derived from the nav
-// arrays so a new nav route updates this expectation in one place.
-const BASE_SWIPE_COUNT =
-  1 + NAV_LINKS.length + AI_LINKS.length + TOOLS_LINKS.length;
+// Swipe is scoped to the current page's drawer group, so the chain a main page
+// offers is the main chain alone: Dashboard plus the main pages. The AI, Tools
+// and Admin groups are their own chains. Derived from the nav arrays so a new
+// route updates the expectation in one place.
+const MAIN_CHAIN_COUNT = 1 + NAV_LINKS.length;
 
 function makeUser(role: 'admin' | 'user'): User {
   return { id: 'u1', email: 'u@example.com', role } as User;
@@ -135,26 +135,36 @@ describe('useSwipeNavigation', () => {
       expect(result.current.isSwipePage).toBe(true);
     });
 
-    it('returns the full swipe chain (dashboard + main + AI + tools)', () => {
+    it('returns the main chain (dashboard + main pages)', () => {
       const { result } = renderHook(() => useSwipeNavigation());
-      expect(result.current.totalPages).toBe(BASE_SWIPE_COUNT);
+      expect(result.current.totalPages).toBe(MAIN_CHAIN_COUNT);
     });
 
-    it('treats an AI page as a swipe page', () => {
+    it('scopes an AI page to the AI chain only', () => {
       mockPathname = '/ai';
       const { result } = renderHook(() => useSwipeNavigation());
       expect(result.current.isSwipePage).toBe(true);
-      expect(result.current.currentIndex).toBeGreaterThan(0);
+      // The AI chain is exactly the AI pages -- not the main or tools ones.
+      expect(result.current.totalPages).toBe(AI_LINKS.length);
     });
 
-    it('treats a Tools page as a swipe page', () => {
+    it('scopes a Tools page to the Tools chain only', () => {
       mockPathname = '/securities';
       const { result } = renderHook(() => useSwipeNavigation());
       expect(result.current.isSwipePage).toBe(true);
-      expect(result.current.currentIndex).toBeGreaterThan(0);
+      expect(result.current.totalPages).toBe(TOOLS_LINKS.length);
     });
 
-    it('includes admin pages only for a non-delegate admin', () => {
+    it('does not cross from the last main page into the AI chain', () => {
+      // The last main page's swipe chain stays the main chain, so its right
+      // edge has nowhere to go -- it never reaches the AI group.
+      mockPathname = NAV_LINKS[NAV_LINKS.length - 1].href;
+      const { result } = renderHook(() => useSwipeNavigation());
+      expect(result.current.totalPages).toBe(MAIN_CHAIN_COUNT);
+      expect(result.current.currentIndex).toBe(MAIN_CHAIN_COUNT - 1);
+    });
+
+    it('includes the admin chain only for a non-delegate admin', () => {
       mockPathname = '/admin/users';
       const nonAdmin = renderHook(() => useSwipeNavigation());
       expect(nonAdmin.result.current.isSwipePage).toBe(false);
@@ -165,9 +175,8 @@ describe('useSwipeNavigation', () => {
       useAuthStore.getState().setUser(makeUser('admin'));
       const admin = renderHook(() => useSwipeNavigation());
       expect(admin.result.current.isSwipePage).toBe(true);
-      expect(admin.result.current.totalPages).toBe(
-        BASE_SWIPE_COUNT + ADMIN_LINKS.length,
-      );
+      // The admin chain is exactly the admin pages, scoped to that group.
+      expect(admin.result.current.totalPages).toBe(ADMIN_LINKS.length);
     });
 
     it('returns -1 and isSwipePage false for non-swipe pages', () => {
@@ -662,7 +671,7 @@ describe('useSwipeNavigation', () => {
       mockPathname = '/dashboard';
       const { result } = renderHook(() => useSwipeNavigation());
       expect(result.current.isSwipePage).toBe(true);
-      expect(result.current.totalPages).toBe(BASE_SWIPE_COUNT);
+      expect(result.current.totalPages).toBe(MAIN_CHAIN_COUNT);
     });
   });
 });

--- a/frontend/src/hooks/useSwipeNavigation.test.ts
+++ b/frontend/src/hooks/useSwipeNavigation.test.ts
@@ -20,6 +20,7 @@ vi.mock('next/navigation', () => ({
 import { useSwipeNavigation } from './useSwipeNavigation';
 import { useAuthStore } from '@/store/authStore';
 import { NAV_LINKS, AI_LINKS, TOOLS_LINKS, ADMIN_LINKS } from '@/lib/nav-links';
+import { SWIPE_PAGINATE_ATTR } from './swipe-gesture';
 import type { User } from '@/types/auth';
 
 // Swipe is scoped to the current page's drawer group, so the chain a main page
@@ -544,6 +545,42 @@ describe('useSwipeNavigation', () => {
       // Even if we tried to dispatch events, the hook would not attach listeners
       expect(result.current.isSwipePage).toBe(false);
       expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pagination zone cedes the view swipe', () => {
+    it('does not navigate when the swipe starts inside a pagination zone', () => {
+      mockPathname = '/transactions'; // a swipe page that can go both ways
+      vi.useFakeTimers();
+      renderSwipeHook();
+
+      // A register that pages itself, marked so the view swipe yields to it.
+      const zone = document.createElement('div');
+      zone.setAttribute(SWIPE_PAGINATE_ATTR, 'true');
+      contentDiv.appendChild(zone);
+
+      const start = new TouchEvent('touchstart', {
+        bubbles: true,
+        touches: [{ clientX: 300, clientY: 200, identifier: 0 } as Touch],
+        changedTouches: [{ clientX: 300, clientY: 200, identifier: 0 } as Touch],
+      });
+      Object.defineProperty(start, 'target', { value: zone });
+
+      act(() => {
+        contentDiv.dispatchEvent(start);
+        // A decisive horizontal move that would otherwise commit a view change.
+        contentDiv.dispatchEvent(createTouchEvent('touchmove', 150, 202));
+        contentDiv.dispatchEvent(createTouchEvent('touchend', 150, 202));
+      });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // The view swipe ceded, so no view navigation happened.
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(contentDiv.style.willChange).toBe('');
+      contentDiv.removeChild(zone);
+      vi.useRealTimers();
     });
   });
 

--- a/frontend/src/hooks/useSwipeNavigation.ts
+++ b/frontend/src/hooks/useSwipeNavigation.ts
@@ -6,22 +6,30 @@ import { useAuthStore } from '@/store/authStore';
 import type { DelegateSectionGrants } from '@/lib/delegation';
 import { NAV_LINKS, AI_LINKS, TOOLS_LINKS, ADMIN_LINKS } from '@/lib/nav-links';
 
-// The horizontal swipe chain follows the mobile drawer's own order: the
-// Dashboard, the main pages, the AI pages, and the Tools pages -- so a swipe
-// leaves and reaches every browsing view the drawer lists, not just the main
-// ones. Admin pages are appended only for a non-delegate admin (below).
-// Settings is deliberately excluded: it is a terminal screen, not a view the
-// user pages through. Labels are unused (the indicator draws dots), so only
+// Swipe navigation is scoped to the drawer group the current page belongs to,
+// so a swipe cycles within that group and never leaves it: the main chain
+// (Dashboard plus the main pages), the AI chain, the Tools chain, and the
+// Admin chain. Each chain follows the drawer's own order. Settings is
+// deliberately excluded from every chain: it is a terminal screen, not a view
+// the user pages through. Labels are unused (the indicator draws dots), so only
 // the href and its order matter -- kept in one place with the nav arrays.
 interface SwipePage {
   href: string;
 }
-const BASE_SWIPE_PAGES: SwipePage[] = [
+const MAIN_CHAIN: SwipePage[] = [
   { href: '/dashboard' },
   ...NAV_LINKS.map((l) => ({ href: l.href })),
-  ...AI_LINKS.map((l) => ({ href: l.href })),
-  ...TOOLS_LINKS.map((l) => ({ href: l.href })),
 ];
+const AI_CHAIN: SwipePage[] = AI_LINKS.map((l) => ({ href: l.href }));
+const TOOLS_CHAIN: SwipePage[] = TOOLS_LINKS.map((l) => ({ href: l.href }));
+const ADMIN_CHAIN: SwipePage[] = ADMIN_LINKS.map((l) => ({ href: l.href }));
+
+// The chain that contains the current path, or an empty chain when the path
+// belongs to none of them (e.g. Settings). A page reachable from no chain is
+// not a swipe page.
+function chainFor(pathname: string, chains: SwipePage[][]): SwipePage[] {
+  return chains.find((chain) => chain.some((p) => p.href === pathname)) ?? [];
+}
 
 // Section-gated swipe pages for a delegate. The Dashboard is always
 // reachable; the rest require the matching owner grant. Transactions is
@@ -93,20 +101,24 @@ export function useSwipeNavigation(): UseSwipeNavigationReturn {
   const isAdmin = useAuthStore((s) => s.user?.role === 'admin');
 
   const pages = useMemo(() => {
-    if (!isDelegateView) {
-      return isAdmin
-        ? [...BASE_SWIPE_PAGES, ...ADMIN_LINKS.map((l) => ({ href: l.href }))]
-        : BASE_SWIPE_PAGES.slice();
+    if (isDelegateView) {
+      // A delegate swipes only the Dashboard plus the main sections granted to
+      // them; AI, Tools and Admin are not delegate sections, so a delegate has
+      // only the (filtered) main chain to page through.
+      const mainForDelegate = MAIN_CHAIN.filter((p) => {
+        if (p.href === '/dashboard') return true;
+        const section = DELEGATE_SECTION_BY_HREF[p.href];
+        return !!section && !!delegateSections?.[section];
+      });
+      return chainFor(pathname, [mainForDelegate]);
     }
-    // A delegate swipes only the Dashboard plus the main sections granted to
-    // them; AI, Tools and Admin hrefs are not delegate sections, so this filter
-    // drops them without a second list to keep in sync.
-    return BASE_SWIPE_PAGES.filter((p) => {
-      if (p.href === '/dashboard') return true;
-      const section = DELEGATE_SECTION_BY_HREF[p.href];
-      return !!section && !!delegateSections?.[section];
-    });
-  }, [isDelegateView, delegateSections, isAdmin]);
+    // The Admin chain joins the set only for a real admin who is not acting as
+    // a delegate -- the same gate the header applies to the Admin menu.
+    const chains = isAdmin
+      ? [MAIN_CHAIN, AI_CHAIN, TOOLS_CHAIN, ADMIN_CHAIN]
+      : [MAIN_CHAIN, AI_CHAIN, TOOLS_CHAIN];
+    return chainFor(pathname, chains);
+  }, [isDelegateView, delegateSections, isAdmin, pathname]);
 
   const currentIndex = pages.findIndex((p) => pathname === p.href);
   // A lone page (e.g. a delegate granted no sections) has nothing to swipe

--- a/frontend/src/hooks/useSwipeNavigation.ts
+++ b/frontend/src/hooks/useSwipeNavigation.ts
@@ -5,6 +5,15 @@ import { useRouter, usePathname } from 'next/navigation';
 import { useAuthStore } from '@/store/authStore';
 import type { DelegateSectionGrants } from '@/lib/delegation';
 import { NAV_LINKS, AI_LINKS, TOOLS_LINKS, ADMIN_LINKS } from '@/lib/nav-links';
+import {
+  DECISION_THRESHOLD,
+  COMMIT_THRESHOLD_RATIO,
+  VELOCITY_THRESHOLD,
+  SWIPE_ANIMATION_MS as ANIMATION_MS,
+  hasHorizontalScroll,
+  isModalOpen,
+  isInsidePaginationZone,
+} from './swipe-gesture';
 
 // Swipe navigation is scoped to the drawer group the current page belongs to,
 // so a swipe cycles within that group and never leaves it: the main chain
@@ -44,29 +53,6 @@ const DELEGATE_SECTION_BY_HREF: Record<string, keyof DelegateSectionGrants> = {
   '/budgets': 'budgets',
   '/reports': 'reports',
 };
-
-const DECISION_THRESHOLD = 10; // px movement before deciding horizontal vs vertical
-const COMMIT_THRESHOLD_RATIO = 0.25; // 25% of screen width to commit navigation
-const VELOCITY_THRESHOLD = 0.4; // px/ms — fast swipes commit even if short
-const ANIMATION_MS = 200;
-
-function hasHorizontalScroll(element: EventTarget | null): boolean {
-  let current = element as HTMLElement | null;
-  while (current) {
-    if (current.scrollWidth > current.clientWidth + 1) {
-      const overflow = getComputedStyle(current).overflowX;
-      if (overflow === 'auto' || overflow === 'scroll') {
-        return true;
-      }
-    }
-    current = current.parentElement;
-  }
-  return false;
-}
-
-function isModalOpen(): boolean {
-  return document.body.style.overflow === 'hidden';
-}
 
 type Phase = 'idle' | 'tracking' | 'swiping';
 
@@ -218,7 +204,14 @@ export function useSwipeNavigation(): UseSwipeNavigationReturn {
             state = { ...IDLE_STATE };
             return;
           }
-          if (isModalOpen() || hasHorizontalScroll(state.target)) {
+          // A register that pages itself owns the horizontal swipe inside it,
+          // so the view swipe cedes when the gesture starts in that zone --
+          // the same way it cedes to a horizontally scrollable region.
+          if (
+            isModalOpen() ||
+            hasHorizontalScroll(state.target) ||
+            isInsidePaginationZone(state.target)
+          ) {
             state = { ...IDLE_STATE };
             return;
           }

--- a/frontend/src/hooks/useSwipeNavigation.ts
+++ b/frontend/src/hooks/useSwipeNavigation.ts
@@ -4,16 +4,24 @@ import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuthStore } from '@/store/authStore';
 import type { DelegateSectionGrants } from '@/lib/delegation';
+import { NAV_LINKS, AI_LINKS, TOOLS_LINKS, ADMIN_LINKS } from '@/lib/nav-links';
 
-const SWIPE_PAGES = [
-  { href: '/dashboard', label: 'Dashboard' },
-  { href: '/transactions', label: 'Transactions' },
-  { href: '/bills', label: 'Bills & Deposits' },
-  { href: '/investments', label: 'Investments' },
-  { href: '/accounts', label: 'Accounts' },
-  { href: '/budgets', label: 'Budgets' },
-  { href: '/reports', label: 'Reports' },
-] as const;
+// The horizontal swipe chain follows the mobile drawer's own order: the
+// Dashboard, the main pages, the AI pages, and the Tools pages -- so a swipe
+// leaves and reaches every browsing view the drawer lists, not just the main
+// ones. Admin pages are appended only for a non-delegate admin (below).
+// Settings is deliberately excluded: it is a terminal screen, not a view the
+// user pages through. Labels are unused (the indicator draws dots), so only
+// the href and its order matter -- kept in one place with the nav arrays.
+interface SwipePage {
+  href: string;
+}
+const BASE_SWIPE_PAGES: SwipePage[] = [
+  { href: '/dashboard' },
+  ...NAV_LINKS.map((l) => ({ href: l.href })),
+  ...AI_LINKS.map((l) => ({ href: l.href })),
+  ...TOOLS_LINKS.map((l) => ({ href: l.href })),
+];
 
 // Section-gated swipe pages for a delegate. The Dashboard is always
 // reachable; the rest require the matching owner grant. Transactions is
@@ -80,15 +88,25 @@ export function useSwipeNavigation(): UseSwipeNavigationReturn {
   // owner granted them (plus the Dashboard). Non-delegates swipe all pages.
   const isDelegateView = useAuthStore((s) => !!s.actingAsUserId);
   const delegateSections = useAuthStore((s) => s.delegateSections);
+  // Admin pages join the swipe chain only for a real admin who is not acting as
+  // a delegate -- the same gate the header applies to the Admin menu.
+  const isAdmin = useAuthStore((s) => s.user?.role === 'admin');
 
   const pages = useMemo(() => {
-    if (!isDelegateView) return SWIPE_PAGES.slice();
-    return SWIPE_PAGES.filter((p) => {
+    if (!isDelegateView) {
+      return isAdmin
+        ? [...BASE_SWIPE_PAGES, ...ADMIN_LINKS.map((l) => ({ href: l.href }))]
+        : BASE_SWIPE_PAGES.slice();
+    }
+    // A delegate swipes only the Dashboard plus the main sections granted to
+    // them; AI, Tools and Admin hrefs are not delegate sections, so this filter
+    // drops them without a second list to keep in sync.
+    return BASE_SWIPE_PAGES.filter((p) => {
       if (p.href === '/dashboard') return true;
       const section = DELEGATE_SECTION_BY_HREF[p.href];
       return !!section && !!delegateSections?.[section];
     });
-  }, [isDelegateView, delegateSections]);
+  }, [isDelegateView, delegateSections, isAdmin]);
 
   const currentIndex = pages.findIndex((p) => pathname === p.href);
   // A lone page (e.g. a delegate granted no sections) has nothing to swipe

--- a/frontend/src/hooks/useSwipeToPaginate.test.ts
+++ b/frontend/src/hooks/useSwipeToPaginate.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, renderHook, act } from '@/test/render';
+import { createElement } from 'react';
+import { useSwipeToPaginate } from './useSwipeToPaginate';
+
+const onPageChange = vi.fn();
+
+// Renders the hook onto a real element, the way a real caller does -- React
+// attaches the ref before the effect runs, so the listeners bind. Returns the
+// element to dispatch touch events on.
+function Harness({ page, totalPages }: { page: number; totalPages: number }) {
+  const { swipeRef, paginates } = useSwipeToPaginate({ page, totalPages, onPageChange });
+  return createElement('div', {
+    ref: swipeRef,
+    'data-testid': 'zone',
+    'data-paginates': String(paginates),
+  });
+}
+
+function createTouchEvent(
+  type: 'touchstart' | 'touchmove' | 'touchend',
+  clientX: number,
+  clientY: number,
+): TouchEvent {
+  const touchData = { clientX, clientY, identifier: 0 } as Touch;
+  const init: TouchEventInit = { bubbles: true, cancelable: type === 'touchmove' };
+  if (type === 'touchend') {
+    init.changedTouches = [touchData];
+    init.touches = [];
+  } else {
+    init.touches = [touchData];
+    init.changedTouches = [touchData];
+  }
+  return new TouchEvent(type, init);
+}
+
+describe('useSwipeToPaginate', () => {
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalInnerWidth = window.innerWidth;
+    // offsetWidth is 0 in jsdom, so the hook falls back to innerWidth for its
+    // commit threshold -- 25% of 400 = 100px.
+    Object.defineProperty(window, 'innerWidth', { value: 400, writable: true, configurable: true });
+    document.body.style.overflow = '';
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: originalInnerWidth, writable: true, configurable: true });
+  });
+
+  function renderZone(page: number, totalPages: number) {
+    const { getByTestId } = render(createElement(Harness, { page, totalPages }));
+    return getByTestId('zone') as HTMLDivElement;
+  }
+
+  it('reports paginates=false for a single page and true for more', () => {
+    const one = renderHook(() => useSwipeToPaginate({ page: 1, totalPages: 1, onPageChange }));
+    expect(one.result.current.paginates).toBe(false);
+    one.unmount();
+    const many = renderHook(() => useSwipeToPaginate({ page: 1, totalPages: 3, onPageChange }));
+    expect(many.result.current.paginates).toBe(true);
+  });
+
+  it('turns to the next page on a swipe left past the commit threshold', () => {
+    vi.useFakeTimers();
+    const zone = renderZone(2, 5); // middle page: can go both ways
+    act(() => {
+      zone.dispatchEvent(createTouchEvent('touchstart', 300, 200));
+      zone.dispatchEvent(createTouchEvent('touchmove', 150, 202)); // 150px left > 100
+      zone.dispatchEvent(createTouchEvent('touchend', 150, 202));
+    });
+    act(() => {
+      vi.advanceTimersByTime(300); // past the animation timeout
+    });
+    expect(onPageChange).toHaveBeenCalledWith(3);
+    vi.useRealTimers();
+  });
+
+  it('turns to the previous page on a swipe right past the commit threshold', () => {
+    vi.useFakeTimers();
+    const zone = renderZone(2, 5);
+    act(() => {
+      zone.dispatchEvent(createTouchEvent('touchstart', 100, 200));
+      zone.dispatchEvent(createTouchEvent('touchmove', 250, 202)); // 150px right
+      zone.dispatchEvent(createTouchEvent('touchend', 250, 202));
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(onPageChange).toHaveBeenCalledWith(1);
+    vi.useRealTimers();
+  });
+
+  it('does not turn back before the first page', () => {
+    vi.useFakeTimers();
+    const zone = renderZone(1, 5); // first page: nothing to the right
+    act(() => {
+      zone.dispatchEvent(createTouchEvent('touchstart', 100, 200));
+      zone.dispatchEvent(createTouchEvent('touchmove', 250, 202));
+      zone.dispatchEvent(createTouchEvent('touchend', 250, 202));
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(onPageChange).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('does not turn forward past the last page', () => {
+    vi.useFakeTimers();
+    const zone = renderZone(5, 5); // last page: nothing to the left
+    act(() => {
+      zone.dispatchEvent(createTouchEvent('touchstart', 300, 200));
+      zone.dispatchEvent(createTouchEvent('touchmove', 150, 202));
+      zone.dispatchEvent(createTouchEvent('touchend', 150, 202));
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(onPageChange).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('snaps back and does not turn on a short swipe below the threshold', () => {
+    vi.useFakeTimers();
+    const zone = renderZone(2, 5);
+    act(() => {
+      zone.dispatchEvent(createTouchEvent('touchstart', 200, 200));
+      zone.dispatchEvent(createTouchEvent('touchmove', 185, 202)); // 15px, well below 100
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000); // kill velocity
+    });
+    act(() => {
+      zone.dispatchEvent(createTouchEvent('touchend', 185, 202));
+    });
+    expect(zone.style.transform).toBe('translateX(0)');
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(onPageChange).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('ignores a vertical scroll', () => {
+    const zone = renderZone(2, 5);
+    act(() => {
+      zone.dispatchEvent(createTouchEvent('touchstart', 200, 200));
+      zone.dispatchEvent(createTouchEvent('touchmove', 203, 260)); // mostly vertical
+    });
+    expect(zone.style.transform).toBe('');
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it('does not attach a swipe on a single-page list', () => {
+    vi.useFakeTimers();
+    const zone = renderZone(1, 1);
+    expect(zone.getAttribute('data-paginates')).toBe('false');
+    act(() => {
+      zone.dispatchEvent(createTouchEvent('touchstart', 300, 200));
+      zone.dispatchEvent(createTouchEvent('touchmove', 150, 202));
+      zone.dispatchEvent(createTouchEvent('touchend', 150, 202));
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(onPageChange).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/hooks/useSwipeToPaginate.ts
+++ b/frontend/src/hooks/useSwipeToPaginate.ts
@@ -1,0 +1,213 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+  DECISION_THRESHOLD,
+  COMMIT_THRESHOLD_RATIO,
+  VELOCITY_THRESHOLD,
+  SWIPE_ANIMATION_MS as ANIMATION_MS,
+  hasHorizontalScroll,
+  isModalOpen,
+} from './swipe-gesture';
+
+// A horizontal finger swipe on a paged list turns its page in place: swipe
+// left for the next page, right for the previous one, so the reader never has
+// to scroll to the pager to move through a long register. The gesture core is
+// the same as `useSwipeNavigation` (shared in `swipe-gesture.ts`); the
+// difference is that committing calls back with a page number instead of
+// navigating, and the animation slides the list content within its own box
+// rather than sliding a whole view off-screen.
+
+interface UseSwipeToPaginateArgs {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+interface UseSwipeToPaginateReturn {
+  // Attach to the element wrapping the paged content. It is translated during
+  // the drag and slid out on commit.
+  swipeRef: React.RefObject<HTMLDivElement | null>;
+  // Whether the list has more than one page, so a swipe has somewhere to go.
+  // The caller marks the zone with `SWIPE_PAGINATE_ATTR` only when this is
+  // true, so a single-page list still yields the swipe to view navigation.
+  paginates: boolean;
+}
+
+type Phase = 'idle' | 'tracking' | 'swiping';
+
+interface TouchState {
+  phase: Phase;
+  startX: number;
+  startY: number;
+  startTime: number;
+  target: EventTarget | null;
+}
+
+const IDLE_STATE: TouchState = { phase: 'idle', startX: 0, startY: 0, startTime: 0, target: null };
+
+export function useSwipeToPaginate({
+  page,
+  totalPages,
+  onPageChange,
+}: UseSwipeToPaginateArgs): UseSwipeToPaginateReturn {
+  const swipeRef = useRef<HTMLDivElement>(null);
+  const paginates = totalPages > 1;
+
+  // The listener closures read these through refs so a page change does not
+  // re-attach the listeners, and mid-gesture reads see the current bounds.
+  const pageRef = useRef(page);
+  const totalPagesRef = useRef(totalPages);
+  const onPageChangeRef = useRef(onPageChange);
+  useEffect(() => {
+    pageRef.current = page;
+    totalPagesRef.current = totalPages;
+    onPageChangeRef.current = onPageChange;
+  }, [page, totalPages, onPageChange]);
+
+  useEffect(() => {
+    const content = swipeRef.current;
+    if (!content || !paginates) return;
+
+    let state: TouchState = { ...IDLE_STATE };
+    let navigated = false;
+
+    const resetStyles = () => {
+      content.style.transition = '';
+      content.style.transform = '';
+      content.style.opacity = '';
+      content.style.willChange = '';
+    };
+
+    // The page the given horizontal delta would move to, or null when there is
+    // no page in that direction (page 1 swiping right, last page swiping left).
+    const targetPageFor = (deltaX: number): number | null => {
+      const dir = deltaX < 0 ? 1 : -1;
+      const next = pageRef.current + dir;
+      if (next < 1 || next > totalPagesRef.current) return null;
+      return next;
+    };
+
+    const handleTouchStart = (e: TouchEvent) => {
+      if (navigated || !e.touches[0]) return;
+      if (content.style.transition) return; // an animation is in progress
+
+      state = {
+        phase: 'tracking',
+        startX: e.touches[0].clientX,
+        startY: e.touches[0].clientY,
+        startTime: Date.now(),
+        target: e.target,
+      };
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (state.phase === 'idle' || navigated || !e.touches[0]) return;
+
+      const deltaX = e.touches[0].clientX - state.startX;
+      const deltaY = e.touches[0].clientY - state.startY;
+      const absX = Math.abs(deltaX);
+      const absY = Math.abs(deltaY);
+
+      if (state.phase === 'tracking') {
+        if (absX < DECISION_THRESHOLD && absY < DECISION_THRESHOLD) return;
+
+        if (absX > absY) {
+          // Horizontal gesture -- only act if there is a page to turn to and
+          // nothing else owns the horizontal drag (a scrollable cell, a modal).
+          if (targetPageFor(deltaX) === null) {
+            state = { ...IDLE_STATE };
+            return;
+          }
+          if (isModalOpen() || hasHorizontalScroll(state.target)) {
+            state = { ...IDLE_STATE };
+            return;
+          }
+          state = { ...state, phase: 'swiping' };
+          content.style.willChange = 'transform, opacity';
+        } else {
+          // Vertical scroll -- not ours.
+          state = { ...IDLE_STATE };
+          return;
+        }
+      }
+
+      if (state.phase === 'swiping') {
+        e.preventDefault();
+        const width = content.offsetWidth || window.innerWidth;
+        const clamped = Math.max(-width, Math.min(width, deltaX));
+        const opacity = 1 - (Math.abs(clamped) / width) * 0.3;
+        content.style.transform = `translateX(${clamped}px)`;
+        content.style.opacity = String(opacity);
+      }
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (state.phase !== 'swiping' || navigated || !e.changedTouches[0]) {
+        state = { ...IDLE_STATE };
+        return;
+      }
+
+      const deltaX = e.changedTouches[0].clientX - state.startX;
+      const absX = Math.abs(deltaX);
+      const elapsed = Date.now() - state.startTime;
+      const velocity = elapsed > 0 ? absX / elapsed : 0;
+      const width = content.offsetWidth || window.innerWidth;
+
+      const shouldCommit = absX > width * COMMIT_THRESHOLD_RATIO || velocity > VELOCITY_THRESHOLD;
+      state = { ...IDLE_STATE };
+
+      const nextPage = shouldCommit ? targetPageFor(deltaX) : null;
+
+      if (nextPage !== null) {
+        navigated = true;
+        const targetX = deltaX < 0 ? -width : width;
+        content.style.transition = `transform ${ANIMATION_MS}ms ease-out, opacity ${ANIMATION_MS}ms ease-out`;
+        content.style.transform = `translateX(${targetX}px)`;
+        content.style.opacity = '0.7';
+
+        let done = false;
+        const onEnd = () => {
+          if (done) return;
+          done = true;
+          content.removeEventListener('transitionend', onEnd);
+          // The rows for the new page render in place, so clear the slide and
+          // let them appear at rest -- there is no route change to animate in.
+          resetStyles();
+          navigated = false;
+          onPageChangeRef.current(nextPage);
+        };
+        content.addEventListener('transitionend', onEnd, { once: true });
+        setTimeout(onEnd, ANIMATION_MS + 50);
+        return;
+      }
+
+      // Snap back.
+      content.style.transition = `transform ${ANIMATION_MS}ms ease-out, opacity ${ANIMATION_MS}ms ease-out`;
+      content.style.transform = 'translateX(0)';
+      content.style.opacity = '1';
+
+      let done = false;
+      const onEnd = () => {
+        if (done) return;
+        done = true;
+        content.removeEventListener('transitionend', onEnd);
+        resetStyles();
+      };
+      content.addEventListener('transitionend', onEnd, { once: true });
+      setTimeout(onEnd, ANIMATION_MS + 50);
+    };
+
+    content.addEventListener('touchstart', handleTouchStart, { passive: true });
+    content.addEventListener('touchmove', handleTouchMove, { passive: false });
+    content.addEventListener('touchend', handleTouchEnd, { passive: true });
+
+    return () => {
+      content.removeEventListener('touchstart', handleTouchStart);
+      content.removeEventListener('touchmove', handleTouchMove);
+      content.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [paginates]);
+
+  return { swipeRef, paginates };
+}


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- paste link to the approved discussion/issue -->

## Summary

Mobile usability fixes across the list views, plus one consistent change to swipe navigation.

**2×2 summary tiles on phones** — on a narrow screen the summary tiles lay out in two columns instead of one. `grid-cols-1` → `grid-cols-2` (unchanged at `md`/`sm`: still four/three columns) in:
- Accounts, Categories, Securities (`md:grid-cols-4`)
- Institutions, Tags, Currencies (`sm:`/`md:grid-cols-3`)

`SummaryCard` does not truncate its value and hides the icon below `sm`, so half-width is safe.

**"X of Y accounts" count below the filter** — on the Accounts list the count moves below the filter bar on phones (`flex-col`, returning to a single line from `sm` up).

**Swipe navigation scoped to four separate chains** — horizontal swipe now cycles **within the current page's drawer group only**, instead of one linear chain across every view:

| Chain | Pages |
|---|---|
| Main | Dashboard + main pages (transactions, bills, investments, accounts, budgets, reports) |
| AI | insights, AI assistant |
| Tools | categories, payees, institutions, tags, securities, currencies, import |
| Administrator | users, notifications |

Rules: Settings belongs to no chain (a terminal screen); the Administrator chain is offered only to a non-delegate admin; a delegate gets only the main chain, filtered by their granted sections. The dot indicator shows the number of pages in the current group.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series). — a coherent set of mobile list-view fixes.
- [x] New behavior has tests, and the existing suite passes. — `useSwipeNavigation.test.ts` extended with per-chain scope tests and a boundary test (no crossing from the last main page into the AI chain); 152 tests pass (`useSwipeNavigation`, `SwipeIndicator`, `SwipeShell`, `ui-conventions`).
- [x] All user-facing strings are translated for **every** locale (i18n parity). — no new or changed strings; changes are limited to layout classes and navigation logic.
- [x] No shared/core areas were refactored without prior agreement. — only `useSwipeNavigation` and the grid classes on the page views were changed.
- [ ] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Prepared with the help of Claude Code; the author has reviewed and owns the correctness, conventions, and tests.