### PR TITLE
fix(reports): keep every report toolbar inside a phone screen

### DIFF
--- a/docs/frontend/ui-conventions.md
+++ b/docs/frontend/ui-conventions.md
@@ -282,18 +282,22 @@ it the handlers; it is a full-width row below every selector on a phone (two
 equal halves when the report also refreshes prices) and the toolbar's trailing
 group from `sm` up. Every report wrote that layout for itself once, and a dozen
 wrote it wrong. `ui-conventions.test.ts` fails a report that renders
-`ExportDropdown` itself, or `RefreshPricesButton` beside one.
+`ExportDropdown` or `RefreshPricesButton` itself -- exporting a single format
+is not a reason to hand-roll a button, because the row takes CSV alone too.
 
 What the shared row encodes, for the two places that still compose by hand:
 
-- **The export's box is not always its button.** `ExportDropdown` renders a
-  bare button in its PDF-only form and a `relative inline-block` wrapper around
-  it when a CSV handler is passed. Sizing the export for a phone
-  (`w-full sm:w-auto`) means sizing the wrapper through `containerClassName`
-  and the button through `className`; where the variant depends on state (a
-  table view that gains a CSV export), pass both. A grid cell stretches that
-  wrapper where a flex row would not, which is why the actions row is a grid.
-  `whitespace-nowrap` on the button keeps the label on one line.
+- **The export's box is not always its button.** `ExportDropdown` draws three
+  shapes from the handlers it is given: a dropdown for CSV and PDF together,
+  and a single button for either alone (a view that is a matrix of figures
+  exports CSV and nothing else; its type refuses both handlers missing). The
+  dropdown wraps its button in a `relative inline-block` box, the single-button
+  forms are the box. So sizing the export for a phone (`w-full sm:w-auto`)
+  means sizing the wrapper through `containerClassName` and the button through
+  `className`; where the shape depends on state (a table view that gains a CSV
+  export), pass both. A grid cell stretches that wrapper where a flex row would
+  not, which is why the actions row is a grid. `whitespace-nowrap` on the
+  button keeps the label on one line.
 - **A button beside a field is the height of the field.** A `py-1.5` button
   against a `py-2` picker reads as a mistake. Put the row in `items-stretch`
   (or give the export's box `self-stretch`) and pass `h-full`; where the field

--- a/docs/frontend/ui-conventions.md
+++ b/docs/frontend/ui-conventions.md
@@ -249,6 +249,55 @@ Two hooks, because two different prerequisites. A control whose one possible out
 
 The hook answers `configured: false` until the status settles **and** for a status read that failed -- deliberately, because "we could not ask" is not "there is a provider", and it is also what keeps a control from flashing in and vanishing. Read the cached `aiApi.getStatus` through the hook rather than fetching status again: one request serves every mounted surface, and a provider added or removed in Settings drops that cache.
 
+## A report toolbar wraps, and nothing in it sizes itself past the screen
+
+A report's controls sit in one card above the figures, and on a phone that card
+is about 311px wide (`px-4` on the page, `p-4` on the card, at 375px). Three
+mistakes put a control off the right of it, and all three were reported by a
+human reading the app on a phone rather than by a test:
+
+- **A row that does not wrap.** `flex gap-2 items-center` holding a picker, a
+  view switch and an export has no way to fold, so the last control leaves the
+  card. Every toolbar row is `flex-wrap`, and a group that deserves its own line
+  on a phone takes `w-full sm:w-auto` rather than relying on the wrap landing
+  where you hoped.
+- **`ml-auto` on a wrapped row.** Pushing the trailing group right is correct on
+  one line and ragged on three: the group lands alone against the right edge
+  under two left-aligned rows. Write it `sm:ml-auto`.
+- **An intrinsic width no ancestor can shrink.** A flex item cannot go below its
+  content's min-content width, so anything inside a control that refuses to wrap
+  sets a floor for the whole toolbar. `MultiSelect`'s `sizeToLongestOption`
+  sizer is the case: invisible `whitespace-nowrap` copies of the longest option
+  labels give the trigger its width, and an uncapped copy made the *minimum*
+  width of the Security Performance picker the longest security name -- wider
+  than the screen. Each copy is capped with `max-w-[calc(100vw-12rem)]`, a
+  definite length (a percentage would resolve against the width being computed
+  and clamp nothing), and 12rem clears the widest page and card padding in the
+  app. Below the cap the control is still as wide as its longest option; above
+  it the trigger shrinks and the selected label truncates.
+
+Two sizing notes for the controls themselves:
+
+- **The export's box is not always its button.** `ExportDropdown` renders a
+  bare button in its PDF-only form and a `relative inline-block` wrapper around
+  it when a CSV handler is passed. A caller sizing the export for a phone
+  (`w-full sm:w-auto`) sizes the wrapper through `containerClassName` and the
+  button through `className`; where the variant depends on state (a table view
+  that gains a CSV export), pass both. `whitespace-nowrap` on the button keeps
+  the label on one line.
+- **A button beside a field is the height of the field.** A `py-1.5` button
+  against a `py-2` picker reads as a mistake. Put the row in `items-stretch`
+  (or give the export's box `self-stretch`) and pass `h-full`; where the field
+  carries a label above it, reserve the label's own space over the button with
+  `LabelSpacer` (`components/ui/LabelSpacer.tsx`) so what stretches is exactly
+  the input's height. Never match the padding by hand -- the figure drifts the
+  next time either control's type scale changes.
+
+`ChartLegend` is the same trade-off answered per caller: it is one column on a
+phone by default, and `phoneColumns={2}` halves the scroll for a legend of short
+names (the spending-by-category legend). A name that has to truncate at half
+width loses its end silently, so check the longest one before asking for two.
+
 ## A `<details>` disclosure is controlled, because jsdom half-implements it
 
 `<details>`/`<summary>` is the disclosure this codebase uses (`PushDiagnostics`, and the foldable Browser push block beside it): native keyboard operation, and the expanded state announced without an `aria-expanded` of our own. But React does not manage `open` the way it manages an input's `value` -- it writes the attribute and stops -- so a component that renders anything off "is this open" must hold that in state, pass `open={state}`, and move it itself. **`onToggle` cannot be the only mover**: jsdom flips `open` on a summary click and fires no `toggle` event at all, so the behaviour is untestable through it and a browser that misses the event leaves the summary describing the wrong state. Handle the summary's `onClick`, `preventDefault()` to cancel the element's own activation behaviour, and toggle state there (Enter and Space on a focused summary dispatch a click, so the keyboard comes with it); keep `onToggle` wired for the toggles no click produces, such as Chrome expanding a `<details>` to reveal a find-in-page match.

--- a/docs/frontend/ui-conventions.md
+++ b/docs/frontend/ui-conventions.md
@@ -276,21 +276,31 @@ human reading the app on a phone rather than by a test:
   app. Below the cap the control is still as wide as its longest option; above
   it the trigger shrinks and the selected label truncates.
 
-Two sizing notes for the controls themselves:
+**The refresh and export buttons are `ReportToolbarActions`, never laid out by
+the report.** Render it as the LAST child of the toolbar's wrapping row and give
+it the handlers; it is a full-width row below every selector on a phone (two
+equal halves when the report also refreshes prices) and the toolbar's trailing
+group from `sm` up. Every report wrote that layout for itself once, and a dozen
+wrote it wrong. `ui-conventions.test.ts` fails a report that renders
+`ExportDropdown` itself, or `RefreshPricesButton` beside one.
+
+What the shared row encodes, for the two places that still compose by hand:
 
 - **The export's box is not always its button.** `ExportDropdown` renders a
   bare button in its PDF-only form and a `relative inline-block` wrapper around
-  it when a CSV handler is passed. A caller sizing the export for a phone
-  (`w-full sm:w-auto`) sizes the wrapper through `containerClassName` and the
-  button through `className`; where the variant depends on state (a table view
-  that gains a CSV export), pass both. `whitespace-nowrap` on the button keeps
-  the label on one line.
+  it when a CSV handler is passed. Sizing the export for a phone
+  (`w-full sm:w-auto`) means sizing the wrapper through `containerClassName`
+  and the button through `className`; where the variant depends on state (a
+  table view that gains a CSV export), pass both. A grid cell stretches that
+  wrapper where a flex row would not, which is why the actions row is a grid.
+  `whitespace-nowrap` on the button keeps the label on one line.
 - **A button beside a field is the height of the field.** A `py-1.5` button
   against a `py-2` picker reads as a mistake. Put the row in `items-stretch`
   (or give the export's box `self-stretch`) and pass `h-full`; where the field
   carries a label above it, reserve the label's own space over the button with
   `LabelSpacer` (`components/ui/LabelSpacer.tsx`) so what stretches is exactly
-  the input's height. Never match the padding by hand -- the figure drifts the
+  the input's height, and hide that spacer below `sm`, where the button has no
+  field beside it. Never match the padding by hand -- the figure drifts the
   next time either control's type scale changes.
 
 `ChartLegend` is the same trade-off answered per caller: it is one column on a

--- a/docs/release-notes/1.16.0.md
+++ b/docs/release-notes/1.16.0.md
@@ -2,213 +2,99 @@
 
 The **phone** release.
 
-Monize has been a desktop app you could open on a phone. This one is built the other way round. It **notifies you** -- browser push to a phone or desktop even when the app is closed, with a per-notification-type matrix deciding what reaches you by email, by push, or only in the bell. It **takes files from the operating system's share sheet** -- a receipt photo, a bank statement -- straight into the transaction form or the import wizard. It **scans a document with the camera**, straightening and cleaning a photo of a receipt while keeping the original beside it. And **every wide table in the app now folds into per-row cards on a phone** instead of scrolling sideways: twenty-four lists and reports, reviewed on a real handset.
+Monize has been a desktop app you could open on a phone; this one is built the other way round. It **notifies you** -- browser push to a phone or desktop even when the app is closed, with a per-type matrix deciding what reaches you by email, by push, or only in the bell. It **takes files from the operating system's share sheet** straight into the transaction form, the import wizard or the AI assistant, and it **scans a receipt with the camera**. And **nearly forty wide tables now fold into per-row cards on a phone** instead of scrolling sideways, alongside swipe navigation, swipe-to-page on the register, and charts and catalogues laid out for a narrow screen.
 
-Away from the phone: **payees grow contact details** -- address, email, phone -- with an optional lookup from Google Places or your own AI provider; **every figure is written in your number convention** rather than en-US, in the fields you type into as well as the ones you read; and **system failures that used to die in a log line** -- a failed backup, a missing `ENCRYPTION_KEY`, a mail server that stopped working -- now raise an alert in the bell and email the administrators.
+Away from the phone: **payees grow contact details** with an optional lookup, **every figure is written in your number convention** rather than en-US, the **AI assistant quotes a foreign account in your default currency**, and **system failures that used to die in a log line** now raise an alert in the bell and email the administrators.
 
-Operators should read [For operators](#for-operators): browser push is off until an administrator enables it, and new migrations are named by timestamp now.
+Operators should read [For operators](#for-operators): push is off until you enable it, automatic backups move to their own admin page, and new migrations are named by timestamp.
 
 ## Notifications
 
-Discussion #1291, delivered in phases. The notification center already existed -- one table, one bell, one write door. This release builds the *delivery* layer on top of it: whether, where, how often, and how loudly each notification reaches you.
+Discussion #1291, delivered in phases. The bell already existed; this release builds the *delivery* layer on top of it.
 
-### A matrix, not a switch
-
-**Settings -> Notifications** now carries a grid: one row per notification type, one column per channel. The types are **Bills and scheduled**, **Budgets**, **System alerts**, **Account balances**, **Investment value** and **Strategy signals**; the channels are **Email (report)**, **Email (alert)**, **Push** and **UnifiedPush**.
-
-Two things about it are deliberate:
-
-- **The bell is not a column.** Every notification is written to the bell, always -- it is the record, and the other channels are fan-outs from it. A grid where a sixth of a phone's width is a column of permanent ticks is width the four real controls needed, so it is one sentence above the grid instead.
-- **Email is two channels, not one.** A monthly budget report and a "your balance just went below 200" are the same word and not the same thing, so they are separately switchable.
-
-Each row also carries a **cooldown** -- off, 5 minutes, 15, 30, an hour, six hours, a day. When something in the same group already fired inside that window, the email and the push are skipped. The bell entry is still written; a cooldown never suppresses the record.
-
-Every switch saves the moment you flip it. There is no Save button to forget.
-
-### Browser push, with no third party in the middle
-
-An instance generates its own Web Push key pair on start (it needs `ENCRYPTION_KEY` set, since the private half is stored encrypted) and signs its own messages. **No Firebase project, no Google Play account, no Apple Developer account.** An administrator turns the channel on in **Admin -> Notifications**, and each person then registers their own devices in **Settings -> Notifications**, with a test notification per device and a per-device Remove.
-
-The awkward parts of push are handled rather than hidden: a device is identified by where it registered, iOS only offers push once Monize is on the Home Screen (and says so), Brave's blocked push service names its own fix, a permission that was granted while Android still hides notifications gets the press-and-hold instructions, and a subscription that has expired, been retired by a key rotation, or failed repeatedly says which of the three it was. There is a **Notification diagnostics** panel that copies the whole report if a device still will not behave.
-
-Rotating the key pair is available to administrators for the case where a key may have been exposed; it is confirmed with the number of devices it will disconnect.
-
-The **Browser push** block also folds away, since most of its height only matters while you are registering something, and it stays folded until you open it again -- remembered in the browser you folded it in, the way row density and the register's date view are, so a phone and a desktop signed into the same account need not agree. Collapsed, its heading carries the count -- how many devices can be delivered to, with any retired ones named separately rather than folded into the same number, and "Device list unavailable" rather than a count when the list did not load. The blocks that merely explain why push is unavailable on a deployment do not fold: hiding that sentence behind a click is worse than no fold at all.
-
-### UnifiedPush
-
-The same encrypted push, delivered to a distributor you run yourself -- ntfy, NextPush -- instead of a browser vendor's infrastructure. It shares the instance's key pair and the instance-wide switch; you register your endpoint in your distributor app and turn the column on. It is a full transport, not a placeholder.
-
-### Reminders you can stop from the notification
-
-Any notification in the bell can be turned into a reminder: **just once more** after a delay, or **repeat until I stop it** on an interval. Stopping works from inside the app *and* from a Stop action on the push itself, because the phone in your hand at 7 a.m. is where you want that button.
-
-Reminders are capped, one per source notification, and swept when the thing they are about is gone.
-
-### Three new things worth being told about
-
-- **Account balance thresholds.** Set an optional "notify below" and "notify above" on any account. The alert fires on a **crossing**, not on the state: a balance that sits at 40 under a 50 threshold notifies once when it first drops, and again only after it has recovered above 50 and crossed down again.
-- **Investment value movement.** Once a day, when your investment accounts move beyond a threshold you set. Deposits and withdrawals are excluded -- it measures market movement and dividends, not money you put in.
-- **GEM strategy signals.** When a strategy's recommendation changes from the previous period, as two distinct events: a **risk-state change** (RISK_ON to RISK_OFF or back, the headline) and an **allocation change** where the risk state held but the target did not.
-
-Bill reminders and scheduled-post failures now fan out through the same dispatch seam, so they obey the same matrix and the same cooldown as everything else.
-
-### System issues reach the person who can fix them
-
-A failed automatic backup used to write a status onto a settings page most operators never revisit and log one line. A partial backup -- a promotion copy or a retention delete that failed -- did not even do that: it logged a warning and the status stayed `success`. A missing `ENCRYPTION_KEY` was a startup warning. A deployment with no SMTP got nothing at all, including, by construction, any report that SMTP itself was broken.
-
-Those are now alerts in the bell: **backup failed**, **backup partial** (naming which part), **encryption key missing**, **provider outage** and **recovery**, **SMTP failing**. Anything only an administrator can act on goes to administrators only, one row each, and the critical ones are also emailed once a day rather than on every occurrence. A scheduled transaction that fails to auto-post goes to the user whose transaction it was.
-
-### The bell itself
-
-Severity chips (critical / warning / info / good news) and a Financial-vs-System filter, and a **Delete all** that respects the filter and reaches past the 50 rows on screen -- it reports how many the server actually dismissed. On a phone the panel now covers the whole screen instead of collapsing inside the sliding header.
-
-### A guided tour of all of it
-
-There is a **Notifications** walkthrough among the guided tours -- offered from What's New, and available any time from **Settings -> Guided tours**. Nine steps in two halves: the bell and its panel first (it opens the panel for you), then the three Settings blocks that decide where a notification goes. It presses nothing on your behalf and asks nothing of you: every step moves on with Next, so you can read the whole thing without changing a setting, and every control it describes stays usable while you read about it if you would rather try one.
-
-It also runs for an account with nothing in the bell yet, which is who it is mostly for.
+- **A matrix, not a switch.** **Settings -> Notifications** carries a grid: one row per notification type (bills and scheduled, budgets, system alerts, account balances, investment value, strategy signals), one column per channel (email report, email alert, push, UnifiedPush). Email is two channels, because a monthly budget report and a "your balance went below 200" are not the same thing. The bell is not a column -- every notification is written there, always. Each row carries a **cooldown** that skips the email and the push but never the record, and every switch saves the moment you flip it.
+- **Browser push, with no third party in the middle.** An instance generates and signs with its own key pair: no Firebase project, no Play or Developer account. An administrator enables the channel, then each person registers their own devices, with a test notification and a Remove per device. The awkward parts are handled rather than hidden -- iOS needing the Home Screen, Brave's blocked push service, Android hiding a permission you granted, a subscription that expired or was retired by a rotation -- and a diagnostics panel copies the whole report when a device still will not behave.
+- **UnifiedPush** delivers the same encrypted push to a distributor you run yourself, ntfy or NextPush. It is a full transport, not a placeholder.
+- **Reminders you can stop from the notification.** Any bell entry can repeat once more after a delay, or on an interval until you stop it -- from inside the app, or from a Stop action on the push itself.
+- **Three new things worth being told about**: account balance thresholds, which fire on a **crossing** rather than a state; a daily investment-value movement that excludes deposits and withdrawals, so it measures the market and not your own transfers; and GEM strategy signals, split into a risk-state change and an allocation change. Bill reminders and scheduled-post failures now fan out through the same seam, so they obey the same matrix and the same cooldown.
+- **System issues reach the person who can fix them.** A failed or partial backup, a missing `ENCRYPTION_KEY`, a provider outage and its recovery, and failing SMTP are alerts in the bell now, rather than a log line or a status page nobody revisits. Anything only an administrator can act on goes to administrators, and the critical ones are emailed once a day rather than on every occurrence.
+- **The bell itself** gains severity chips, a Financial-vs-System filter, and a **Delete all** that respects the filter, reaches past the rows on screen and reports how many the server dismissed. On a phone the panel covers the whole screen.
+- **A nine-step guided tour** covers all of it, offered from What's New and available any time from **Settings -> Guided tours**. It presses nothing on your behalf, and it runs for an account with an empty bell, which is who it is mostly for.
 
 ## Attachments
 
 Discussion #1292, both parts.
 
-### Scan a document
-
-Beside **Upload** there is now **Scan document**. On a phone it opens the rear camera; on a desktop, the file picker. The photo is analysed in your browser -- a WebAssembly build of OpenCV in a Web Worker, loaded the first time you open the dialog -- and never leaves the device unprocessed.
-
-You get a preview with the detected page boundary, **four draggable corners** if the detection was wrong, a **Finish** choice (colour, greyscale, black and white, or straightened-but-otherwise-untouched, each with a sentence on what it is for), brightness and contrast sliders, and **Rotate** where there is something to rotate. Quality problems -- a blurred photo, a page running off the edge of the frame, an output too small to read fine print -- are warnings with a Retake action, never a block.
-
-**A scan is one attachment, not two.** The enhanced image and the original photo are stored as a linked pair, written in one transaction, counted as one against the per-transaction limit, listed as one row, and deleted together. The original is byte-for-byte what the camera produced: no re-encoding, no orientation rewrite, no metadata stripped. It is reachable through an **Original** toggle wherever the attachment is shown.
-
-### Preview instead of download
-
-Clicking an attachment now opens it in Monize. Images draw with a Fit / Actual size toggle, PDFs render in the app with page navigation, and Download is a footer action rather than the only thing a click can do. A scanned document offers the same Enhanced / Original switch, and Download follows whichever is on screen. Files staged in the New Transaction window preview the same way, before they are uploaded.
-
-### Share into Monize
-
-An installed Monize now appears in the operating system's share sheet (Android Chromium and desktop Chromium; iOS Safari does not support this and keeps the file picker). Share a receipt photo, a PDF, or a statement export, and Monize opens a **review screen**: every file the OS handed over, with a reason beside anything it cannot use, and the destinations its contents support -- a new transaction with the files attached, or the import wizard.
-
-**Nothing is imported, attached or saved without a press.** The share opens the same transaction form and the same import wizard with the same mapping and review steps you would reach through the file picker; it adds no new door. A share that mixes files to attach with files to import is refused with an explanation, because the two go to different places and guessing is worse than asking. A share that arrives while you are logged out is held on the device and offered again after login; shared files are kept locally for an hour and then removed. Upload limits are checked before any byte reaches the server, and the server's own limits are unchanged.
+- **Scan document** sits beside Upload: the rear camera on a phone, the file picker on a desktop. The photo is analysed in your browser by a WebAssembly OpenCV build in a worker, and never leaves the device unprocessed. You get the detected page boundary with **four draggable corners**, a finish choice (colour, greyscale, black and white, or straightened but otherwise untouched), brightness and contrast, and rotation. A blurred photo or a page running off the frame is a warning with a Retake, never a block.
+- **A scan is one attachment, not two.** The enhanced image and the original photo are a linked pair: one row, one count against the per-transaction limit, deleted together. The original is byte-for-byte what the camera produced, reachable through an **Original** toggle wherever the attachment appears.
+- **Clicking an attachment opens it in Monize** instead of downloading it. Images get Fit and Actual size, PDFs render with page navigation, Download becomes a footer action, and files staged in a new transaction preview the same way before they are uploaded.
+- **Share into Monize.** An installed Monize appears in the operating system's share sheet (Android and desktop Chromium; iOS Safari does not support it). A **review screen** lists every file the OS handed over, with a reason beside anything unusable, and offers the destinations its contents support. Nothing is imported, attached or saved without a press. A share that mixes files to attach with files to import is refused with an explanation rather than guessed at, and a share that arrives while you are logged out is held on the device for an hour and offered again after login.
 
 ## On a phone
 
-### Wide tables become cards
+**Nearly forty tables** now render as per-row cards below the phone breakpoint instead of scrolling horizontally: the transaction register, accounts, institutions, currencies, securities, payees and bills, the investment register, the holdings list, a security's transaction history, saved loan scenarios, the amortization schedule, and the tables in some twenty reports. Each was laid out against the real numbers the API returns rather than a guess at their width, sorting and row navigation still work, and PDF and CSV exports derive from the same column definitions as the screen. Three were converted and then **reverted** after review on a handset -- Monthly Spending Trend, Net Worth and the Categories list are narrow enough as tables, and a card was worse.
 
-Twenty-four tables now render as per-row cards below the phone breakpoint instead of scrolling horizontally: the **transaction register**, **accounts**, **institutions**, **currencies**, **securities**, **payees**, **bills**, the **investment register** and the **loan amortization schedule**, plus the tables in **Income vs Expenses**, **Savings Rate**, **Credit Utilization**, **Currency Exposure**, **Sector Weightings**, **Security Type Allocation**, **Budget vs Actual** (both its summary and its category-averages tables), **Budget Health Score**, **Flex Group Analysis**, **Category Performance**, **Bill Payment History**, **Recurring Expenses**, **Investment Transactions** and **Uncategorized Transactions**.
+**A horizontal swipe moves between views**, following the drawer's own order and cycling within the group you are in: the main pages, AI, Tools, and Admin for an administrator who is not a delegate. On the transaction register the same gesture **turns the page** instead, left for the next and right for the previous, and a single-page register hands the gesture back to view navigation.
 
-Each was laid out against the real numbers the API returns rather than a guess at their width, sorting and row navigation still work, and PDF and CSV exports are derived from the same column definitions as the screen, so a card layout cannot silently disagree with an export. Three were converted and then **reverted** after review on a handset -- Monthly Spending Trend, Net Worth and the Categories list are narrow enough as tables, and a card was worse.
-
-Tab strips that overflow now fade at the edge that hides more tabs and scroll the selected one into view, instead of ending in an ambiguous cut.
-
-### Elsewhere on the phone
-
-- The **Transactions** account info widget gains a caret that opens the account switcher, so you can change account without going back to the list. The menu is drawn above everything and clamped to the viewport, and on a touch device it opens without the keyboard leaping up.
-- **Both account switchers** -- that caret and the one beside an account's name on its own page -- put your starred accounts at the top, under a **Favourites** heading, in the order you arranged them, with everything else alphabetically below. Where you have starred accounts but never dragged them into an order, they are alphabetical too, so the same accounts read the same way on every screen; the account detail page's list was previously in no particular order at all. Typing in the filter still reaches both sections.
-- Attachments render on the phone transaction card, and the transaction form header stacks rather than crushing itself.
+Charts and lists were rebuilt for the width. The **total sits inside the donut's hole** and a **legend is one vertical column**; a security's weighting bars become tiles; summary cards become a two-column tile grid; the reports catalogue becomes a compact tile grid instead of one tall card per row. Elsewhere: an account switcher caret on the Transactions widget, **favourites first** in both account switchers with everything else alphabetical below, attachments on the transaction card, overflowing tab strips that fade and scroll the selected tab into view, and several titles that wrap now instead of being clipped.
 
 ## Payees
 
-### Contact details
+Payees hold an **address**, an **email** and a **phone number** beside the website. The address opens a map -- your device's own app, or a new **Map provider** preference on the desktop. Phone numbers are stored in one canonical international form, so the same payee reads the same way whichever country you looked it up in, and a number with no country code is rejected with an example.
 
-Payees now hold an **address**, an **email** and a **phone number** alongside the website. The address is a link that opens a map -- your phone or tablet uses its own map app, and on the desktop a new **Map provider** preference chooses between Apple, Bing, Google, OpenStreetMap, Waze, or automatic.
-
-Phone numbers are stored in one canonical international form regardless of where the number is from, so the same payee reads the same way whichever country you looked it up in, and a number without a country code is rejected with an example rather than stored ambiguously.
-
-### Look it up
-
-**Settings -> Payee Lookup** turns on an optional lookup of a payee's website, address, email and phone. Two sources are supported and you choose the order they are tried in:
-
-- **Google Places** -- directory facts, cheaper per lookup, no email address. Either the operator configures a key for the whole deployment (you get a simple on/off) or you configure your own with your own monthly limit.
-- **Your existing AI provider** -- can find an email address, costs a model call. You can pin which provider answers, or leave it to priority order.
-
-It can run automatically on a new payee, or on demand from the **Look up details** button. Either way the result is **shown for confirmation before it is written**, with each suggested and each replaced field marked and an undo; where a lookup returns several candidates, you pick the match. What is sent is stated on the switch that consents to it: the payee's name, plus any notes, website, address, email and phone it already holds, so the lookup can tell the right business and the right branch apart.
-
-A lookup that failed is reported as a failure. An answer that could not be read is a failure. Neither is reported as "nothing found", because those have different fixes.
+**Settings -> Payee Lookup** turns on an optional lookup of those fields, from **Google Places** (directory facts, cheaper, no email address) or **your existing AI provider** (can find an email, costs a model call), in the order you choose. It runs on a new payee or on demand, and the result is always **shown for confirmation before it is written**, with each suggested and replaced field marked, an undo, and a pick-the-match step where there are several candidates. What gets sent is stated on the switch that consents to it. A lookup that failed and an answer that could not be read are both reported as failures rather than as "nothing found", because those have different fixes.
 
 ## Numbers in your own convention
 
-Monize has had a number-format preference and a preference-blind formatter side by side, and the second was the one a component reached for when the first needed a hook. So a Polish user with `numberFormat: pl-PL` read `zl18,812.71` on the Securities page while every other screen used their own convention (#1316).
+A preference-blind formatter sat beside the number-format preference, and it was the one a component reached for, so a Polish user read `zl18,812.71` on the Securities page while every other screen used their own convention (#1316). Every user-facing figure now goes through the configured number locale -- amounts, share quantities, percentages, rates and file sizes -- with four fingerprints scanned for, including a bare `toLocaleString()`, which follows the *browser* precisely where an explicit preference exists to override it.
 
-Every user-facing figure now goes through the configured number locale -- amounts, share quantities, percentages, rates and file sizes -- and four fingerprints that reproduced every instance found are now scanned for, including `toLocaleString()` with no locale, which follows the *browser* when an explicit preference exists precisely to override it.
+**The fields you type into follow it too.** `1200,99` in a comma-decimal locale is 1,200.99 and not 120,099, a figure copied out of a localized column can be pasted back in, the on-field calculator agrees with the field it sits in, and Indian lakh grouping survives a round trip.
 
-**The fields you type into follow it too.** Number inputs parse and format in your locale, so `1200,99` in a comma-decimal locale is 1,200.99 and not 120,099, a figure copied out of a localized column can be pasted back in, the on-field calculator agrees with the field it sits in, and Indian lakh grouping survives a round trip. Native-numeral input is normalized rather than discarded.
+Month labels and summary text across the reports are translated rather than hard-coded English: Monthly Comparison, Year over Year, budget trends, recurring-expense metadata, security-type allocation and scheduled-transaction markers. Report cards on a phone honour your date format.
 
-Month labels and summary text in **Monthly Comparison** and **Year over Year** are translated rather than hard-coded English, along with a month-click crash and a delta sign found while doing it.
+## Reports
+
+The **Investment Performance** chart had four defects in one view. It sent every security you hold and failed past the backend's cap, so it now plots the twenty largest holdings and says so when you hold more. Its PDF export drew a legend from the holdings table while the chart plotted percentage return. Its subtitle was borrowed from a chart about hand-picked instruments. And its range labels read English to everyone.
+
+Three figures stopped lying: a dividend period that genuinely earned nothing says **zero** rather than "unknown", a dividend total no longer drifts from the rows it sums, and a figure derived from a partial subtotal is marked partial. A report's currency travels with its uncategorized totals. Sortable headers and allocation rows are operable from the keyboard, and Budget Health Score sorts its Group column by the label you can actually see.
+
+## The AI assistant
+
+**A foreign account is quoted in your default currency.** It used to come back in its own currency beside totals in yours, so a model either left it unconverted or converted it at a rate it invented. Every account now carries its converted balance and the rate applied, and a currency pair with no rate is named as missing rather than guessed.
+
+**The calculator converts.** A new `convert` operation prices an amount between two currencies at the rate on a date, today unless you name another, and reports the amount, both codes, the rate and the date it used. No rate is an error, never an estimate, and the assistant is told never to do the arithmetic itself.
+
+**A shared file can go straight to the assistant.** The share review screen gains *Send to AI Assistant*, staging the files on the chat composer and sending nothing until you press send. It appears only when a provider can answer and the chat would accept every file in the share, since its limits are tighter than the import wizard's.
 
 ## Investments and loans
 
-### Securities gain a Value column
-
-The securities list showed how many shares you held and nothing about what they were worth, and the only way to refresh the prices behind that figure was to leave for the Investments page. There is now a **Value** column -- shares times latest close, in the security's own currency, so nothing is converted and no exchange rate can be missing -- and a **Refresh** button for prices.
-
-Zero shares is a measured zero. A position held at a price nobody could fetch is **unknown**, shown as such with the reason, never as a zero that reads like a worthless holding; sorting sinks unknowns in both directions rather than letting an unpriceable security head an ascending list as the cheapest thing you own.
-
-### A scheduled investment's warning charges the account that pays
-
-The below-zero warning on a scheduled investment was measured against the brokerage account, which is not where the cash comes from. It now charges the settlement account -- the funding account or the linked cash sleeve -- the same account the posting actually moves.
-
-### The loan simulator says why it cannot answer
-
-Two blank spaces on the loan detail page now explain themselves:
-
-- **The overpayment simulator** used to disappear whenever a forward projection could not be built. It now names the cause -- paid off, no payment frequency, no saved interest rate, or no determinable installment -- and the last one names the usual reason, which is installments booked as ordinary expenses on the source account, where the loan schedule can never see them.
-- **An unknown payoff date and remaining interest** are two different problems with opposite fixes. An installment below one period's interest (usually a stale payment amount you can correct, and both figures are shown so you can compare them) is not the same as a term running past the projection horizon, which is a property of the loan.
-
-And a stated installment no longer outranks reality: where a lender re-amortizes after an overpayment, a real payment observed after the stated one supersedes it. A 1,200.99 stated in a 2022 rate-change row was reading as "the installment" on the summary card, the PDF, the reports and the transactions sidebar while the bank had long since dropped it to about 860. A zero-amount interest row -- a payment holiday -- stays in the schedule instead of being dropped.
+- **Securities gain a Value column** -- shares times latest close, in the security's own currency, so no exchange rate can be missing -- and a **Refresh** button, instead of a trip to the Investments page. A position nobody could price is **unknown** with a reason, never a zero that reads like a worthless holding, and sorting sinks unknowns in both directions.
+- **A force price update keeps the year it fetched** rather than clipping it back to a recent purchase date, and it refreshes the Overview tab's chart, which used to go on showing the old line.
+- **A scheduled investment's below-zero warning charges the settlement account** -- the funding account or the linked cash sleeve -- not the brokerage account the cash never came from.
+- **The loan simulator says why it cannot answer.** The overpayment simulator names the cause instead of disappearing, and an unknown payoff date is told apart from unknown remaining interest, which have opposite fixes. A stated installment also stops outranking reality: where a lender re-amortizes after an overpayment, a real payment observed later supersedes it, and a payment holiday stays in the schedule instead of being dropped.
 
 ## The register
 
-Column visibility was hand-written per cell and had drifted: Status appeared last of all on a wide screen despite ranking high, Attachments appeared before Tags, and the Account column rendered on single-account pages where every row repeats the page's own title.
-
-There is now one contract: a fixed order (Date, Account, Payee, Category, Description, Ref #, Tags, Attachments, Amount, Balance, Status, Actions) and one priority tier per column, each tier mapping to exactly one breakpoint. Density -- Normal, Compact, Dense -- changes how tall a row is and never which columns exist.
-
-The **Payee** column also stops being squeezed out of existence. It has a floor width so Description cannot take the room it needs, is uncapped while Description is on screen, and scales with the register rather than being pinned at a fixed pixel width.
+Column visibility was hand-written per cell and had drifted -- Status last on a wide screen, Attachments before Tags, an Account column on single-account pages where every row repeats the page title. There is now one contract: a fixed order, and one priority tier per column mapping to exactly one breakpoint. Density changes how tall a row is, never which columns exist. The **Payee** column also gets a floor width, so Description can no longer squeeze it out of existence.
 
 ## For operators
 
-### Browser push has to be switched on
-
-Push is off until an administrator enables it in **Admin -> Notifications**, and the instance needs `ENCRYPTION_KEY` set before it can generate a key pair at all -- the private half is stored encrypted. The Admin page states, per channel, whether it is on, off, or unconfigured, and why. Nothing about existing deployments changes if you leave it alone.
-
-If you restore a backup onto a different instance, or change `ENCRYPTION_KEY` under a live database, the stored key pair stops being readable; the page says so and rotating recovers it, at the cost of every device registering again.
-
-### New migrations are named by timestamp
-
-The `NNN_` counter is retired (#1277). It was a manually policed global value that did not scale with parallel work: two branches from one base both correctly read "the current max is 164", both correctly picked 165, and nothing either could do locally detected the other -- which had already happened six times. New migrations are `YYYYMMDDHHMMSS_description.sql`, generated from the UTC second of authoring, so a prefix cannot be produced twice.
-
-**Existing migrations are untouched and nothing is renumbered.** Apply order is numeric on the prefix and then the full filename -- written once and imported by the runner, the integration harnesses, the migration lint and the prefix check -- so every fourteen-digit timestamp follows every three-digit prefix and the transition is purely additive.
-
-### Google Places (optional)
-
-`GOOGLE_PLACES_API_KEY` and `GOOGLE_PLACES_MONTHLY_CAP` in `.env.example` make Places available to everyone on the deployment; leave them unset and each user may configure their own key instead. The default cap is 1,000 requests a month, which is the free allowance for the Text Search SKU that actually returns the fields this lookup needs. Restrict the key by **IP address**, not by HTTP referrer -- Monize calls Google from the server, where anything holding the key can send whatever referrer it likes; if your deployment has no stable egress IP, `PUBLIC_APP_URL`'s origin is now sent as the `Referer` so a referrer restriction remains workable.
-
-### Smaller operational changes
-
-- **Per-PR preview images are retired**, and the 481 they had left behind in the registry were swept. Base OS packages in the published images are upgraded.
-- **RLS bypass entries are no longer logged individually.** They were one line per entry and drowned everything else.
-- The **NPM Audit** CI gate now tells a real vulnerability apart from an npmjs.com outage instead of failing the build for both.
+- **Browser push has to be switched on** in **Admin -> Notifications**, and the instance needs `ENCRYPTION_KEY` before it can generate a key pair, since the private half is stored encrypted. The page states per channel whether it is on, off or unconfigured, and why. Nothing changes on an existing deployment if you leave it alone. Restoring a backup onto another instance, or changing the key under a live database, makes the stored pair unreadable; the page says so, and rotating recovers it at the cost of every device registering again.
+- **New migrations are named by timestamp** (#1277). The `NNN_` counter was a manually policed global that did not survive parallel work and had already collided six times. New files are `YYYYMMDDHHMMSS_description.sql`. **Existing migrations are untouched and nothing is renumbered**, with the apply order written once and imported by the runner, the harnesses and the lint, so the transition is purely additive.
+- **Automatic backups move to Admin -> Backups**, an admin-only page; **Settings -> Backup & Restore** keeps your own manual export and restore. The copy there now says what automatic backup actually is -- a compressed per-user server backup, not a database dump and not the manual export's format -- and stops claiming to govern the whole deployment, since the schedule and retention are the administrator's own while everyone else runs on fixed defaults. In demo mode its controls are disabled with a note naming why.
+- **An OIDC login that fails in the back channel says why.** The callback logs the token endpoint's real response, and `OIDC_DEBUG=true` logs the discovery, token and userinfo calls. It logs token bodies, so leave it off outside diagnosis.
+- **Google Places is optional.** `GOOGLE_PLACES_API_KEY` and `GOOGLE_PLACES_MONTHLY_CAP` make it available deployment-wide; leave them unset and each user may bring their own key. Restrict the key by **IP address**, not by referrer, because the call is made from the server; where there is no stable egress IP, the app's own origin is now sent as the `Referer`.
+- Smaller changes: **per-PR preview images are retired** and the 481 they left in the registry swept, base OS packages upgraded, **RLS bypass entries no longer logged one line each**, the **NPM Audit** gate telling a real vulnerability apart from an npmjs.com outage with its advisories and the front-end Dependabot alerts cleared, gemma4 replacing deepseek-v3.1 in the Ollama Cloud samples, and **a horizontal-scaling plan written down** -- a `CLUSTER_MODE` switch, correctness-bearing state staying in PostgreSQL, Redis reserved for throttler counters and a wake-up channel -- with nothing built yet.
 
 ## Under the hood
 
-### The MCP server
+**The MCP server** now serves protocol revision **2026-07-28 beside the 2025-era revisions**, from one definition on the v2 SDK, with the era decided by the SDK's own request classification rather than a header check; Claude Desktop, `claude mcp add` and Codex are untouched. Identity is resolved per request, since the 2026 revision has no session at all. **The per-request cost is roughly halved**: `tools/list` rides in the model's context on every request and had reached 78 KB across 20 tools with nothing measuring it, so descriptions say each thing once, schema fragments are shared, and a test now fails when a tool or the total exceeds a cap that ratchets down as tools shrink. Two write-path fixes: a client that cannot show a confirmation dialog is no longer refused every write, and a confirmation is fingerprinted against the change it approved.
 
-- **Protocol revision 2026-07-28 is served beside the 2025-era revisions**, from one server definition, on the v2 SDK. Claude Desktop's connector, `claude mcp add` and Codex are untouched -- the era is decided by the SDK's own request classification rather than a header check, so a malformed envelope or a mismatched version header gets the error answer its own era defines.
-- **Identity is resolved per request.** The 2026 revision has no session at all, so the transport seeds the bearer token's user itself on every request.
-- **The per-request cost is roughly halved.** Every byte of `tools/list` rides in the model's context on every single request, and nothing measured it: the payload had reached 78 KB across 20 tools. Tool descriptions now say each thing once, input-schema fragments are shared, output schemas declare what a model reasons about rather than every column, and each tool result is sent once as structured content instead of twice. A test serializes the real `tools/list` through the SDK and fails when a tool, the total, or the server instructions exceed a cap -- a ratchet that lowers as tools shrink and rises only as a reviewed decision.
-- **Two write-path fixes**: a client that cannot show a confirmation dialog is no longer refused every write, and a confirmation is fingerprinted against the change it approved rather than the round it was built in. `list_payees`' filter works, and now narrows, sorts and caps. A number a model wrote as a string is accepted.
-
-### Everyday fixes
-
-- The **introduction tour** can open an account's detail page and walk its steps, rather than stopping at the account list (#1317). Its coach mark is parked clear of the row actions it names.
-- **Guided Tours** moves to sit just above About in Settings, and the Preferences section is regrouped into Language & Region, Appearance, Dates & Numbers, Investments, Transactions and Application, with visible group boundaries.
-- **Budget Health Score's** PDF export sorts a copy rather than the response it was handed.
-- The six overdue security-scanner exceptions, and the one due that week, were reviewed rather than renewed; the two auto-backup path-traversal exceptions CI still reports were restored with their reasoning.
-- Test infrastructure: hooks render through the shared intl provider, and a test now **fails on a missing translation message** instead of quietly rendering the key.
+Everyday fixes: the **introduction tour** can open an account's detail page and walk its steps (#1317); **Guided Tours** moves above About and the Preferences section is regrouped with visible boundaries; the redundant **share inbox banner** is gone; sortable-column types and mobile-card chrome classes are shared, with a guard that fails when a copy drifts; the **agent instruction files** are reorganised so `AGENTS.md` is canonical and the `CLAUDE.md` files index `docs/`; seven overdue security-scanner exceptions were reviewed rather than renewed; and a test now **fails on a missing translation message** instead of quietly rendering the key.
 
 ## Credit
 
-**@WMP** carried the notification programme end to end -- the preference matrix, Web Push and UnifiedPush transports, reminders, dispatch and throttling, and all three new producers (#1291) -- along with the localized number inputs, the loan simulator work, the first half of the phone-card conversion and the report i18n fixes. That is most of this release. Discussions #1291 and #1292 and issues #1277, #1316, #1317 and #1323 are addressed here.
+**@WMP** carried the notification programme end to end (#1291) -- the preference matrix, both push transports, reminders, dispatch and throttling, and all three new producers -- along with most of the phone work: both halves of the card conversion, swipe navigation and register paging, the phone-native charts and catalogue tiles, and the report i18n fixes. Also the localized number inputs, the loan simulator, the backup page split and the OIDC diagnostics. That is most of this release. Discussions #1291 and #1292 and issues #1277, #1316, #1317 and #1323 are addressed here.
 
 ## All Changes
 * Surface system-level issues through the existing alerts interface by @kenlasko in https://github.com/kenlasko/monize/pull/1286
@@ -249,5 +135,23 @@ The `NNN_` counter is retired (#1277). It was a manually policed global value th
 * Review the overdue Bearer exceptions (#1323) by @kenlasko in https://github.com/kenlasko/monize/pull/1329
 * Account switcher caret on the Transactions Account Info widget by @kenlasko in https://github.com/kenlasko/monize/pull/1330
 * A notifications tour, a foldable Browser push block, and favourites-first account pickers by @kenlasko in https://github.com/kenlasko/monize/pull/1332
+* Add a "Send to AI Assistant" destination to the share review screen by @kenlasko in https://github.com/kenlasko/monize/pull/1334
+* Replace deepseek-v3.1 with gemma4 in Ollama Cloud sample models by @kenlasko in https://github.com/kenlasko/monize/pull/1335
+* fix(share): remove the redundant share inbox banner by @kenlasko in https://github.com/kenlasko/monize/pull/1337
+* docs: plan for horizontal scaling with optional Redis by @kenlasko in https://github.com/kenlasko/monize/pull/1338
+* Resolve the Dependabot alerts and pin down CodeQL suppression placement by @kenlasko in https://github.com/kenlasko/monize/pull/1339
+* Wrap report tables on phones and finish the mobile-table follow-ups by @WMP in https://github.com/kenlasko/monize/pull/1340
+* Force price update: keep a full year of history, refresh the chart by @WMP in https://github.com/kenlasko/monize/pull/1341
+* feat(oidc): surface back-channel failures in OIDC callback by @WMP in https://github.com/kenlasko/monize/pull/1342
+* Reports catalogue: compact tile grid on mobile by @WMP in https://github.com/kenlasko/monize/pull/1343
+* Mobile: wrap long detail titles and keep the reminder dialog independent of its panel by @WMP in https://github.com/kenlasko/monize/pull/1344
+* Mobile: card layouts for wide tables and tap-whole-card amortization rows by @WMP in https://github.com/kenlasko/monize/pull/1345
+* Mobile: standardized categorical charts (donut centre, vertical legend, weighting tiles) by @WMP in https://github.com/kenlasko/monize/pull/1346
+* Separate user Backup & Restore from admin Automatic Backup (Admin -> Backups) by @WMP in https://github.com/kenlasko/monize/pull/1347
+* Investment charts: historical performance chart, mobile focus fix, range-boundary tests by @WMP in https://github.com/kenlasko/monize/pull/1348
+* Shrink the agent instruction files: AGENTS.md is canonical, CLAUDE.md indexes docs/ by @WMP in https://github.com/kenlasko/monize/pull/1352
+* feat(ai): quote foreign account balances in the default currency and add a convert operation to calculate by @kenlasko in https://github.com/kenlasko/monize/pull/1353
+* Audit the agent instruction files by @WMP in https://github.com/kenlasko/monize/pull/1354
+* fix(mobile): 2x2 summary tiles, accounts count below filter, and group-scoped swipe navigation by @WMP in https://github.com/kenlasko/monize/pull/1355
 
 **Full Changelog**: https://github.com/kenlasko/monize/compare/v1.15.1...v1.16.0

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -51,6 +51,7 @@ npm run i18n:check         # Verify the pseudo-locale is up to date (CI gate)
 | CSV | `exportToCsv` / `exportCsvSections` (`lib/csv-export.ts`) | a second `text/csv` Blob |
 | Random id | `crypto.randomUUID()` | `Math.random()` |
 | Chart colour | `chartColors` tokens (`lib/chart-colors.ts`) | a hex literal in a `fill`, `stroke` or `stopColor` |
+| Toolbar row on a phone | `flex-wrap`, `w-full sm:w-auto`, `sm:ml-auto`, a button's height from `items-stretch` + `LabelSpacer` | an unwrapped row, a bare `ml-auto`, a hand-matched padding |
 
 **A write that moves money calls `invalidateBalanceCaches()`** (or `clearAllCache()` where the write can touch anything). `src/lib/balance-cache.guard.test.ts` scans for the omission.
 
@@ -69,7 +70,7 @@ npm run i18n:check         # Verify the pseudo-locale is up to date (CI gate)
 | Work | Read |
 |---|---|
 | API calls, caching, asynchronous state, ownership of joint accounts | `docs/frontend/api-and-cache.md` |
-| Cards, dialogs, pickers, switchers, rows, links, attachments, tours, settings screens | `docs/frontend/ui-conventions.md` |
+| Cards, dialogs, pickers, switchers, rows, links, attachments, tours, settings screens, report toolbars | `docs/frontend/ui-conventions.md` |
 | Inputs, number and date formatting, phone numbers, text caps, CSV, form modals | `docs/frontend/forms-and-formatting.md` |
 | Tables, registers, density, pagination, phones | `docs/frontend/tables-and-registers.md` |
 | Money figures: scheduled occurrences, loans, portfolio ranges, chart reductions, unknown values | `docs/frontend/financial-figures.md`, then `docs/financial-semantics.md`, `docs/time-series-contract.md`, `docs/system-invariants.md` |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -51,6 +51,7 @@ npm run i18n:check         # Verify the pseudo-locale is up to date (CI gate)
 | CSV | `exportToCsv` / `exportCsvSections` (`lib/csv-export.ts`) | a second `text/csv` Blob |
 | Random id | `crypto.randomUUID()` | `Math.random()` |
 | Chart colour | `chartColors` tokens (`lib/chart-colors.ts`) | a hex literal in a `fill`, `stroke` or `stopColor` |
+| Report refresh / export buttons | `ReportToolbarActions`, last child of the toolbar row | rendering `ExportDropdown` or `RefreshPricesButton` in a report |
 | Toolbar row on a phone | `flex-wrap`, `w-full sm:w-auto`, `sm:ml-auto`, a button's height from `items-stretch` + `LabelSpacer` | an unwrapped row, a bare `ml-auto`, a hand-matched padding |
 
 **A write that moves money calls `invalidateBalanceCaches()`** (or `clearAllCache()` where the write can touch anything). `src/lib/balance-cache.guard.test.ts` scans for the omission.

--- a/frontend/src/components/accounts/loan-detail/LoanDetailView.test.tsx
+++ b/frontend/src/components/accounts/loan-detail/LoanDetailView.test.tsx
@@ -71,6 +71,9 @@ function renderView(account: Account) {
       rateChanges={[]}
       onScenariosChanged={vi.fn()}
       onRateChangesChanged={vi.fn()}
+      // The container owns the export button and takes the handler through
+      // this ref; the view itself renders none.
+      exportPdfRef={{ current: null }}
     />,
   );
 }

--- a/frontend/src/components/accounts/loan-detail/LoanDetailView.tsx
+++ b/frontend/src/components/accounts/loan-detail/LoanDetailView.tsx
@@ -21,7 +21,6 @@ import {
   type ScenarioOutcome,
 } from '@/components/accounts/loan-detail/ScenarioComparisonChart';
 import { createScenarioLabels } from '@/components/accounts/loan-detail/loan-scenario-labels';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { sanitizeFilename } from '@/lib/export-filename';
 import { buildScheduleDisplayRows, type DisplayRow } from '@/lib/loan-schedule-rows';
 import type { CellValue, PdfTableSection } from '@/lib/pdf-export';
@@ -73,12 +72,13 @@ interface LoanDetailViewProps {
   onScenariosChanged: () => void;
   onRateChangesChanged: () => void;
   /**
-   * When provided, the loan's PDF export handler is published here (so a parent
-   * -- e.g. the account detail header -- can trigger it) and the inline export
-   * button is not rendered. Left unset on the reports surface, which keeps the
-   * inline button.
+   * The loan's PDF export handler is published here for the container to
+   * trigger -- the account detail header renders it beside View Transactions,
+   * the overpayment simulator report in its account-selector card. This view
+   * draws no export button of its own: a loose button above the summary cards
+   * sat outside the card every other control was in, worst on a phone.
    */
-  exportPdfRef?: MutableRefObject<(() => Promise<void>) | null>;
+  exportPdfRef: MutableRefObject<(() => Promise<void>) | null>;
 }
 
 /**
@@ -339,20 +339,14 @@ export function LoanDetailView({
     });
   };
 
-  // Published to the parent (account header) so it can render the export button
-  // on the same row as View Transactions; when set, the inline button below is
-  // suppressed. Assigned during render (not in an effect) so the latest closure
-  // -- with the current scenarios/schedule -- is always what fires on click.
-  if (exportPdfRef) exportPdfRef.current = handleExportPdf;
+  // Published to the container so it can render the export button in its own
+  // control row. Assigned during render (not in an effect) so the latest
+  // closure -- with the current scenarios/schedule -- is always what fires on
+  // click.
+  exportPdfRef.current = handleExportPdf;
 
   return (
     <div className="space-y-6" ref={viewRef}>
-      {!exportPdfRef && (
-        <div className="flex justify-end">
-          <ExportDropdown onExportPdf={handleExportPdf} />
-        </div>
-      )}
-
       <LoanSummaryCards
         account={account}
         startingBalance={history.startingBalance}

--- a/frontend/src/components/reports/BillPaymentHistoryReport.tsx
+++ b/frontend/src/components/reports/BillPaymentHistoryReport.tsx
@@ -22,7 +22,7 @@ import { useChartMonthFormat } from '@/hooks/useChartMonthFormat';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { exportToCsv } from '@/lib/csv-export';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import { INTERACTIVE_ROW_FOCUS_CLASS, activateOnKey } from '@/components/ui/interactive-row';
@@ -373,8 +373,8 @@ export function BillPaymentHistoryReport() {
             >
               {t('billPaymentHistory.byBill')}
             </button>
-            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
           </div>
+          <ReportToolbarActions onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/BudgetHealthScoreReport.tsx
+++ b/frontend/src/components/reports/BudgetHealthScoreReport.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useCallback, useRef } from 'react';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { budgetsApi } from '@/lib/budgets';
 import { BudgetHealthGauge } from '@/components/budgets/BudgetHealthGauge';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportError } from '@/components/reports/ReportError';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
@@ -367,7 +367,7 @@ export function BudgetHealthScoreReport() {
               </option>
             ))}
           </select>
-          <ExportDropdown onExportPdf={handleExportPdf} />
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/BudgetSeasonalPatternsReport.tsx
+++ b/frontend/src/components/reports/BudgetSeasonalPatternsReport.tsx
@@ -16,7 +16,7 @@ import { budgetsApi } from '@/lib/budgets';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useTranslations } from 'next-intl';
 import { useReportData } from '@/hooks/useReportData';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportError } from '@/components/reports/ReportError';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
@@ -190,7 +190,7 @@ export function BudgetSeasonalPatternsReport() {
               </select>
             )}
           </div>
-          <ExportDropdown onExportPdf={handleExportPdf} />
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/BudgetTrendReport.tsx
+++ b/frontend/src/components/reports/BudgetTrendReport.tsx
@@ -18,7 +18,7 @@ import { useDateFormat } from '@/hooks/useDateFormat';
 import { useChartMonthFormat } from '@/hooks/useChartMonthFormat';
 import { useTranslations } from 'next-intl';
 import { useReportData } from '@/hooks/useReportData';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportError } from '@/components/reports/ReportError';
 import { chartColors } from '@/lib/chart-colors';
 import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
@@ -144,9 +144,7 @@ export function BudgetTrendReport() {
             <option value={12}>{t('budgetTrend.months12')}</option>
             <option value={24}>{t('budgetTrend.months24')}</option>
           </select>
-          <div className="ml-auto">
-            <ExportDropdown onExportPdf={handleExportPdf} />
-          </div>
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/BudgetVsActualReport.tsx
+++ b/frontend/src/components/reports/BudgetVsActualReport.tsx
@@ -22,7 +22,7 @@ import { useChartMonthFormat } from '@/hooks/useChartMonthFormat';
 import { useTranslations } from 'next-intl';
 import { useReportData } from '@/hooks/useReportData';
 import { BudgetCategoryTrend } from '@/components/budgets/BudgetCategoryTrend';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportError } from '@/components/reports/ReportError';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
@@ -393,8 +393,8 @@ export function BudgetVsActualReport() {
                 {t('budgetVsActual.viewByCategory')}
               </button>
             </div>
-            <ExportDropdown onExportPdf={handleExportPdf} />
           </div>
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/CashFlowReport.tsx
+++ b/frontend/src/components/reports/CashFlowReport.tsx
@@ -26,7 +26,7 @@ import { useChartDateFormat } from "@/hooks/useChartDateFormat";
 import { useDateRange } from "@/hooks/useDateRange";
 import { useReportData } from "@/hooks/useReportData";
 import { DateRangeSelector } from "@/components/ui/DateRangeSelector";
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ChartTooltip } from "@/components/reports/ChartTooltip";
 import { ReportError } from "@/components/reports/ReportError";
 import { chartColors } from "@/lib/chart-colors";
@@ -267,7 +267,7 @@ export function CashFlowReport() {
             customEndDate={endDate}
             onCustomEndDateChange={setEndDate}
           />
-          <ExportDropdown onExportPdf={handleExportPdf} />
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/CategoryPerformanceReport.tsx
+++ b/frontend/src/components/reports/CategoryPerformanceReport.tsx
@@ -6,7 +6,7 @@ import { budgetsApi } from '@/lib/budgets';
 import type { Budget, CategoryTrendSeries } from '@/types/budget';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useReportData } from '@/hooks/useReportData';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportError } from '@/components/reports/ReportError';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
@@ -473,9 +473,7 @@ export function CategoryPerformanceReport() {
             <option value={6}>{t('categoryPerformance.months6')}</option>
             <option value={12}>{t('categoryPerformance.months12')}</option>
           </select>
-          <div className="ml-auto">
-            <ExportDropdown onExportPdf={handleExportPdf} />
-          </div>
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/CreditUtilizationReport.tsx
+++ b/frontend/src/components/reports/CreditUtilizationReport.tsx
@@ -27,7 +27,7 @@ import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useReportData } from '@/hooks/useReportData';
 import { usePersistedAccountFilter } from '@/hooks/usePersistedAccountFilter';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -359,10 +359,6 @@ export function CreditUtilizationReport() {
     <div className="space-y-6">
       {/* Account Filter */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
-        {/* `items-stretch`, so the export is the height of the picker beside
-            it rather than the height of its own text: the two are one row of
-            controls, and a short button against a full-height field reads as a
-            mistake. On a phone each takes its own line and its own height. */}
         <div className="flex flex-wrap gap-3 items-stretch justify-between">
           <ReportAccountMultiSelect
             accounts={creditAccounts}
@@ -370,7 +366,7 @@ export function CreditUtilizationReport() {
             onChange={setSelectedAccountIds}
             filter={() => true}
           />
-          <ExportDropdown onExportPdf={handleExportPdf} className="h-full" />
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/CreditUtilizationReport.tsx
+++ b/frontend/src/components/reports/CreditUtilizationReport.tsx
@@ -359,14 +359,18 @@ export function CreditUtilizationReport() {
     <div className="space-y-6">
       {/* Account Filter */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
-        <div className="flex flex-wrap gap-3 items-center justify-between">
+        {/* `items-stretch`, so the export is the height of the picker beside
+            it rather than the height of its own text: the two are one row of
+            controls, and a short button against a full-height field reads as a
+            mistake. On a phone each takes its own line and its own height. */}
+        <div className="flex flex-wrap gap-3 items-stretch justify-between">
           <ReportAccountMultiSelect
             accounts={creditAccounts}
             value={selectedAccountIds}
             onChange={setSelectedAccountIds}
             filter={() => true}
           />
-          <ExportDropdown onExportPdf={handleExportPdf} />
+          <ExportDropdown onExportPdf={handleExportPdf} className="h-full" />
         </div>
       </div>
 

--- a/frontend/src/components/reports/CurrencyExposureReport.tsx
+++ b/frontend/src/components/reports/CurrencyExposureReport.tsx
@@ -15,9 +15,8 @@ import { HoldingWithMarketValue } from '@/types/investment';
 import { Account } from '@/types/account';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -438,10 +437,10 @@ export function CurrencyExposureReport() {
               className="w-full sm:w-48"
             />
           </div>
-          <div className="flex flex-wrap gap-2 items-center">
-            <RefreshPricesButton onRefreshComplete={reload} />
-            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
-          </div>
+          <ReportToolbarActions
+            onRefreshComplete={reload}
+            onExportPdf={handleExportPdf}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/CurrencyExposureReport.tsx
+++ b/frontend/src/components/reports/CurrencyExposureReport.tsx
@@ -428,17 +428,19 @@ export function CurrencyExposureReport() {
       {/* Account Filter */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center justify-between">
-          <div className="flex flex-wrap gap-3 items-center">
+          {/* Full width on a phone, the toolbar's fixed width from `sm` up. */}
+          <div className="flex w-full flex-wrap gap-3 items-center sm:w-auto">
             <ReportAccountMultiSelect
               accounts={accounts}
               value={selectedAccountIds}
               onChange={setSelectedAccountIds}
               mode="portfolio"
+              className="w-full sm:w-48"
             />
           </div>
-          <div className="flex gap-2 items-center">
+          <div className="flex flex-wrap gap-2 items-center">
             <RefreshPricesButton onRefreshComplete={reload} />
-            <ExportDropdown onExportPdf={handleExportPdf} />
+            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
@@ -37,7 +37,7 @@ import {
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useReportData } from '@/hooks/useReportData';
 import { usePersistedAccountId } from '@/hooks/usePersistedAccountFilter';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportError } from '@/components/reports/ReportError';
 import { chartColors } from '@/lib/chart-colors';
 import { useChartDateFormat } from '@/hooks/useChartDateFormat';
@@ -680,8 +680,8 @@ export function DebtPayoffTimelineReport() {
             >
               {t('debtPayoff.viewPrincipalVsInterest')}
             </button>
-            <ExportDropdown onExportPdf={handleExportPdf} />
           </div>
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -1148,7 +1148,11 @@ export function DividendIncomeReport() {
             value={dateRange}
             onChange={setDateRange}
           />
-          <div className="ml-auto shrink-0 flex gap-2 items-center">
+          {/* Five controls do not fit a phone on one unwrapped line: the group
+              wrapped nothing and the export was pushed past the right edge of
+              the card. It wraps here, and the export takes a line of its own
+              below the view buttons, its label on one line. */}
+          <div className="flex w-full flex-wrap gap-2 items-center sm:ml-auto sm:w-auto sm:shrink-0">
             <button
               onClick={() => setViewType('monthly')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
@@ -1180,9 +1184,14 @@ export function DividendIncomeReport() {
               {t('dividendIncome.viewBySecurity')}
             </button>
             <RefreshPricesButton onRefreshComplete={reloadAll} />
+            {/* Both widths: this export is the CSV+PDF variant (a wrapper the
+                container class sizes) on a table view and the PDF-only variant
+                (no wrapper, the button itself) everywhere else. */}
             <ExportDropdown
               onExportPdf={handleExportPdf}
               onExportCsv={isTableView ? handleExportCsv : undefined}
+              containerClassName="w-full sm:w-auto"
+              className="w-full justify-center whitespace-nowrap sm:w-auto"
             />
           </div>
         </div>

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -1147,10 +1147,9 @@ export function DividendIncomeReport() {
             value={dateRange}
             onChange={setDateRange}
           />
-          {/* Five controls do not fit a phone on one unwrapped line: the group
-              wrapped nothing and the export was pushed past the right edge of
-              the card. It wraps here, and the export takes a line of its own
-              below the view buttons, its label on one line. */}
+          {/* The three view buttons wrap onto their own line on a phone: this
+              group used to hold the refresh and the export too, unwrapped, and
+              the export was pushed past the right edge of the card. */}
           <div className="flex w-full flex-wrap gap-2 items-center sm:ml-auto sm:w-auto sm:shrink-0">
             <button
               onClick={() => setViewType('monthly')}
@@ -1183,93 +1182,99 @@ export function DividendIncomeReport() {
               {t('dividendIncome.viewBySecurity')}
             </button>
           </div>
+        </div>
+        {/* The chart/table switch and the series toggles are selectors too, so
+            the actions row sits BELOW them rather than in the row above: on a
+            phone the refresh and the export are the last thing in the card.
+            The row is always rendered, because the actions are -- the
+            sub-controls inside it belong to the monthly and daily views. */}
+        <div className="mt-3 flex flex-wrap gap-4 items-center">
+          {(viewType === 'monthly' || viewType === 'daily') && (
+            <>
+              <div
+                className="inline-flex rounded-md border border-gray-200 dark:border-gray-600 overflow-hidden text-sm"
+                role="group"
+                aria-label="Monthly display mode"
+              >
+                <button
+                  onClick={() => setMonthlyDisplay('chart')}
+                  className={`px-3 py-1 font-medium transition-colors ${
+                    monthlyDisplay === 'chart'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                  }`}
+                >
+                  {t('dividendIncome.displayChart')}
+                </button>
+                <button
+                  onClick={() => setMonthlyDisplay('table')}
+                  className={`px-3 py-1 font-medium transition-colors ${
+                    monthlyDisplay === 'table'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                  }`}
+                >
+                  {t('dividendIncome.displayTable')}
+                </button>
+              </div>
+              <div className="flex flex-wrap gap-2 items-center">
+                <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  {t('dividendIncome.showLabel')}
+                </span>
+                {(Object.keys(SERIES_COLORS) as SeriesKey[]).map((key) => {
+                  const active = visibleSeries[key];
+                  return (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => toggleSeries(key)}
+                      aria-pressed={active}
+                      className={`px-3 py-1 text-sm font-medium rounded-md border transition-colors ${
+                        active
+                          ? 'text-white border-transparent'
+                          : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-600'
+                      }`}
+                      style={
+                        active
+                          ? { backgroundColor: SERIES_COLORS[key].positive }
+                          : undefined
+                      }
+                    >
+                      {seriesLabels[key]}
+                    </button>
+                  );
+                })}
+              </div>
+              {viewType === 'daily' && (
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={hideInactiveDays}
+                  onClick={() => setHideInactiveDays((v) => !v)}
+                  className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 sm:ml-auto"
+                >
+                  <span
+                    className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ${
+                      hideInactiveDays ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-600'
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform duration-200 ${
+                        hideInactiveDays ? 'translate-x-4' : 'translate-x-0'
+                      }`}
+                    />
+                  </span>
+                  {t('dividendIncome.hideInactiveDays')}
+                </button>
+              )}
+            </>
+          )}
           <ReportToolbarActions
             onRefreshComplete={reloadAll}
             onExportPdf={handleExportPdf}
             onExportCsv={isTableView ? handleExportCsv : undefined}
           />
         </div>
-        {/* Monthly/Daily view sub-controls: chart/table switch + series toggles */}
-        {(viewType === 'monthly' || viewType === 'daily') && (
-          <div className="flex flex-wrap gap-4 mt-3 items-center">
-            <div
-              className="inline-flex rounded-md border border-gray-200 dark:border-gray-600 overflow-hidden text-sm"
-              role="group"
-              aria-label="Monthly display mode"
-            >
-              <button
-                onClick={() => setMonthlyDisplay('chart')}
-                className={`px-3 py-1 font-medium transition-colors ${
-                  monthlyDisplay === 'chart'
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300'
-                }`}
-              >
-                {t('dividendIncome.displayChart')}
-              </button>
-              <button
-                onClick={() => setMonthlyDisplay('table')}
-                className={`px-3 py-1 font-medium transition-colors ${
-                  monthlyDisplay === 'table'
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300'
-                }`}
-              >
-                {t('dividendIncome.displayTable')}
-              </button>
-            </div>
-            <div className="flex flex-wrap gap-2 items-center">
-              <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                {t('dividendIncome.showLabel')}
-              </span>
-              {(Object.keys(SERIES_COLORS) as SeriesKey[]).map((key) => {
-                const active = visibleSeries[key];
-                return (
-                  <button
-                    key={key}
-                    type="button"
-                    onClick={() => toggleSeries(key)}
-                    aria-pressed={active}
-                    className={`px-3 py-1 text-sm font-medium rounded-md border transition-colors ${
-                      active
-                        ? 'text-white border-transparent'
-                        : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-600'
-                    }`}
-                    style={
-                      active
-                        ? { backgroundColor: SERIES_COLORS[key].positive }
-                        : undefined
-                    }
-                  >
-                    {seriesLabels[key]}
-                  </button>
-                );
-              })}
-            </div>
-            {viewType === 'daily' && (
-              <button
-                type="button"
-                role="switch"
-                aria-checked={hideInactiveDays}
-                onClick={() => setHideInactiveDays((v) => !v)}
-                className="ml-auto flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400"
-              >
-                <span
-                  className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ${
-                    hideInactiveDays ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-600'
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform duration-200 ${
-                      hideInactiveDays ? 'translate-x-4' : 'translate-x-0'
-                    }`}
-                  />
-                </span>
-                {t('dividendIncome.hideInactiveDays')}
-              </button>
-            )}
-          </div>
-        )}
       </div>
 
       {filteredTransactions.length === 0 && filteredCapitalGains.length === 0 && filteredDailyCapitalGains.length === 0 ? (

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -28,9 +28,8 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { MultiSelect } from '@/components/ui/MultiSelect';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import {
   CAPTION_CLASS,
@@ -1183,17 +1182,12 @@ export function DividendIncomeReport() {
             >
               {t('dividendIncome.viewBySecurity')}
             </button>
-            <RefreshPricesButton onRefreshComplete={reloadAll} />
-            {/* Both widths: this export is the CSV+PDF variant (a wrapper the
-                container class sizes) on a table view and the PDF-only variant
-                (no wrapper, the button itself) everywhere else. */}
-            <ExportDropdown
-              onExportPdf={handleExportPdf}
-              onExportCsv={isTableView ? handleExportCsv : undefined}
-              containerClassName="w-full sm:w-auto"
-              className="w-full justify-center whitespace-nowrap sm:w-auto"
-            />
           </div>
+          <ReportToolbarActions
+            onRefreshComplete={reloadAll}
+            onExportPdf={handleExportPdf}
+            onExportCsv={isTableView ? handleExportCsv : undefined}
+          />
         </div>
         {/* Monthly/Daily view sub-controls: chart/table switch + series toggles */}
         {(viewType === 'monthly' || viewType === 'daily') && (

--- a/frontend/src/components/reports/DividendYieldGrowthReport.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.tsx
@@ -569,7 +569,12 @@ export function DividendYieldGrowthReport() {
             value={selectedAccountIds}
             onChange={setSelectedAccountIds}
           />
-          <div className="flex gap-2 items-center">
+          {/* `items-stretch`, not `items-center`: squeezed onto a phone these
+              three labels wrap onto a different number of lines each, and a
+              one-word button (Frequency) stood shorter than the two beside it.
+              They wrap onto their own lines here, all the height of the
+              tallest on the line. */}
+          <div className="flex flex-wrap gap-2 items-stretch">
             <button
               onClick={() => setViewType('yield')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
@@ -595,9 +600,11 @@ export function DividendYieldGrowthReport() {
               {t('dividendYieldGrowth.viewFrequency')}
             </button>
           </div>
-          <div className="ml-auto flex gap-2 items-center">
+          {/* `ml-auto` from `sm` up only: on a phone this is a row of its own
+              and belongs at the left edge like the rows above it. */}
+          <div className="flex flex-wrap gap-2 items-center sm:ml-auto">
             <RefreshPricesButton onRefreshComplete={reload} />
-            <ExportDropdown onExportPdf={handleExportPdf} />
+            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/DividendYieldGrowthReport.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.tsx
@@ -22,9 +22,8 @@ import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { gainLossColor } from '@/lib/format';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -600,12 +599,10 @@ export function DividendYieldGrowthReport() {
               {t('dividendYieldGrowth.viewFrequency')}
             </button>
           </div>
-          {/* `ml-auto` from `sm` up only: on a phone this is a row of its own
-              and belongs at the left edge like the rows above it. */}
-          <div className="flex flex-wrap gap-2 items-center sm:ml-auto">
-            <RefreshPricesButton onRefreshComplete={reload} />
-            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
-          </div>
+          <ReportToolbarActions
+            onRefreshComplete={reload}
+            onExportPdf={handleExportPdf}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/DuplicateTransactionReport.tsx
+++ b/frontend/src/components/reports/DuplicateTransactionReport.tsx
@@ -169,7 +169,9 @@ export function DuplicateTransactionReport() {
             value={dateRange}
             onChange={setDateRange}
           />
-          <div className="flex items-center gap-3">
+          {/* `items-stretch`, so the export is the height of the sensitivity
+              picker beside it rather than the height of its own text. */}
+          <div className="flex flex-wrap items-stretch gap-3">
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-600 dark:text-gray-400">{t('duplicateTransactions.sensitivityLabel')}</span>
               <select
@@ -182,7 +184,12 @@ export function DuplicateTransactionReport() {
                 <option value="low">{t('duplicateTransactions.sensitivityLow')}</option>
               </select>
             </div>
-            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} disabled={duplicateGroups.length === 0} />
+            <ExportDropdown
+              onExportCsv={handleExportCsv}
+              onExportPdf={handleExportPdf}
+              disabled={duplicateGroups.length === 0}
+              className="h-full whitespace-nowrap"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/DuplicateTransactionReport.tsx
+++ b/frontend/src/components/reports/DuplicateTransactionReport.tsx
@@ -11,7 +11,7 @@ import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { exportToCsv } from '@/lib/csv-export';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
@@ -169,8 +169,6 @@ export function DuplicateTransactionReport() {
             value={dateRange}
             onChange={setDateRange}
           />
-          {/* `items-stretch`, so the export is the height of the sensitivity
-              picker beside it rather than the height of its own text. */}
           <div className="flex flex-wrap items-stretch gap-3">
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-600 dark:text-gray-400">{t('duplicateTransactions.sensitivityLabel')}</span>
@@ -184,13 +182,12 @@ export function DuplicateTransactionReport() {
                 <option value="low">{t('duplicateTransactions.sensitivityLow')}</option>
               </select>
             </div>
-            <ExportDropdown
-              onExportCsv={handleExportCsv}
-              onExportPdf={handleExportPdf}
-              disabled={duplicateGroups.length === 0}
-              className="h-full whitespace-nowrap"
-            />
           </div>
+          <ReportToolbarActions
+            onExportCsv={handleExportCsv}
+            onExportPdf={handleExportPdf}
+            disabled={duplicateGroups.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/FlexGroupAnalysisReport.tsx
+++ b/frontend/src/components/reports/FlexGroupAnalysisReport.tsx
@@ -18,7 +18,7 @@ import { budgetsApi } from '@/lib/budgets';
 import type { Budget, FlexGroupCategory, FlexGroupStatus } from '@/types/budget';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useReportData } from '@/hooks/useReportData';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportError } from '@/components/reports/ReportError';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
@@ -396,7 +396,7 @@ export function FlexGroupAnalysisReport() {
               <option key={b.id} value={b.id}>{b.name}</option>
             ))}
           </select>
-          <ExportDropdown onExportPdf={handleExportPdf} />
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/ForeignCurrencyFeesReport.tsx
+++ b/frontend/src/components/reports/ForeignCurrencyFeesReport.tsx
@@ -342,13 +342,17 @@ export function ForeignCurrencyFeesReport() {
       {/* Controls */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center">
+          {/* Both pickers take the card's width on a phone -- side by side
+              they are wider than the screen -- and their toolbar widths from
+              `sm` up. */}
           <ReportAccountMultiSelect
             accounts={accounts}
             value={selectedAccountIds}
             onChange={handleAccountChange}
             filter={hasFxFee}
+            className="w-full sm:w-48"
           />
-          <div className="w-52 max-w-full">
+          <div className="w-full max-w-full sm:w-52">
             <MultiSelect
               ariaLabel={t('currencyFilter.label')}
               options={currencyOptions}

--- a/frontend/src/components/reports/GeographicAllocationReport.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.tsx
@@ -19,9 +19,8 @@ import { HoldingWithMarketValue, Security } from '@/types/investment';
 import { Account } from '@/types/account';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -570,14 +569,14 @@ export function GeographicAllocationReport() {
             >
               {t('geographicAllocation.viewByCountry')}
             </button>
-            <RefreshPricesButton
-              onRefreshComplete={() => {
-                reload();
-                reloadCountry();
-              }}
-            />
-            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
           </div>
+          <ReportToolbarActions
+            onRefreshComplete={() => {
+              reload();
+              reloadCountry();
+            }}
+            onExportPdf={handleExportPdf}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/GeographicAllocationReport.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.tsx
@@ -527,15 +527,19 @@ export function GeographicAllocationReport() {
       {/* Filters & View Toggle */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center justify-between">
-          <div className="flex flex-wrap gap-3 items-center">
+          {/* Full width on a phone, the toolbar's fixed width from `sm` up. */}
+          <div className="flex w-full flex-wrap gap-3 items-center sm:w-auto">
             <ReportAccountMultiSelect
               accounts={accounts}
               value={selectedAccountIds}
               onChange={setSelectedAccountIds}
               mode="portfolio"
+              className="w-full sm:w-48"
             />
           </div>
-          <div className="flex items-center gap-2">
+          {/* Five controls: they wrap on a phone rather than carrying the
+              export off the right of the card. */}
+          <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
             <button
               onClick={() => setViewType('region')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
@@ -572,7 +576,7 @@ export function GeographicAllocationReport() {
                 reloadCountry();
               }}
             />
-            <ExportDropdown onExportPdf={handleExportPdf} />
+            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/HealthScoreHistoryReport.tsx
+++ b/frontend/src/components/reports/HealthScoreHistoryReport.tsx
@@ -14,7 +14,7 @@ import {
 } from 'recharts';
 import { budgetsApi } from '@/lib/budgets';
 import type { HealthScoreHistoryPoint } from '@/types/budget';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportError } from '@/components/reports/ReportError';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useReportData } from '@/hooks/useReportData';
@@ -223,9 +223,7 @@ export function HealthScoreHistoryReport() {
             <option value={12}>{t('healthScoreHistory.months12')}</option>
             <option value={24}>{t('healthScoreHistory.months24')}</option>
           </select>
-          <div className="ml-auto">
-            <ExportDropdown onExportPdf={handleExportPdf} />
-          </div>
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/IncomeBySourceReport.tsx
+++ b/frontend/src/components/reports/IncomeBySourceReport.tsx
@@ -25,7 +25,7 @@ import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 import { DonutCenterTotal } from '@/components/ui/DonutCenterTotal';
 import { ChartLegend } from '@/components/ui/ChartLegend';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -258,12 +258,12 @@ export function IncomeBySourceReport() {
               onChange={(v) => setViewType(v as 'pie' | 'bar' | 'table')}
               options={['pie', 'bar', 'table']}
             />
-            <ExportDropdown
-              onExportPdf={handleExportPdf}
-              onExportCsv={handleExportCsv}
-              disabled={chartData.length === 0}
-            />
           </div>
+          <ReportToolbarActions
+            onExportPdf={handleExportPdf}
+            onExportCsv={handleExportCsv}
+            disabled={chartData.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/IncomeVsExpensesReport.tsx
+++ b/frontend/src/components/reports/IncomeVsExpensesReport.tsx
@@ -29,7 +29,7 @@ import { useReportData } from "@/hooks/useReportData";
 import { useSortableTable, compareValues } from "@/hooks/useSortableTable";
 import { DateRangeSelector } from "@/components/ui/DateRangeSelector";
 import { ChartViewToggle } from "@/components/ui/ChartViewToggle";
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { ChartTooltip } from "@/components/reports/ChartTooltip";
 import { ReportError } from "@/components/reports/ReportError";
@@ -305,12 +305,12 @@ export function IncomeVsExpensesReport() {
               onChange={(v) => setViewType(v as 'bar' | 'table')}
               options={['bar', 'table']}
             />
-            <ExportDropdown
-              onExportPdf={handleExportPdf}
-              onExportCsv={handleExportCsv}
-              disabled={chartData.length === 0}
-            />
           </div>
+          <ReportToolbarActions
+            onExportPdf={handleExportPdf}
+            onExportCsv={handleExportCsv}
+            disabled={chartData.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/InvestmentPerformanceReport.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.tsx
@@ -16,9 +16,8 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { gainLossColor } from '@/lib/format';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SecurityComparisonChart, SecurityComparisonChartHandle } from '@/components/reports/SecurityComparisonChart';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { useDateRange } from '@/hooks/useDateRange';
@@ -416,7 +415,6 @@ export function InvestmentPerformanceReport() {
             >
               {t('investmentPerformance.viewAllocation')}
             </button>
-            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
           </div>
         </div>
         {/* The chart's window and the export belong to the toolbar, not to the
@@ -439,12 +437,9 @@ export function InvestmentPerformanceReport() {
               size="sm"
             />
           )}
-          {/* PDF only, so the button IS the box this row lays out: it takes
-              the width here, not a wrapper. `whitespace-nowrap` keeps the
-              label on one line at any width. */}
-          <ExportDropdown
+          <ReportToolbarActions
+            onRefreshComplete={() => setReloadKey((k) => k + 1)}
             onExportPdf={handleExportPdf}
-            className="w-full justify-center whitespace-nowrap sm:ml-auto sm:w-auto"
           />
         </div>
       </div>

--- a/frontend/src/components/reports/InvestmentPerformanceReport.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.tsx
@@ -395,7 +395,7 @@ export function InvestmentPerformanceReport() {
               onChange={setSelectedAccountIds}
             />
           </div>
-          <div className="flex gap-2 items-center">
+          <div className="flex flex-wrap gap-2 items-center">
             <button
               onClick={() => setViewType('performance')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
@@ -417,8 +417,35 @@ export function InvestmentPerformanceReport() {
               {t('investmentPerformance.viewAllocation')}
             </button>
             <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
-            <ExportDropdown onExportPdf={handleExportPdf} />
           </div>
+        </div>
+        {/* The chart's window and the export belong to the toolbar, not to the
+            chart: the range selector used to sit loose above the chart, outside
+            the card every other control is in, and the export shared a row it
+            was pushed off the right of on a phone. Stacked below `sm`, so the
+            export is a full-width line under the window it exports; one row
+            from `sm` up, export at the trailing edge whether or not the
+            allocation view has hidden the window. */}
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          {viewType === 'performance' && (
+            <DateRangeSelector
+              ranges={CHART_RANGES}
+              // Only `all` needs translating; 1M/3M/YTD/1Y/5Y are
+              // locale-neutral abbreviations `formatLabel` handles.
+              labels={{ all: t('investmentPerformance.rangeAll') }}
+              value={perfRange}
+              onChange={setPerfRange}
+              activeColour="bg-blue-600"
+              size="sm"
+            />
+          )}
+          {/* PDF only, so the button IS the box this row lays out: it takes
+              the width here, not a wrapper. `whitespace-nowrap` keeps the
+              label on one line at any width. */}
+          <ExportDropdown
+            onExportPdf={handleExportPdf}
+            className="w-full justify-center whitespace-nowrap sm:ml-auto sm:w-auto"
+          />
         </div>
       </div>
 
@@ -432,18 +459,6 @@ export function InvestmentPerformanceReport() {
               on their own tabs. The chart owns its own fetch, keyed on the held
               securities and the window, and renders the server's percent-return
               series with its null/exclusion handling intact. */}
-          <div className="mb-6 flex justify-end">
-            <DateRangeSelector
-              ranges={CHART_RANGES}
-              // Only `all` needs translating; 1M/3M/YTD/1Y/5Y are
-              // locale-neutral abbreviations `formatLabel` handles.
-              labels={{ all: t('investmentPerformance.rangeAll') }}
-              value={perfRange}
-              onChange={setPerfRange}
-              activeColour="bg-blue-600"
-              size="sm"
-            />
-          </div>
           <SecurityComparisonChart
             securityIds={performanceSecurityIds}
             indexCodes={[]}

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -315,13 +315,21 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
               </div>
             </div>
           </div>
-          <div className="flex items-center gap-3">
-            <RefreshPricesButton onRefreshComplete={executeReport} />
+          {/* The pair spans its own row below the fields on a phone, the way
+              `ReportToolbarActions` lays out every other report's. This one
+              writes it out because its export is a plain CSV button, not the
+              `ExportDropdown` that row renders. */}
+          <div className="grid w-full grid-cols-2 gap-2 sm:ml-auto sm:flex sm:w-auto sm:items-center sm:gap-3">
+            <RefreshPricesButton
+              onRefreshComplete={executeReport}
+              className="h-full w-full sm:w-auto"
+            />
             <Button
               variant="outline"
               size="sm"
               onClick={handleExportCsv}
               disabled={!result || result.rowCount === 0}
+              className="h-full w-full whitespace-nowrap sm:w-auto"
             >
               {t('investmentReportViewer.exportCsv')}
             </Button>

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { DateInput } from '@/components/ui/DateInput';
 import { MultiSelect } from '@/components/ui/MultiSelect';
 import { SortableHeader } from '@/components/ui/SortableHeader';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { investmentReportsApi } from '@/lib/investment-reports';
 import { accountsApi } from '@/lib/accounts';
 import { Account } from '@/types/account';
@@ -315,25 +315,14 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
               </div>
             </div>
           </div>
-          {/* The pair spans its own row below the fields on a phone, the way
-              `ReportToolbarActions` lays out every other report's. This one
-              writes it out because its export is a plain CSV button, not the
-              `ExportDropdown` that row renders. */}
-          <div className="grid w-full grid-cols-2 gap-2 sm:ml-auto sm:flex sm:w-auto sm:items-center sm:gap-3">
-            <RefreshPricesButton
-              onRefreshComplete={executeReport}
-              className="h-full w-full sm:w-auto"
-            />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleExportCsv}
-              disabled={!result || result.rowCount === 0}
-              className="h-full w-full whitespace-nowrap sm:w-auto"
-            >
-              {t('investmentReportViewer.exportCsv')}
-            </Button>
-          </div>
+          {/* CSV only: a custom report is rows, and the viewer draws no chart
+              to put in a PDF. */}
+          <ReportToolbarActions
+            onRefreshComplete={executeReport}
+            onExportCsv={handleExportCsv}
+            disabled={!result || result.rowCount === 0}
+            className="sm:self-auto"
+          />
         </div>
         <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
           {asOfOverride ? (

--- a/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
+++ b/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
@@ -14,10 +14,9 @@ import { useDateRange } from '@/hooks/useDateRange';
 import { useReportData } from '@/hooks/useReportData';
 import { usePersistedAccountFilter } from '@/hooks/usePersistedAccountFilter';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { MultiSelect } from '@/components/ui/MultiSelect';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { ReportError } from '@/components/reports/ReportError';
 import { exportToCsv } from '@/lib/csv-export';
 import { SortableHeader } from '@/components/ui/SortableHeader';
@@ -453,20 +452,12 @@ export function InvestmentTransactionHistoryReport() {
             value={dateRange}
             onChange={setDateRange}
           />
-          {/* A two-column grid on a phone so the pair fills its own line and
-              neither button is left hanging past the card; the grid stretches
-              each child, which an `inline-block` export wrapper would not do
-              for itself. */}
-          <div className="grid w-full grid-cols-2 gap-2 sm:ml-auto sm:flex sm:w-auto sm:shrink-0 sm:items-center">
-            <RefreshPricesButton onRefreshComplete={reload} className="w-full sm:w-auto" />
-            <ExportDropdown
-              onExportCsv={handleExportCsv}
-              onExportPdf={handleExportPdf}
-              disabled={filteredTransactions.length === 0}
-              containerClassName="w-full sm:w-auto"
-              className="w-full justify-center sm:w-auto"
-            />
-          </div>
+          <ReportToolbarActions
+            onRefreshComplete={reload}
+            onExportCsv={handleExportCsv}
+            onExportPdf={handleExportPdf}
+            disabled={filteredTransactions.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
+++ b/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
@@ -425,14 +425,19 @@ export function InvestmentTransactionHistoryReport() {
 
       {/* Controls */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
+        {/* One control per line on a phone, the desktop row from `sm` up. The
+            two pickers are `w-48` each: side by side they are wider than a
+            phone, and the pair was pushed off the right of the screen rather
+            than wrapped, because the box holding them did not wrap. */}
         <div className="flex flex-wrap gap-3 items-center">
-          <div className="flex gap-3 items-center">
+          <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center">
             <ReportAccountMultiSelect
               accounts={accounts}
               value={selectedAccountIds}
               onChange={setSelectedAccountIds}
+              className="w-full sm:w-48"
             />
-            <div className="w-48">
+            <div className="w-full sm:w-48">
               <MultiSelect
                 ariaLabel={t('investmentTransactions.filterByAction')}
                 placeholder={t('investmentTransactions.allActionsPlaceholder')}
@@ -448,9 +453,19 @@ export function InvestmentTransactionHistoryReport() {
             value={dateRange}
             onChange={setDateRange}
           />
-          <div className="ml-auto shrink-0 flex gap-2 items-center">
-            <RefreshPricesButton onRefreshComplete={reload} />
-            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} disabled={filteredTransactions.length === 0} />
+          {/* A two-column grid on a phone so the pair fills its own line and
+              neither button is left hanging past the card; the grid stretches
+              each child, which an `inline-block` export wrapper would not do
+              for itself. */}
+          <div className="grid w-full grid-cols-2 gap-2 sm:ml-auto sm:flex sm:w-auto sm:shrink-0 sm:items-center">
+            <RefreshPricesButton onRefreshComplete={reload} className="w-full sm:w-auto" />
+            <ExportDropdown
+              onExportCsv={handleExportCsv}
+              onExportPdf={handleExportPdf}
+              disabled={filteredTransactions.length === 0}
+              containerClassName="w-full sm:w-auto"
+              className="w-full justify-center sm:w-auto"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/LoanAmortizationReport.tsx
+++ b/frontend/src/components/reports/LoanAmortizationReport.tsx
@@ -21,7 +21,7 @@ import {
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useFinancialToday } from '@/hooks/useFinancialToday';
 import { exportToCsv } from '@/lib/csv-export';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { LabelSpacer } from '@/components/ui/LabelSpacer';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
@@ -480,20 +480,23 @@ export function LoanAmortizationReport() {
                 ))}
             </select>
           </div>
-          {/* The export stands beside a labelled field, so it is the height of
-              the FIELD, not of the field plus its label: reserve the label's
-              own space above it and stretch into what is left, rather than
-              matching the select's padding with a figure that drifts the next
-              time either control's type scale changes. */}
-          <div className="ml-auto flex flex-col">
-            <LabelSpacer />
-            <div className="flex flex-1 items-stretch">
-              <ExportDropdown
-                onExportCsv={handleExportCsv}
-                onExportPdf={handleExportPdf}
-                className="h-full"
-              />
+          {/* The export stands beside a LABELLED field, so from `sm` up it is
+              the height of the field, not of the field plus its label: reserve
+              the label's own space above it and let the actions row stretch
+              into what is left, rather than matching the select's padding with
+              a figure that drifts the next time either control's type scale
+              changes. Below `sm` the spacer collapses with the row. */}
+          <div className="flex w-full flex-col sm:ml-auto sm:w-auto">
+            {/* The reserved label space is the desktop's alone: on a phone the
+                export is a row of its own and has no field beside it. */}
+            <div className="hidden sm:block">
+              <LabelSpacer />
             </div>
+            <ReportToolbarActions
+              onExportCsv={handleExportCsv}
+              onExportPdf={handleExportPdf}
+              className="sm:flex-1"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/LoanAmortizationReport.tsx
+++ b/frontend/src/components/reports/LoanAmortizationReport.tsx
@@ -22,6 +22,7 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useFinancialToday } from '@/hooks/useFinancialToday';
 import { exportToCsv } from '@/lib/csv-export';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { LabelSpacer } from '@/components/ui/LabelSpacer';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { useReportData } from '@/hooks/useReportData';
@@ -479,8 +480,20 @@ export function LoanAmortizationReport() {
                 ))}
             </select>
           </div>
-          <div className="ml-auto">
-            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
+          {/* The export stands beside a labelled field, so it is the height of
+              the FIELD, not of the field plus its label: reserve the label's
+              own space above it and stretch into what is left, rather than
+              matching the select's padding with a figure that drifts the next
+              time either control's type scale changes. */}
+          <div className="ml-auto flex flex-col">
+            <LabelSpacer />
+            <div className="flex flex-1 items-stretch">
+              <ExportDropdown
+                onExportCsv={handleExportCsv}
+                onExportPdf={handleExportPdf}
+                className="h-full"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/LoanOverpaymentSimulatorReport.tsx
+++ b/frontend/src/components/reports/LoanOverpaymentSimulatorReport.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/Button';
@@ -12,6 +12,7 @@ import { fetchAllAccountTransactions, fetchLoanInterestTransactions } from '@/li
 import { useReportData } from '@/hooks/useReportData';
 import { usePersistedAccountId } from '@/hooks/usePersistedAccountFilter';
 import { ReportError } from '@/components/reports/ReportError';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { LoanDetailView } from '@/components/accounts/loan-detail/LoanDetailView';
 import { LineOfCreditView } from '@/components/accounts/loan-detail/LineOfCreditView';
 import type { AccountType } from '@/types/account';
@@ -32,6 +33,13 @@ const ACCOUNT_STORAGE_KEY = 'monize-reports-loan-overpayment-simulator-account';
 export function LoanOverpaymentSimulatorReport() {
   const t = useTranslations('reports');
   const router = useRouter();
+  /**
+   * The loan view publishes its PDF export here instead of drawing its own
+   * button below the card, the way the account detail header already takes it.
+   * That puts the export in this report's control card, under the account it
+   * exports -- on a phone it was a stray button floating outside the card.
+   */
+  const exportPdfRef = useRef<(() => Promise<void>) | null>(null);
 
   const {
     data: accountsData,
@@ -88,6 +96,9 @@ export function LoanOverpaymentSimulatorReport() {
     },
     [selectedAccountId, selectedAccount, isRevolving],
   );
+
+  /** The amortizing loan body is up: the only state with a PDF to export. */
+  const showsLoanDetail = Boolean(selectedAccount) && !isRevolving && !dataLoading;
 
   const transactions = accountData?.transactions ?? [];
   const interestTransactions = accountData?.interestTransactions ?? [];
@@ -152,10 +163,19 @@ export function LoanOverpaymentSimulatorReport() {
             <Button
               variant="outline"
               onClick={() => router.push(`/transactions?accountId=${selectedAccount.id}`)}
+              className="w-full whitespace-nowrap sm:w-auto"
             >
               {t('loanOverpayment.viewTransactions')}
             </Button>
           )}
+          {/* Disabled rather than absent while the loan view is not up (no
+              account, a line of credit, or still loading): there is nothing to
+              export yet, and a button that comes and goes moves the row. */}
+          <ReportToolbarActions
+            onExportPdf={() => { void exportPdfRef.current?.(); }}
+            disabled={!showsLoanDetail}
+            className="sm:self-auto"
+          />
         </div>
       </div>
 
@@ -167,7 +187,7 @@ export function LoanOverpaymentSimulatorReport() {
         </div>
       )}
 
-      {selectedAccount && !isRevolving && !dataLoading && (
+      {showsLoanDetail && selectedAccount && (
         <LoanDetailView
           account={selectedAccount}
           transactions={transactions}
@@ -176,6 +196,7 @@ export function LoanOverpaymentSimulatorReport() {
           rateChanges={rateChanges}
           onScenariosChanged={reloadAccountData}
           onRateChangesChanged={reload}
+          exportPdfRef={exportPdfRef}
         />
       )}
     </div>

--- a/frontend/src/components/reports/MonteCarloReport.tsx
+++ b/frontend/src/components/reports/MonteCarloReport.tsx
@@ -42,7 +42,7 @@ import {
 } from './MonteCarloPerformanceSummary';
 import { HoldingStatsTable } from './MonteCarloHoldingStatsTable';
 import { CsvSection, exportCsvSections } from '@/lib/csv-export';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { NumericInput } from '@/components/ui/NumericInput';
 import { CurrencyInput } from '@/components/ui/CurrencyInput';
@@ -1151,11 +1151,11 @@ export function MonteCarloReport() {
                       </button>
                     ))}
                   </div>
-                  <ExportDropdown
-                    onExportCsv={handleExportCsv}
-                    onExportPdf={handleExportPdf}
-                  />
                 </div>
+                <ReportToolbarActions
+                  onExportCsv={handleExportCsv}
+                  onExportPdf={handleExportPdf}
+                />
               </div>
 
               {/* Chart stays mounted whether or not it's the visible view, so

--- a/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
+++ b/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
@@ -1129,11 +1129,14 @@ export function MonthlyCategoryBreakdownReport() {
               />
               <span>{t('monthlyCategoryBreakdown.showDeviations')}</span>
             </div>
+            {/* CSV only, so this is not `ReportToolbarActions` (which renders
+                the PDF-capable `ExportDropdown`); it follows the same phone
+                rule by hand -- a line of its own, spanning the row. */}
             <button
               type="button"
               onClick={handleExportCsv}
               disabled={!hasData}
-              className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full justify-center whitespace-nowrap px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed sm:w-auto"
             >
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />

--- a/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
+++ b/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
@@ -19,6 +19,7 @@ import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { ReportError } from '@/components/reports/ReportError';
 import { exportToCsv } from '@/lib/csv-export';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 
 const RANGE_STORAGE_KEY = 'monize-reports-monthly-category-breakdown-range';
 const PERCENTAGES_STORAGE_KEY =
@@ -1129,21 +1130,10 @@ export function MonthlyCategoryBreakdownReport() {
               />
               <span>{t('monthlyCategoryBreakdown.showDeviations')}</span>
             </div>
-            {/* CSV only, so this is not `ReportToolbarActions` (which renders
-                the PDF-capable `ExportDropdown`); it follows the same phone
-                rule by hand -- a line of its own, spanning the row. */}
-            <button
-              type="button"
-              onClick={handleExportCsv}
-              disabled={!hasData}
-              className="w-full justify-center whitespace-nowrap px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed sm:w-auto"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-              </svg>
-              {t('monthlyCategoryBreakdown.exportCsv')}
-            </button>
           </div>
+          {/* CSV only: this view is a matrix of figures, with nothing to render
+              as a picture. */}
+          <ReportToolbarActions onExportCsv={handleExportCsv} disabled={!hasData} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/MonthlyComparisonReport.tsx
+++ b/frontend/src/components/reports/MonthlyComparisonReport.tsx
@@ -392,7 +392,9 @@ export function MonthlyComparisonReport() {
     <div ref={chartRef} className="space-y-6">
       {/* Month Picker */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
-        <div className="flex items-center justify-between">
+        {/* Wraps, so the actions row lands under the month stepper on a phone
+            instead of being squeezed beside it. */}
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-4 flex-1 justify-center">
             <button
               onClick={goBack}

--- a/frontend/src/components/reports/MonthlyComparisonReport.tsx
+++ b/frontend/src/components/reports/MonthlyComparisonReport.tsx
@@ -25,7 +25,7 @@ import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { gainLossColor } from '@/lib/format';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { chartColors } from '@/lib/chart-colors';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -420,7 +420,7 @@ export function MonthlyComparisonReport() {
               </svg>
             </button>
           </div>
-          <ExportDropdown onExportPdf={handleExportPdf} />
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
@@ -25,7 +25,7 @@ import { useReportData } from "@/hooks/useReportData";
 import { useSortableTable, compareValues } from "@/hooks/useSortableTable";
 import { DateRangeSelector } from "@/components/ui/DateRangeSelector";
 import { ChartViewToggle } from "@/components/ui/ChartViewToggle";
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { ChartTooltip } from "@/components/reports/ChartTooltip";
 import { ReportError } from "@/components/reports/ReportError";
@@ -213,12 +213,12 @@ export function MonthlySpendingTrendReport() {
               onChange={(v) => setViewType(v as 'line' | 'table')}
               options={['line', 'table']}
             />
-            <ExportDropdown
-              onExportPdf={handleExportPdf}
-              onExportCsv={handleExportCsv}
-              disabled={chartData.length === 0}
-            />
           </div>
+          <ReportToolbarActions
+            onExportPdf={handleExportPdf}
+            onExportCsv={handleExportCsv}
+            disabled={chartData.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -330,7 +330,11 @@ export function NetWorthReport() {
             customEndDate={endDate}
             onCustomEndDateChange={setEndDate}
           />
-          <div className="flex items-center gap-3">
+          {/* The row did not wrap, so the export sat past the right edge of a
+              phone. It takes the full width below `sm`, which puts it on a
+              line of its own under the view toggle and the recalculate
+              button, and goes back beside them from `sm` up. */}
+          <div className="flex w-full flex-wrap items-center gap-3 sm:w-auto">
             <ChartViewToggle
               value={chartType}
               onChange={(v) => setChartType(v as 'line' | 'bar' | 'stacked' | 'table')}
@@ -343,7 +347,13 @@ export function NetWorthReport() {
             >
               {isRecalculating ? t('netWorth.recalculating') : t('netWorth.recalculate')}
             </button>
-            <ExportDropdown onExportPdf={handleExportPdf} onExportCsv={handleExportCsv} disabled={chartData.length === 0} />
+            <ExportDropdown
+              onExportPdf={handleExportPdf}
+              onExportCsv={handleExportCsv}
+              disabled={chartData.length === 0}
+              containerClassName="w-full sm:w-auto"
+              className="w-full justify-center sm:w-auto"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -29,7 +29,7 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { exportToCsv } from '@/lib/csv-export';
 import { useReportData } from '@/hooks/useReportData';
@@ -347,14 +347,12 @@ export function NetWorthReport() {
             >
               {isRecalculating ? t('netWorth.recalculating') : t('netWorth.recalculate')}
             </button>
-            <ExportDropdown
-              onExportPdf={handleExportPdf}
-              onExportCsv={handleExportCsv}
-              disabled={chartData.length === 0}
-              containerClassName="w-full sm:w-auto"
-              className="w-full justify-center sm:w-auto"
-            />
           </div>
+          <ReportToolbarActions
+            onExportPdf={handleExportPdf}
+            onExportCsv={handleExportCsv}
+            disabled={chartData.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -878,11 +878,14 @@ export function PortfolioValueReport() {
       {/* Controls */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-4 items-center justify-between">
-          <div className="flex flex-wrap gap-2 items-center">
+          <div className="flex w-full flex-wrap gap-2 items-center sm:w-auto">
+            {/* Full width on a phone: at `w-48` the picker and the ten range
+                buttons beside it are wider than the screen. */}
             <ReportAccountMultiSelect
               accounts={accounts}
               value={selectedAccountIds}
               onChange={setSelectedAccountIds}
+              className="w-full sm:w-48"
             />
             <DateRangeSelector
               ranges={['1d', '1w', 'mtd', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']}
@@ -891,7 +894,9 @@ export function PortfolioValueReport() {
               activeColour="bg-emerald-600"
             />
           </div>
-          <div className="flex items-center gap-3">
+          {/* Four controls: they wrap on a phone rather than carrying the
+              export off the right of the card. */}
+          <div className="flex w-full flex-wrap items-center gap-3 sm:w-auto">
             {/* Total vs. per-security stacked view, available on every range. */}
             <div className="inline-flex rounded-md overflow-hidden border border-gray-200 dark:border-gray-600">
               {(['total', 'securities'] as const).map((mode) => {
@@ -926,6 +931,8 @@ export function PortfolioValueReport() {
               onExportPdf={handleExportPdf}
               onExportCsv={handleExportCsv}
               disabled={chartPoints.length === 0}
+              containerClassName="w-full sm:w-auto"
+              className="w-full justify-center whitespace-nowrap sm:w-auto"
             />
           </div>
         </div>

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -32,9 +32,8 @@ import { usePortfolioChangeBaseline } from '@/hooks/usePortfolioChangeBaseline';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -926,15 +925,13 @@ export function PortfolioValueReport() {
               options={['area', 'table']}
               activeColour="bg-emerald-600"
             />
-            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
-            <ExportDropdown
-              onExportPdf={handleExportPdf}
-              onExportCsv={handleExportCsv}
-              disabled={chartPoints.length === 0}
-              containerClassName="w-full sm:w-auto"
-              className="w-full justify-center whitespace-nowrap sm:w-auto"
-            />
           </div>
+          <ReportToolbarActions
+            onRefreshComplete={() => setReloadKey((k) => k + 1)}
+            onExportPdf={handleExportPdf}
+            onExportCsv={handleExportCsv}
+            disabled={chartPoints.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/RealizedGainsReport.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.tsx
@@ -425,17 +425,22 @@ export function RealizedGainsReport() {
       {/* Controls */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center">
+          {/* Full width on a phone, the toolbar's fixed width from `sm` up. */}
           <ReportAccountMultiSelect
             accounts={accounts}
             value={selectedAccountIds}
             onChange={setSelectedAccountIds}
+            className="w-full sm:w-48"
           />
           <DateRangeSelector
             ranges={['6m', '1y', '2y', 'all']}
             value={dateRange}
             onChange={setDateRange}
           />
-          <div className="ml-auto shrink-0 flex gap-2 items-center">
+          {/* `ml-auto` only from `sm` up: on a phone every group is a row of
+              its own, and pushing this one right left it hanging under two
+              left-aligned rows. */}
+          <div className="flex flex-wrap gap-2 items-center sm:ml-auto sm:shrink-0">
             <RefreshPricesButton onRefreshComplete={reload} />
             <button
               onClick={() => setViewType('chart')}
@@ -463,7 +468,12 @@ export function RealizedGainsReport() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18M3 6h18M3 18h18" />
               </svg>
             </button>
-            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} disabled={entries.length === 0} />
+            <ExportDropdown
+              onExportCsv={handleExportCsv}
+              onExportPdf={handleExportPdf}
+              disabled={entries.length === 0}
+              className="whitespace-nowrap"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/RealizedGainsReport.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.tsx
@@ -26,9 +26,8 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { exportToCsv } from '@/lib/csv-export';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import {
@@ -441,7 +440,6 @@ export function RealizedGainsReport() {
               its own, and pushing this one right left it hanging under two
               left-aligned rows. */}
           <div className="flex flex-wrap gap-2 items-center sm:ml-auto sm:shrink-0">
-            <RefreshPricesButton onRefreshComplete={reload} />
             <button
               onClick={() => setViewType('chart')}
               title={t('realizedGains.viewChart')}
@@ -468,13 +466,13 @@ export function RealizedGainsReport() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18M3 6h18M3 18h18" />
               </svg>
             </button>
-            <ExportDropdown
-              onExportCsv={handleExportCsv}
-              onExportPdf={handleExportPdf}
-              disabled={entries.length === 0}
-              className="whitespace-nowrap"
-            />
           </div>
+          <ReportToolbarActions
+            onRefreshComplete={reload}
+            onExportCsv={handleExportCsv}
+            onExportPdf={handleExportPdf}
+            disabled={entries.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/RecurringExpensesReport.tsx
+++ b/frontend/src/components/reports/RecurringExpensesReport.tsx
@@ -467,27 +467,36 @@ export function RecurringExpensesReport() {
 
       {/* Controls */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
-        <div className="flex items-center gap-3">
-          <label className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
-            {t('recurringExpenses.minOccurrencesLabel')}
-          </label>
-          <select
-            value={minOccurrences}
-            onChange={(e) => setMinOccurrences(Number(e.target.value))}
-            className="w-16 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
-          >
-            <option value={2}>2+</option>
-            <option value={3}>3+</option>
-            <option value={4}>4+</option>
-            <option value={5}>5+</option>
-            <option value={6}>6+</option>
-          </select>
-          <span className="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-            {t('recurringExpenses.inLast6Months')}
-          </span>
-          <div className="ml-auto shrink-0">
-            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
+        {/* The threshold sentence and the export were one unwrapped row: on a
+            phone the two labels either side of the picker squeezed it and the
+            export was pushed past the right edge of the card. The sentence
+            takes a row of its own below `sm`, the export the row under it. */}
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:gap-3">
+            <label className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+              {t('recurringExpenses.minOccurrencesLabel')}
+            </label>
+            <select
+              value={minOccurrences}
+              onChange={(e) => setMinOccurrences(Number(e.target.value))}
+              className="w-16 shrink-0 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
+            >
+              <option value={2}>2+</option>
+              <option value={3}>3+</option>
+              <option value={4}>4+</option>
+              <option value={5}>5+</option>
+              <option value={6}>6+</option>
+            </select>
+            <span className="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+              {t('recurringExpenses.inLast6Months')}
+            </span>
           </div>
+          <ExportDropdown
+            onExportCsv={handleExportCsv}
+            onExportPdf={handleExportPdf}
+            containerClassName="w-full self-stretch sm:ml-auto sm:w-auto sm:shrink-0"
+            className="h-full w-full justify-center whitespace-nowrap sm:w-auto"
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/RecurringExpensesReport.tsx
+++ b/frontend/src/components/reports/RecurringExpensesReport.tsx
@@ -24,7 +24,7 @@ import { useDateFormat } from '@/hooks/useDateFormat';
 import { chartSeriesColor } from '@/lib/chart-colors';
 import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
 import { exportToCsv } from '@/lib/csv-export';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import { INTERACTIVE_ROW_FOCUS_CLASS, activateOnKey } from '@/components/ui/interactive-row';
@@ -491,11 +491,9 @@ export function RecurringExpensesReport() {
               {t('recurringExpenses.inLast6Months')}
             </span>
           </div>
-          <ExportDropdown
+          <ReportToolbarActions
             onExportCsv={handleExportCsv}
             onExportPdf={handleExportPdf}
-            containerClassName="w-full self-stretch sm:ml-auto sm:w-auto sm:shrink-0"
-            className="h-full w-full justify-center whitespace-nowrap sm:w-auto"
           />
         </div>
       </div>

--- a/frontend/src/components/reports/ReportChart.tsx
+++ b/frontend/src/components/reports/ReportChart.tsx
@@ -21,7 +21,7 @@ import { useDateFormat } from '@/hooks/useDateFormat';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { chartColors } from '@/lib/chart-colors';
 import { exportToCsv } from '@/lib/csv-export';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { LinkifiedText } from '@/components/ui/LinkifiedText';
 
 // Default columns if none specified
@@ -141,8 +141,8 @@ export function ReportChart({ viewType, data, groupBy, onDataPointClick, tableCo
   const isTimeBased = groupBy === GroupByType.MONTH || groupBy === GroupByType.WEEK || groupBy === GroupByType.DAY;
 
   const exportBar = (
-    <div className="flex justify-end px-4 py-2">
-      <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
+    <div className="flex px-4 py-2">
+      <ReportToolbarActions onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
     </div>
   );
 

--- a/frontend/src/components/reports/ReportToolbarActions.test.tsx
+++ b/frontend/src/components/reports/ReportToolbarActions.test.tsx
@@ -67,6 +67,18 @@ describe('ReportToolbarActions', () => {
     expect(screen.getByTitle('Export report')).toBeInTheDocument();
   });
 
+  it('takes a CSV-only report, whose view has no picture to export', () => {
+    const { container } = render(<ReportToolbarActions onExportCsv={vi.fn()} />);
+
+    // Same row, same phone rule: one button spanning it.
+    expect(row(container).className).toContain('grid-cols-1');
+    expect(row(container).className).toContain('w-full');
+    const button = screen.getByTitle('Export CSV');
+    expect(button.className).toContain('w-full');
+    expect(button.className).toContain('whitespace-nowrap');
+    expect(screen.queryByTitle('Export PDF')).not.toBeInTheDocument();
+  });
+
   it('lets a caller opt out of stretching on a taller toolbar line', () => {
     const { container } = render(
       <ReportToolbarActions onExportPdf={vi.fn()} className="sm:self-auto" />,

--- a/frontend/src/components/reports/ReportToolbarActions.test.tsx
+++ b/frontend/src/components/reports/ReportToolbarActions.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@/test/render';
+import { ReportToolbarActions } from './ReportToolbarActions';
+
+/**
+ * The rule this component exists to hold: on a phone a report's refresh and
+ * export are one row of their own, below every selector, spanning the card.
+ * jsdom applies no media queries, so the phone layout is read off the classes
+ * -- the base (unprefixed) ones are the phone's, the `sm:` ones the desktop's.
+ */
+
+vi.mock('@/hooks/usePriceRefresh', () => ({
+  usePriceRefresh: () => ({ isRefreshing: false, triggerManualRefresh: vi.fn() }),
+}));
+
+const row = (container: HTMLElement) => container.firstElementChild!;
+
+describe('ReportToolbarActions', () => {
+  it('gives a lone export the whole row on a phone', () => {
+    const { container } = render(<ReportToolbarActions onExportPdf={vi.fn()} />);
+
+    expect(row(container).className).toContain('w-full');
+    expect(row(container).className).toContain('grid-cols-1');
+    // The export's own box is stretched by the cell, and the button fills it:
+    // the CSV form renders an inline-block wrapper that would otherwise be as
+    // wide as its text.
+    const button = screen.getByTitle('Export PDF');
+    expect(button.className).toContain('w-full');
+    expect(button.className).toContain('whitespace-nowrap');
+  });
+
+  it('splits the row in two when the report also refreshes prices', () => {
+    const { container } = render(
+      <ReportToolbarActions onExportPdf={vi.fn()} onRefreshComplete={vi.fn()} />,
+    );
+
+    expect(row(container).className).toContain('grid-cols-2');
+    expect(row(container).className).toContain('w-full');
+    // Both halves, and both filling their half.
+    const refresh = screen.getByTitle('Refresh security prices');
+    expect(refresh.className).toContain('w-full');
+    expect(screen.getByTitle('Export PDF').className).toContain('w-full');
+  });
+
+  it('goes back to the toolbar’s trailing group from sm up', () => {
+    const { container } = render(
+      <ReportToolbarActions onExportPdf={vi.fn()} onRefreshComplete={vi.fn()} />,
+    );
+
+    const className = row(container).className;
+    expect(className).toContain('sm:ml-auto');
+    expect(className).toContain('sm:flex');
+    expect(className).toContain('sm:w-auto');
+    // A button on one line with a picker is the height of the picker.
+    expect(className).toContain('sm:self-stretch');
+    expect(screen.getByTitle('Export PDF').className).toContain('h-full');
+  });
+
+  it('offers CSV only when the view has something tabular to write', () => {
+    const { rerender } = render(<ReportToolbarActions onExportPdf={vi.fn()} />);
+    // PDF-only: one button, no menu.
+    expect(screen.getByTitle('Export PDF')).toBeInTheDocument();
+
+    rerender(
+      <ReportToolbarActions onExportPdf={vi.fn()} onExportCsv={vi.fn()} />,
+    );
+    expect(screen.getByTitle('Export report')).toBeInTheDocument();
+  });
+
+  it('lets a caller opt out of stretching on a taller toolbar line', () => {
+    const { container } = render(
+      <ReportToolbarActions onExportPdf={vi.fn()} className="sm:self-auto" />,
+    );
+    // twMerge keeps the caller's value, not both.
+    expect(row(container).className).toContain('sm:self-auto');
+    expect(row(container).className).not.toContain('sm:self-stretch');
+  });
+});

--- a/frontend/src/components/reports/ReportToolbarActions.tsx
+++ b/frontend/src/components/reports/ReportToolbarActions.tsx
@@ -4,21 +4,29 @@ import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { cn } from '@/lib/utils';
 
-interface ReportToolbarActionsProps {
+interface ReportToolbarActionsBaseProps {
   /**
    * Present only on a report whose figures depend on security prices: it
    * renders the price-refresh button beside the export. Omit it and the export
    * takes the whole row.
    */
   onRefreshComplete?: (lastUpdated?: string) => void | Promise<void>;
-  onExportPdf: () => void;
-  /** Omit where the current view has nothing tabular to write. */
-  onExportCsv?: () => void;
   /** Disables the export (an empty report has nothing to export). */
   disabled?: boolean;
   /** Extra classes for the row, for a caller that has to opt out of a default. */
   className?: string;
 }
+
+/**
+ * The formats, in the three shapes `ExportDropdown` draws: both, PDF alone, or
+ * CSV alone (a report whose view is a matrix of figures with nothing to render
+ * as a picture). At least one is required -- the row exists to export.
+ */
+type ReportToolbarActionsProps = ReportToolbarActionsBaseProps &
+  (
+    | { onExportPdf: () => void; onExportCsv?: () => void }
+    | { onExportPdf?: undefined; onExportCsv: () => void }
+  );
 
 /**
  * The trailing actions of a report's toolbar: refresh (where the report has
@@ -47,10 +55,11 @@ interface ReportToolbarActionsProps {
  */
 export function ReportToolbarActions({
   onRefreshComplete,
-  onExportPdf,
-  onExportCsv,
   disabled,
   className,
+  // The two handlers travel together as one value: destructured apart, the
+  // union widens to two optional props and the export no longer type-checks.
+  ...formats
 }: ReportToolbarActionsProps) {
   const hasRefresh = onRefreshComplete !== undefined;
 
@@ -70,8 +79,7 @@ export function ReportToolbarActions({
         />
       )}
       <ExportDropdown
-        onExportPdf={onExportPdf}
-        onExportCsv={onExportCsv}
+        {...formats}
         disabled={disabled}
         containerClassName="w-full sm:w-auto"
         className="h-full w-full justify-center whitespace-nowrap sm:w-auto"

--- a/frontend/src/components/reports/ReportToolbarActions.tsx
+++ b/frontend/src/components/reports/ReportToolbarActions.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
+import { cn } from '@/lib/utils';
+
+interface ReportToolbarActionsProps {
+  /**
+   * Present only on a report whose figures depend on security prices: it
+   * renders the price-refresh button beside the export. Omit it and the export
+   * takes the whole row.
+   */
+  onRefreshComplete?: (lastUpdated?: string) => void | Promise<void>;
+  onExportPdf: () => void;
+  /** Omit where the current view has nothing tabular to write. */
+  onExportCsv?: () => void;
+  /** Disables the export (an empty report has nothing to export). */
+  disabled?: boolean;
+  /** Extra classes for the row, for a caller that has to opt out of a default. */
+  className?: string;
+}
+
+/**
+ * The trailing actions of a report's toolbar: refresh (where the report has
+ * one) and export.
+ *
+ * **On a phone this is a row of its own, below every selector, spanning the
+ * card**: one full-width button, or two equal halves when the report also
+ * refreshes prices. From `sm` up it is the toolbar's trailing group at the
+ * right edge, where it has always been.
+ *
+ * The layout lives here rather than in each report because every report got it
+ * slightly differently and a dozen of them got it wrong: an unwrapped row
+ * carried the export off the right of a phone, and the ones that did wrap left
+ * it stranded mid-toolbar or hanging against the right edge. The grid is what
+ * makes "spanning the row" true for the export as well as the refresh --
+ * `ExportDropdown`'s CSV form lays out as an `inline-block` wrapper, which a
+ * grid cell stretches and a flex row would not.
+ *
+ * `sm:self-stretch` with `h-full` on the buttons is the desktop half: on one
+ * line with a picker, a button is the height of the picker, not of its own
+ * text. A caller whose toolbar line is taller than a field (a labelled field,
+ * a legend) passes `sm:self-auto`.
+ *
+ * Render it as the LAST child of the toolbar's wrapping row, so the phone's
+ * wrap puts it under everything else.
+ */
+export function ReportToolbarActions({
+  onRefreshComplete,
+  onExportPdf,
+  onExportCsv,
+  disabled,
+  className,
+}: ReportToolbarActionsProps) {
+  const hasRefresh = onRefreshComplete !== undefined;
+
+  return (
+    <div
+      className={cn(
+        'grid w-full gap-2',
+        hasRefresh ? 'grid-cols-2' : 'grid-cols-1',
+        'sm:ml-auto sm:flex sm:w-auto sm:shrink-0 sm:items-center sm:self-stretch',
+        className,
+      )}
+    >
+      {hasRefresh && (
+        <RefreshPricesButton
+          onRefreshComplete={onRefreshComplete}
+          className="h-full w-full sm:w-auto"
+        />
+      )}
+      <ExportDropdown
+        onExportPdf={onExportPdf}
+        onExportCsv={onExportCsv}
+        disabled={disabled}
+        containerClassName="w-full sm:w-auto"
+        className="h-full w-full justify-center whitespace-nowrap sm:w-auto"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/reports/SavingsRateReport.tsx
+++ b/frontend/src/components/reports/SavingsRateReport.tsx
@@ -21,7 +21,7 @@ import type { Budget, SavingsRatePoint } from '@/types/budget';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { useChartMonthFormat } from '@/hooks/useChartMonthFormat';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -321,9 +321,7 @@ export function SavingsRateReport() {
               <option value={50}>50%</option>
             </select>
           </div>
-          <div className="ml-auto">
-            <ExportDropdown onExportPdf={handleExportPdf} />
-          </div>
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/SeasonalSpendingMapReport.tsx
+++ b/frontend/src/components/reports/SeasonalSpendingMapReport.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { budgetsApi } from '@/lib/budgets';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { useReportData } from '@/hooks/useReportData';
@@ -195,9 +195,7 @@ export function SeasonalSpendingMapReport() {
               <option key={b.id} value={b.id}>{b.name}</option>
             ))}
           </select>
-          <div className="ml-auto">
-            <ExportDropdown onExportPdf={handleExportPdf} />
-          </div>
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/SectorWeightingsReport.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.tsx
@@ -21,10 +21,9 @@ import { Security } from '@/types/investment';
 import { Account } from '@/types/account';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { MultiSelect } from '@/components/ui/MultiSelect';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -391,10 +390,10 @@ export function SectorWeightingsReport() {
               </button>
             )}
           </div>
-          <div className="flex flex-wrap gap-2 items-center">
-            <RefreshPricesButton onRefreshComplete={loadWeightings} />
-            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
-          </div>
+          <ReportToolbarActions
+            onRefreshComplete={loadWeightings}
+            onExportPdf={handleExportPdf}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/SectorWeightingsReport.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.tsx
@@ -354,17 +354,22 @@ export function SectorWeightingsReport() {
       {/* Filters */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center justify-between">
-          <div className="flex flex-wrap gap-3 items-center">
+          {/* Each picker takes the full width of the card on a phone -- at
+              `w-48` a pair of them is wider than the screen and an account or
+              security name has nowhere to go -- and returns to the fixed
+              toolbar width from `sm` up. */}
+          <div className="flex w-full flex-wrap gap-3 items-center sm:w-auto">
             {/* Account Filter */}
             <ReportAccountMultiSelect
               accounts={accounts}
               value={selectedAccountIds}
               onChange={setSelectedAccountIds}
               mode="portfolio"
+              className="w-full sm:w-48"
             />
 
             {/* Security Filter */}
-            <div className="w-48">
+            <div className="w-full sm:w-48">
               <MultiSelect
                 ariaLabel={t('sectorWeightings.filterBySecurityLabel')}
                 placeholder={t('sectorWeightings.allSecuritiesPlaceholder')}
@@ -386,9 +391,9 @@ export function SectorWeightingsReport() {
               </button>
             )}
           </div>
-          <div className="flex gap-2 items-center">
+          <div className="flex flex-wrap gap-2 items-center">
             <RefreshPricesButton onRefreshComplete={loadWeightings} />
-            <ExportDropdown onExportPdf={handleExportPdf} />
+            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -608,11 +608,14 @@ export function SecurityPerformanceReport() {
           error states belong to the body below, not to the whole report. */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 space-y-4">
         <div className="flex flex-wrap gap-4 items-center justify-between">
-          <div className="flex flex-wrap gap-2 items-center">
-            {/* Sized to their longest option, not to the current selection:
-                these two sit in the toolbar, and a control that stretches on
-                every pick drags the range selector around under the cursor. */}
-            <div className="min-w-[250px]">
+          <div className="flex w-full flex-wrap gap-2 items-center sm:w-auto">
+            {/* From `sm` up, sized to their longest option rather than to the
+                current selection: these two sit in the toolbar, and a control
+                that stretches on every pick drags the range selector around
+                under the cursor. On a phone there is no room for that -- the
+                longest security name is wider than the screen -- so each takes
+                the full line and the selected name truncates. */}
+            <div className="w-full sm:w-auto sm:min-w-[250px]">
               <MultiSelect
                 ariaLabel={t('securityPerformance.selectSecuritiesPlaceholder')}
                 options={securityOptions}
@@ -622,7 +625,7 @@ export function SecurityPerformanceReport() {
                 sizeToLongestOption
               />
             </div>
-            <div className="min-w-[250px]">
+            <div className="w-full sm:w-auto sm:min-w-[250px]">
               <MultiSelect
                 ariaLabel={t('securityPerformance.selectIndexesPlaceholder')}
                 options={indexOptions}
@@ -633,7 +636,7 @@ export function SecurityPerformanceReport() {
               />
             </div>
           </div>
-          <div className="flex gap-2 items-center">
+          <div className="flex flex-wrap gap-2 items-center">
             {isSingle && (
               <>
                 <button

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -28,8 +28,7 @@ import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -665,9 +664,15 @@ export function SecurityPerformanceReport() {
                 </button>
               </>
             )}
-            <RefreshPricesButton onRefreshComplete={() => { reloadBase(); reloadDetail(); setAllRefreshKey((k) => k + 1); }} />
-            {(isSingle || isComparison) && <ExportDropdown onExportPdf={handleExportPdf} />}
           </div>
+          {/* The export is disabled rather than absent until a security is
+              picked: a button that appears on selection moves the row under
+              the reader's thumb on a phone. */}
+          <ReportToolbarActions
+            onRefreshComplete={() => { reloadBase(); reloadDetail(); setAllRefreshKey((k) => k + 1); }}
+            onExportPdf={handleExportPdf}
+            disabled={!isSingle && !isComparison}
+          />
         </div>
 
         {/*

--- a/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
+++ b/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
@@ -20,10 +20,9 @@ import { HoldingWithMarketValue } from '@/types/investment';
 import { Account } from '@/types/account';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
 import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
-import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { INTERACTIVE_ROW_FOCUS_CLASS, activateOnKey } from '@/components/ui/interactive-row';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
@@ -484,10 +483,10 @@ export function SecurityTypeAllocationReport() {
               className="w-full sm:w-48"
             />
           </div>
-          <div className="flex flex-wrap gap-2 items-center">
-            <RefreshPricesButton onRefreshComplete={loadData} />
-            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
-          </div>
+          <ReportToolbarActions
+            onRefreshComplete={loadData}
+            onExportPdf={handleExportPdf}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
+++ b/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
@@ -473,17 +473,20 @@ export function SecurityTypeAllocationReport() {
       {/* Account Filter */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center justify-between">
-          <div className="flex flex-wrap gap-3 items-center">
+          {/* Full width on a phone, the toolbar's fixed width from `sm` up:
+              at `w-48` an account name has nowhere to go. */}
+          <div className="flex w-full flex-wrap gap-3 items-center sm:w-auto">
             <ReportAccountMultiSelect
               accounts={accounts}
               value={selectedAccountIds}
               onChange={setSelectedAccountIds}
               mode="portfolio"
+              className="w-full sm:w-48"
             />
           </div>
-          <div className="flex gap-2 items-center">
+          <div className="flex flex-wrap gap-2 items-center">
             <RefreshPricesButton onRefreshComplete={loadData} />
-            <ExportDropdown onExportPdf={handleExportPdf} />
+            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/SpendingAnomaliesReport.tsx
+++ b/frontend/src/components/reports/SpendingAnomaliesReport.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation';
 import { builtInReportsApi } from '@/lib/built-in-reports';
 import { SpendingAnomaly } from '@/types/built-in-reports';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
 
@@ -179,12 +179,7 @@ export function SpendingAnomaliesReport() {
             <option value={2.5}>{t('spendingAnomalies.sensitivityLow')}</option>
             <option value={3}>{t('spendingAnomalies.sensitivityVeryLow')}</option>
           </select>
-          <div className="w-full self-stretch sm:ml-auto sm:w-auto sm:shrink-0">
-            <ExportDropdown
-              onExportPdf={handleExportPdf}
-              className="h-full w-full justify-center whitespace-nowrap sm:w-auto"
-            />
-          </div>
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/SpendingAnomaliesReport.tsx
+++ b/frontend/src/components/reports/SpendingAnomaliesReport.tsx
@@ -161,7 +161,11 @@ export function SpendingAnomaliesReport() {
 
       {/* Controls */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
-        <div className="flex items-center gap-3">
+        {/* The export is the height of the sensitivity picker beside it, not
+            of its own text: `self-stretch` on the box it sits in and `h-full`
+            on the button, so the two read as one row of controls. On a phone
+            the row wraps and the export takes a line of its own. */}
+        <div className="flex flex-wrap items-center gap-3">
           <label className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
             {t('spendingAnomalies.sensitivityLabel')}
           </label>
@@ -175,8 +179,11 @@ export function SpendingAnomaliesReport() {
             <option value={2.5}>{t('spendingAnomalies.sensitivityLow')}</option>
             <option value={3}>{t('spendingAnomalies.sensitivityVeryLow')}</option>
           </select>
-          <div className="ml-auto shrink-0">
-            <ExportDropdown onExportPdf={handleExportPdf} />
+          <div className="w-full self-stretch sm:ml-auto sm:w-auto sm:shrink-0">
+            <ExportDropdown
+              onExportPdf={handleExportPdf}
+              className="h-full w-full justify-center whitespace-nowrap sm:w-auto"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/SpendingByCategoryReport.tsx
+++ b/frontend/src/components/reports/SpendingByCategoryReport.tsx
@@ -28,7 +28,7 @@ import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 import { DonutCenterTotal } from '@/components/ui/DonutCenterTotal';
 import { ChartLegend } from '@/components/ui/ChartLegend';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import type {
@@ -266,12 +266,12 @@ export function SpendingByCategoryReport() {
               onChange={(v) => setViewType(v as 'pie' | 'bar' | 'table')}
               options={['pie', 'bar', 'table']}
             />
-            <ExportDropdown
-              onExportPdf={handleExportPdf}
-              onExportCsv={handleExportCsv}
-              disabled={chartData.length === 0}
-            />
           </div>
+          <ReportToolbarActions
+            onExportPdf={handleExportPdf}
+            onExportCsv={handleExportCsv}
+            disabled={chartData.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/SpendingByCategoryReport.tsx
+++ b/frontend/src/components/reports/SpendingByCategoryReport.tsx
@@ -476,9 +476,12 @@ export function SpendingByCategoryReport() {
               </div>
             )}
 
-            {/* Legend -- one vertical column on a phone, dense grid from `sm` up. */}
+            {/* Legend -- two columns on a phone (category names are short and
+                a full-width column of them is a long scroll past the chart),
+                denser still from `sm` up. */}
             <ChartLegend
               className="mt-6"
+              phoneColumns={2}
               columnsClassName="sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
               items={chartData.map((item, index) => {
                 const percentage = totalExpenses > 0 ? (item.value / totalExpenses) * 100 : 0;

--- a/frontend/src/components/reports/SpendingByPayeeReport.tsx
+++ b/frontend/src/components/reports/SpendingByPayeeReport.tsx
@@ -23,7 +23,7 @@ import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 import { chartColors, chartSeriesColor } from '@/lib/chart-colors';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
 import { ReportError } from '@/components/reports/ReportError';
@@ -159,12 +159,12 @@ export function SpendingByPayeeReport() {
               onChange={(v) => setViewType(v as 'bar' | 'table')}
               options={['bar', 'table']}
             />
-            <ExportDropdown
-              onExportPdf={handleExportPdf}
-              onExportCsv={handleExportCsv}
-              disabled={chartData.length === 0}
-            />
           </div>
+          <ReportToolbarActions
+            onExportPdf={handleExportPdf}
+            onExportCsv={handleExportCsv}
+            disabled={chartData.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/TaxSummaryReport.tsx
+++ b/frontend/src/components/reports/TaxSummaryReport.tsx
@@ -6,7 +6,7 @@ import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { builtInReportsApi } from '@/lib/built-in-reports';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { exportToCsv } from '@/lib/csv-export';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
 
@@ -88,7 +88,7 @@ export function TaxSummaryReport() {
     <div className="space-y-6">
       {/* Year Selector */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
-        <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-4">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
               {t('taxSummary.taxYear')}
@@ -103,7 +103,7 @@ export function TaxSummaryReport() {
               ))}
             </select>
           </div>
-          <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
+          <ReportToolbarActions onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/UncategorizedTransactionsReport.tsx
+++ b/frontend/src/components/reports/UncategorizedTransactionsReport.tsx
@@ -14,7 +14,7 @@ import { useDateFormat } from '@/hooks/useDateFormat';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { exportToCsv } from '@/lib/csv-export';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { CAPTION_CLASS, CellLabel, PHONE_HEADER_CLASS } from '@/components/ui/Table';
 import { INTERACTIVE_ROW_FOCUS_CLASS, activateOnKey } from '@/components/ui/interactive-row';
@@ -386,7 +386,7 @@ export function UncategorizedTransactionsReport() {
         </div>
       ) : (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 overflow-hidden">
-          <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-center justify-between gap-3">
             <div>
               <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                 {t('uncategorizedTransactions.tableTitle')}
@@ -395,7 +395,7 @@ export function UncategorizedTransactionsReport() {
                 {t('uncategorizedTransactions.tableSubtitle')}
               </p>
             </div>
-            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
+            <ReportToolbarActions onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
           </div>
           {/* Below `sm` the table becomes a block and each row wraps into a
               two-column grid of EQUAL `minmax(0,1fr)` tracks (for the reason

--- a/frontend/src/components/reports/UpcomingBillsReport.test.tsx
+++ b/frontend/src/components/reports/UpcomingBillsReport.test.tsx
@@ -21,7 +21,10 @@ vi.mock('@/hooks/useNumberFormat', async () => {
     }),
   };
 });
-vi.mock('@/lib/utils', () => ({
+// Partial mock: the report's date parsing is pinned here, but `cn` and the
+// rest of the module are the real ones -- the components in this tree use them.
+vi.mock('@/lib/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/utils')>()),
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
 }));
 

--- a/frontend/src/components/reports/UpcomingBillsReport.tsx
+++ b/frontend/src/components/reports/UpcomingBillsReport.tsx
@@ -24,7 +24,7 @@ import {
   occurrenceKind,
 } from '@/lib/scheduled-kind';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { exportToCsv } from '@/lib/csv-export';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
@@ -421,13 +421,12 @@ export function UpcomingBillsReport() {
                 {t('upcomingBills.listView')}
               </button>
             </div>
-            <ExportDropdown
-              onExportCsv={handleExportCsv}
-              onExportPdf={handleExportPdf}
-              disabled={upcomingBills.length === 0}
-              className="whitespace-nowrap"
-            />
           </div>
+          <ReportToolbarActions
+            onExportCsv={handleExportCsv}
+            onExportPdf={handleExportPdf}
+            disabled={upcomingBills.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/UpcomingBillsReport.tsx
+++ b/frontend/src/components/reports/UpcomingBillsReport.tsx
@@ -367,7 +367,10 @@ export function UpcomingBillsReport() {
 
       {/* Controls */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
-        <div className="flex items-center justify-between">
+        {/* The month stepper alone fills a phone, so the view switch and the
+            export take a line of their own below it rather than being pushed
+            off the right of the card. One row from `sm` up. */}
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-2">
             <button
               onClick={() => setCurrentMonth(subMonths(currentMonth, 1))}
@@ -395,7 +398,7 @@ export function UpcomingBillsReport() {
               {t('upcomingBills.todayButton')}
             </button>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex w-full flex-wrap items-center gap-3 sm:w-auto">
             <div className="flex gap-2">
               <button
                 onClick={() => setViewType('calendar')}
@@ -418,7 +421,12 @@ export function UpcomingBillsReport() {
                 {t('upcomingBills.listView')}
               </button>
             </div>
-            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} disabled={upcomingBills.length === 0} />
+            <ExportDropdown
+              onExportCsv={handleExportCsv}
+              onExportPdf={handleExportPdf}
+              disabled={upcomingBills.length === 0}
+              className="whitespace-nowrap"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/WeekendVsWeekdayReport.tsx
+++ b/frontend/src/components/reports/WeekendVsWeekdayReport.tsx
@@ -21,7 +21,7 @@ import { chartColors, CHART_SERIES } from '@/lib/chart-colors';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
 import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
@@ -255,8 +255,8 @@ export function WeekendVsWeekdayReport() {
             >
               {t('weekendVsWeekday.viewByCategory')}
             </button>
-            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
           </div>
+          <ReportToolbarActions onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/WeekendVsWeekdayReport.tsx
+++ b/frontend/src/components/reports/WeekendVsWeekdayReport.tsx
@@ -219,7 +219,12 @@ export function WeekendVsWeekdayReport() {
             value={dateRange}
             onChange={setDateRange}
           />
-          <div className="flex gap-2 items-center">
+          {/* `items-stretch`, not `items-center`: squeezed onto a phone these
+              labels wrap onto a different number of lines each, and the
+              one-word button (Overview) stood shorter than the two beside it.
+              They wrap onto their own lines here, all the height of the
+              tallest on the line. */}
+          <div className="flex flex-wrap gap-2 items-stretch">
             <button
               onClick={() => setViewType('comparison')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
@@ -250,7 +255,7 @@ export function WeekendVsWeekdayReport() {
             >
               {t('weekendVsWeekday.viewByCategory')}
             </button>
-            <ExportDropdown onExportPdf={handleExportPdf} />
+            <ExportDropdown onExportPdf={handleExportPdf} className="whitespace-nowrap" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/YearOverYearReport.tsx
+++ b/frontend/src/components/reports/YearOverYearReport.tsx
@@ -22,8 +22,8 @@ import { useChartDateFormat } from "@/hooks/useChartDateFormat";
 import { useSortableTable, compareValues } from "@/hooks/useSortableTable";
 import { chartColors, chartSeriesColor } from "@/lib/chart-colors";
 import { resolvePdfColor } from "@/components/reports/resolve-pdf-color";
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { ChartViewToggle } from "@/components/ui/ChartViewToggle";
-import { ExportDropdown } from "@/components/ui/ExportDropdown";
 import { SortableHeader } from "@/components/ui/SortableHeader";
 import { exportToCsv } from "@/lib/csv-export";
 import { useReportData } from "@/hooks/useReportData";
@@ -281,22 +281,22 @@ export function YearOverYearReport() {
               </button>
             ))}
           </div>
-          {/* `ml-auto` from `sm` up only. On a phone the three groups wrap
-              onto three lines, and pushing the last one to the right edge left
-              it hanging under two left-aligned rows; on one line it is still
-              the trailing group. */}
+          {/* `ml-auto` from `sm` up only. On a phone the groups wrap onto
+              lines of their own, and pushing this one to the right edge left it
+              hanging under two left-aligned rows; on one line it is still the
+              trailing group. */}
           <div className="flex items-center gap-3 sm:ml-auto">
             <ChartViewToggle
               value={viewType}
               onChange={(v) => setViewType(v as 'bar' | 'table')}
               options={['bar', 'table']}
             />
-            <ExportDropdown
-              onExportPdf={handleExportPdf}
-              onExportCsv={handleExportCsv}
-              disabled={chartData.length === 0}
-            />
           </div>
+          <ReportToolbarActions
+            onExportPdf={handleExportPdf}
+            onExportCsv={handleExportCsv}
+            disabled={chartData.length === 0}
+          />
         </div>
       </div>
 

--- a/frontend/src/components/reports/YearOverYearReport.tsx
+++ b/frontend/src/components/reports/YearOverYearReport.tsx
@@ -281,7 +281,11 @@ export function YearOverYearReport() {
               </button>
             ))}
           </div>
-          <div className="ml-auto flex items-center gap-3">
+          {/* `ml-auto` from `sm` up only. On a phone the three groups wrap
+              onto three lines, and pushing the last one to the right edge left
+              it hanging under two left-aligned rows; on one line it is still
+              the trailing group. */}
+          <div className="flex items-center gap-3 sm:ml-auto">
             <ChartViewToggle
               value={viewType}
               onChange={(v) => setViewType(v as 'bar' | 'table')}

--- a/frontend/src/components/reports/account-balances/AccountBalancesControls.test.tsx
+++ b/frontend/src/components/reports/account-balances/AccountBalancesControls.test.tsx
@@ -167,9 +167,13 @@ describe('AccountBalancesControls layout', () => {
    * fields (the date, group-by, sort-by), and used to be a hand-rolled pair of
    * icon buttons centred against that row -- shorter than every field beside
    * them, because nothing reserved the label space above them the way `Select`
-   * does above its own input. `ChartViewToggle`/`ExportDropdown` now sit in a
+   * does above its own input. `ChartViewToggle` and the export now sit in a
    * column shaped exactly like the sort-direction toggle's: same spacer, same
    * `items-stretch` row, so what is left to stretch into is the field height.
+   *
+   * The spacer is the DESKTOP's alone (`hidden sm:block`): on a phone there is
+   * no field beside these controls, and the export is a row of its own through
+   * `ReportToolbarActions`.
    */
   it('gives the view toggle and export button the height of the fields beside them', () => {
     renderControls();
@@ -177,16 +181,21 @@ describe('AccountBalancesControls layout', () => {
     const exportButton = screen.getByTestId('export-dropdown');
 
     // Both controls share one stretched row, inside a column that reserves a
-    // label spacer above them -- the same shape the sort-direction toggle uses.
-    // `ChartViewToggle` wraps its own buttons in a `flex gap-2` div, so the
-    // shared row is one level up from the button itself.
+    // label spacer above them. `ChartViewToggle` wraps its own buttons in a
+    // `flex gap-2` div and the export sits in its actions row, so the shared
+    // row is one level up from each button.
     const row = tableButton.parentElement!.parentElement!;
-    expect(row).toBe(exportButton.parentElement);
+    expect(row).toBe(exportButton.parentElement!.parentElement);
     expect(row.className).toContain('items-stretch');
+    // It wraps, so the export takes a line of its own on a phone.
+    expect(row.className).toContain('flex-wrap');
 
     const column = row.parentElement!;
-    const spacer = column.firstElementChild!;
-    expect(spacer).not.toBe(row);
+    const spacerWrapper = column.firstElementChild!;
+    expect(spacerWrapper).not.toBe(row);
+    expect(spacerWrapper.className).toContain('hidden');
+    expect(spacerWrapper.className).toContain('sm:block');
+    const spacer = spacerWrapper.firstElementChild!;
     expect(spacer.getAttribute('aria-hidden')).toBe('true');
     expect(spacer.className).toContain('mb-1');
     expect(spacer.className).toContain('text-sm');

--- a/frontend/src/components/reports/account-balances/AccountBalancesControls.tsx
+++ b/frontend/src/components/reports/account-balances/AccountBalancesControls.tsx
@@ -5,7 +5,7 @@ import { DateInput } from '@/components/ui/DateInput';
 import { Select } from '@/components/ui/Select';
 import { MultiSelect, type MultiSelectOption } from '@/components/ui/MultiSelect';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
-import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportToolbarActions } from '@/components/reports/ReportToolbarActions';
 import { LabelSpacer } from '@/components/ui/LabelSpacer';
 import {
   GROUP_BY_OPTIONS,
@@ -147,24 +147,28 @@ export function AccountBalancesControls({
           </div>
         </div>
         {/* The view toggle and the export button are controls on a row of
-            labelled fields, so they take the fields' height the same way the
-            sort-direction button does: the label's space is reserved above
-            them, and what is left is stretched into. They were previously a
-            hand-rolled pair of icon buttons centred against the row, which
-            stood short of every field beside them -- `ChartViewToggle` is the
-            component 19 other surfaces use for exactly this. */}
+            labelled fields, so from `sm` up they take the fields' height the
+            same way the sort-direction button does: the label's space is
+            reserved above them, and what is left is stretched into. They were
+            previously a hand-rolled pair of icon buttons centred against the
+            row, which stood short of every field beside them --
+            `ChartViewToggle` is the component 19 other surfaces use for exactly
+            this. On a phone there is no field beside them, so the reserved
+            space goes and the export takes a line of its own. */}
         <div className="flex flex-col">
-          <LabelSpacer />
-          <div className="flex flex-1 items-stretch gap-2">
+          <div className="hidden sm:block">
+            <LabelSpacer />
+          </div>
+          <div className="flex flex-1 flex-wrap items-stretch gap-2">
             <ChartViewToggle
               value={viewMode === 'chart' ? 'pie' : 'table'}
               onChange={(view) => onViewModeChange(view === 'pie' ? 'chart' : 'table')}
               options={['table', 'pie']}
             />
-            <ExportDropdown
+            <ReportToolbarActions
               onExportPdf={onExportPdf}
               onExportCsv={onExportCsv}
-              className="h-full"
+              className="sm:ml-0"
             />
           </div>
         </div>

--- a/frontend/src/components/reports/account-balances/AccountBalancesControls.tsx
+++ b/frontend/src/components/reports/account-balances/AccountBalancesControls.tsx
@@ -6,6 +6,7 @@ import { Select } from '@/components/ui/Select';
 import { MultiSelect, type MultiSelectOption } from '@/components/ui/MultiSelect';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { LabelSpacer } from '@/components/ui/LabelSpacer';
 import {
   GROUP_BY_OPTIONS,
   SORT_BY_OPTIONS,
@@ -40,25 +41,6 @@ interface Props {
 }
 
 const SCOPES: BalanceScope[] = ['all', 'assets', 'liabilities'];
-
-/**
- * The space a `Select` gives its label, reserved above a control that has none.
- *
- * A button standing beside a labelled field is the height of the *field*, not
- * of the field plus its label. Reserving the label's own space above it means
- * what is left to stretch into is exactly the input's height, with no magic
- * number that a font or padding change would silently invalidate --
- * `self-stretch` alone measures from the top of the label and stands a label
- * taller. Both the sort-direction toggle and the view/export group need it, so
- * the rule lives in one place rather than being written out twice.
- */
-function LabelSpacer() {
-  return (
-    <span aria-hidden="true" className="mb-1 block text-sm font-medium">
-      {'\u00a0'}
-    </span>
-  );
-}
 
 /**
  * The report's toolbar: the date the balances are measured at, what is

--- a/frontend/src/components/ui/ChartLegend.test.tsx
+++ b/frontend/src/components/ui/ChartLegend.test.tsx
@@ -30,6 +30,21 @@ describe('ChartLegend', () => {
     }
   });
 
+  /**
+   * Two columns on a phone is opt-in, per legend. A legend of short names (a
+   * category legend of twenty rows) reads better halved than as a long scroll
+   * past the chart; the default stays one column, because a name that has to
+   * truncate loses its end silently.
+   */
+  it('gives a phone two columns when the caller asks for them', () => {
+    const { container } = render(<ChartLegend items={ITEMS} phoneColumns={2} />);
+    const list = container.querySelector('ul')!;
+    expect(list.className).toContain('grid-cols-2');
+    expect(list.className).not.toContain('grid-cols-1');
+    // The larger breakpoints are still the caller's to set.
+    expect(list.className).toContain('sm:grid-cols-2');
+  });
+
   it('honours a caller-supplied column layout, still vertical on mobile', () => {
     const { container } = render(
       <ChartLegend items={ITEMS} columnsClassName="sm:grid-cols-2 md:grid-cols-4" />,

--- a/frontend/src/components/ui/ChartLegend.tsx
+++ b/frontend/src/components/ui/ChartLegend.tsx
@@ -24,23 +24,40 @@ export interface ChartLegendItem {
 interface ChartLegendProps {
   items: readonly ChartLegendItem[];
   /**
-   * Column classes applied from `sm` up. Mobile is ALWAYS a single vertical
-   * column -- the point of this component -- so a caller only says how the
-   * legend widens on larger screens. Default: two from `sm`, three from `lg`.
+   * Column classes applied from `sm` up. A caller only says how the legend
+   * widens on larger screens; the phone layout is `phoneColumns`. Default: two
+   * from `sm`, three from `lg`.
    */
   columnsClassName?: string;
+  /**
+   * How many columns the legend has on a phone. One by default, which is what
+   * a legend of long names needs. Pass `2` where the names are short enough to
+   * read at half width -- a category legend of twenty rows is a long scroll in
+   * one column -- and check the longest name at 320px: each row truncates
+   * rather than wrapping, so an over-narrow column silently hides the end of a
+   * name.
+   */
+  phoneColumns?: 1 | 2;
   className?: string;
 }
 
 const DEFAULT_COLUMNS = 'sm:grid-cols-2 lg:grid-cols-3';
 
+/** The phone column count, as the class it compiles to. */
+const PHONE_COLUMNS: Record<1 | 2, string> = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+};
+
 /**
- * The legend beside a categorical chart (a pie, a donut), rendered VERTICALLY on
- * a phone and in compact multiple columns from `sm` up.
+ * The legend beside a categorical chart (a pie, a donut), rendered in one
+ * vertical column on a phone by default and in compact multiple columns from
+ * `sm` up.
  *
- * A two- or three-column legend on a 320px screen wraps every name onto its own
- * cramped half-width; one column per row gives each name the whole width and
- * reads straight down beside the chart. From `sm` the caller's
+ * A three-column legend on a 320px screen wraps every name onto its own cramped
+ * third-width; one column per row gives each name the whole width and reads
+ * straight down beside the chart. A legend whose names are short can say
+ * `phoneColumns={2}` and halve the scroll instead. From `sm` the caller's
  * `columnsClassName` restores the dense desktop grid.
  *
  * A row with an `onClick` is a button (with a `focus-visible` ring and a
@@ -53,11 +70,12 @@ const DEFAULT_COLUMNS = 'sm:grid-cols-2 lg:grid-cols-3';
 export function ChartLegend({
   items,
   columnsClassName = DEFAULT_COLUMNS,
+  phoneColumns = 1,
   className,
 }: ChartLegendProps) {
   return (
     <ul
-      className={`grid grid-cols-1 gap-x-3 gap-y-1 ${columnsClassName} ${className ?? ''}`}
+      className={`grid ${PHONE_COLUMNS[phoneColumns]} gap-x-3 gap-y-1 ${columnsClassName} ${className ?? ''}`}
     >
       {items.map((item) => {
         const inner = (

--- a/frontend/src/components/ui/ExportDropdown.test.tsx
+++ b/frontend/src/components/ui/ExportDropdown.test.tsx
@@ -83,6 +83,42 @@ describe('ExportDropdown', () => {
     expect(screen.getByTitle('Export report').className).toContain('w-full');
   });
 
+  /**
+   * A report whose view is a matrix of figures (the monthly category
+   * breakdown) or a custom report's rows has nothing to render as a picture,
+   * so it exports CSV and nothing else. Both used to hand-roll this button --
+   * a third copy of the styling, and one that missed the phone layout.
+   */
+  describe('CSV-only variant', () => {
+    it('renders one CSV button, not a dropdown', () => {
+      const onExportCsv = vi.fn();
+      render(<ExportDropdown onExportCsv={onExportCsv} />);
+
+      const button = screen.getByTitle('Export CSV');
+      expect(button.tagName).toBe('BUTTON');
+      // No menu to open: the PDF entry that would need one is not offered.
+      expect(screen.queryByText('PDF')).not.toBeInTheDocument();
+
+      fireEvent.click(button);
+      expect(onExportCsv).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables that button like the others', () => {
+      render(<ExportDropdown onExportCsv={vi.fn()} disabled />);
+      expect(screen.getByTitle('Export CSV')).toBeDisabled();
+    });
+
+    it('is the box its toolbar lays out, sized through className', () => {
+      const { container } = render(
+        <ExportDropdown onExportCsv={vi.fn()} className="w-full whitespace-nowrap" />,
+      );
+      const root = container.firstElementChild!;
+      expect(root.tagName).toBe('BUTTON');
+      expect(root.className).toContain('w-full');
+      expect(root.className).toContain('whitespace-nowrap');
+    });
+  });
+
   it('sizes the PDF-only variant through className, having no wrapper', () => {
     const { container } = render(
       <ExportDropdown onExportPdf={vi.fn()} className="w-full whitespace-nowrap" />,

--- a/frontend/src/components/ui/ExportDropdown.test.tsx
+++ b/frontend/src/components/ui/ExportDropdown.test.tsx
@@ -59,4 +59,40 @@ describe('ExportDropdown', () => {
     );
     expect(screen.getByTitle('Export report')).toBeDisabled();
   });
+
+  /**
+   * The CSV+PDF variant lays out as its positioning wrapper, which is
+   * `inline-block` and therefore as wide as the button's text whatever the
+   * button is told. A toolbar giving the export its own full line on a phone
+   * has to be able to size that box, or the line stays button-wide.
+   */
+  it('applies containerClassName to the wrapper the toolbar lays out', () => {
+    const { container } = render(
+      <ExportDropdown
+        onExportCsv={vi.fn()}
+        onExportPdf={vi.fn()}
+        containerClassName="w-full sm:w-auto"
+        className="w-full justify-center"
+      />,
+    );
+
+    const wrapper = container.firstElementChild!;
+    expect(wrapper.className).toContain('relative');
+    expect(wrapper.className).toContain('w-full');
+    expect(wrapper.className).toContain('sm:w-auto');
+    expect(screen.getByTitle('Export report').className).toContain('w-full');
+  });
+
+  it('sizes the PDF-only variant through className, having no wrapper', () => {
+    const { container } = render(
+      <ExportDropdown onExportPdf={vi.fn()} className="w-full whitespace-nowrap" />,
+    );
+
+    // The button IS the box here, so a caller sizes it directly; a
+    // containerClassName would have nowhere to land.
+    const root = container.firstElementChild!;
+    expect(root.tagName).toBe('BUTTON');
+    expect(root.className).toContain('w-full');
+    expect(root.className).toContain('whitespace-nowrap');
+  });
 });

--- a/frontend/src/components/ui/ExportDropdown.tsx
+++ b/frontend/src/components/ui/ExportDropdown.tsx
@@ -18,6 +18,15 @@ interface ExportDropdownProps {
    * the same.
    */
   className?: string;
+  /**
+   * Extra classes for the positioning wrapper the CSV+PDF variant renders --
+   * the box a toolbar lays out, which is `inline-block` and therefore as wide
+   * as the button's text whatever the button itself is told. A toolbar giving
+   * the export its own full line on a phone (`w-full sm:w-auto`) has to size
+   * this, not only the trigger. Ignored by the PDF-only variant, which has no
+   * wrapper: there the button IS the box, so `className` sizes it.
+   */
+  containerClassName?: string;
 }
 
 export function ExportDropdown({
@@ -25,6 +34,7 @@ export function ExportDropdown({
   onExportPdf,
   disabled,
   className,
+  containerClassName,
 }: ExportDropdownProps) {
   const t = useTranslations('common');
   const [isOpen, setIsOpen] = useState(false);
@@ -74,7 +84,7 @@ export function ExportDropdown({
   }
 
   return (
-    <div ref={dropdownRef} className="relative inline-block">
+    <div ref={dropdownRef} className={cn('relative inline-block', containerClassName)}>
       <button
         onClick={() => setIsOpen(!isOpen)}
         disabled={disabled || isExporting}

--- a/frontend/src/components/ui/ExportDropdown.tsx
+++ b/frontend/src/components/ui/ExportDropdown.tsx
@@ -6,9 +6,7 @@ import toast from 'react-hot-toast';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { cn } from '@/lib/utils';
 
-interface ExportDropdownProps {
-  onExportCsv?: () => void;
-  onExportPdf: () => void;
+interface ExportDropdownBaseProps {
   disabled?: boolean;
   /**
    * Extra classes for the trigger button, for a caller that has to size it --
@@ -23,11 +21,23 @@ interface ExportDropdownProps {
    * the box a toolbar lays out, which is `inline-block` and therefore as wide
    * as the button's text whatever the button itself is told. A toolbar giving
    * the export its own full line on a phone (`w-full sm:w-auto`) has to size
-   * this, not only the trigger. Ignored by the PDF-only variant, which has no
-   * wrapper: there the button IS the box, so `className` sizes it.
+   * this, not only the trigger. Ignored by the single-format variants, which
+   * have no wrapper: there the button IS the box, so `className` sizes it.
    */
   containerClassName?: string;
 }
+
+/**
+ * At least one format, in one of three shapes: both (a dropdown), PDF alone or
+ * CSV alone (a single button each). A component with neither handler would
+ * render a button that exports nothing, so the union refuses it at the type
+ * level rather than at runtime.
+ */
+type ExportDropdownProps = ExportDropdownBaseProps &
+  (
+    | { onExportPdf: () => void; onExportCsv?: () => void }
+    | { onExportPdf?: undefined; onExportCsv: () => void }
+  );
 
 export function ExportDropdown({
   onExportCsv,
@@ -52,6 +62,7 @@ export function ExportDropdown({
 
   const handleExportPdf = async () => {
     close();
+    if (!onExportPdf) return;
     setIsExporting(true);
     try {
       await onExportPdf();
@@ -62,6 +73,35 @@ export function ExportDropdown({
       setIsExporting(false);
     }
   };
+
+  /**
+   * CSV-only mode: one button, the same shape the PDF-only one has.
+   *
+   * A report whose current view has nothing to draw (a matrix of figures, a
+   * custom report's rows) exports CSV and nothing else, and used to hand-roll
+   * this button -- a third copy of the styling, and one that missed the phone
+   * layout `ReportToolbarActions` gives the other two. Writing to a file is
+   * synchronous here, so there is no `isExporting` state to show: the PDF path
+   * has one because it renders the DOM to an image first.
+   */
+  if (!onExportPdf) {
+    return (
+      <button
+        onClick={handleExportCsv}
+        disabled={disabled}
+        className={cn(
+          'px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed',
+          className,
+        )}
+        title={t('exportDropdown.exportCsv')}
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        {t('exportDropdown.exportCsv')}
+      </button>
+    );
+  }
 
   // PDF-only mode: render a single button instead of a dropdown
   if (!onExportCsv) {

--- a/frontend/src/components/ui/LabelSpacer.tsx
+++ b/frontend/src/components/ui/LabelSpacer.tsx
@@ -1,0 +1,23 @@
+/**
+ * The space a labelled field gives its label, reserved above a control that has
+ * none.
+ *
+ * A button standing beside a labelled field is the height of the *field*, not
+ * of the field plus its label. Reserving the label's own space above it means
+ * what is left to stretch into is exactly the input's height, with no magic
+ * number that a font or padding change would silently invalidate --
+ * `self-stretch` alone measures from the top of the label and stands a label
+ * taller, and matching the field's padding by hand drifts the first time either
+ * control's type scale changes.
+ *
+ * Use it with a `flex flex-col` wrapper and a `flex-1 items-stretch` row around
+ * the control, the way `AccountBalancesControls` and the loan amortization
+ * toolbar do.
+ */
+export function LabelSpacer() {
+  return (
+    <span aria-hidden="true" className="mb-1 block text-sm font-medium">
+      {'\u00a0'}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/MultiSelect.test.tsx
+++ b/frontend/src/components/ui/MultiSelect.test.tsx
@@ -594,6 +594,42 @@ describe('MultiSelect', () => {
       expect(labels).toContain('The longest index name in the whole catalog');
     });
 
+    /**
+     * The sizer's copies never wrap, so an uncapped one makes the trigger's
+     * MINIMUM width the longest label: no ancestor can shrink the control, and
+     * a security whose name is wider than a phone carried the report's whole
+     * toolbar off the right of the screen. The cap is a definite length, so it
+     * clamps that intrinsic contribution; a percentage would not, because the
+     * width it resolves against is the one being computed.
+     */
+    it('caps each sizer copy against the viewport so the trigger can still shrink', () => {
+      render(
+        <MultiSelect
+          options={[
+            {
+              value: 'a',
+              label:
+                'VERYLONGSYMBOL - A security whose name is wider than any phone screen',
+            },
+          ]}
+          value={[]}
+          onChange={onChange}
+          sizeToLongestOption
+        />,
+      );
+
+      const copies = [
+        ...screen.getByTestId('multiselect-sizer').querySelectorAll('[data-sizer]'),
+      ];
+      expect(copies.length).toBeGreaterThan(0);
+      for (const copy of copies) {
+        expect(copy.className).toContain('max-w-[calc(100vw-12rem)]');
+        // The cap only works while the copy refuses to wrap -- a wrapping copy
+        // would size the trigger to a word instead of to the label.
+        expect(copy.className).toContain('whitespace-nowrap');
+      }
+    });
+
     it('renders no sizer by default, leaving other call sites untouched', () => {
       render(<MultiSelect options={flatOptions} value={[]} onChange={onChange} />);
       expect(screen.queryByTestId('multiselect-sizer')).not.toBeInTheDocument();

--- a/frontend/src/components/ui/MultiSelect.tsx
+++ b/frontend/src/components/ui/MultiSelect.tsx
@@ -331,13 +331,26 @@ export function MultiSelect({
              browser still measures it in the real font, but it cannot be
              found by text queries, duplicate what screen readers announce, or
              be caught by the user's find-in-page. pr-7 stands in for the
-             chevron and its gap. */
+             chevron and its gap.
+
+             Each copy is capped at `100vw - 12rem`, which is the sizer's whole
+             safety net: the copies never wrap, so an unbounded one makes the
+             trigger's *minimum* width the longest label and no ancestor can
+             shrink it -- a security named beyond the width of a phone pushed
+             the control, and the toolbar around it, off the right of the
+             screen. The cap is a definite length, so it clamps that intrinsic
+             contribution; 12rem clears the widest page and card padding this
+             app puts around a toolbar (lg:px-12 plus p-4), so the trigger
+             stays inside the viewport at every breakpoint. Below the cap
+             nothing changes -- the control is still as wide as its longest
+             option -- and above it the trigger shrinks and the selected label
+             truncates, which is what the visible row is already built for. */
           <div aria-hidden="true" data-testid="multiselect-sizer" className="h-0 overflow-hidden">
             {sizerLabels.map(sizerLabel => (
               <div
                 key={sizerLabel}
                 data-sizer={sizerLabel}
-                className="invisible whitespace-nowrap pr-7 after:content-[attr(data-sizer)]"
+                className="invisible max-w-[calc(100vw-12rem)] whitespace-nowrap pr-7 after:content-[attr(data-sizer)]"
               />
             ))}
           </div>

--- a/frontend/src/i18n/messages/de/common.json
+++ b/frontend/src/i18n/messages/de/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Exportieren",
+    "exportCsv": "CSV exportieren",
     "exporting": "Wird exportiert...",
     "exportPdf": "PDF exportieren",
     "exportReport": "Bericht exportieren",

--- a/frontend/src/i18n/messages/de/reports.json
+++ b/frontend/src/i18n/messages/de/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "Stichtag",
     "currencyLabel": "Währung",
     "currencyNative": "Nativ",
-    "exportCsv": "CSV exportieren",
     "generating": "Bericht wird erstellt...",
     "updating": "Wird aktualisiert...",
     "resetToLatest": "Auf letzten Handelstag zurücksetzen",
@@ -1079,7 +1078,6 @@
     "transferTo": "Nach",
     "overallTotal": "Gesamtsumme",
     "includeCurrentMonth": "Laufenden Monat einbeziehen",
-    "exportCsv": "CSV exportieren",
     "csvParentColumn": "Übergeordnete Kategorie"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/en/common.json
+++ b/frontend/src/i18n/messages/en/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Export",
+    "exportCsv": "Export CSV",
     "exporting": "Exporting...",
     "exportPdf": "Export PDF",
     "exportReport": "Export report",

--- a/frontend/src/i18n/messages/en/reports.json
+++ b/frontend/src/i18n/messages/en/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "As of date",
     "currencyLabel": "Currency",
     "currencyNative": "Native",
-    "exportCsv": "Export CSV",
     "generating": "Generating report...",
     "updating": "Updating...",
     "resetToLatest": "Reset to latest market day",
@@ -1079,7 +1078,6 @@
     "transferTo": "To",
     "overallTotal": "Overall total",
     "includeCurrentMonth": "Include current month",
-    "exportCsv": "Export CSV",
     "csvParentColumn": "Parent category"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/es/common.json
+++ b/frontend/src/i18n/messages/es/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Exportar",
+    "exportCsv": "Exportar CSV",
     "exporting": "Exportando...",
     "exportPdf": "Exportar PDF",
     "exportReport": "Exportar informe",

--- a/frontend/src/i18n/messages/es/reports.json
+++ b/frontend/src/i18n/messages/es/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "Con fecha de",
     "currencyLabel": "Divisa",
     "currencyNative": "Nativa",
-    "exportCsv": "Exportar CSV",
     "generating": "Generando informe...",
     "updating": "Actualizando...",
     "resetToLatest": "Restablecer al último día de mercado",
@@ -1079,7 +1078,6 @@
     "transferTo": "A",
     "overallTotal": "Total general",
     "includeCurrentMonth": "Incluir mes actual",
-    "exportCsv": "Exportar CSV",
     "csvParentColumn": "Categoría principal"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/fr/common.json
+++ b/frontend/src/i18n/messages/fr/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Exporter",
+    "exportCsv": "Exporter en CSV",
     "exporting": "Exportation...",
     "exportPdf": "Exporter en PDF",
     "exportReport": "Exporter le rapport",

--- a/frontend/src/i18n/messages/fr/reports.json
+++ b/frontend/src/i18n/messages/fr/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "À la date du",
     "currencyLabel": "Devise",
     "currencyNative": "Natif",
-    "exportCsv": "Exporter CSV",
     "generating": "Génération du rapport...",
     "updating": "Mise à jour...",
     "resetToLatest": "Réinitialiser au dernier jour de marché",
@@ -1079,7 +1078,6 @@
     "transferTo": "Vers",
     "overallTotal": "Total général",
     "includeCurrentMonth": "Inclure le mois en cours",
-    "exportCsv": "Exporter en CSV",
     "csvParentColumn": "Catégorie parente"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/hi/common.json
+++ b/frontend/src/i18n/messages/hi/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "निर्यात",
+    "exportCsv": "CSV निर्यात करें",
     "exporting": "निर्यात हो रहा है...",
     "exportPdf": "PDF निर्यात करें",
     "exportReport": "रिपोर्ट निर्यात करें",

--- a/frontend/src/i18n/messages/hi/reports.json
+++ b/frontend/src/i18n/messages/hi/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "इस तिथि के अनुसार",
     "currencyLabel": "मुद्रा",
     "currencyNative": "मूल",
-    "exportCsv": "CSV निर्यात करें",
     "generating": "रिपोर्ट उत्पन्न हो रही है...",
     "updating": "अपडेट हो रहा है...",
     "resetToLatest": "नवीनतम बाजार दिन पर रीसेट करें",
@@ -1079,7 +1078,6 @@
     "transferTo": "तक",
     "overallTotal": "समग्र कुल",
     "includeCurrentMonth": "वर्तमान महीना शामिल करें",
-    "exportCsv": "CSV निर्यात करें",
     "csvParentColumn": "मूल श्रेणी"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/id/common.json
+++ b/frontend/src/i18n/messages/id/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Ekspor",
+    "exportCsv": "Ekspor CSV",
     "exporting": "Mengekspor...",
     "exportPdf": "Ekspor PDF",
     "exportReport": "Ekspor laporan",

--- a/frontend/src/i18n/messages/id/reports.json
+++ b/frontend/src/i18n/messages/id/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "Per tanggal",
     "currencyLabel": "Mata Uang",
     "currencyNative": "Asli",
-    "exportCsv": "Ekspor CSV",
     "generating": "Membuat laporan...",
     "updating": "Memperbarui...",
     "resetToLatest": "Atur ulang ke hari pasar terbaru",
@@ -1079,7 +1078,6 @@
     "transferTo": "Ke",
     "overallTotal": "Total keseluruhan",
     "includeCurrentMonth": "Sertakan bulan saat ini",
-    "exportCsv": "Ekspor CSV",
     "csvParentColumn": "Kategori induk"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/it/common.json
+++ b/frontend/src/i18n/messages/it/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Esporta",
+    "exportCsv": "Esporta CSV",
     "exporting": "Esportazione...",
     "exportPdf": "Esporta PDF",
     "exportReport": "Esporta report",

--- a/frontend/src/i18n/messages/it/reports.json
+++ b/frontend/src/i18n/messages/it/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "Alla data",
     "currencyLabel": "Valuta",
     "currencyNative": "Nativa",
-    "exportCsv": "Esporta CSV",
     "generating": "Generazione report...",
     "updating": "Aggiornamento...",
     "resetToLatest": "Ripristina all'ultimo giorno di mercato",
@@ -1079,7 +1078,6 @@
     "transferTo": "A",
     "overallTotal": "Totale complessivo",
     "includeCurrentMonth": "Includi mese corrente",
-    "exportCsv": "Esporta CSV",
     "csvParentColumn": "Categoria principale"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/ja/common.json
+++ b/frontend/src/i18n/messages/ja/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "エクスポート",
+    "exportCsv": "CSVエクスポート",
     "exporting": "エクスポート中...",
     "exportPdf": "PDF をエクスポート",
     "exportReport": "レポートをエクスポート",

--- a/frontend/src/i18n/messages/ja/reports.json
+++ b/frontend/src/i18n/messages/ja/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "基準日",
     "currencyLabel": "通貨",
     "currencyNative": "現地通貨",
-    "exportCsv": "CSVエクスポート",
     "generating": "レポートを生成中...",
     "updating": "更新中...",
     "resetToLatest": "最新の市場日にリセット",
@@ -1079,7 +1078,6 @@
     "transferTo": "へ",
     "overallTotal": "全体合計",
     "includeCurrentMonth": "今月を含める",
-    "exportCsv": "CSVエクスポート",
     "csvParentColumn": "親カテゴリ"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/ko/common.json
+++ b/frontend/src/i18n/messages/ko/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "내보내기",
+    "exportCsv": "CSV 내보내기",
     "exporting": "내보내는 중...",
     "exportPdf": "PDF 내보내기",
     "exportReport": "보고서 내보내기",

--- a/frontend/src/i18n/messages/ko/reports.json
+++ b/frontend/src/i18n/messages/ko/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "기준일",
     "currencyLabel": "통화",
     "currencyNative": "현지 통화",
-    "exportCsv": "CSV 내보내기",
     "generating": "보고서 생성 중...",
     "updating": "업데이트 중...",
     "resetToLatest": "최신 시장일로 초기화",
@@ -1079,7 +1078,6 @@
     "transferTo": "입금",
     "overallTotal": "전체 합계",
     "includeCurrentMonth": "현재 월 포함",
-    "exportCsv": "CSV 내보내기",
     "csvParentColumn": "상위 카테고리"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/nl/common.json
+++ b/frontend/src/i18n/messages/nl/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Exporteren",
+    "exportCsv": "CSV exporteren",
     "exporting": "Exporteren...",
     "exportPdf": "PDF exporteren",
     "exportReport": "Rapport exporteren",

--- a/frontend/src/i18n/messages/nl/reports.json
+++ b/frontend/src/i18n/messages/nl/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "Peildatum",
     "currencyLabel": "Valuta",
     "currencyNative": "Eigen",
-    "exportCsv": "Exporteren als CSV",
     "generating": "Rapport genereren...",
     "updating": "Bijwerken...",
     "resetToLatest": "Terugzetten naar laatste marktdag",
@@ -1079,7 +1078,6 @@
     "transferTo": "Naar",
     "overallTotal": "Totaal-generaal",
     "includeCurrentMonth": "Huidige maand opnemen",
-    "exportCsv": "CSV exporteren",
     "csvParentColumn": "Hoofdcategorie"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/pl/common.json
+++ b/frontend/src/i18n/messages/pl/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Eksportuj",
+    "exportCsv": "Eksportuj CSV",
     "exporting": "Eksportowanie...",
     "exportPdf": "Eksportuj PDF",
     "exportReport": "Eksportuj raport",

--- a/frontend/src/i18n/messages/pl/reports.json
+++ b/frontend/src/i18n/messages/pl/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "Na dzień",
     "currencyLabel": "Waluta",
     "currencyNative": "Natywna",
-    "exportCsv": "Eksportuj CSV",
     "generating": "Generowanie raportu...",
     "updating": "Aktualizowanie...",
     "resetToLatest": "Resetuj do ostatniego dnia rynkowego",
@@ -1079,7 +1078,6 @@
     "transferTo": "Do",
     "overallTotal": "Suma całkowita",
     "includeCurrentMonth": "Uwzględnij bieżący miesiąc",
-    "exportCsv": "Eksportuj CSV",
     "csvParentColumn": "Kategoria nadrzędna"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/pt-BR/common.json
+++ b/frontend/src/i18n/messages/pt-BR/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Exportar",
+    "exportCsv": "Exportar CSV",
     "exporting": "Exportando...",
     "exportPdf": "Exportar PDF",
     "exportReport": "Exportar relatório",

--- a/frontend/src/i18n/messages/pt-BR/reports.json
+++ b/frontend/src/i18n/messages/pt-BR/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "Com referência à data",
     "currencyLabel": "Moeda",
     "currencyNative": "Nativa",
-    "exportCsv": "Exportar CSV",
     "generating": "Gerando relatório...",
     "updating": "Atualizando...",
     "resetToLatest": "Redefinir para o último dia de mercado",
@@ -1079,7 +1078,6 @@
     "transferTo": "Para",
     "overallTotal": "Total geral",
     "includeCurrentMonth": "Incluir mês atual",
-    "exportCsv": "Exportar CSV",
     "csvParentColumn": "Categoria principal"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/pt/common.json
+++ b/frontend/src/i18n/messages/pt/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Exportar",
+    "exportCsv": "Exportar CSV",
     "exporting": "A exportar...",
     "exportPdf": "Exportar PDF",
     "exportReport": "Exportar relatório",

--- a/frontend/src/i18n/messages/pt/reports.json
+++ b/frontend/src/i18n/messages/pt/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "Com referência à data",
     "currencyLabel": "Moeda",
     "currencyNative": "Nativa",
-    "exportCsv": "Exportar CSV",
     "generating": "A gerar relatório...",
     "updating": "A atualizar...",
     "resetToLatest": "Repor para o último dia de mercado",
@@ -1079,7 +1078,6 @@
     "transferTo": "Para",
     "overallTotal": "Total geral",
     "includeCurrentMonth": "Incluir mês atual",
-    "exportCsv": "Exportar CSV",
     "csvParentColumn": "Categoria principal"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/ru/common.json
+++ b/frontend/src/i18n/messages/ru/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Экспорт",
+    "exportCsv": "Экспорт CSV",
     "exporting": "Экспорт...",
     "exportPdf": "Экспорт в PDF",
     "exportReport": "Экспорт отчёта",

--- a/frontend/src/i18n/messages/ru/reports.json
+++ b/frontend/src/i18n/messages/ru/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "По состоянию на",
     "currencyLabel": "Валюта",
     "currencyNative": "Родная",
-    "exportCsv": "Экспорт CSV",
     "generating": "Создание отчёта...",
     "updating": "Обновление...",
     "resetToLatest": "Сбросить до последнего рыночного дня",
@@ -1079,7 +1078,6 @@
     "transferTo": "В",
     "overallTotal": "Общий итог",
     "includeCurrentMonth": "Включить текущий месяц",
-    "exportCsv": "Экспорт CSV",
     "csvParentColumn": "Родительская категория"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/tr/common.json
+++ b/frontend/src/i18n/messages/tr/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Dışa Aktar",
+    "exportCsv": "CSV Dışa Aktar",
     "exporting": "Dışa aktarılıyor...",
     "exportPdf": "PDF Olarak Dışa Aktar",
     "exportReport": "Raporu dışa aktar",

--- a/frontend/src/i18n/messages/tr/reports.json
+++ b/frontend/src/i18n/messages/tr/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "İtibariyle tarih",
     "currencyLabel": "Para Birimi",
     "currencyNative": "Yerel",
-    "exportCsv": "CSV Dışa Aktar",
     "generating": "Rapor oluşturuluyor...",
     "updating": "Güncelleniyor...",
     "resetToLatest": "Son piyasa gününe sıfırla",
@@ -1079,7 +1078,6 @@
     "transferTo": "Alıcı",
     "overallTotal": "Genel toplam",
     "includeCurrentMonth": "Mevcut ayı dahil et",
-    "exportCsv": "CSV Dışa Aktar",
     "csvParentColumn": "Ana kategori"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/uk/common.json
+++ b/frontend/src/i18n/messages/uk/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Експорт",
+    "exportCsv": "Експорт CSV",
     "exporting": "Експортування...",
     "exportPdf": "Експортувати PDF",
     "exportReport": "Експортувати звіт",

--- a/frontend/src/i18n/messages/uk/reports.json
+++ b/frontend/src/i18n/messages/uk/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "Станом на дату",
     "currencyLabel": "Валюта",
     "currencyNative": "Рідна",
-    "exportCsv": "Експорт CSV",
     "generating": "Генерація звіту...",
     "updating": "Оновлення...",
     "resetToLatest": "Скинути до останнього торгового дня",
@@ -1079,7 +1078,6 @@
     "transferTo": "До",
     "overallTotal": "Загальний підсумок",
     "includeCurrentMonth": "Включати поточний місяць",
-    "exportCsv": "Експорт CSV",
     "csvParentColumn": "Батьківська категорія"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/vi/common.json
+++ b/frontend/src/i18n/messages/vi/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "Xuất",
+    "exportCsv": "Xuất CSV",
     "exporting": "Đang xuất...",
     "exportPdf": "Xuất PDF",
     "exportReport": "Xuất báo cáo",

--- a/frontend/src/i18n/messages/vi/reports.json
+++ b/frontend/src/i18n/messages/vi/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "Tính đến ngày",
     "currencyLabel": "Tiền tệ",
     "currencyNative": "Nguyên bản",
-    "exportCsv": "Xuất CSV",
     "generating": "Đang tạo báo cáo...",
     "updating": "Đang cập nhật...",
     "resetToLatest": "Đặt lại về ngày thị trường gần nhất",
@@ -1079,7 +1078,6 @@
     "transferTo": "Đến",
     "overallTotal": "Tổng tổng cộng",
     "includeCurrentMonth": "Bao gồm tháng hiện tại",
-    "exportCsv": "Xuất CSV",
     "csvParentColumn": "Danh mục cha"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/xx/common.json
+++ b/frontend/src/i18n/messages/xx/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "[XX-Export-XX]",
+    "exportCsv": "[XX-Export CSV-XX]",
     "exporting": "[XX-Exporting...-XX]",
     "exportPdf": "[XX-Export PDF-XX]",
     "exportReport": "[XX-Export report-XX]",

--- a/frontend/src/i18n/messages/xx/reports.json
+++ b/frontend/src/i18n/messages/xx/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "[XX-As of date-XX]",
     "currencyLabel": "[XX-Currency-XX]",
     "currencyNative": "[XX-Native-XX]",
-    "exportCsv": "[XX-Export CSV-XX]",
     "generating": "[XX-Generating report...-XX]",
     "updating": "[XX-Updating...-XX]",
     "resetToLatest": "[XX-Reset to latest market day-XX]",
@@ -1079,7 +1078,6 @@
     "transferTo": "[XX-To-XX]",
     "overallTotal": "[XX-Overall total-XX]",
     "includeCurrentMonth": "[XX-Include current month-XX]",
-    "exportCsv": "[XX-Export CSV-XX]",
     "csvParentColumn": "[XX-Parent category-XX]"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/zh-CN/common.json
+++ b/frontend/src/i18n/messages/zh-CN/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "导出",
+    "exportCsv": "导出 CSV",
     "exporting": "导出中...",
     "exportPdf": "导出 PDF",
     "exportReport": "导出报告",

--- a/frontend/src/i18n/messages/zh-CN/reports.json
+++ b/frontend/src/i18n/messages/zh-CN/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "截至日期",
     "currencyLabel": "货币",
     "currencyNative": "本币",
-    "exportCsv": "导出 CSV",
     "generating": "正在生成报告...",
     "updating": "更新中...",
     "resetToLatest": "重置为最新交易日",
@@ -1079,7 +1078,6 @@
     "transferTo": "转入至",
     "overallTotal": "总计",
     "includeCurrentMonth": "包含当月",
-    "exportCsv": "导出 CSV",
     "csvParentColumn": "父分类"
   },
   "monthlyComparison": {

--- a/frontend/src/i18n/messages/zh-TW/common.json
+++ b/frontend/src/i18n/messages/zh-TW/common.json
@@ -60,6 +60,7 @@
   },
   "exportDropdown": {
     "export": "匯出",
+    "exportCsv": "匯出 CSV",
     "exporting": "匯出中...",
     "exportPdf": "匯出 PDF",
     "exportReport": "匯出報告",

--- a/frontend/src/i18n/messages/zh-TW/reports.json
+++ b/frontend/src/i18n/messages/zh-TW/reports.json
@@ -722,7 +722,6 @@
     "labelAsOfDate": "截至日期",
     "currencyLabel": "貨幣",
     "currencyNative": "原幣",
-    "exportCsv": "匯出 CSV",
     "generating": "產生報表中...",
     "updating": "更新中...",
     "resetToLatest": "重置為最新市場日",
@@ -1079,7 +1078,6 @@
     "transferTo": "至",
     "overallTotal": "整體總計",
     "includeCurrentMonth": "包含當月",
-    "exportCsv": "匯出 CSV",
     "csvParentColumn": "上層類別"
   },
   "monthlyComparison": {

--- a/frontend/src/test/ui-conventions.test.ts
+++ b/frontend/src/test/ui-conventions.test.ts
@@ -2890,7 +2890,9 @@ describe("a report's export and refresh are one actions row", () => {
    * full-width row below every selector on a phone, two equal halves when the
    * report also refreshes prices, the toolbar's trailing group from `sm` up.
    * A report that renders `ExportDropdown` or `RefreshPricesButton` itself is
-   * writing that layout a second time.
+   * writing that layout a second time. `ExportDropdown` draws all three shapes
+   * -- CSV and PDF, PDF alone, CSV alone -- so a report exporting one format is
+   * not a reason to hand-roll a button either.
    *
    * The rule is about REPORTS. `components/ui/ExportDropdown.tsx` is the button
    * itself, `RefreshPricesButton.tsx` wraps the refresh hook for callers
@@ -2903,25 +2905,13 @@ describe("a report's export and refresh are one actions row", () => {
     "/src/components/ui/ExportDropdown.tsx",
     "/src/components/reports/RefreshPricesButton.tsx",
   ]);
-  const RENDERS_EXPORT = /<ExportDropdown\b/;
-  const RENDERS_REFRESH = /<RefreshPricesButton\b/;
+  const RENDERS_ACTION = /<(ExportDropdown|RefreshPricesButton)\b/;
 
-  /**
-   * A refresh button is only half a layout: it is banned in a report that also
-   * has an export, because there the pair is what the shared row arranges. A
-   * report with no export at all (the custom investment report viewer, whose
-   * export is a plain CSV button) has nothing to pair it with, so it lays its
-   * own out -- and there is no second way to get that wrong.
-   */
   function reportsRenderingTheirOwn(): string[] {
     return productionSources()
       .filter(([path]) => path.startsWith("/src/components/reports/"))
       .filter(([path]) => !MECHANISM.has(path))
-      .filter(([, source]) => {
-        const code = withoutComments(source);
-        if (RENDERS_EXPORT.test(code)) return true;
-        return RENDERS_REFRESH.test(code) && /<ReportToolbarActions\b/.test(code);
-      })
+      .filter(([, source]) => RENDERS_ACTION.test(withoutComments(source)))
       .map(([path]) => path);
   }
 
@@ -2939,13 +2929,13 @@ describe("a report's export and refresh are one actions row", () => {
   });
 
   it("catches the pattern it bans", () => {
-    expect(RENDERS_EXPORT.test(withoutComments("<ExportDropdown onExportPdf={x} />"))).toBe(
+    expect(RENDERS_ACTION.test(withoutComments("<ExportDropdown onExportPdf={x} />"))).toBe(
       true,
     );
-    expect(RENDERS_REFRESH.test(withoutComments("<RefreshPricesButton />"))).toBe(true);
+    expect(RENDERS_ACTION.test(withoutComments("<RefreshPricesButton />"))).toBe(true);
     // ...and reads its own explanation as prose, not as a violation.
     expect(
-      RENDERS_EXPORT.test(withoutComments("// wired to the <ExportDropdown /> above")),
+      RENDERS_ACTION.test(withoutComments("// wired to the <ExportDropdown /> above")),
     ).toBe(false);
   });
 });

--- a/frontend/src/test/ui-conventions.test.ts
+++ b/frontend/src/test/ui-conventions.test.ts
@@ -2881,3 +2881,71 @@ describe("a random value comes from the Web Crypto API", () => {
     expect(WEAK_RANDOM.test(withoutComments("// not Math.random"))).toBe(false);
   });
 });
+
+describe("a report's export and refresh are one actions row", () => {
+  /**
+   * Every report toolbar laid its trailing buttons out for itself, and a dozen
+   * of them got it wrong the same way: an unwrapped row carried the export off
+   * the right of a phone. `ReportToolbarActions` is the one answer -- a
+   * full-width row below every selector on a phone, two equal halves when the
+   * report also refreshes prices, the toolbar's trailing group from `sm` up.
+   * A report that renders `ExportDropdown` or `RefreshPricesButton` itself is
+   * writing that layout a second time.
+   *
+   * The rule is about REPORTS. `components/ui/ExportDropdown.tsx` is the button
+   * itself, `RefreshPricesButton.tsx` wraps the refresh hook for callers
+   * outside this tree (an account detail header), and `ReportToolbarActions`
+   * composes both -- those three are the mechanism, not instances of it.
+   */
+  const ACTIONS_OWNER = "/src/components/reports/ReportToolbarActions.tsx";
+  const MECHANISM = new Set([
+    ACTIONS_OWNER,
+    "/src/components/ui/ExportDropdown.tsx",
+    "/src/components/reports/RefreshPricesButton.tsx",
+  ]);
+  const RENDERS_EXPORT = /<ExportDropdown\b/;
+  const RENDERS_REFRESH = /<RefreshPricesButton\b/;
+
+  /**
+   * A refresh button is only half a layout: it is banned in a report that also
+   * has an export, because there the pair is what the shared row arranges. A
+   * report with no export at all (the custom investment report viewer, whose
+   * export is a plain CSV button) has nothing to pair it with, so it lays its
+   * own out -- and there is no second way to get that wrong.
+   */
+  function reportsRenderingTheirOwn(): string[] {
+    return productionSources()
+      .filter(([path]) => path.startsWith("/src/components/reports/"))
+      .filter(([path]) => !MECHANISM.has(path))
+      .filter(([, source]) => {
+        const code = withoutComments(source);
+        if (RENDERS_EXPORT.test(code)) return true;
+        return RENDERS_REFRESH.test(code) && /<ReportToolbarActions\b/.test(code);
+      })
+      .map(([path]) => path);
+  }
+
+  it("has no report laying out its own export or refresh button", () => {
+    expect(reportsRenderingTheirOwn()).toEqual([]);
+  });
+
+  it("still finds the shared row in use, so the rule cannot pass by accident", () => {
+    const users = productionSources().filter(([path, source]) =>
+      path.startsWith("/src/components/reports/") &&
+      path !== ACTIONS_OWNER &&
+      /<ReportToolbarActions\b/.test(withoutComments(source)),
+    );
+    expect(users.length).toBeGreaterThan(20);
+  });
+
+  it("catches the pattern it bans", () => {
+    expect(RENDERS_EXPORT.test(withoutComments("<ExportDropdown onExportPdf={x} />"))).toBe(
+      true,
+    );
+    expect(RENDERS_REFRESH.test(withoutComments("<RefreshPricesButton />"))).toBe(true);
+    // ...and reads its own explanation as prose, not as a violation.
+    expect(
+      RENDERS_EXPORT.test(withoutComments("// wired to the <ExportDropdown /> above")),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Linked discussion / issue

No discussion or issue: the work was requested directly by the maintainer, report by report, in a working session, and this PR is maintainer-authored (the checklist workflow skips the propose-first gate for `OWNER`). The first checklist box below is therefore left unticked rather than ticked falsely. Happy to open a retrospective issue if the record is wanted.

## Summary

Report control cards were built as unwrapped rows of fixed-width controls, so on a phone the trailing control left the card: the securities picker on Security Performance, and the export on Net Worth, Investment Performance, Gains/Dividends, Portfolio Value, Geographic Allocation, Recurring Expenses, Upcoming Bills and others. Each report also arranged its own trailing buttons, so the same mistake had about forty places to live.

Three causes, fixed at the source:

- **An intrinsic width no ancestor could shrink.** `MultiSelect`'s `sizeToLongestOption` sizer renders invisible `whitespace-nowrap` copies of the longest option labels to set the trigger's width. Uncapped, those copies made the longest security name the trigger's *minimum* width, so nothing up the tree could shrink it. Each copy now carries a definite `max-w-[calc(100vw-12rem)]`, which clears the widest page and card padding in the app; a percentage would resolve against the width being computed and clamp nothing. Below the cap the control is still as wide as its longest option.
- **Rows that did not wrap, and `ml-auto` on rows that did.** Toolbar rows wrap now, groups that need a line of their own take `w-full sm:w-auto`, and `ml-auto` became `sm:ml-auto` so a wrapped row is not left hanging against the right edge.
- **Buttons shorter than the field beside them.** A `py-1.5` button against a `py-2` picker reads as a mistake. Those rows take `items-stretch`/`self-stretch` with `h-full`, and `LabelSpacer` (promoted out of `AccountBalancesControls` into `components/ui`) reserves a label's own space above a button so the stretch measures the input, not the input plus its label.

The layout itself now lives in one place. **`ReportToolbarActions`** is a full-width row below every selector on a phone, two equal halves when the report also refreshes prices, and the toolbar's trailing group from `sm` up; every report renders it as the last child of its toolbar row. A grid is what makes "spanning the row" true for the export as well as the refresh, because `ExportDropdown`'s CSV form lays out as an `inline-block` wrapper that a grid cell stretches and a flex row does not.

Supporting changes, each asked for in the same session:

- `ExportDropdown` draws three shapes from the handlers it is given (CSV and PDF, PDF alone, CSV alone) and its props are a union, so a call with neither handler fails to compile. That folded in the two reports that exported CSV only and had hand-rolled their own buttons.
- `ChartLegend` gained `phoneColumns`; the spending-by-category legend opts into two columns on a phone.
- On Security Performance the export is disabled rather than absent until a security is picked, so the row does not move under the reader. On the Loan Overpayment Simulator the loan view publishes its export handler through `exportPdfRef` (as the account detail header already took it) instead of drawing a loose button outside the control card, so `LoanDetailView` renders no export of its own.

Desktop layout is unchanged throughout; every rule above is a phone rule with an `sm:` counterpart.

## Invariants touched

None. This is presentation only: no figure, total, balance or query changed.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

On the shared-areas box: `ExportDropdown`, `ChartLegend`, `MultiSelect` and the new `ReportToolbarActions` and `LabelSpacer` are shared components, and changing them was the point of the request ("review all reports and ensure...") rather than a drive-by refactor.

### Verification

Run on the branch head:

```
lint          0 errors (1 pre-existing warning in public/sw.js)
type-check    clean
i18n:check    clean; parity suite 1669 pass
test:cov      statements 91.3, branches 86.03, functions 88.88, lines 92.52
build         compiled successfully
doc guards    instruction-files + doc-paths, 26 pass
```

New tests cover the sizer cap, all three export shapes, both export sizing paths, the actions row on a phone and from `sm` up, and the two-column legend. `ui-conventions.test.ts` gained a guard that fails any report rendering `ExportDropdown` or `RefreshPricesButton` itself. The rules are written up in `docs/frontend/ui-conventions.md` with a line in the frontend index.

Two fixes fell out of the sweep: `UpcomingBillsReport.test.tsx` mocked `@/lib/utils` wholesale and lost `cn` with it (a partial mock now, as the testing rules require), and the account-balances layout test was updated to the new structure.

**Caveat worth a reviewer's eye:** jsdom applies no media queries, so these tests assert the breakpoint classes rather than rendered widths. A pass over the reports at phone width before merge is worthwhile.

## AI assistance disclosure

Written with Claude Code (Claude Opus 5) across an interactive session, on maintainer instruction report by report. Every gate above was run locally on the branch head; the diff and the design decisions were reviewed and are owned by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kar69hNFWw6DdftwEy4sVn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kar69hNFWw6DdftwEy4sVn)_