### PR TITLE
feat(demo): give demo payees contact details and brand icons

### DIFF
--- a/backend/src/database/demo-seed-data/payees.spec.ts
+++ b/backend/src/database/demo-seed-data/payees.spec.ts
@@ -1,0 +1,74 @@
+import { demoPayees } from "./payees";
+import { normalizePhoneNumber } from "../../common/phone-number.util";
+
+/**
+ * The demo payees are written straight into the table by raw SQL, so nothing
+ * on the way validates them: a website the detail page cannot link, an address
+ * longer than the form allows, or a phone in a shape `PayeesService` would
+ * have normalized all ship as data the demo shows and the payee form then
+ * refuses to save back.
+ */
+describe("demo payee contact details", () => {
+  const withWebsite = demoPayees.filter((p) => p.website);
+  const withPhone = demoPayees.filter((p) => p.phone);
+  const withAddress = demoPayees.filter((p) => p.address);
+
+  it("carries contact details on the brand payees, so the sweeps below are not vacuous", () => {
+    // A refactor that drops the fields would otherwise leave every rule here
+    // passing over an empty list.
+    expect(withWebsite.length).toBeGreaterThan(25);
+    expect(withPhone.length).toBeGreaterThan(25);
+    expect(withAddress.length).toBeGreaterThan(25);
+  });
+
+  it("stores every phone in the form PayeesService would have normalized it to", () => {
+    // Not merely "is valid": equal to its own stored form, which is what makes
+    // a demo row and a row the user saves over it compare equal.
+    const offenders = withPhone
+      .map((payee) => ({
+        payee,
+        result: normalizePhoneNumber(payee.phone as string, null),
+      }))
+      .filter(
+        ({ payee, result }) => !result.ok || result.stored !== payee.phone,
+      )
+      .map(({ payee }) => `${payee.name}: ${payee.phone}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("gives every website an absolute https address with a host", () => {
+    // The column stores absolute URLs so the detail page can put one straight
+    // into an anchor, and the favicon resolver takes the host from it.
+    const offenders = withWebsite
+      .filter((payee) => {
+        try {
+          const url = new URL(payee.website as string);
+          return url.protocol !== "https:" || !url.hostname.includes(".");
+        } catch {
+          return true;
+        }
+      })
+      .map((payee) => `${payee.name}: ${payee.website}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps every value inside the column and DTO bounds", () => {
+    const offenders: string[] = [];
+    for (const payee of demoPayees) {
+      if ((payee.website?.length ?? 0) > 2048)
+        offenders.push(`${payee.name}: website`);
+      if ((payee.address?.length ?? 0) > 500)
+        offenders.push(`${payee.name}: address`);
+      if ((payee.phone?.length ?? 0) > 50)
+        offenders.push(`${payee.name}: phone`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("names each payee once", () => {
+    // The insert is ON CONFLICT DO NOTHING on (user_id, name), so a duplicate
+    // name would silently seed one payee and drop the other's details.
+    const names = demoPayees.map((payee) => payee.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/backend/src/database/demo-seed-data/payees.ts
+++ b/backend/src/database/demo-seed-data/payees.ts
@@ -1,57 +1,285 @@
 export interface DemoPayee {
   name: string;
   categoryPath: string; // "Parent > Subcategory" or just "Category"
+  /**
+   * The payee's real site, absolute, so the seeder can resolve a brand icon
+   * from it exactly as a user-entered website would. Omitted for the payees
+   * that stand in for a person or a private business: a made-up domain would
+   * resolve to no favicon and a link to nowhere.
+   */
+  website?: string;
+  /** Free text, one field, as the column stores it. */
+  address?: string;
+  /**
+   * E.164, already in the form `PayeesService` would normalize a typed number
+   * to, so a demo row and a row the user saves over it hold one format and a
+   * `tel:` link dials the same digits either way.
+   *
+   * Invented, but not from the fictional `555` range: the `max` metadata the
+   * normalizer uses correctly rejects it, and a demo row the payee form then
+   * refuses to save is worse than no number. They are instead a synthetic
+   * block -- exchange `260`, sequential last four -- in the payee's own area
+   * code, or `833` where a national brand would publish a toll-free line.
+   */
+  phone?: string;
 }
 
+/**
+ * Street addresses and phone numbers here are invented; no demo row carries a
+ * business's real line. The websites are real, and are what the payee brand
+ * icons are resolved from.
+ */
 export const demoPayees: DemoPayee[] = [
   // Income
-  { name: "Maple Leaf Technologies", categoryPath: "Salary" },
+  {
+    name: "Maple Leaf Technologies",
+    categoryPath: "Salary",
+    address: "2400 Yonge Street, Suite 1100, Toronto, ON M4P 2H4",
+    phone: "+14162600101",
+  },
   { name: "Freelance Client - WebDev", categoryPath: "Freelance" },
 
   // Housing
-  { name: "Scotiabank Mortgage", categoryPath: "Housing > Rent/Mortgage" },
-  { name: "Hydro One", categoryPath: "Bills & Utilities > Electricity" },
-  { name: "Enbridge Gas", categoryPath: "Bills & Utilities > Insurance" },
-  { name: "Toronto Water", categoryPath: "Bills & Utilities > Water" },
+  {
+    name: "Scotiabank Mortgage",
+    categoryPath: "Housing > Rent/Mortgage",
+    website: "https://www.scotiabank.com",
+    address: "44 King Street West, Toronto, ON M5H 1H1",
+    phone: "+18332600102",
+  },
+  {
+    name: "Hydro One",
+    categoryPath: "Bills & Utilities > Electricity",
+    website: "https://www.hydroone.com",
+    address: "483 Bay Street, Toronto, ON M5G 2P5",
+    phone: "+18332600103",
+  },
+  {
+    name: "Enbridge Gas",
+    categoryPath: "Bills & Utilities > Insurance",
+    website: "https://www.enbridgegas.com",
+    address: "500 Consumers Road, North York, ON M2J 1P8",
+    phone: "+18332600104",
+  },
+  {
+    name: "Toronto Water",
+    categoryPath: "Bills & Utilities > Water",
+    website: "https://www.toronto.ca",
+    address: "100 Queen Street West, Toronto, ON M5H 2N2",
+    phone: "+14162600105",
+  },
 
   // Transport
-  { name: "Shell", categoryPath: "Transportation > Fuel" },
-  { name: "Esso", categoryPath: "Transportation > Fuel" },
-  { name: "TTC", categoryPath: "Transportation > Public Transit" },
-  { name: "Canadian Tire Auto", categoryPath: "Transportation > Maintenance" },
-  { name: "Aviva Insurance", categoryPath: "Transportation > Car Insurance" },
+  {
+    name: "Shell",
+    categoryPath: "Transportation > Fuel",
+    website: "https://www.shell.ca",
+    address: "1810 Danforth Avenue, Toronto, ON M4C 1J4",
+    phone: "+14162600106",
+  },
+  {
+    name: "Esso",
+    categoryPath: "Transportation > Fuel",
+    website: "https://www.esso.ca",
+    address: "2350 Lake Shore Boulevard West, Toronto, ON M8V 1B5",
+    phone: "+14162600107",
+  },
+  {
+    name: "TTC",
+    categoryPath: "Transportation > Public Transit",
+    website: "https://www.ttc.ca",
+    address: "1900 Yonge Street, Toronto, ON M4S 1Z2",
+    phone: "+14162600108",
+  },
+  {
+    name: "Canadian Tire Auto",
+    categoryPath: "Transportation > Maintenance",
+    website: "https://www.canadiantire.ca",
+    address: "839 Yonge Street, Toronto, ON M4W 2H2",
+    phone: "+14162600109",
+  },
+  {
+    name: "Aviva Insurance",
+    categoryPath: "Transportation > Car Insurance",
+    website: "https://www.avivacanada.com",
+    address: "10 Aviva Way, Markham, ON L6G 0G1",
+    phone: "+18332600110",
+  },
 
   // Food & Dining
-  { name: "Loblaws", categoryPath: "Food > Groceries" },
-  { name: "No Frills", categoryPath: "Food > Groceries" },
-  { name: "Metro", categoryPath: "Food > Groceries" },
-  { name: "Costco", categoryPath: "Food > Groceries" },
-  { name: "Tim Hortons", categoryPath: "Food > Coffee Shops" },
-  { name: "Starbucks", categoryPath: "Food > Coffee Shops" },
-  { name: "Swiss Chalet", categoryPath: "Food > Restaurants" },
-  { name: "Uber Eats", categoryPath: "Food > Restaurants" },
-  { name: "The Keg Steakhouse", categoryPath: "Food > Restaurants" },
+  {
+    name: "Loblaws",
+    categoryPath: "Food > Groceries",
+    website: "https://www.loblaws.ca",
+    address: "60 Carlton Street, Toronto, ON M5B 1J2",
+    phone: "+14162600111",
+  },
+  {
+    name: "No Frills",
+    categoryPath: "Food > Groceries",
+    website: "https://www.nofrills.ca",
+    address: "449 Dundas Street East, Toronto, ON M5A 2B1",
+    phone: "+14162600112",
+  },
+  {
+    name: "Metro",
+    categoryPath: "Food > Groceries",
+    website: "https://www.metro.ca",
+    address: "444 Yonge Street, Toronto, ON M4Y 1S9",
+    phone: "+14162600113",
+  },
+  {
+    name: "Costco",
+    categoryPath: "Food > Groceries",
+    website: "https://www.costco.ca",
+    address: "50 Thermos Road, Scarborough, ON M1L 4W2",
+    phone: "+14162600114",
+  },
+  {
+    name: "Tim Hortons",
+    categoryPath: "Food > Coffee Shops",
+    website: "https://www.timhortons.ca",
+    address: "318 Bay Street, Toronto, ON M5H 2R2",
+    phone: "+14162600115",
+  },
+  {
+    name: "Starbucks",
+    categoryPath: "Food > Coffee Shops",
+    website: "https://www.starbucks.ca",
+    address: "225 Queen Street West, Toronto, ON M5V 1Z4",
+    phone: "+14162600116",
+  },
+  {
+    name: "Swiss Chalet",
+    categoryPath: "Food > Restaurants",
+    website: "https://www.swisschalet.com",
+    address: "234 Bloor Street West, Toronto, ON M5S 1T8",
+    phone: "+14162600117",
+  },
+  {
+    name: "Uber Eats",
+    categoryPath: "Food > Restaurants",
+    website: "https://www.ubereats.com",
+    address: "121 Bloor Street East, Toronto, ON M4W 3M5",
+    phone: "+18332600118",
+  },
+  {
+    name: "The Keg Steakhouse",
+    categoryPath: "Food > Restaurants",
+    website: "https://www.kegsteakhouse.com",
+    address: "515 Jarvis Street, Toronto, ON M4Y 2H6",
+    phone: "+14162600119",
+  },
 
   // Shopping
-  { name: "Amazon.ca", categoryPath: "Shopping > Electronics" },
-  { name: "Best Buy", categoryPath: "Shopping > Electronics" },
-  { name: "IKEA", categoryPath: "Shopping > Home Goods" },
-  { name: "Winners", categoryPath: "Shopping > Clothing" },
+  {
+    name: "Amazon.ca",
+    categoryPath: "Shopping > Electronics",
+    website: "https://www.amazon.ca",
+    address: "120 Bremner Boulevard, Toronto, ON M5J 0A8",
+    phone: "+18332600120",
+  },
+  {
+    name: "Best Buy",
+    categoryPath: "Shopping > Electronics",
+    website: "https://www.bestbuy.ca",
+    address: "65 Dundas Street West, Toronto, ON M5G 2C3",
+    phone: "+18332600121",
+  },
+  {
+    name: "IKEA",
+    categoryPath: "Shopping > Home Goods",
+    website: "https://www.ikea.com",
+    address: "15 Provost Drive, North York, ON M2K 2X9",
+    phone: "+18332600122",
+  },
+  {
+    name: "Winners",
+    categoryPath: "Shopping > Clothing",
+    website: "https://www.winners.ca",
+    address: "444 Yonge Street, Toronto, ON M5B 2H4",
+    phone: "+14162600123",
+  },
 
   // Bills & Subscriptions
-  { name: "Bell Canada", categoryPath: "Bills & Utilities > Phone" },
-  { name: "Rogers Internet", categoryPath: "Bills & Utilities > Internet" },
-  { name: "Netflix", categoryPath: "Entertainment > Streaming Services" },
-  { name: "Spotify", categoryPath: "Entertainment > Streaming Services" },
-  { name: "Disney+", categoryPath: "Entertainment > Streaming Services" },
+  {
+    name: "Bell Canada",
+    categoryPath: "Bills & Utilities > Phone",
+    website: "https://www.bell.ca",
+    address: "483 Bay Street, Toronto, ON M5G 2C9",
+    phone: "+18332600124",
+  },
+  {
+    name: "Rogers Internet",
+    categoryPath: "Bills & Utilities > Internet",
+    website: "https://www.rogers.com",
+    address: "333 Bloor Street East, Toronto, ON M4W 1G9",
+    phone: "+18332600125",
+  },
+  {
+    name: "Netflix",
+    categoryPath: "Entertainment > Streaming Services",
+    website: "https://www.netflix.com",
+    address: "100 Winchester Circle, Los Gatos, CA 95032",
+    phone: "+18332600126",
+  },
+  {
+    name: "Spotify",
+    categoryPath: "Entertainment > Streaming Services",
+    website: "https://www.spotify.com",
+    address: "150 Greenwich Street, New York, NY 10007",
+    phone: "+18332600127",
+  },
+  {
+    name: "Disney+",
+    categoryPath: "Entertainment > Streaming Services",
+    website: "https://www.disneyplus.com",
+    address: "500 South Buena Vista Street, Burbank, CA 91521",
+    phone: "+18332600128",
+  },
 
   // Health
-  { name: "Shoppers Drug Mart", categoryPath: "Health > Pharmacy" },
-  { name: "GoodLife Fitness", categoryPath: "Health > Gym" },
-  { name: "Dr. Smith", categoryPath: "Health > Doctor Visits" },
+  {
+    name: "Shoppers Drug Mart",
+    categoryPath: "Health > Pharmacy",
+    website: "https://www.shoppersdrugmart.ca",
+    address: "465 Yonge Street, Toronto, ON M4Y 1X4",
+    phone: "+14162600129",
+  },
+  {
+    name: "GoodLife Fitness",
+    categoryPath: "Health > Gym",
+    website: "https://www.goodlifefitness.com",
+    address: "137 Yonge Street, Toronto, ON M5C 1W6",
+    phone: "+18332600130",
+  },
+  {
+    name: "Dr. Smith",
+    categoryPath: "Health > Doctor Visits",
+    address: "720 Spadina Avenue, Suite 305, Toronto, ON M5S 2T9",
+    phone: "+14162600131",
+  },
 
   // Other
-  { name: "Cineplex", categoryPath: "Entertainment > Movies" },
-  { name: "Air Canada", categoryPath: "Travel" },
-  { name: "Airbnb", categoryPath: "Travel" },
+  {
+    name: "Cineplex",
+    categoryPath: "Entertainment > Movies",
+    website: "https://www.cineplex.com",
+    address: "259 Richmond Street West, Toronto, ON M5V 3M6",
+    phone: "+14162600132",
+  },
+  {
+    name: "Air Canada",
+    categoryPath: "Travel",
+    website: "https://www.aircanada.com",
+    address: "6001 Boulevard Robert-Bourassa, Dorval, QC H4S 1Z4",
+    phone: "+18332600133",
+  },
+  {
+    name: "Airbnb",
+    categoryPath: "Travel",
+    website: "https://www.airbnb.ca",
+    address: "888 Brannan Street, San Francisco, CA 94103",
+    phone: "+18332600134",
+  },
 ];

--- a/backend/src/database/demo-seed.service.spec.ts
+++ b/backend/src/database/demo-seed.service.spec.ts
@@ -5,7 +5,7 @@ import { SeedService } from "./seed.service";
 import { FaviconService } from "../common/favicon/favicon.service";
 import { demoAccounts } from "./demo-seed-data/accounts";
 import { demoInstitutions } from "./demo-seed-data/institutions";
-import { demoPayees } from "./demo-seed-data/payees";
+import { demoPayees, DemoPayee } from "./demo-seed-data/payees";
 import { demoScheduledTransactions } from "./demo-seed-data/scheduled";
 import { demoSecurities } from "./demo-seed-data/securities";
 import { demoReports } from "./demo-seed-data/reports";
@@ -256,6 +256,77 @@ describe("DemoSeedService", () => {
 
       // demoPayees + Transfer payee
       expect(payeeCalls.length).toBe(demoPayees.length + 1);
+    });
+
+    it("writes each payee's website, address and phone", async () => {
+      await service.seedDemoData("user-123");
+
+      const sample = demoPayees.find((payee) => payee.website) as DemoPayee;
+      const insert = dataSource.query.mock.calls.find(
+        (call: [string, unknown[]]) =>
+          call[0].includes("INSERT INTO payees") && call[1][1] === sample.name,
+      );
+
+      expect(insert[0]).toContain("website");
+      expect(insert[1]).toEqual(
+        expect.arrayContaining([sample.website, sample.address, sample.phone]),
+      );
+    });
+
+    it("leaves the contact details of a payee that has none null", async () => {
+      await service.seedDemoData("user-123");
+
+      // A person or a private client carries no website, and a made-up one
+      // would render a broken icon and a link to nowhere.
+      const bare = demoPayees.find((payee) => !payee.website) as DemoPayee;
+      const insert = dataSource.query.mock.calls.find(
+        (call: [string, unknown[]]) =>
+          call[0].includes("INSERT INTO payees") && call[1][1] === bare.name,
+      );
+
+      expect(insert[1][3]).toBeNull();
+    });
+
+    it("caches a fetched brand logo on the payee", async () => {
+      logoService.fetchFavicon.mockResolvedValue({
+        data: Buffer.from("icon"),
+        contentType: "image/png",
+      });
+
+      await service.seedDemoData("user-123");
+
+      const withSite = demoPayees.filter((payee) => payee.website);
+      for (const payee of withSite) {
+        expect(logoService.fetchFavicon).toHaveBeenCalledWith(payee.website);
+      }
+
+      const sample = withSite[0];
+      const insert = dataSource.query.mock.calls.find(
+        (call: [string, unknown[]]) =>
+          call[0].includes("INSERT INTO payees") && call[1][1] === sample.name,
+      );
+      expect(insert[1]).toEqual(
+        expect.arrayContaining([Buffer.from("icon"), "image/png", true]),
+      );
+    });
+
+    it("seeds a payee whose favicon cannot be fetched with no logo", async () => {
+      // The favicon resolver is a third party; an unreachable one leaves the
+      // payee on its letter badge rather than failing the seed.
+      logoService.fetchFavicon.mockRejectedValue(new Error("offline"));
+
+      await service.seedDemoData("user-123");
+
+      const sample = demoPayees.find((payee) => payee.website) as DemoPayee;
+      const insert = dataSource.query.mock.calls.find(
+        (call: [string, unknown[]]) =>
+          call[0].includes("INSERT INTO payees") && call[1][1] === sample.name,
+      );
+      expect(insert[1][6]).toBeNull();
+      expect(insert[1][8]).toBe(false);
+      // The attempt is still stamped: the column records when the favicon was
+      // last looked for, and null there would mean it never was.
+      expect(insert[1][9]).toEqual(expect.any(String));
     });
 
     it("seeds transactions including regular, splits, and transfers", async () => {

--- a/backend/src/database/demo-seed.service.ts
+++ b/backend/src/database/demo-seed.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { DataSource } from "typeorm";
 import { withScopedDb } from "../common/db/scoped-db";
+import { mapWithConcurrency } from "../common/concurrency.util";
 
 import { withSystemContext } from "../common/db/with-context";
 import { SeedService } from "./seed.service";
@@ -17,6 +18,13 @@ import {
 } from "./demo-seed-data/securities";
 import { demoReports } from "./demo-seed-data/reports";
 import { demoPreferences } from "./demo-seed-data/preferences";
+
+/**
+ * Favicon fetches in flight while seeding payees. Bounded rather than one
+ * `Promise.all` over every payee: the resolver is a third party and a demo
+ * seed should not arrive as a burst of forty simultaneous requests.
+ */
+const PAYEE_LOGO_CONCURRENCY = 6;
 
 @Injectable()
 export class DemoSeedService {
@@ -451,6 +459,18 @@ export class DemoSeedService {
     return accountMap;
   }
 
+  /**
+   * Seed the demo payees, their contact details and their brand icons.
+   *
+   * Contact details are written as the user's own: `contact_lookup_at` and
+   * `contact_lookup_source` stay NULL, so the demo shows what a filled-in
+   * payee looks like rather than one the lookup answered for, and the
+   * background enrichment is still free to run on a payee that has none.
+   *
+   * Logos are fetched best-effort and bounded, like the institutions above:
+   * an unreachable favicon resolver leaves the payee on its letter badge,
+   * which is what a real create does too.
+   */
   private async seedPayees(
     userId: string,
     categoryMap: Map<string, string>,
@@ -459,15 +479,43 @@ export class DemoSeedService {
 
     const payeeMap = new Map<string, string>();
 
-    for (const payee of demoPayees) {
+    const logos = await mapWithConcurrency(
+      demoPayees,
+      PAYEE_LOGO_CONCURRENCY,
+      (payee) =>
+        payee.website
+          ? this.logoService.fetchFavicon(payee.website).catch(() => null)
+          : Promise.resolve(null),
+    );
+
+    for (let i = 0; i < demoPayees.length; i++) {
+      const payee = demoPayees[i];
+      const logo = logos[i];
       const categoryId = categoryMap.get(payee.categoryPath) || null;
       const result = await withScopedDb(this.dataSource, (manager) =>
         manager.query(
-          `INSERT INTO payees (user_id, name, default_category_id)
-         VALUES ($1, $2, $3)
+          `INSERT INTO payees (
+           user_id, name, default_category_id, website, address, phone,
+           logo_data, logo_content_type, has_logo, logo_fetched_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
          ON CONFLICT (user_id, name) DO NOTHING
          RETURNING id`,
-          [userId, payee.name, categoryId],
+          [
+            userId,
+            payee.name,
+            categoryId,
+            payee.website ?? null,
+            payee.address ?? null,
+            payee.phone ?? null,
+            logo ? logo.data : null,
+            logo ? logo.contentType : null,
+            logo ? true : false,
+            // The column records the last attempt, so a website whose favicon
+            // did not resolve is stamped and a payee with no website stays
+            // null -- what `brandLogoColumns` writes on a real create.
+            payee.website ? new Date().toISOString() : null,
+          ],
         ),
       );
       if (result.length > 0) {

--- a/backend/src/payees/phone-normalization.guard.spec.ts
+++ b/backend/src/payees/phone-normalization.guard.spec.ts
@@ -37,8 +37,10 @@ function withoutComments(source: string): string {
 
 /**
  * A phone value being put somewhere, in each dialect this codebase uses: an
- * object literal, an assignment, and raw SQL. Deliberately by shape rather than
- * by file, because the point is to catch the writer nobody has thought of yet.
+ * object literal, an assignment, and raw SQL -- both the `UPDATE` that names
+ * the column and the `INSERT` that names it in a column list. Deliberately by
+ * shape rather than by file, because the point is to catch the writer nobody
+ * has thought of yet.
  */
 const PHONE_WRITES: ReadonlyArray<{ what: string; pattern: RegExp }> = [
   { what: "an entity or update field", pattern: /\bphone:\s*(?!undefined\b)/ },
@@ -46,6 +48,14 @@ const PHONE_WRITES: ReadonlyArray<{ what: string; pattern: RegExp }> = [
   {
     what: "raw SQL setting phone",
     pattern: /\bSET\b[\s\S]{0,200}?\bphone\s*=/i,
+  },
+  {
+    // `[^)]` keeps the match inside the column list: an INSERT that does not
+    // name the column, followed anywhere later in the file by the word, is not
+    // a write. A row of placeholders says nothing about which column each one
+    // fills, so the column list is the only place an INSERT declares itself.
+    what: "raw SQL inserting a phone column",
+    pattern: /\bINSERT\s+INTO\s+\w+\s*\([^)]{0,400}\bphone\b/i,
   },
 ];
 
@@ -82,14 +92,18 @@ const NORMALIZING_DOORS: Record<string, string> = {
 
 /**
  * Files that carry a phone value past a database call without deciding its
- * format -- a read model, or an adapter over a service that normalizes. Each is
- * listed with the reason, because ending up here should be a decision.
+ * format -- a read model, an adapter over a service that normalizes, or a
+ * writer of a fixed constant whose format another spec pins. Each is listed
+ * with the reason, because ending up here should be a decision, and the reason
+ * has to name what decides the format instead of this file.
  */
 const PASSES_THROUGH: Record<string, string> = {
   "ai/actions/ai-actions.service.ts":
     "builds a CreatePayeeDto/UpdatePayeeDto and calls PayeesService, which normalizes; it holds no Payee repository",
   "mcp/tools/payees.tool.ts":
     "builds tool rows and calls PayeesService, which normalizes; it holds no Payee repository",
+  "database/demo-seed.service.ts":
+    "writes the fixed demo payee numbers from demo-seed-data/payees.ts, whose spec asserts each one already equals its own normalized stored form",
 };
 
 function sourceFiles(): string[] {
@@ -171,6 +185,26 @@ describe("a payee phone is stored in one form", () => {
     const sql = `await m.query("UPDATE payees SET phone = $1 WHERE id = $2");`;
     expect(PHONE_WRITES.some(({ pattern }) => pattern.test(sql))).toBe(true);
     expect(PERSISTS.test(sql)).toBe(true);
+
+    // An INSERT names the column in its list rather than beside its value, so
+    // the UPDATE pattern above reads straight past it -- which is how a seeder
+    // came to write this column without going through a door.
+    const insert = `await m.query(\`INSERT INTO payees (
+        user_id, name, website, address, phone
+      ) VALUES ($1, $2, $3, $4, $5)\`);`;
+    expect(PHONE_WRITES.some(({ pattern }) => pattern.test(insert))).toBe(true);
+    expect(PERSISTS.test(insert)).toBe(true);
+  });
+
+  it("does not read an INSERT that leaves the column alone as a write", () => {
+    // The word appearing later in the file -- another statement, a variable, a
+    // returned column -- is not this INSERT naming the column.
+    const insert = `await m.query(\`INSERT INTO payees (user_id, name) VALUES ($1, $2)\`);
+      const phone = row.phone;`;
+    const inserts = PHONE_WRITES.find(({ what }) =>
+      what.includes("inserting"),
+    ) as { pattern: RegExp };
+    expect(inserts.pattern.test(insert)).toBe(false);
   });
 
   it("does not read a declaration as a write", () => {

--- a/docs/backend/entities-and-dtos.md
+++ b/docs/backend/entities-and-dtos.md
@@ -67,9 +67,10 @@ normalized. And **the lookup normalizes before any caller sees a suggestion**
 enrichment `UPDATE` safe: it writes a model's answer straight into the column
 with no DTO anywhere in its path. `phone-normalization.guard.spec.ts` fails on a
 file that both writes a phone and reaches the database without going through a
-door, and `common/phone-number-cases.json` is the truth table this layer and the
-frontend both assert, so the two can never disagree about which numbers are
-accepted.
+door -- an object field, an assignment, an `UPDATE` naming the column or an
+`INSERT` listing it -- and `common/phone-number-cases.json` is the truth table
+this layer and the frontend both assert, so the two can never disagree about
+which numbers are accepted.
 
 **A region is a fact about the reader, not evidence about a third party.**
 `number_format` says where *this user* dials from, which is exactly what places


### PR DESCRIPTION
## Linked discussion / issue

Approved in: no discussion or issue. Requested directly by the maintainer ("update the demo website dummy payees to include payee address/phone/website information"), so the propose-first gate is bypassed by author association rather than by a linked proposal. The first checklist box is left unticked rather than ticked falsely; link a discussion here if you would rather it be ticked.

## Summary

Demo payees carried only a name and a default category, so the payee list and detail pages showed letter badges and empty contact sections. Each brand payee now carries its real website, an invented street address and an invented phone, and the seeder resolves a favicon from the website the way the institution seed already does.

The websites are real because they are what the icons are resolved from. The addresses and phone numbers are not: no demo row holds a business's real line. The numbers avoid the fictional `555` range, which the `max` metadata the payee form normalizes through correctly rejects, so a `555` demo row would be one the form then refuses to save back. They are a synthetic block instead: exchange `260` with a sequential last four, in the payee's own area code, or `833` for a toll-free line. They are stored in the E.164 form `PayeesService` would have normalized a typed number to, so a demo row and a row the user saves over it dial the same digits.

Contact details are written as the user's own. `contact_lookup_at` and `contact_lookup_source` stay `NULL`, so the demo shows a filled-in payee rather than one an AI lookup answered for, and the "looked up automatically" badge stays off. Payees standing in for a person or a private client (the freelance client, Dr. Smith, Transfer) get no website, so nothing renders a broken icon or a link to nowhere. Favicon fetches are bounded at six in flight and best-effort: an unreachable resolver leaves the payee on its letter badge and still stamps the attempt, which is what `brandLogoColumns` writes on a real create.

The second commit widens `phone-normalization.guard.spec.ts`. It looked for an object field, an assignment and an `UPDATE` naming the column, so a raw `INSERT` listing `phone` among its columns wrote the column without going through a normalizing door. That gap is how this seeder came to write one. The new pattern stays inside the column list, so an `INSERT` that does not name the column is not a write however often the word appears later in the file. The seeder is recorded as a pass-through, with the reason naming what decides the format instead: a fixed constant whose own spec asserts each number already equals its normalized stored form. That list may only shrink, so the entry cannot outlive its reason.

## Invariants touched

INV-PAYEE-001. The seeded rows leave `contact_lookup_at` NULL, so the automatic lookup may still run once on a demo payee, and the enrichment's `COALESCE` means it can only fill what the seed left empty. No seeded value can be overwritten by a lookup.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

Notes on two of those boxes. No user-facing string was added: the demo data is seeded content, not copy, and no catalog key changed. The guard widening is the only shared-area edit; it strengthens the rule and adds no exemption beyond the one this change creates, and the maintainer asked for it explicitly.

### Tests

New `demo-seed-data/payees.spec.ts` holds the data: every phone equals its own normalized stored form, every website is absolute `https` with a host, values fit the column and DTO bounds, and no name repeats (the insert is `ON CONFLICT DO NOTHING` on the name, so a duplicate would silently drop one payee's details). `demo-seed.service.spec.ts` gains four cases: the contact columns reach the insert, a payee with no website inserts nulls, a fetched logo is cached, and a failed fetch inserts no bytes while still stamping the attempt. The guard gains two counter-tests: the multi-line `INSERT` shape is caught, and an `INSERT` that leaves the column alone is not.

### Verification

```
backend: npm run lint && npx tsc --noEmit && npm run typecheck   # clean
backend: TZ=UTC npm run test:unit -- --coverage                  # 610 suites, 15887 passed, 2 skipped
backend: npm run build                                           # clean
root:    node scripts/check-env-docs.mjs                         # OK
root:    node scripts/check-docs-manifests.mjs                   # OK
```

`npm run test:integration` was not run: the environment this was developed in has no PostgreSQL and no Docker. Nothing under `backend/test/integration/` exercises the demo seed, so what is unverified is the seeder's raw `INSERT` against a real database. Worth a local run before merge, since the statement gained seven columns.

## AI assistance disclosure

Written by Claude Code (Opus 5) in a Claude Code on the web session, on the maintainer's instructions: the payee data, the seeder change, the guard widening, the tests and this description. Every command quoted above was run in that session, and its output is what is reported. The unrun integration suite is called out rather than assumed to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RChLvzfywcZ68vN2rBSiFy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RChLvzfywcZ68vN2rBSiFy)_