### PR TITLE
chore(claude): pre-approve npm ci and npm install in settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,8 @@
       "Bash(npm run i18n:*)",
       "Bash(npm run migration:lint*)",
       "Bash(npm run build*)",
+      "Bash(npm ci*)",
+      "Bash(npm install*)",
       "Bash(npx tsc *)",
       "Bash(npx jest *)",
       "Bash(npx vitest *)",


### PR DESCRIPTION
## Linked discussion / issue

<!-- TODO: paste the approved discussion/issue link. Maintainer-authored PRs
     (OWNER/MEMBER/COLLABORATOR) bypass the `approved-to-build` label gate in
     .github/workflows/pr-checklist.yml, but the template still expects this
     field filled in. -->

Closes #
Approved in:

## Summary

Pre-approves `npm ci` and `npm install` in `.claude/settings.json` so a fresh
web/remote coding session — which starts with an empty `node_modules` — can
restore dependencies and run the verification gates (`lint`, `type-check`,
`test`, `build`) without a per-command permission prompt.

`npm ci` restores the exact versions pinned in `package-lock.json`; it is
project setup, not a dependency change, and is already the sanctioned setup
command in `e2e/CLAUDE.md`. Nothing else changes.

Single file changed:

- `.claude/settings.json` — two entries added to `permissions.allow`:
  `Bash(npm ci*)` and `Bash(npm install*)`.

Note for reviewers: `Bash(npm install*)` also matches `npm install <package>`,
which adds a dependency — an action `AGENTS.md` lists under "Ask first". If the
intent is to allow only restoring pinned dependencies, narrow the entry to
`Bash(npm ci*)` alone (`npm ci` never edits `package.json`/`package-lock.json`).

## Invariants touched

None.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. <!-- fill the link, or note the maintainer bypass -->
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes. <!-- N/A: config-only change to .claude/settings.json; no code or test surface, existing suite unaffected -->
- [x] All user-facing strings are translated for **every** locale (i18n parity). <!-- N/A: no user-facing strings -->
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`. <!-- branched from origin/main -->
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Drafted with AI assistance (Claude Code). The change is a two-line addition to
`.claude/settings.json`; I have reviewed it and own the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tv57zcLyeRGvfqBXUzXdM7
